### PR TITLE
[codex] Implement built-in context drivers

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -586,10 +586,28 @@ version = "0.0.1-alpha0"
 [[package]]
 name = "context-mcp-generic"
 version = "0.0.1-alpha0"
+dependencies = [
+ "agentenv-core",
+ "agentenv-mcp",
+ "agentenv-proto",
+ "async-trait",
+ "driver-conformance",
+ "reqwest",
+ "serde_json",
+ "tokio",
+ "url",
+]
 
 [[package]]
 name = "context-none"
 version = "0.0.1-alpha0"
+dependencies = [
+ "agentenv-core",
+ "agentenv-proto",
+ "async-trait",
+ "driver-conformance",
+ "tokio",
+]
 
 [[package]]
 name = "core-foundation"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -582,6 +582,18 @@ dependencies = [
 [[package]]
 name = "context-filesystem"
 version = "0.0.1-alpha0"
+dependencies = [
+ "agentenv-core",
+ "agentenv-proto",
+ "async-trait",
+ "driver-conformance",
+ "serde",
+ "serde_json",
+ "tempfile",
+ "thiserror",
+ "tokio",
+ "tracing",
+]
 
 [[package]]
 name = "context-mcp-generic"

--- a/blueprints/claude+filesystem+openshell.yaml
+++ b/blueprints/claude+filesystem+openshell.yaml
@@ -23,6 +23,9 @@ agent:
 context:
   driver: filesystem
   mount: ~/projects            # mounted read-write into the sandbox; exposed as MCP
+  # exclude:
+  #   - ".git/"
+  #   - "node_modules/"
 
 inference:
   driver: passthrough          # agent uses its own key directly; no in-sandbox proxy

--- a/crates/agentenv-core/src/agent_common.rs
+++ b/crates/agentenv-core/src/agent_common.rs
@@ -1,6 +1,6 @@
 use std::collections::BTreeMap;
 
-use agentenv_proto::AgentHealthCheckProbe;
+use agentenv_proto::{AgentHealthCheckProbe, McpEndpoint, McpTransport};
 use serde::{Deserialize, Serialize};
 
 #[derive(Debug, Clone, Copy, Default, Deserialize, Serialize, PartialEq, Eq)]
@@ -32,6 +32,10 @@ pub fn version_probe(binary: &str) -> AgentHealthCheckProbe {
         env: BTreeMap::new(),
         success_exit_codes: vec![0],
     }
+}
+
+pub fn is_no_context_mcp_endpoint(endpoint: &McpEndpoint) -> bool {
+    endpoint.transport == McpTransport::Stdio && endpoint.url.trim().is_empty()
 }
 
 fn is_safe_npm_version(version: &str) -> bool {

--- a/crates/agentenv-core/src/context_common.rs
+++ b/crates/agentenv-core/src/context_common.rs
@@ -185,8 +185,9 @@ mod tests {
 
     use super::{
         context_initialize, empty_credential_requirements, empty_network_rules, empty_result,
-        endpoint_host_rule, expand_tilde, local_context_capabilities, optional_bool,
-        optional_string_list, remote_context_capabilities, required_object, required_string,
+        endpoint_host_rule, expand_tilde, local_context_capabilities, object_required_string,
+        optional_bool, optional_string, optional_string_list, remote_context_capabilities,
+        required_object, required_string, successful_preflight,
     };
 
     #[test]
@@ -229,6 +230,7 @@ mod tests {
         let spec = ContextSpec {
             config: BTreeMap::from([
                 ("mount".to_owned(), json!("/tmp/project")),
+                ("nickname".to_owned(), json!("alice")),
                 ("readonly".to_owned(), json!(false)),
                 ("exclude".to_owned(), json!([".git/", "target/"])),
                 (
@@ -241,6 +243,10 @@ mod tests {
         assert_eq!(
             required_string(&spec.config, "mount").unwrap(),
             "/tmp/project"
+        );
+        assert_eq!(
+            optional_string(&spec.config, "nickname").unwrap(),
+            Some("alice".to_owned())
         );
         assert_eq!(
             optional_bool(&spec.config, "readonly").unwrap(),
@@ -257,6 +263,38 @@ mod tests {
                 .unwrap(),
             &json!("https://example.com/mcp")
         );
+    }
+
+    #[test]
+    fn config_helpers_reject_invalid_types_and_empty_strings() {
+        let spec = ContextSpec {
+            config: BTreeMap::from([
+                ("nickname".to_owned(), json!(42)),
+                ("profile".to_owned(), json!("")),
+            ]),
+        };
+
+        let err = optional_string(&spec.config, "nickname").expect_err("wrong type must fail");
+        assert!(matches!(
+            err,
+            crate::driver::DriverError::InvalidConfig { field, message }
+                if field == "nickname" && message == "must be a string"
+        ));
+
+        let err = object_required_string(
+            required_object(
+                &BTreeMap::from([("profile".to_owned(), json!({"name": ""}))]),
+                "profile",
+            )
+            .unwrap(),
+            "name",
+        )
+        .expect_err("empty string must fail");
+        assert!(matches!(
+            err,
+            crate::driver::DriverError::InvalidConfig { field, message }
+                if field == "name" && message == "must not be empty"
+        ));
     }
 
     #[test]
@@ -289,6 +327,12 @@ mod tests {
         assert_eq!(empty_result(), agentenv_proto::EmptyResult {});
         assert!(empty_network_rules().rules.is_empty());
         assert!(empty_credential_requirements().requirements.is_empty());
+    }
+
+    #[test]
+    fn successful_preflight_reports_ok_without_issues() {
+        assert_eq!(successful_preflight().ok, true);
+        assert!(successful_preflight().issues.is_empty());
     }
 
     #[test]

--- a/crates/agentenv-core/src/context_common.rs
+++ b/crates/agentenv-core/src/context_common.rs
@@ -331,7 +331,7 @@ mod tests {
 
     #[test]
     fn successful_preflight_reports_ok_without_issues() {
-        assert_eq!(successful_preflight().ok, true);
+        assert!(successful_preflight().ok);
         assert!(successful_preflight().issues.is_empty());
     }
 

--- a/crates/agentenv-core/src/context_common.rs
+++ b/crates/agentenv-core/src/context_common.rs
@@ -178,15 +178,15 @@ mod tests {
     use std::collections::BTreeMap;
 
     use agentenv_proto::{
-        Capabilities, ContextCapabilities, ContextSpec, HttpAccessLevel, McpEndpoint, McpTransport,
-        NetworkTarget,
+        Capabilities, ContextCapabilities, ContextSpec, DriverKind, HttpAccessLevel, McpEndpoint,
+        McpTransport, NetworkTarget, SCHEMA_VERSION,
     };
     use serde_json::json;
 
     use super::{
-        context_initialize, empty_credential_requirements, empty_network_rules, endpoint_host_rule,
-        expand_tilde, local_context_capabilities, optional_bool, optional_string_list,
-        remote_context_capabilities, required_object, required_string,
+        context_initialize, empty_credential_requirements, empty_network_rules, empty_result,
+        endpoint_host_rule, expand_tilde, local_context_capabilities, optional_bool,
+        optional_string_list, remote_context_capabilities, required_object, required_string,
     };
 
     #[test]
@@ -194,6 +194,9 @@ mod tests {
         let result = context_initialize("filesystem", local_context_capabilities());
 
         assert_eq!(result.driver.name, "filesystem");
+        assert_eq!(result.driver.kind, DriverKind::Context);
+        assert_eq!(result.driver.version, env!("CARGO_PKG_VERSION"));
+        assert_eq!(result.driver.protocol_version, SCHEMA_VERSION);
         let Capabilities::Context(capabilities) = result.capabilities else {
             panic!("expected context capabilities");
         };
@@ -283,6 +286,7 @@ mod tests {
 
     #[test]
     fn empty_results_are_empty() {
+        assert_eq!(empty_result(), agentenv_proto::EmptyResult {});
         assert!(empty_network_rules().rules.is_empty());
         assert!(empty_credential_requirements().requirements.is_empty());
     }
@@ -292,5 +296,17 @@ mod tests {
         let expanded = expand_tilde("~/project", Some("/home/alice"));
 
         assert_eq!(expanded.to_string_lossy(), "/home/alice/project");
+    }
+
+    #[test]
+    fn tilde_expansion_handles_root_and_plain_paths() {
+        assert_eq!(
+            expand_tilde("~", Some("/home/alice")).to_string_lossy(),
+            "/home/alice"
+        );
+        assert_eq!(
+            expand_tilde("plain/path", Some("/home/alice")).to_string_lossy(),
+            "plain/path"
+        );
     }
 }

--- a/crates/agentenv-core/src/context_common.rs
+++ b/crates/agentenv-core/src/context_common.rs
@@ -1,0 +1,296 @@
+use std::{collections::BTreeMap, path::PathBuf};
+
+use agentenv_proto::{
+    Capabilities, ContextCapabilities, CredentialRequirementsResult, DriverInfo, DriverKind,
+    EmptyResult, HttpAccessLevel, InitializeResult, McpEndpoint, NetworkRule, NetworkTarget,
+    PreflightResult, RequiredNetworkRulesResult, SCHEMA_VERSION,
+};
+use serde_json::{Map, Value};
+
+use crate::driver::{DriverError, DriverResult};
+
+pub fn context_initialize(
+    driver_name: &str,
+    capabilities: ContextCapabilities,
+) -> InitializeResult {
+    InitializeResult {
+        driver: DriverInfo {
+            name: driver_name.to_owned(),
+            kind: DriverKind::Context,
+            version: env!("CARGO_PKG_VERSION").to_owned(),
+            protocol_version: SCHEMA_VERSION.to_owned(),
+        },
+        capabilities: Capabilities::Context(capabilities),
+    }
+}
+
+pub fn local_context_capabilities() -> ContextCapabilities {
+    ContextCapabilities {
+        is_remote: false,
+        is_shared: false,
+        supports_zones: false,
+        supports_snapshots: false,
+    }
+}
+
+pub fn remote_context_capabilities() -> ContextCapabilities {
+    ContextCapabilities {
+        is_remote: true,
+        is_shared: true,
+        supports_zones: false,
+        supports_snapshots: false,
+    }
+}
+
+pub fn successful_preflight() -> PreflightResult {
+    PreflightResult {
+        ok: true,
+        issues: Vec::new(),
+    }
+}
+
+pub fn empty_result() -> EmptyResult {
+    EmptyResult {}
+}
+
+pub fn empty_network_rules() -> RequiredNetworkRulesResult {
+    RequiredNetworkRulesResult { rules: Vec::new() }
+}
+
+pub fn empty_credential_requirements() -> CredentialRequirementsResult {
+    CredentialRequirementsResult {
+        requirements: Vec::new(),
+    }
+}
+
+pub fn required_string(config: &BTreeMap<String, Value>, field: &str) -> DriverResult<String> {
+    match config.get(field) {
+        Some(Value::String(value)) if !value.trim().is_empty() => Ok(value.clone()),
+        Some(Value::String(_)) => Err(invalid_config(field, "must not be empty")),
+        Some(_) => Err(invalid_config(field, "must be a string")),
+        None => Err(invalid_config(field, "is required")),
+    }
+}
+
+pub fn optional_string(
+    config: &BTreeMap<String, Value>,
+    field: &str,
+) -> DriverResult<Option<String>> {
+    match config.get(field) {
+        None => Ok(None),
+        Some(Value::String(value)) if !value.trim().is_empty() => Ok(Some(value.clone())),
+        Some(Value::String(_)) => Err(invalid_config(field, "must not be empty")),
+        Some(_) => Err(invalid_config(field, "must be a string")),
+    }
+}
+
+pub fn optional_bool(config: &BTreeMap<String, Value>, field: &str) -> DriverResult<Option<bool>> {
+    match config.get(field) {
+        None => Ok(None),
+        Some(Value::Bool(value)) => Ok(Some(*value)),
+        Some(_) => Err(invalid_config(field, "must be a boolean")),
+    }
+}
+
+pub fn optional_string_list(
+    config: &BTreeMap<String, Value>,
+    field: &str,
+) -> DriverResult<Vec<String>> {
+    match config.get(field) {
+        None => Ok(Vec::new()),
+        Some(Value::Array(values)) => values
+            .iter()
+            .enumerate()
+            .map(|(index, value)| match value {
+                Value::String(item) if !item.trim().is_empty() => Ok(item.clone()),
+                Value::String(_) => Err(invalid_config(
+                    field,
+                    &format!("item {index} must not be empty"),
+                )),
+                _ => Err(invalid_config(
+                    field,
+                    &format!("item {index} must be a string"),
+                )),
+            })
+            .collect(),
+        Some(_) => Err(invalid_config(field, "must be an array of strings")),
+    }
+}
+
+pub fn required_object<'a>(
+    config: &'a BTreeMap<String, Value>,
+    field: &str,
+) -> DriverResult<&'a Map<String, Value>> {
+    match config.get(field) {
+        Some(Value::Object(object)) => Ok(object),
+        Some(_) => Err(invalid_config(field, "must be an object")),
+        None => Err(invalid_config(field, "is required")),
+    }
+}
+
+pub fn object_required_string(object: &Map<String, Value>, field: &str) -> DriverResult<String> {
+    match object.get(field) {
+        Some(Value::String(value)) if !value.trim().is_empty() => Ok(value.clone()),
+        Some(Value::String(_)) => Err(invalid_config(field, "must not be empty")),
+        Some(_) => Err(invalid_config(field, "must be a string")),
+        None => Err(invalid_config(field, "is required")),
+    }
+}
+
+pub fn endpoint_host_rule(endpoint: &McpEndpoint) -> DriverResult<NetworkRule> {
+    let parsed = url::Url::parse(&endpoint.url)
+        .map_err(|_| invalid_config("endpoint.url", "must be a valid URL"))?;
+
+    let host = parsed
+        .host_str()
+        .map(str::to_owned)
+        .ok_or_else(|| invalid_config("endpoint.url", "must include a host"))?;
+    let port = parsed.port_or_known_default();
+    let scheme = Some(parsed.scheme().to_owned());
+
+    Ok(NetworkRule {
+        target: NetworkTarget::Host {
+            host,
+            port,
+            scheme,
+            http_access: Some(HttpAccessLevel::Full),
+        },
+    })
+}
+
+pub fn expand_tilde(path: &str, home: Option<&str>) -> PathBuf {
+    match (path.strip_prefix("~/"), home) {
+        (Some(rest), Some(home)) => PathBuf::from(home).join(rest),
+        _ if path == "~" => home.map_or_else(|| PathBuf::from(path), PathBuf::from),
+        _ => PathBuf::from(path),
+    }
+}
+
+pub fn invalid_config(field: &str, message: &str) -> DriverError {
+    DriverError::InvalidConfig {
+        field: field.to_owned(),
+        message: message.to_owned(),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::collections::BTreeMap;
+
+    use agentenv_proto::{
+        Capabilities, ContextCapabilities, ContextSpec, HttpAccessLevel, McpEndpoint, McpTransport,
+        NetworkTarget,
+    };
+    use serde_json::json;
+
+    use super::{
+        context_initialize, empty_credential_requirements, empty_network_rules, endpoint_host_rule,
+        expand_tilde, local_context_capabilities, optional_bool, optional_string_list,
+        remote_context_capabilities, required_object, required_string,
+    };
+
+    #[test]
+    fn context_initialize_reports_context_driver_metadata() {
+        let result = context_initialize("filesystem", local_context_capabilities());
+
+        assert_eq!(result.driver.name, "filesystem");
+        let Capabilities::Context(capabilities) = result.capabilities else {
+            panic!("expected context capabilities");
+        };
+        assert_eq!(
+            capabilities,
+            ContextCapabilities {
+                is_remote: false,
+                is_shared: false,
+                supports_zones: false,
+                supports_snapshots: false,
+            }
+        );
+    }
+
+    #[test]
+    fn remote_context_capabilities_are_remote_and_shared() {
+        assert_eq!(
+            remote_context_capabilities(),
+            ContextCapabilities {
+                is_remote: true,
+                is_shared: true,
+                supports_zones: false,
+                supports_snapshots: false,
+            }
+        );
+    }
+
+    #[test]
+    fn config_helpers_parse_expected_types() {
+        let spec = ContextSpec {
+            config: BTreeMap::from([
+                ("mount".to_owned(), json!("/tmp/project")),
+                ("readonly".to_owned(), json!(false)),
+                ("exclude".to_owned(), json!([".git/", "target/"])),
+                (
+                    "endpoint".to_owned(),
+                    json!({"url": "https://example.com/mcp"}),
+                ),
+            ]),
+        };
+
+        assert_eq!(
+            required_string(&spec.config, "mount").unwrap(),
+            "/tmp/project"
+        );
+        assert_eq!(
+            optional_bool(&spec.config, "readonly").unwrap(),
+            Some(false)
+        );
+        assert_eq!(
+            optional_string_list(&spec.config, "exclude").unwrap(),
+            vec![".git/".to_owned(), "target/".to_owned()]
+        );
+        assert_eq!(
+            required_object(&spec.config, "endpoint")
+                .unwrap()
+                .get("url")
+                .unwrap(),
+            &json!("https://example.com/mcp")
+        );
+    }
+
+    #[test]
+    fn endpoint_host_rule_preserves_host_port_scheme_and_full_access() {
+        let rule = endpoint_host_rule(&McpEndpoint {
+            url: "https://mcp.example.com:8443/sse".to_owned(),
+            transport: McpTransport::HttpSse,
+            headers: BTreeMap::new(),
+        })
+        .unwrap();
+
+        let NetworkTarget::Host {
+            host,
+            port,
+            scheme,
+            http_access,
+        } = rule.target
+        else {
+            panic!("expected host rule");
+        };
+
+        assert_eq!(host, "mcp.example.com");
+        assert_eq!(port, Some(8443));
+        assert_eq!(scheme.as_deref(), Some("https"));
+        assert_eq!(http_access, Some(HttpAccessLevel::Full));
+    }
+
+    #[test]
+    fn empty_results_are_empty() {
+        assert!(empty_network_rules().rules.is_empty());
+        assert!(empty_credential_requirements().requirements.is_empty());
+    }
+
+    #[test]
+    fn tilde_expansion_uses_home_when_available() {
+        let expanded = expand_tilde("~/project", Some("/home/alice"));
+
+        assert_eq!(expanded.to_string_lossy(), "/home/alice/project");
+    }
+}

--- a/crates/agentenv-core/src/lib.rs
+++ b/crates/agentenv-core/src/lib.rs
@@ -2,6 +2,7 @@
 
 pub mod agent_common;
 pub mod blueprint;
+pub mod context_common;
 pub mod digest;
 pub mod driver;
 pub mod error;

--- a/crates/drivers/agent-claude/src/lib.rs
+++ b/crates/drivers/agent-claude/src/lib.rs
@@ -1,6 +1,8 @@
 #![forbid(unsafe_code)]
 
-use agentenv_core::agent_common::{npm_package_spec, version_probe, AgentMode, SharedAgentConfig};
+use agentenv_core::agent_common::{
+    is_no_context_mcp_endpoint, npm_package_spec, version_probe, AgentMode, SharedAgentConfig,
+};
 use agentenv_core::driver::{AgentDriver, DriverError, DriverResult};
 use agentenv_proto::{
     assert_compatible_schema_version, AgentCapabilities, AgentHealthCheckProbe, AgentSpec,
@@ -75,7 +77,12 @@ impl AgentDriver for ClaudeDriver {
     ) -> DriverResult<RenderMcpConfigResult> {
         let mut mcp_servers = Map::new();
 
-        for (index, endpoint) in params.endpoints.into_iter().enumerate() {
+        for endpoint in params
+            .endpoints
+            .into_iter()
+            .filter(|endpoint| !is_no_context_mcp_endpoint(endpoint))
+        {
+            let index = mcp_servers.len();
             let mut server = Map::new();
             match endpoint.transport {
                 McpTransport::Stdio => {
@@ -339,6 +346,11 @@ mod tests {
         let rendered = driver
             .render_mcp_config(RenderMcpConfigParams {
                 endpoints: vec![
+                    McpEndpoint {
+                        url: String::new(),
+                        transport: McpTransport::Stdio,
+                        headers: BTreeMap::new(),
+                    },
                     McpEndpoint {
                         url: "agentenv-context".to_owned(),
                         transport: McpTransport::Stdio,

--- a/crates/drivers/agent-codex/src/lib.rs
+++ b/crates/drivers/agent-codex/src/lib.rs
@@ -1,6 +1,8 @@
 #![forbid(unsafe_code)]
 
-use agentenv_core::agent_common::{npm_package_spec, version_probe, AgentMode, SharedAgentConfig};
+use agentenv_core::agent_common::{
+    is_no_context_mcp_endpoint, npm_package_spec, version_probe, AgentMode, SharedAgentConfig,
+};
 use agentenv_core::driver::{AgentDriver, DriverError, DriverResult};
 use agentenv_proto::{
     assert_compatible_schema_version, AgentCapabilities, AgentHealthCheckProbe, AgentSpec,
@@ -75,12 +77,17 @@ impl AgentDriver for CodexDriver {
     ) -> DriverResult<RenderMcpConfigResult> {
         let mut content = String::new();
 
-        for (index, endpoint) in params.endpoints.into_iter().enumerate() {
-            if index > 0 {
+        let mut rendered_index = 0;
+        for endpoint in params.endpoints {
+            if is_no_context_mcp_endpoint(&endpoint) {
+                continue;
+            }
+
+            if rendered_index > 0 {
                 content.push('\n');
             }
 
-            content.push_str(&format!("[mcp_servers.endpoint_{index}]\n"));
+            content.push_str(&format!("[mcp_servers.endpoint_{rendered_index}]\n"));
             match endpoint.transport {
                 McpTransport::Stdio => {
                     content.push_str("command = ");
@@ -114,6 +121,8 @@ impl AgentDriver for CodexDriver {
                 }
                 content.push_str(" }\n");
             }
+
+            rendered_index += 1;
         }
 
         Ok(RenderMcpConfigResult { content })
@@ -375,6 +384,11 @@ mod tests {
         let rendered = driver
             .render_mcp_config(RenderMcpConfigParams {
                 endpoints: vec![
+                    McpEndpoint {
+                        url: String::new(),
+                        transport: McpTransport::Stdio,
+                        headers: BTreeMap::new(),
+                    },
                     McpEndpoint {
                         url: "agentenv-context".to_owned(),
                         transport: McpTransport::Stdio,

--- a/crates/drivers/agent-openclaw/src/lib.rs
+++ b/crates/drivers/agent-openclaw/src/lib.rs
@@ -1,6 +1,8 @@
 #![forbid(unsafe_code)]
 
-use agentenv_core::agent_common::{npm_package_spec, version_probe, AgentMode};
+use agentenv_core::agent_common::{
+    is_no_context_mcp_endpoint, npm_package_spec, version_probe, AgentMode,
+};
 use agentenv_core::driver::{AgentDriver, DriverError, DriverResult};
 use agentenv_proto::{
     assert_compatible_schema_version, AgentCapabilities, AgentHealthCheckProbe, AgentSpec,
@@ -76,7 +78,12 @@ impl AgentDriver for OpenClawDriver {
     ) -> DriverResult<RenderMcpConfigResult> {
         let mut mcp_servers = Map::new();
 
-        for (index, endpoint) in params.endpoints.into_iter().enumerate() {
+        for endpoint in params
+            .endpoints
+            .into_iter()
+            .filter(|endpoint| !is_no_context_mcp_endpoint(endpoint))
+        {
+            let index = mcp_servers.len();
             let mut server = Map::new();
             match endpoint.transport {
                 McpTransport::Stdio => {
@@ -497,6 +504,11 @@ mod tests {
         let rendered = driver
             .render_mcp_config(RenderMcpConfigParams {
                 endpoints: vec![
+                    McpEndpoint {
+                        url: String::new(),
+                        transport: McpTransport::Stdio,
+                        headers: BTreeMap::new(),
+                    },
                     McpEndpoint {
                         url: "agentenv-context".to_owned(),
                         transport: McpTransport::Stdio,

--- a/crates/drivers/context-filesystem/Cargo.toml
+++ b/crates/drivers/context-filesystem/Cargo.toml
@@ -9,3 +9,17 @@ homepage.workspace = true
 authors.workspace = true
 readme = "README.md"
 description = "Filesystem context driver scaffold for agentenv"
+
+[dependencies]
+agentenv-core = { path = "../../agentenv-core" }
+agentenv-proto = { path = "../../agentenv-proto" }
+async-trait.workspace = true
+serde.workspace = true
+serde_json.workspace = true
+thiserror.workspace = true
+tracing.workspace = true
+
+[dev-dependencies]
+driver-conformance = { path = "../../../tests/driver-conformance" }
+tempfile = "=3.16.0"
+tokio.workspace = true

--- a/crates/drivers/context-filesystem/README.md
+++ b/crates/drivers/context-filesystem/README.md
@@ -1,3 +1,22 @@
 # context-filesystem
 
-M1 scaffold crate for the `agentenv` workspace.
+Built-in filesystem context driver for agentenv.
+
+Supported config:
+
+```yaml
+context:
+  driver: filesystem
+  mount: ~/projects/myapp
+  readonly: false
+  exclude:
+    - ".git/"
+    - "node_modules/"
+```
+
+The driver validates the mount, stores an opaque context handle, and exposes a stdio
+MCP endpoint command for `agentenv-fs-mcp`. The server exposes read-only tools:
+`fs_read`, `fs_grep`, `fs_list`, and `fs_search`.
+
+Exclude patterns are intentionally simple. Values ending in `/` match path prefixes.
+Other values match exact path segments or filename substrings.

--- a/crates/drivers/context-filesystem/src/bin/agentenv-fs-mcp.rs
+++ b/crates/drivers/context-filesystem/src/bin/agentenv-fs-mcp.rs
@@ -1,0 +1,236 @@
+use std::{
+    env,
+    io::{self, BufRead, BufReader, Write},
+    path::PathBuf,
+};
+
+use context_filesystem::{FilesystemMcpServer, ToolCall};
+use serde_json::{json, Value};
+
+fn main() {
+    let args: Vec<String> = env::args().collect();
+    let Ok(config) = parse_args(&args) else {
+        eprintln!("usage: agentenv-fs-mcp --root <path> [--readonly] [--exclude <pattern>]...");
+        std::process::exit(2);
+    };
+
+    let stdin = io::stdin();
+    let stdout = io::stdout();
+    let mut reader = BufReader::new(stdin.lock());
+    let mut writer = stdout.lock();
+
+    while let Ok(request) = read_framed_json(&mut reader) {
+        let response = handle_request(
+            config.root.clone(),
+            config.readonly,
+            config.exclude.clone(),
+            request,
+        );
+        if write_framed_json(&mut writer, &response).is_err() {
+            break;
+        }
+    }
+}
+
+#[derive(Debug, Clone)]
+struct CliConfig {
+    root: PathBuf,
+    readonly: bool,
+    exclude: Vec<String>,
+}
+
+fn parse_args(args: &[String]) -> Result<CliConfig, String> {
+    let mut root = None;
+    let mut readonly = false;
+    let mut exclude = Vec::new();
+    let mut index = 1;
+    while index < args.len() {
+        match args[index].as_str() {
+            "--root" => {
+                index += 1;
+                root = args.get(index).map(PathBuf::from);
+            }
+            "--readonly" => readonly = true,
+            "--exclude" => {
+                index += 1;
+                let value = args
+                    .get(index)
+                    .filter(|value| !value.trim().is_empty())
+                    .ok_or_else(|| "--exclude requires a value".to_owned())?;
+                exclude.push(value.clone());
+            }
+            other => return Err(format!("unknown argument `{other}`")),
+        }
+        index += 1;
+    }
+
+    Ok(CliConfig {
+        root: root.ok_or_else(|| "--root is required".to_owned())?,
+        readonly,
+        exclude,
+    })
+}
+
+pub fn handle_request(
+    root: PathBuf,
+    readonly: bool,
+    exclude: Vec<String>,
+    request: Value,
+) -> Value {
+    let id = request.get("id").cloned().unwrap_or(Value::Null);
+    let method = request.get("method").and_then(Value::as_str).unwrap_or("");
+
+    match method {
+        "initialize" => success(
+            id,
+            json!({
+                "protocolVersion": "2024-11-05",
+                "capabilities": {"tools": {}},
+                "serverInfo": {"name": "agentenv-fs-mcp", "version": env!("CARGO_PKG_VERSION")}
+            }),
+        ),
+        "tools/list" => match FilesystemMcpServer::new(root, readonly, exclude) {
+            Ok(server) => success(id, json!({"tools": server.tools_list()})),
+            Err(err) => error(id, -32603, err.to_string()),
+        },
+        "tools/call" => {
+            let Some(params) = request.get("params") else {
+                return error(id, -32602, "missing params".to_owned());
+            };
+            let Some(name) = params.get("name").and_then(Value::as_str) else {
+                return error(id, -32602, "missing tool name".to_owned());
+            };
+            let arguments = params
+                .get("arguments")
+                .cloned()
+                .unwrap_or_else(|| json!({}));
+            match FilesystemMcpServer::new(root, readonly, exclude).and_then(|server| {
+                server.call_tool(ToolCall {
+                    name: name.to_owned(),
+                    arguments,
+                })
+            }) {
+                Ok(result) => success(id, result),
+                Err(err) => error(id, -32602, err.to_string()),
+            }
+        }
+        _ => error(id, -32601, format!("unknown method `{method}`")),
+    }
+}
+
+fn success(id: Value, result: Value) -> Value {
+    json!({"jsonrpc": "2.0", "id": id, "result": result})
+}
+
+fn error(id: Value, code: i64, message: String) -> Value {
+    json!({"jsonrpc": "2.0", "id": id, "error": {"code": code, "message": message}})
+}
+
+pub fn write_framed_json<W: Write>(writer: &mut W, message: &Value) -> io::Result<()> {
+    let payload = serde_json::to_vec(message).map_err(|err| {
+        io::Error::new(io::ErrorKind::InvalidData, format!("serialize JSON: {err}"))
+    })?;
+    write!(writer, "Content-Length: {}\r\n\r\n", payload.len())?;
+    writer.write_all(&payload)?;
+    writer.flush()
+}
+
+pub fn read_framed_json<R: BufRead>(reader: &mut R) -> io::Result<Value> {
+    let mut content_length = None;
+    loop {
+        let mut line = String::new();
+        if reader.read_line(&mut line)? == 0 {
+            return Err(io::Error::new(
+                io::ErrorKind::UnexpectedEof,
+                "missing JSON-RPC header",
+            ));
+        }
+        if line == "\r\n" {
+            break;
+        }
+        if let Some(raw) = line.strip_prefix("Content-Length: ") {
+            content_length = Some(raw.trim().parse::<usize>().map_err(|err| {
+                io::Error::new(
+                    io::ErrorKind::InvalidData,
+                    format!("invalid Content-Length: {err}"),
+                )
+            })?);
+        }
+    }
+
+    let length = content_length.ok_or_else(|| {
+        io::Error::new(io::ErrorKind::InvalidData, "missing Content-Length header")
+    })?;
+    let mut payload = vec![0; length];
+    reader.read_exact(&mut payload)?;
+    serde_json::from_slice(&payload).map_err(|err| {
+        io::Error::new(
+            io::ErrorKind::InvalidData,
+            format!("invalid JSON payload: {err}"),
+        )
+    })
+}
+
+#[cfg(test)]
+mod tests {
+    use std::io::{BufReader, Cursor};
+
+    use serde_json::json;
+
+    use super::{handle_request, read_framed_json, write_framed_json};
+
+    #[test]
+    fn framed_json_round_trips() {
+        let mut bytes = Vec::new();
+        write_framed_json(&mut bytes, &json!({"jsonrpc": "2.0", "id": 1})).unwrap();
+        let mut reader = BufReader::new(Cursor::new(bytes));
+
+        let value = read_framed_json(&mut reader).unwrap();
+
+        assert_eq!(value, json!({"jsonrpc": "2.0", "id": 1}));
+    }
+
+    #[test]
+    fn initialize_request_returns_server_info() {
+        let tmp = tempfile::tempdir().unwrap();
+        let response = handle_request(
+            tmp.path().to_path_buf(),
+            true,
+            Vec::new(),
+            json!({
+                "jsonrpc": "2.0",
+                "id": 1,
+                "method": "initialize",
+                "params": {}
+            }),
+        );
+
+        assert_eq!(response["jsonrpc"], "2.0");
+        assert_eq!(response["id"], 1);
+        assert_eq!(response["result"]["serverInfo"]["name"], "agentenv-fs-mcp");
+    }
+
+    #[test]
+    fn tools_call_fs_read_returns_json_rpc_result() {
+        let tmp = tempfile::tempdir().unwrap();
+        std::fs::write(tmp.path().join("note.txt"), "hello").unwrap();
+        let response = handle_request(
+            tmp.path().to_path_buf(),
+            true,
+            Vec::new(),
+            json!({
+                "jsonrpc": "2.0",
+                "id": 2,
+                "method": "tools/call",
+                "params": {
+                    "name": "fs_read",
+                    "arguments": {"path": "note.txt"}
+                }
+            }),
+        );
+
+        assert_eq!(response["jsonrpc"], "2.0");
+        assert_eq!(response["id"], 2);
+        assert_eq!(response["result"], json!({"content": "hello"}));
+    }
+}

--- a/crates/drivers/context-filesystem/src/bin/agentenv-fs-mcp.rs
+++ b/crates/drivers/context-filesystem/src/bin/agentenv-fs-mcp.rs
@@ -7,6 +7,8 @@ use std::{
 use context_filesystem::{FilesystemMcpServer, ToolCall};
 use serde_json::{json, Value};
 
+const MAX_FRAME_BYTES: usize = 4 * 1024 * 1024;
+
 fn main() {
     let args: Vec<String> = env::args().collect();
     let Ok(config) = parse_args(&args) else {
@@ -48,16 +50,12 @@ fn parse_args(args: &[String]) -> Result<CliConfig, String> {
         match args[index].as_str() {
             "--root" => {
                 index += 1;
-                root = args.get(index).map(PathBuf::from);
+                root = Some(PathBuf::from(required_value(args, index, "--root")?));
             }
             "--readonly" => readonly = true,
             "--exclude" => {
                 index += 1;
-                let value = args
-                    .get(index)
-                    .filter(|value| !value.trim().is_empty())
-                    .ok_or_else(|| "--exclude requires a value".to_owned())?;
-                exclude.push(value.clone());
+                exclude.push(required_value(args, index, "--exclude")?);
             }
             other => return Err(format!("unknown argument `{other}`")),
         }
@@ -69,6 +67,20 @@ fn parse_args(args: &[String]) -> Result<CliConfig, String> {
         readonly,
         exclude,
     })
+}
+
+fn required_value(args: &[String], index: usize, flag: &str) -> Result<String, String> {
+    let value = args
+        .get(index)
+        .ok_or_else(|| format!("{flag} requires a value"))?;
+    if value.trim().is_empty() || is_flag_token(value) {
+        return Err(format!("{flag} requires a value"));
+    }
+    Ok(value.clone())
+}
+
+fn is_flag_token(value: &str) -> bool {
+    matches!(value, "--root" | "--readonly" | "--exclude")
 }
 
 pub fn handle_request(
@@ -161,6 +173,12 @@ pub fn read_framed_json<R: BufRead>(reader: &mut R) -> io::Result<Value> {
     let length = content_length.ok_or_else(|| {
         io::Error::new(io::ErrorKind::InvalidData, "missing Content-Length header")
     })?;
+    if length > MAX_FRAME_BYTES {
+        return Err(io::Error::new(
+            io::ErrorKind::InvalidData,
+            format!("Content-Length too large: {length} bytes"),
+        ));
+    }
     let mut payload = vec![0; length];
     reader.read_exact(&mut payload)?;
     serde_json::from_slice(&payload).map_err(|err| {
@@ -177,7 +195,7 @@ mod tests {
 
     use serde_json::json;
 
-    use super::{handle_request, read_framed_json, write_framed_json};
+    use super::{handle_request, parse_args, read_framed_json, write_framed_json, MAX_FRAME_BYTES};
 
     #[test]
     fn framed_json_round_trips() {
@@ -188,6 +206,46 @@ mod tests {
         let value = read_framed_json(&mut reader).unwrap();
 
         assert_eq!(value, json!({"jsonrpc": "2.0", "id": 1}));
+    }
+
+    #[test]
+    fn read_framed_json_rejects_oversized_content_length() {
+        let too_large = MAX_FRAME_BYTES + 1;
+        let bytes = format!("Content-Length: {too_large}\r\n\r\n");
+        let mut reader = BufReader::new(Cursor::new(bytes.into_bytes()));
+
+        let err = read_framed_json(&mut reader).unwrap_err();
+
+        assert_eq!(err.kind(), std::io::ErrorKind::InvalidData);
+        assert!(err.to_string().contains("too large"));
+    }
+
+    #[test]
+    fn parse_args_rejects_root_followed_by_flag_token() {
+        let args = vec![
+            "agentenv-fs-mcp".to_owned(),
+            "--root".to_owned(),
+            "--readonly".to_owned(),
+        ];
+
+        let err = parse_args(&args).unwrap_err();
+
+        assert!(err.contains("--root"));
+    }
+
+    #[test]
+    fn parse_args_rejects_exclude_followed_by_flag_token() {
+        let args = vec![
+            "agentenv-fs-mcp".to_owned(),
+            "--root".to_owned(),
+            ".".to_owned(),
+            "--exclude".to_owned(),
+            "--readonly".to_owned(),
+        ];
+
+        let err = parse_args(&args).unwrap_err();
+
+        assert!(err.contains("--exclude"));
     }
 
     #[test]

--- a/crates/drivers/context-filesystem/src/lib.rs
+++ b/crates/drivers/context-filesystem/src/lib.rs
@@ -3,6 +3,7 @@
 use std::{
     collections::{btree_map::Entry, BTreeMap},
     fs,
+    io::Read,
     path::{Component, Path, PathBuf},
     sync::{Mutex, MutexGuard},
 };
@@ -27,6 +28,7 @@ use thiserror::Error;
 pub const CRATE_NAME: &str = "context-filesystem";
 const DRIVER_NAME: &str = "filesystem";
 const MAX_READ_BYTES: u64 = 1024 * 1024;
+const MAX_TRAVERSAL_ENTRIES: usize = 100_000;
 const DEFAULT_LIMIT: usize = 100;
 const MAX_LIMIT: usize = 1000;
 
@@ -190,14 +192,22 @@ impl FilesystemMcpServer {
         let mut matches = Vec::new();
         for relative in paths {
             let full = self.root.join(&relative);
-            if fs::metadata(&full)
-                .map(|metadata| metadata.is_dir())
-                .unwrap_or(true)
-            {
+            let Ok(metadata) = fs::metadata(&full) else {
+                continue;
+            };
+            if metadata.is_dir() || metadata.len() > MAX_READ_BYTES {
                 continue;
             }
 
-            let Ok(content) = fs::read_to_string(&full) else {
+            let Ok(file) = fs::File::open(&full) else {
+                continue;
+            };
+            let mut bytes = Vec::new();
+            let mut reader = file.take(MAX_READ_BYTES + 1);
+            if reader.read_to_end(&mut bytes).is_err() || bytes.len() as u64 > MAX_READ_BYTES {
+                continue;
+            }
+            let Ok(content) = String::from_utf8(bytes) else {
                 continue;
             };
             for (index, line) in content.lines().enumerate() {
@@ -259,6 +269,10 @@ impl FilesystemMcpServer {
         if !canonical.starts_with(&self.root) {
             return Err(FsMcpError::OutsideRoot(path.to_owned()));
         }
+        let canonical_relative = self.relative_string(&canonical)?;
+        if self.is_excluded(&canonical_relative) {
+            return Err(FsMcpError::Excluded(path.to_owned()));
+        }
 
         Ok(canonical)
     }
@@ -269,6 +283,17 @@ impl FilesystemMcpServer {
         recursive: bool,
         paths: &mut Vec<String>,
     ) -> Result<(), FsMcpError> {
+        let mut traversed = 0;
+        self.collect_paths_inner(root, recursive, paths, &mut traversed)
+    }
+
+    fn collect_paths_inner(
+        &self,
+        root: &Path,
+        recursive: bool,
+        paths: &mut Vec<String>,
+        traversed: &mut usize,
+    ) -> Result<(), FsMcpError> {
         let metadata = fs::metadata(root).map_err(|source| FsMcpError::Io {
             path: root.display().to_string(),
             source,
@@ -278,6 +303,47 @@ impl FilesystemMcpServer {
             return Ok(());
         }
 
+        for path in self.sorted_child_paths(root, traversed)? {
+            let relative = self.relative_string(&path)?;
+            if self.is_excluded(&relative) {
+                continue;
+            }
+
+            let Ok(symlink_metadata) = fs::symlink_metadata(&path) else {
+                continue;
+            };
+            let Ok(canonical) = fs::canonicalize(&path) else {
+                continue;
+            };
+            if !canonical.starts_with(&self.root) {
+                continue;
+            }
+            let canonical_relative = self.relative_string(&canonical)?;
+            if self.is_excluded(&canonical_relative) {
+                continue;
+            }
+
+            let Ok(metadata) = fs::metadata(&canonical) else {
+                continue;
+            };
+            if metadata.is_dir() {
+                if recursive && !symlink_metadata.file_type().is_symlink() {
+                    self.collect_paths_inner(&path, recursive, paths, traversed)?;
+                }
+            } else if metadata.is_file() {
+                paths.push(relative);
+            }
+        }
+
+        Ok(())
+    }
+
+    fn sorted_child_paths(
+        &self,
+        root: &Path,
+        traversed: &mut usize,
+    ) -> Result<Vec<PathBuf>, FsMcpError> {
+        let mut paths = Vec::new();
         for entry in fs::read_dir(root).map_err(|source| FsMcpError::Io {
             path: root.display().to_string(),
             source,
@@ -286,31 +352,20 @@ impl FilesystemMcpServer {
                 Ok(entry) => entry,
                 Err(_) => continue,
             };
-            let path = entry.path();
-            let relative = self.relative_string(&path)?;
-            if self.is_excluded(&relative) {
-                continue;
-            }
-
-            let Ok(canonical) = fs::canonicalize(&path) else {
-                continue;
-            };
-            if !canonical.starts_with(&self.root) {
-                continue;
-            }
-
-            let Ok(metadata) = fs::metadata(&canonical) else {
-                continue;
-            };
-            if metadata.is_dir() {
-                if recursive {
-                    self.collect_paths(&path, recursive, paths)?;
-                }
-            } else if metadata.is_file() {
-                paths.push(relative);
-            }
+            Self::count_traversal_entry(traversed)?;
+            paths.push(entry.path());
         }
+        paths.sort();
+        Ok(paths)
+    }
 
+    fn count_traversal_entry(traversed: &mut usize) -> Result<(), FsMcpError> {
+        if *traversed >= MAX_TRAVERSAL_ENTRIES {
+            return Err(FsMcpError::InvalidParams(
+                "filesystem traversal limit exceeded".to_owned(),
+            ));
+        }
+        *traversed += 1;
         Ok(())
     }
 
@@ -685,7 +740,7 @@ mod mcp_tool_tests {
 
     use serde_json::json;
 
-    use super::{FilesystemMcpServer, ToolCall};
+    use super::{FilesystemMcpServer, ToolCall, MAX_READ_BYTES};
 
     #[test]
     fn tools_list_advertises_expected_tools() {
@@ -880,6 +935,98 @@ mod mcp_tool_tests {
             .unwrap();
 
         assert_eq!(listed, json!({"paths": ["alpha.txt"]}));
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn symlink_to_excluded_directory_target_is_blocked_and_skipped() {
+        use std::os::unix::fs::symlink;
+
+        let tmp = tempfile::tempdir().unwrap();
+        fs::create_dir(tmp.path().join("secret")).unwrap();
+        fs::write(tmp.path().join("secret/token.txt"), "secret-token\n").unwrap();
+        symlink(tmp.path().join("secret"), tmp.path().join("public")).unwrap();
+        let server =
+            FilesystemMcpServer::new(tmp.path().to_path_buf(), true, vec!["secret/".to_owned()])
+                .unwrap();
+
+        let err = server
+            .call_tool(ToolCall {
+                name: "fs_read".to_owned(),
+                arguments: json!({"path": "public/token.txt"}),
+            })
+            .unwrap_err();
+        assert!(err.to_string().contains("excluded"));
+
+        let listed = server
+            .call_tool(ToolCall {
+                name: "fs_list".to_owned(),
+                arguments: json!({"path": ".", "recursive": true}),
+            })
+            .unwrap();
+        assert_eq!(listed, json!({"paths": []}));
+
+        let searched = server
+            .call_tool(ToolCall {
+                name: "fs_search".to_owned(),
+                arguments: json!({"query": "token"}),
+            })
+            .unwrap();
+        assert_eq!(searched, json!({"paths": []}));
+
+        let grep = server
+            .call_tool(ToolCall {
+                name: "fs_grep".to_owned(),
+                arguments: json!({"pattern": "secret-token"}),
+            })
+            .unwrap();
+        assert_eq!(grep, json!({"matches": []}));
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn symlink_directory_loop_is_not_followed_during_recursive_listing() {
+        use std::os::unix::fs::symlink;
+
+        let tmp = tempfile::tempdir().unwrap();
+        fs::write(tmp.path().join("ordinary.txt"), "ordinary\n").unwrap();
+        symlink(".", tmp.path().join("loop")).unwrap();
+        let server = FilesystemMcpServer::new(tmp.path().to_path_buf(), true, Vec::new()).unwrap();
+
+        let listed = server
+            .call_tool(ToolCall {
+                name: "fs_list".to_owned(),
+                arguments: json!({"path": ".", "recursive": true}),
+            })
+            .unwrap();
+
+        assert_eq!(listed, json!({"paths": ["ordinary.txt"]}));
+    }
+
+    #[test]
+    fn fs_grep_skips_files_larger_than_read_cap() {
+        let tmp = tempfile::tempdir().unwrap();
+        let mut content = vec![b'a'; MAX_READ_BYTES as usize + 1];
+        content[0..6].copy_from_slice(b"needle");
+        fs::write(tmp.path().join("huge.txt"), content).unwrap();
+        fs::write(tmp.path().join("small.txt"), "needle\n").unwrap();
+        let server = FilesystemMcpServer::new(tmp.path().to_path_buf(), true, Vec::new()).unwrap();
+
+        let grep = server
+            .call_tool(ToolCall {
+                name: "fs_grep".to_owned(),
+                arguments: json!({"pattern": "needle"}),
+            })
+            .unwrap();
+
+        assert_eq!(
+            grep,
+            json!({
+                "matches": [
+                    {"path": "small.txt", "line": 1, "text": "needle"}
+                ]
+            })
+        );
     }
 
     #[cfg(unix)]

--- a/crates/drivers/context-filesystem/src/lib.rs
+++ b/crates/drivers/context-filesystem/src/lib.rs
@@ -3,7 +3,7 @@
 use std::{
     collections::{btree_map::Entry, BTreeMap},
     fs,
-    path::PathBuf,
+    path::{Component, Path, PathBuf},
     sync::{Mutex, MutexGuard},
 };
 
@@ -21,9 +21,327 @@ use agentenv_proto::{
     McpTransport, PreflightParams, PreflightResult, RequiredNetworkRulesResult, ShutdownParams,
 };
 use async_trait::async_trait;
+use serde_json::{json, Value};
+use thiserror::Error;
 
 pub const CRATE_NAME: &str = "context-filesystem";
 const DRIVER_NAME: &str = "filesystem";
+const MAX_READ_BYTES: u64 = 1024 * 1024;
+const DEFAULT_LIMIT: usize = 100;
+const MAX_LIMIT: usize = 1000;
+
+#[derive(Debug, Clone)]
+pub struct ToolCall {
+    pub name: String,
+    pub arguments: Value,
+}
+
+#[derive(Debug, Error)]
+pub enum FsMcpError {
+    #[error("invalid params: {0}")]
+    InvalidParams(String),
+    #[error("path `{0}` is outside root")]
+    OutsideRoot(String),
+    #[error("path `{0}` is excluded")]
+    Excluded(String),
+    #[error("path `{0}` is a directory")]
+    Directory(String),
+    #[error("file `{0}` is too large")]
+    FileTooLarge(String),
+    #[error("file `{0}` is not UTF-8 text")]
+    Binary(String),
+    #[error("unknown tool `{0}`")]
+    UnknownTool(String),
+    #[error("filesystem error for `{path}`: {source}")]
+    Io {
+        path: String,
+        #[source]
+        source: std::io::Error,
+    },
+}
+
+#[derive(Debug, Clone)]
+pub struct FilesystemMcpServer {
+    root: PathBuf,
+    readonly: bool,
+    exclude: Vec<String>,
+}
+
+impl FilesystemMcpServer {
+    pub fn new(root: PathBuf, readonly: bool, exclude: Vec<String>) -> Result<Self, FsMcpError> {
+        let root = fs::canonicalize(&root).map_err(|source| FsMcpError::Io {
+            path: root.display().to_string(),
+            source,
+        })?;
+        if !root.is_dir() {
+            return Err(FsMcpError::InvalidParams(format!(
+                "{} is not a directory",
+                root.display()
+            )));
+        }
+
+        Ok(Self {
+            root,
+            readonly,
+            exclude,
+        })
+    }
+
+    pub fn tools_list(&self) -> Value {
+        json!([
+            {
+                "name": "fs_grep",
+                "description": "Search file contents under the mounted root",
+                "readOnly": self.readonly
+            },
+            {
+                "name": "fs_list",
+                "description": "List files under the mounted root",
+                "readOnly": self.readonly
+            },
+            {
+                "name": "fs_read",
+                "description": "Read a UTF-8 text file under the mounted root",
+                "readOnly": self.readonly
+            },
+            {
+                "name": "fs_search",
+                "description": "Search filenames under the mounted root",
+                "readOnly": self.readonly
+            }
+        ])
+    }
+
+    pub fn call_tool(&self, call: ToolCall) -> Result<Value, FsMcpError> {
+        match call.name.as_str() {
+            "fs_read" => self.fs_read(&call.arguments),
+            "fs_list" => self.fs_list(&call.arguments),
+            "fs_search" => self.fs_search(&call.arguments),
+            "fs_grep" => self.fs_grep(&call.arguments),
+            other => Err(FsMcpError::UnknownTool(other.to_owned())),
+        }
+    }
+
+    fn fs_read(&self, args: &Value) -> Result<Value, FsMcpError> {
+        let path = self.required_arg(args, "path")?;
+        let resolved = self.resolve_path(path)?;
+        let metadata = fs::metadata(&resolved).map_err(|source| FsMcpError::Io {
+            path: path.to_owned(),
+            source,
+        })?;
+        if metadata.is_dir() {
+            return Err(FsMcpError::Directory(path.to_owned()));
+        }
+        if metadata.len() > MAX_READ_BYTES {
+            return Err(FsMcpError::FileTooLarge(path.to_owned()));
+        }
+
+        let bytes = fs::read(&resolved).map_err(|source| FsMcpError::Io {
+            path: path.to_owned(),
+            source,
+        })?;
+        let content = String::from_utf8(bytes).map_err(|_| FsMcpError::Binary(path.to_owned()))?;
+
+        Ok(json!({ "content": content }))
+    }
+
+    fn fs_list(&self, args: &Value) -> Result<Value, FsMcpError> {
+        let path = self.optional_arg(args, "path").unwrap_or(".");
+        let recursive = args
+            .get("recursive")
+            .and_then(Value::as_bool)
+            .unwrap_or(false);
+        let root = self.resolve_path(path)?;
+        let mut paths = Vec::new();
+
+        self.collect_paths(&root, recursive, &mut paths)?;
+        paths.sort();
+
+        Ok(json!({ "paths": paths }))
+    }
+
+    fn fs_search(&self, args: &Value) -> Result<Value, FsMcpError> {
+        let query = self.required_arg(args, "query")?;
+        let path = self.optional_arg(args, "path").unwrap_or(".");
+        let limit = self.limit(args);
+        let root = self.resolve_path(path)?;
+        let mut paths = Vec::new();
+
+        self.collect_paths(&root, true, &mut paths)?;
+        paths.retain(|path| path.rsplit('/').next().unwrap_or(path).contains(query));
+        paths.sort();
+        paths.truncate(limit);
+
+        Ok(json!({ "paths": paths }))
+    }
+
+    fn fs_grep(&self, args: &Value) -> Result<Value, FsMcpError> {
+        let pattern = self.required_arg(args, "pattern")?;
+        let path = self.optional_arg(args, "path").unwrap_or(".");
+        let limit = self.limit(args);
+        let root = self.resolve_path(path)?;
+        let mut paths = Vec::new();
+
+        self.collect_paths(&root, true, &mut paths)?;
+        paths.sort();
+
+        let mut matches = Vec::new();
+        for relative in paths {
+            let full = self.root.join(&relative);
+            if fs::metadata(&full)
+                .map(|metadata| metadata.is_dir())
+                .unwrap_or(true)
+            {
+                continue;
+            }
+
+            let Ok(content) = fs::read_to_string(&full) else {
+                continue;
+            };
+            for (index, line) in content.lines().enumerate() {
+                if line.contains(pattern) {
+                    matches.push(json!({
+                        "path": relative,
+                        "line": index + 1,
+                        "text": line,
+                    }));
+                    if matches.len() == limit {
+                        return Ok(json!({ "matches": matches }));
+                    }
+                }
+            }
+        }
+
+        Ok(json!({ "matches": matches }))
+    }
+
+    fn required_arg<'a>(&self, args: &'a Value, field: &str) -> Result<&'a str, FsMcpError> {
+        self.optional_arg(args, field)
+            .ok_or_else(|| FsMcpError::InvalidParams(format!("missing `{field}`")))
+    }
+
+    fn optional_arg<'a>(&self, args: &'a Value, field: &str) -> Option<&'a str> {
+        args.get(field)
+            .and_then(Value::as_str)
+            .filter(|value| !value.trim().is_empty())
+    }
+
+    fn limit(&self, args: &Value) -> usize {
+        args.get("limit")
+            .and_then(Value::as_u64)
+            .map(|value| value as usize)
+            .unwrap_or(DEFAULT_LIMIT)
+            .clamp(1, MAX_LIMIT)
+    }
+
+    fn resolve_path(&self, path: &str) -> Result<PathBuf, FsMcpError> {
+        let relative = Path::new(path);
+        if relative.is_absolute() {
+            return Err(FsMcpError::OutsideRoot(path.to_owned()));
+        }
+        if relative
+            .components()
+            .any(|component| matches!(component, Component::ParentDir))
+        {
+            return Err(FsMcpError::OutsideRoot(path.to_owned()));
+        }
+        if self.is_excluded(path) {
+            return Err(FsMcpError::Excluded(path.to_owned()));
+        }
+
+        let joined = self.root.join(relative);
+        let canonical = fs::canonicalize(&joined).map_err(|source| FsMcpError::Io {
+            path: path.to_owned(),
+            source,
+        })?;
+        if !canonical.starts_with(&self.root) {
+            return Err(FsMcpError::OutsideRoot(path.to_owned()));
+        }
+
+        Ok(canonical)
+    }
+
+    fn collect_paths(
+        &self,
+        root: &Path,
+        recursive: bool,
+        paths: &mut Vec<String>,
+    ) -> Result<(), FsMcpError> {
+        let metadata = fs::metadata(root).map_err(|source| FsMcpError::Io {
+            path: root.display().to_string(),
+            source,
+        })?;
+        if metadata.is_file() {
+            self.push_file_path(root, paths)?;
+            return Ok(());
+        }
+
+        for entry in fs::read_dir(root).map_err(|source| FsMcpError::Io {
+            path: root.display().to_string(),
+            source,
+        })? {
+            let entry = match entry {
+                Ok(entry) => entry,
+                Err(_) => continue,
+            };
+            let path = entry.path();
+            let relative = self.relative_string(&path)?;
+            if self.is_excluded(&relative) {
+                continue;
+            }
+
+            let Ok(canonical) = fs::canonicalize(&path) else {
+                continue;
+            };
+            if !canonical.starts_with(&self.root) {
+                continue;
+            }
+
+            let Ok(metadata) = fs::metadata(&canonical) else {
+                continue;
+            };
+            if metadata.is_dir() {
+                if recursive {
+                    self.collect_paths(&path, recursive, paths)?;
+                }
+            } else if metadata.is_file() {
+                paths.push(relative);
+            }
+        }
+
+        Ok(())
+    }
+
+    fn push_file_path(&self, path: &Path, paths: &mut Vec<String>) -> Result<(), FsMcpError> {
+        let relative = self.relative_string(path)?;
+        if !self.is_excluded(&relative) {
+            paths.push(relative);
+        }
+        Ok(())
+    }
+
+    fn relative_string(&self, path: &Path) -> Result<String, FsMcpError> {
+        let relative = path
+            .strip_prefix(&self.root)
+            .map_err(|_| FsMcpError::OutsideRoot(path.display().to_string()))?;
+
+        Ok(relative.to_string_lossy().replace('\\', "/"))
+    }
+
+    fn is_excluded(&self, relative: &str) -> bool {
+        let normalized = relative.trim_start_matches("./");
+        self.exclude.iter().any(|pattern| {
+            if let Some(prefix) = pattern.strip_suffix('/') {
+                normalized == prefix || normalized.starts_with(&format!("{prefix}/"))
+            } else {
+                normalized == pattern
+                    || normalized
+                        .split('/')
+                        .any(|segment| segment == pattern || segment.contains(pattern))
+            }
+        })
+    }
+}
 
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct FilesystemConfig {
@@ -356,5 +674,217 @@ mod tests {
         driver_conformance::assert_context_driver_contract(&mut driver, spec(tmp.path()))
             .await
             .unwrap();
+    }
+}
+
+#[cfg(test)]
+mod mcp_tool_tests {
+    use std::fs;
+
+    use serde_json::json;
+
+    use super::{FilesystemMcpServer, ToolCall};
+
+    #[test]
+    fn tools_list_advertises_expected_tools() {
+        let tmp = tempfile::tempdir().unwrap();
+        let server = FilesystemMcpServer::new(tmp.path().to_path_buf(), true, Vec::new()).unwrap();
+        let tools = server.tools_list();
+
+        let names: Vec<_> = tools
+            .as_array()
+            .unwrap()
+            .iter()
+            .map(|tool| tool.get("name").unwrap().as_str().unwrap())
+            .collect();
+        assert_eq!(names, vec!["fs_grep", "fs_list", "fs_read", "fs_search"]);
+    }
+
+    #[test]
+    fn fs_read_reads_utf8_file_under_root() {
+        let tmp = tempfile::tempdir().unwrap();
+        fs::write(tmp.path().join("README.md"), "hello\n").unwrap();
+        let server = FilesystemMcpServer::new(tmp.path().to_path_buf(), true, Vec::new()).unwrap();
+
+        let result = server
+            .call_tool(ToolCall {
+                name: "fs_read".to_owned(),
+                arguments: json!({"path": "README.md"}),
+            })
+            .unwrap();
+
+        assert_eq!(result, json!({"content": "hello\n"}));
+    }
+
+    #[test]
+    fn fs_read_rejects_traversal_and_excluded_paths() {
+        let tmp = tempfile::tempdir().unwrap();
+        fs::create_dir(tmp.path().join(".git")).unwrap();
+        fs::write(tmp.path().join(".git/config"), "secret").unwrap();
+        let server =
+            FilesystemMcpServer::new(tmp.path().to_path_buf(), true, vec![".git/".to_owned()])
+                .unwrap();
+
+        assert!(server
+            .call_tool(ToolCall {
+                name: "fs_read".to_owned(),
+                arguments: json!({"path": "../outside"}),
+            })
+            .unwrap_err()
+            .to_string()
+            .contains("outside root"));
+        assert!(server
+            .call_tool(ToolCall {
+                name: "fs_read".to_owned(),
+                arguments: json!({"path": ".git/config"}),
+            })
+            .unwrap_err()
+            .to_string()
+            .contains("excluded"));
+    }
+
+    #[test]
+    fn fs_list_search_and_grep_skip_excluded_paths_and_sort_results() {
+        let tmp = tempfile::tempdir().unwrap();
+        fs::create_dir_all(tmp.path().join("src")).unwrap();
+        fs::create_dir_all(tmp.path().join("target")).unwrap();
+        fs::write(tmp.path().join("src/lib.rs"), "pub fn alpha() {}\n").unwrap();
+        fs::write(tmp.path().join("src/main.rs"), "fn main() {}\nalpha();\n").unwrap();
+        fs::write(tmp.path().join("target/cache.txt"), "alpha\n").unwrap();
+        let server =
+            FilesystemMcpServer::new(tmp.path().to_path_buf(), true, vec!["target/".to_owned()])
+                .unwrap();
+
+        let listed = server
+            .call_tool(ToolCall {
+                name: "fs_list".to_owned(),
+                arguments: json!({"path": ".", "recursive": true}),
+            })
+            .unwrap();
+        assert_eq!(listed, json!({"paths": ["src/lib.rs", "src/main.rs"]}));
+
+        let searched = server
+            .call_tool(ToolCall {
+                name: "fs_search".to_owned(),
+                arguments: json!({"query": "main"}),
+            })
+            .unwrap();
+        assert_eq!(searched, json!({"paths": ["src/main.rs"]}));
+
+        let grep = server
+            .call_tool(ToolCall {
+                name: "fs_grep".to_owned(),
+                arguments: json!({"pattern": "alpha"}),
+            })
+            .unwrap();
+        assert_eq!(
+            grep,
+            json!({
+                "matches": [
+                    {"path": "src/lib.rs", "line": 1, "text": "pub fn alpha() {}"},
+                    {"path": "src/main.rs", "line": 2, "text": "alpha();"}
+                ]
+            })
+        );
+    }
+
+    #[test]
+    fn fs_read_rejects_absolute_paths_directories_binary_and_oversized_files() {
+        let tmp = tempfile::tempdir().unwrap();
+        fs::create_dir(tmp.path().join("dir")).unwrap();
+        fs::write(tmp.path().join("binary.bin"), b"\xff\xfe\xfd").unwrap();
+        fs::write(tmp.path().join("large.txt"), vec![b'a'; 1024 * 1024 + 1]).unwrap();
+        let server = FilesystemMcpServer::new(tmp.path().to_path_buf(), true, Vec::new()).unwrap();
+
+        let absolute = tmp.path().join("large.txt");
+        assert!(server
+            .call_tool(ToolCall {
+                name: "fs_read".to_owned(),
+                arguments: json!({"path": absolute}),
+            })
+            .unwrap_err()
+            .to_string()
+            .contains("outside root"));
+        assert!(server
+            .call_tool(ToolCall {
+                name: "fs_read".to_owned(),
+                arguments: json!({"path": "dir"}),
+            })
+            .unwrap_err()
+            .to_string()
+            .contains("directory"));
+        assert!(server
+            .call_tool(ToolCall {
+                name: "fs_read".to_owned(),
+                arguments: json!({"path": "binary.bin"}),
+            })
+            .unwrap_err()
+            .to_string()
+            .contains("UTF-8"));
+        assert!(server
+            .call_tool(ToolCall {
+                name: "fs_read".to_owned(),
+                arguments: json!({"path": "large.txt"}),
+            })
+            .unwrap_err()
+            .to_string()
+            .contains("too large"));
+    }
+
+    #[test]
+    fn fs_search_and_grep_limits_are_respected() {
+        let tmp = tempfile::tempdir().unwrap();
+        fs::write(tmp.path().join("alpha_one.txt"), "needle\nneedle again\n").unwrap();
+        fs::write(tmp.path().join("alpha_two.txt"), "needle\n").unwrap();
+        let server = FilesystemMcpServer::new(tmp.path().to_path_buf(), true, Vec::new()).unwrap();
+
+        let searched = server
+            .call_tool(ToolCall {
+                name: "fs_search".to_owned(),
+                arguments: json!({"query": "alpha", "limit": 1}),
+            })
+            .unwrap();
+        assert_eq!(searched, json!({"paths": ["alpha_one.txt"]}));
+
+        let grep = server
+            .call_tool(ToolCall {
+                name: "fs_grep".to_owned(),
+                arguments: json!({"pattern": "needle", "limit": 2}),
+            })
+            .unwrap();
+        assert_eq!(
+            grep,
+            json!({
+                "matches": [
+                    {"path": "alpha_one.txt", "line": 1, "text": "needle"},
+                    {"path": "alpha_one.txt", "line": 2, "text": "needle again"}
+                ]
+            })
+        );
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn symlink_escaping_root_is_rejected() {
+        use std::os::unix::fs::symlink;
+
+        let tmp = tempfile::tempdir().unwrap();
+        let outside = tempfile::tempdir().unwrap();
+        fs::write(outside.path().join("secret.txt"), "secret").unwrap();
+        symlink(
+            outside.path().join("secret.txt"),
+            tmp.path().join("link.txt"),
+        )
+        .unwrap();
+        let server = FilesystemMcpServer::new(tmp.path().to_path_buf(), true, Vec::new()).unwrap();
+
+        let err = server
+            .call_tool(ToolCall {
+                name: "fs_read".to_owned(),
+                arguments: json!({"path": "link.txt"}),
+            })
+            .unwrap_err();
+
+        assert!(err.to_string().contains("outside root"));
     }
 }

--- a/crates/drivers/context-filesystem/src/lib.rs
+++ b/crates/drivers/context-filesystem/src/lib.rs
@@ -1,4 +1,360 @@
 #![forbid(unsafe_code)]
 
-/// Placeholder surface for the M1 workspace scaffold.
+use std::{
+    collections::{btree_map::Entry, BTreeMap},
+    fs,
+    path::PathBuf,
+    sync::{Mutex, MutexGuard},
+};
+
+use agentenv_core::{
+    context_common::{
+        context_initialize, empty_credential_requirements, empty_network_rules, empty_result,
+        expand_tilde, local_context_capabilities, optional_bool, optional_string_list,
+        required_string, successful_preflight,
+    },
+    driver::{ContextDriver, DriverError, DriverResult},
+};
+use agentenv_proto::{
+    ContextHandle, ContextHandleRequest, ContextSpec, ContextStatus, CredentialRequirementsParams,
+    CredentialRequirementsResult, EmptyResult, InitializeParams, InitializeResult, McpEndpoint,
+    McpTransport, PreflightParams, PreflightResult, RequiredNetworkRulesResult, ShutdownParams,
+};
+use async_trait::async_trait;
+
 pub const CRATE_NAME: &str = "context-filesystem";
+const DRIVER_NAME: &str = "filesystem";
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct FilesystemConfig {
+    pub root: PathBuf,
+    pub readonly: bool,
+    pub exclude: Vec<String>,
+}
+
+#[derive(Debug, Clone)]
+struct FilesystemState {
+    config: FilesystemConfig,
+}
+
+#[derive(Debug)]
+struct FilesystemStore {
+    next_id: u64,
+    states: BTreeMap<String, FilesystemState>,
+}
+
+#[derive(Debug)]
+pub struct FilesystemContextDriver {
+    store: Mutex<FilesystemStore>,
+}
+
+impl Default for FilesystemContextDriver {
+    fn default() -> Self {
+        Self {
+            store: Mutex::new(FilesystemStore {
+                next_id: 1,
+                states: BTreeMap::new(),
+            }),
+        }
+    }
+}
+
+#[async_trait]
+impl ContextDriver for FilesystemContextDriver {
+    async fn initialize(&mut self, _params: InitializeParams) -> DriverResult<InitializeResult> {
+        Ok(context_initialize(
+            DRIVER_NAME,
+            local_context_capabilities(),
+        ))
+    }
+
+    async fn preflight(&self, _params: PreflightParams) -> DriverResult<PreflightResult> {
+        Ok(successful_preflight())
+    }
+
+    async fn provision(&self, spec: ContextSpec) -> DriverResult<ContextHandle> {
+        let config = filesystem_config_from_spec(&spec)?;
+        let mut store = self.store()?;
+        let handle = loop {
+            let handle = format!("{DRIVER_NAME}|{}", store.next_id);
+            store.next_id += 1;
+            if let Entry::Vacant(entry) = store.states.entry(handle.clone()) {
+                entry.insert(FilesystemState {
+                    config: config.clone(),
+                });
+                break handle;
+            }
+        };
+
+        Ok(ContextHandle { handle })
+    }
+
+    async fn mcp_endpoint(&self, params: ContextHandleRequest) -> DriverResult<McpEndpoint> {
+        let state = self.state(&params.handle)?;
+
+        Ok(McpEndpoint {
+            url: filesystem_endpoint_command(&state.config),
+            transport: McpTransport::Stdio,
+            headers: BTreeMap::new(),
+        })
+    }
+
+    async fn required_network_rules(
+        &self,
+        params: ContextHandleRequest,
+    ) -> DriverResult<RequiredNetworkRulesResult> {
+        self.state(&params.handle)?;
+
+        Ok(empty_network_rules())
+    }
+
+    async fn credential_requirements(
+        &self,
+        _params: CredentialRequirementsParams,
+    ) -> DriverResult<CredentialRequirementsResult> {
+        Ok(empty_credential_requirements())
+    }
+
+    async fn status(&self, params: ContextHandleRequest) -> DriverResult<ContextStatus> {
+        let state = self.state(&params.handle)?;
+        let healthy = state.config.root.is_dir();
+        let detail = if healthy {
+            Some(format!("mounted {}", state.config.root.display()))
+        } else {
+            Some(format!(
+                "{} is not a directory",
+                state.config.root.display()
+            ))
+        };
+
+        Ok(ContextStatus { healthy, detail })
+    }
+
+    async fn teardown(&self, params: ContextHandleRequest) -> DriverResult<EmptyResult> {
+        let mut store = self.store()?;
+        store
+            .states
+            .remove(&params.handle)
+            .ok_or_else(|| invalid_handle(&params.handle))?;
+
+        Ok(empty_result())
+    }
+
+    async fn shutdown(&mut self, _params: ShutdownParams) -> DriverResult<EmptyResult> {
+        Ok(empty_result())
+    }
+}
+
+impl FilesystemContextDriver {
+    fn state(&self, handle: &str) -> DriverResult<FilesystemState> {
+        let store = self.store()?;
+        store
+            .states
+            .get(handle)
+            .cloned()
+            .ok_or_else(|| invalid_handle(handle))
+    }
+
+    fn store(&self) -> DriverResult<MutexGuard<'_, FilesystemStore>> {
+        self.store.lock().map_err(|_| DriverError::CleanupFailed {
+            message: "filesystem context store mutex poisoned".to_owned(),
+        })
+    }
+}
+
+pub fn filesystem_config_from_spec(spec: &ContextSpec) -> DriverResult<FilesystemConfig> {
+    let mount = required_string(&spec.config, "mount")?;
+    let home = std::env::var("HOME").ok();
+    let expanded = expand_tilde(&mount, home.as_deref());
+    let root = fs::canonicalize(&expanded).map_err(|err| DriverError::InvalidConfig {
+        field: "mount".to_owned(),
+        message: format!("failed to canonicalize `{}`: {err}", expanded.display()),
+    })?;
+    if !root.is_dir() {
+        return Err(DriverError::InvalidConfig {
+            field: "mount".to_owned(),
+            message: format!("{} is not a directory", root.display()),
+        });
+    }
+
+    Ok(FilesystemConfig {
+        root,
+        readonly: optional_bool(&spec.config, "readonly")?.unwrap_or(true),
+        exclude: optional_string_list(&spec.config, "exclude")?,
+    })
+}
+
+pub fn filesystem_endpoint_command(config: &FilesystemConfig) -> String {
+    let mut parts = vec![
+        "agentenv-fs-mcp".to_owned(),
+        "--root".to_owned(),
+        shell_quote(&config.root.to_string_lossy()),
+    ];
+
+    if config.readonly {
+        parts.push("--readonly".to_owned());
+    }
+
+    for pattern in &config.exclude {
+        parts.push("--exclude".to_owned());
+        parts.push(shell_quote(pattern));
+    }
+
+    parts.join(" ")
+}
+
+fn shell_quote(value: &str) -> String {
+    if value
+        .chars()
+        .all(|ch| ch.is_ascii_alphanumeric() || matches!(ch, '/' | '.' | '_' | '-' | ':'))
+    {
+        value.to_owned()
+    } else {
+        format!("'{}'", value.replace('\'', "'\\''"))
+    }
+}
+
+fn invalid_handle(handle: &str) -> DriverError {
+    DriverError::InvalidHandle {
+        handle: handle.to_owned(),
+        message: "unknown filesystem context handle".to_owned(),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::{collections::BTreeMap, fs};
+
+    use agentenv_core::driver::ContextDriver;
+    use agentenv_proto::{
+        Capabilities, ContextHandleRequest, ContextSpec, CredentialRequirementsParams,
+        InitializeParams, LogLevel, McpTransport, SCHEMA_VERSION,
+    };
+    use serde_json::json;
+
+    use super::{filesystem_config_from_spec, FilesystemContextDriver};
+
+    fn init_params() -> InitializeParams {
+        InitializeParams {
+            schema_version: SCHEMA_VERSION.to_owned(),
+            core_version: "0.0.1-alpha0".to_owned(),
+            workdir: "/tmp/agentenv-test".to_owned(),
+            log_level: LogLevel::Info,
+        }
+    }
+
+    fn spec(root: &std::path::Path) -> ContextSpec {
+        ContextSpec {
+            config: BTreeMap::from([
+                ("mount".to_owned(), json!(root.to_string_lossy())),
+                ("readonly".to_owned(), json!(false)),
+                ("exclude".to_owned(), json!([".git/", "target/"])),
+            ]),
+        }
+    }
+
+    #[test]
+    fn filesystem_config_parses_mount_readonly_and_excludes() {
+        let tmp = tempfile::tempdir().unwrap();
+        let config = filesystem_config_from_spec(&spec(tmp.path())).unwrap();
+
+        assert_eq!(config.root, tmp.path().canonicalize().unwrap());
+        assert!(!config.readonly);
+        assert_eq!(
+            config.exclude,
+            vec![".git/".to_owned(), "target/".to_owned()]
+        );
+    }
+
+    #[test]
+    fn filesystem_config_rejects_missing_mount() {
+        let err = filesystem_config_from_spec(&ContextSpec {
+            config: BTreeMap::new(),
+        })
+        .unwrap_err();
+
+        assert!(err.to_string().contains("mount"));
+    }
+
+    #[test]
+    fn filesystem_config_rejects_file_mount() {
+        let tmp = tempfile::tempdir().unwrap();
+        let file = tmp.path().join("file.txt");
+        fs::write(&file, "not a directory").unwrap();
+
+        let err = filesystem_config_from_spec(&spec(&file)).unwrap_err();
+
+        assert!(err.to_string().contains("directory"));
+    }
+
+    #[tokio::test]
+    async fn initialize_returns_local_capabilities() {
+        let mut driver = FilesystemContextDriver::default();
+        let result = driver.initialize(init_params()).await.unwrap();
+
+        assert_eq!(result.driver.name, "filesystem");
+        let Capabilities::Context(capabilities) = result.capabilities else {
+            panic!("expected context capabilities");
+        };
+        assert!(!capabilities.is_remote);
+        assert!(!capabilities.is_shared);
+        assert!(!capabilities.supports_zones);
+        assert!(!capabilities.supports_snapshots);
+    }
+
+    #[tokio::test]
+    async fn provision_returns_stdio_endpoint_and_empty_rules() {
+        let tmp = tempfile::tempdir().unwrap();
+        let driver = FilesystemContextDriver::default();
+        let handle = driver.provision(spec(tmp.path())).await.unwrap();
+        let request = ContextHandleRequest {
+            handle: handle.handle.clone(),
+        };
+
+        let endpoint = driver.mcp_endpoint(request.clone()).await.unwrap();
+        let rules = driver
+            .required_network_rules(request.clone())
+            .await
+            .unwrap();
+        let credentials = driver
+            .credential_requirements(CredentialRequirementsParams::default())
+            .await
+            .unwrap();
+
+        assert_eq!(endpoint.transport, McpTransport::Stdio);
+        assert!(endpoint.url.contains("agentenv-fs-mcp"));
+        assert!(endpoint.url.contains("--root"));
+        assert!(endpoint.url.contains("--exclude"));
+        assert!(rules.rules.is_empty());
+        assert!(credentials.requirements.is_empty());
+    }
+
+    #[tokio::test]
+    async fn status_reports_unhealthy_when_mount_disappears() {
+        let tmp = tempfile::tempdir().unwrap();
+        let driver = FilesystemContextDriver::default();
+        let handle = driver.provision(spec(tmp.path())).await.unwrap();
+        let mount = tmp.into_path();
+        fs::remove_dir_all(&mount).unwrap();
+
+        let status = driver
+            .status(ContextHandleRequest {
+                handle: handle.handle,
+            })
+            .await
+            .unwrap();
+
+        assert!(!status.healthy);
+        assert!(status.detail.unwrap().contains("not a directory"));
+    }
+
+    #[tokio::test]
+    async fn filesystem_driver_satisfies_context_conformance_contract() {
+        let tmp = tempfile::tempdir().unwrap();
+        let mut driver = FilesystemContextDriver::default();
+
+        driver_conformance::assert_context_driver_contract(&mut driver, spec(tmp.path()))
+            .await
+            .unwrap();
+    }
+}

--- a/crates/drivers/context-filesystem/src/lib.rs
+++ b/crates/drivers/context-filesystem/src/lib.rs
@@ -151,11 +151,13 @@ impl FilesystemMcpServer {
             .get("recursive")
             .and_then(Value::as_bool)
             .unwrap_or(false);
+        let limit = self.limit(args);
         let root = self.resolve_path(path)?;
         let mut paths = Vec::new();
 
         self.collect_paths(&root, recursive, &mut paths)?;
         paths.sort();
+        paths.truncate(limit);
 
         Ok(json!({ "paths": paths }))
     }
@@ -861,6 +863,23 @@ mod mcp_tool_tests {
                 ]
             })
         );
+    }
+
+    #[test]
+    fn fs_list_limit_returns_first_sorted_paths() {
+        let tmp = tempfile::tempdir().unwrap();
+        fs::write(tmp.path().join("beta.txt"), "beta\n").unwrap();
+        fs::write(tmp.path().join("alpha.txt"), "alpha\n").unwrap();
+        let server = FilesystemMcpServer::new(tmp.path().to_path_buf(), true, Vec::new()).unwrap();
+
+        let listed = server
+            .call_tool(ToolCall {
+                name: "fs_list".to_owned(),
+                arguments: json!({"limit": 1}),
+            })
+            .unwrap();
+
+        assert_eq!(listed, json!({"paths": ["alpha.txt"]}));
     }
 
     #[cfg(unix)]

--- a/crates/drivers/context-filesystem/tests/fs_mcp_stdio.rs
+++ b/crates/drivers/context-filesystem/tests/fs_mcp_stdio.rs
@@ -3,7 +3,7 @@ use std::io::{self, BufRead, BufReader, Write};
 use serde_json::Value;
 
 #[test]
-fn process_smoke_reads_file_over_stdio() {
+fn process_smoke_exercises_initialize_tools_list_and_read_over_stdio() {
     let tmp = tempfile::tempdir().unwrap();
     std::fs::write(tmp.path().join("note.txt"), "hello").unwrap();
     let binary = env!("CARGO_BIN_EXE_agentenv-fs-mcp");
@@ -16,21 +16,58 @@ fn process_smoke_reads_file_over_stdio() {
         .spawn()
         .unwrap();
 
-    let request = serde_json::json!({
+    let mut stdin = child.stdin.take().unwrap();
+    let mut reader = BufReader::new(child.stdout.take().unwrap());
+
+    let initialize_request = serde_json::json!({
         "jsonrpc": "2.0",
-        "id": 7,
+        "id": 1,
+        "method": "initialize",
+        "params": {}
+    });
+    write_framed_json(&mut stdin, &initialize_request).unwrap();
+    let initialize_response = read_framed_json(&mut reader).unwrap();
+    assert_eq!(
+        initialize_response["result"]["serverInfo"]["name"],
+        "agentenv-fs-mcp"
+    );
+
+    let list_request = serde_json::json!({
+        "jsonrpc": "2.0",
+        "id": 2,
+        "method": "tools/list",
+        "params": {}
+    });
+    write_framed_json(&mut stdin, &list_request).unwrap();
+    let list_response = read_framed_json(&mut reader).unwrap();
+    let tool_names: Vec<_> = list_response["result"]["tools"]
+        .as_array()
+        .unwrap()
+        .iter()
+        .map(|tool| tool["name"].as_str().unwrap())
+        .collect();
+    assert_eq!(
+        tool_names,
+        vec!["fs_grep", "fs_list", "fs_read", "fs_search"]
+    );
+
+    let read_request = serde_json::json!({
+        "jsonrpc": "2.0",
+        "id": 3,
         "method": "tools/call",
         "params": {"name": "fs_read", "arguments": {"path": "note.txt"}}
     });
-    write_framed_json(child.stdin.as_mut().unwrap(), &request).unwrap();
-    drop(child.stdin.take());
+    write_framed_json(&mut stdin, &read_request).unwrap();
+    drop(stdin);
 
-    let mut reader = BufReader::new(child.stdout.take().unwrap());
-    let response = read_framed_json(&mut reader).unwrap();
+    let read_response = read_framed_json(&mut reader).unwrap();
     let status = child.wait().unwrap();
 
     assert!(status.success());
-    assert_eq!(response["result"], serde_json::json!({"content": "hello"}));
+    assert_eq!(
+        read_response["result"],
+        serde_json::json!({"content": "hello"})
+    );
 }
 
 fn write_framed_json<W: Write>(writer: &mut W, message: &Value) -> io::Result<()> {

--- a/crates/drivers/context-filesystem/tests/fs_mcp_stdio.rs
+++ b/crates/drivers/context-filesystem/tests/fs_mcp_stdio.rs
@@ -1,0 +1,79 @@
+use std::io::{self, BufRead, BufReader, Write};
+
+use serde_json::Value;
+
+#[test]
+fn process_smoke_reads_file_over_stdio() {
+    let tmp = tempfile::tempdir().unwrap();
+    std::fs::write(tmp.path().join("note.txt"), "hello").unwrap();
+    let binary = env!("CARGO_BIN_EXE_agentenv-fs-mcp");
+    let mut child = std::process::Command::new(binary)
+        .arg("--root")
+        .arg(tmp.path())
+        .arg("--readonly")
+        .stdin(std::process::Stdio::piped())
+        .stdout(std::process::Stdio::piped())
+        .spawn()
+        .unwrap();
+
+    let request = serde_json::json!({
+        "jsonrpc": "2.0",
+        "id": 7,
+        "method": "tools/call",
+        "params": {"name": "fs_read", "arguments": {"path": "note.txt"}}
+    });
+    write_framed_json(child.stdin.as_mut().unwrap(), &request).unwrap();
+    drop(child.stdin.take());
+
+    let mut reader = BufReader::new(child.stdout.take().unwrap());
+    let response = read_framed_json(&mut reader).unwrap();
+    let status = child.wait().unwrap();
+
+    assert!(status.success());
+    assert_eq!(response["result"], serde_json::json!({"content": "hello"}));
+}
+
+fn write_framed_json<W: Write>(writer: &mut W, message: &Value) -> io::Result<()> {
+    let payload = serde_json::to_vec(message).map_err(|err| {
+        io::Error::new(io::ErrorKind::InvalidData, format!("serialize JSON: {err}"))
+    })?;
+    write!(writer, "Content-Length: {}\r\n\r\n", payload.len())?;
+    writer.write_all(&payload)?;
+    writer.flush()
+}
+
+fn read_framed_json<R: BufRead>(reader: &mut R) -> io::Result<Value> {
+    let mut content_length = None;
+    loop {
+        let mut line = String::new();
+        if reader.read_line(&mut line)? == 0 {
+            return Err(io::Error::new(
+                io::ErrorKind::UnexpectedEof,
+                "missing JSON-RPC header",
+            ));
+        }
+        if line == "\r\n" {
+            break;
+        }
+        if let Some(raw) = line.strip_prefix("Content-Length: ") {
+            content_length = Some(raw.trim().parse::<usize>().map_err(|err| {
+                io::Error::new(
+                    io::ErrorKind::InvalidData,
+                    format!("invalid Content-Length: {err}"),
+                )
+            })?);
+        }
+    }
+
+    let length = content_length.ok_or_else(|| {
+        io::Error::new(io::ErrorKind::InvalidData, "missing Content-Length header")
+    })?;
+    let mut payload = vec![0; length];
+    reader.read_exact(&mut payload)?;
+    serde_json::from_slice(&payload).map_err(|err| {
+        io::Error::new(
+            io::ErrorKind::InvalidData,
+            format!("invalid JSON payload: {err}"),
+        )
+    })
+}

--- a/crates/drivers/context-mcp-generic/Cargo.toml
+++ b/crates/drivers/context-mcp-generic/Cargo.toml
@@ -9,3 +9,16 @@ homepage.workspace = true
 authors.workspace = true
 readme = "README.md"
 description = "Generic MCP context driver scaffold for agentenv"
+
+[dependencies]
+agentenv-core = { path = "../../agentenv-core" }
+agentenv-mcp = { path = "../../agentenv-mcp" }
+agentenv-proto = { path = "../../agentenv-proto" }
+async-trait.workspace = true
+reqwest.workspace = true
+serde_json.workspace = true
+url.workspace = true
+
+[dev-dependencies]
+driver-conformance = { path = "../../../tests/driver-conformance" }
+tokio.workspace = true

--- a/crates/drivers/context-mcp-generic/README.md
+++ b/crates/drivers/context-mcp-generic/README.md
@@ -1,3 +1,20 @@
 # context-mcp-generic
 
-M1 scaffold crate for the `agentenv` workspace.
+Built-in context driver for existing MCP HTTP endpoints.
+
+Supported config:
+
+```yaml
+context:
+  driver: mcp-generic
+  endpoint:
+    url: https://mcp.example.com/sse
+    transport: http+sse
+  credentials:
+    MCP_TOKEN:
+      source: env
+```
+
+The driver validates outbound endpoint URLs through the shared SSRF validator,
+declares an optional `MCP_TOKEN` credential name, returns one network allow rule
+for the endpoint host, and never stores credential values.

--- a/crates/drivers/context-mcp-generic/src/lib.rs
+++ b/crates/drivers/context-mcp-generic/src/lib.rs
@@ -2,7 +2,9 @@
 
 use std::{
     collections::{btree_map::Entry, BTreeMap},
+    net::SocketAddr,
     sync::{Mutex, MutexGuard},
+    time::Duration,
 };
 
 use agentenv_core::{
@@ -11,9 +13,9 @@ use agentenv_core::{
         remote_context_capabilities, required_object, successful_preflight,
     },
     driver::{ContextDriver, DriverError, DriverResult},
-    security::ssrf::{DnsResolver, SsrfOptions, SystemDnsResolver},
+    security::ssrf::{DnsResolver, SsrfOptions, SystemDnsResolver, ValidatedUrl},
 };
-use agentenv_mcp::validate_mcp_endpoint;
+use agentenv_mcp::{validate_mcp_endpoint, ValidatedMcpEndpoint};
 use agentenv_proto::{
     ContextHandle, ContextHandleRequest, ContextSpec, ContextStatus, CredentialKind,
     CredentialRequirement, CredentialRequirementsParams, CredentialRequirementsResult, EmptyResult,
@@ -25,6 +27,7 @@ use serde_json::json;
 
 pub const CRATE_NAME: &str = "context-mcp-generic";
 const DRIVER_NAME: &str = "mcp-generic";
+const MCP_PROBE_TIMEOUT: Duration = Duration::from_secs(10);
 
 #[cfg(test)]
 #[derive(Debug, Clone, Copy)]
@@ -113,9 +116,14 @@ impl ContextDriver for GenericMcpContextDriver {
 
     async fn provision(&self, spec: ContextSpec) -> DriverResult<ContextHandle> {
         let endpoint = endpoint_from_spec(&spec)?;
-        if self.probe.validate_ssrf {
-            validate_endpoint_for_driver(&endpoint, &SystemDnsResolver)?;
-        }
+        let validated_endpoint = if self.probe.validate_ssrf {
+            Some(validated_endpoint_for_driver(
+                &endpoint,
+                &SystemDnsResolver,
+            )?)
+        } else {
+            None
+        };
 
         if self.probe.enabled
             && matches!(
@@ -123,7 +131,18 @@ impl ContextDriver for GenericMcpContextDriver {
                 McpTransport::Http | McpTransport::HttpSse
             )
         {
-            probe_mcp_initialize(&endpoint.url).await?;
+            if let Some(validated_url) = validated_endpoint
+                .as_ref()
+                .and_then(|endpoint| endpoint.validated_url.as_ref())
+            {
+                probe_mcp_initialize_with_validated_url(&endpoint.url, validated_url).await?;
+            } else if self.probe.validate_ssrf {
+                return Err(DriverError::PreflightFailed {
+                    message: "MCP initialize probe requires a validated URL".to_owned(),
+                });
+            } else {
+                probe_mcp_initialize(&endpoint.url).await?;
+            }
         }
 
         let mut store = self.store()?;
@@ -218,20 +237,77 @@ pub fn validate_endpoint_for_driver(
     endpoint: &McpEndpoint,
     resolver: &dyn DnsResolver,
 ) -> DriverResult<()> {
+    validated_endpoint_for_driver(endpoint, resolver).map(|_| ())
+}
+
+fn validated_endpoint_for_driver(
+    endpoint: &McpEndpoint,
+    resolver: &dyn DnsResolver,
+) -> DriverResult<ValidatedMcpEndpoint> {
     let options = SsrfOptions {
         allow_ssh_http: true,
         ..SsrfOptions::default()
     };
 
-    validate_mcp_endpoint(endpoint, options, resolver)
-        .map(|_| ())
-        .map_err(|err| DriverError::InvalidConfig {
-            field: "endpoint.url".to_owned(),
-            message: err.to_string(),
-        })
+    validate_mcp_endpoint(endpoint, options, resolver).map_err(|err| DriverError::InvalidConfig {
+        field: "endpoint.url".to_owned(),
+        message: err.to_string(),
+    })
 }
 
 pub async fn probe_mcp_initialize(url: &str) -> DriverResult<()> {
+    let client =
+        mcp_probe_client_builder()
+            .build()
+            .map_err(|err| DriverError::PreflightFailed {
+                message: format!("MCP initialize client build failed: {err}"),
+            })?;
+
+    send_mcp_initialize(client, url).await
+}
+
+async fn probe_mcp_initialize_with_validated_url(
+    url: &str,
+    validated_url: &ValidatedUrl,
+) -> DriverResult<()> {
+    let port =
+        validated_url
+            .url
+            .port_or_known_default()
+            .ok_or_else(|| DriverError::PreflightFailed {
+                message: "MCP initialize validated URL did not include a usable port".to_owned(),
+            })?;
+    let addrs = validated_url
+        .pinned_ips
+        .iter()
+        .copied()
+        .map(|ip| SocketAddr::new(ip, port))
+        .collect::<Vec<_>>();
+
+    if addrs.is_empty() {
+        return Err(DriverError::PreflightFailed {
+            message: "MCP initialize validated URL did not include pinned IPs".to_owned(),
+        });
+    }
+
+    let client = mcp_probe_client_builder()
+        .resolve_to_addrs(&validated_url.host, &addrs)
+        .build()
+        .map_err(|err| DriverError::PreflightFailed {
+            message: format!("MCP initialize client build failed: {err}"),
+        })?;
+
+    send_mcp_initialize(client, url).await
+}
+
+fn mcp_probe_client_builder() -> reqwest::ClientBuilder {
+    reqwest::Client::builder()
+        .redirect(reqwest::redirect::Policy::none())
+        .no_proxy()
+        .timeout(MCP_PROBE_TIMEOUT)
+}
+
+async fn send_mcp_initialize(client: reqwest::Client, url: &str) -> DriverResult<()> {
     let request_body = serde_json::to_vec(&json!({
         "jsonrpc": "2.0",
         "id": 1,
@@ -249,7 +325,7 @@ pub async fn probe_mcp_initialize(url: &str) -> DriverResult<()> {
         message: format!("MCP initialize request serialization failed: {err}"),
     })?;
 
-    let response = reqwest::Client::new()
+    let response = client
         .post(url)
         .header(reqwest::header::CONTENT_TYPE, "application/json")
         .body(request_body)
@@ -301,11 +377,15 @@ mod tests {
     use std::{
         collections::BTreeMap,
         io::{Read, Write},
-        net::TcpListener,
+        net::{IpAddr, TcpListener},
         thread,
+        time::{Duration, Instant},
     };
 
-    use agentenv_core::{driver::ContextDriver, security::ssrf::StaticDnsResolver};
+    use agentenv_core::{
+        driver::ContextDriver,
+        security::ssrf::{StaticDnsResolver, ValidatedUrl},
+    };
     use agentenv_proto::{
         Capabilities, ContextHandleRequest, ContextSpec, CredentialRequirementsParams,
         InitializeParams, LogLevel, McpTransport, NetworkTarget, SCHEMA_VERSION,
@@ -313,8 +393,8 @@ mod tests {
     use serde_json::{json, Value};
 
     use super::{
-        endpoint_from_spec, probe_mcp_initialize, validate_endpoint_for_driver,
-        GenericMcpContextDriver, ProbeExpectation,
+        endpoint_from_spec, probe_mcp_initialize, probe_mcp_initialize_with_validated_url,
+        validate_endpoint_for_driver, GenericMcpContextDriver, ProbeExpectation,
     };
 
     fn init_params() -> InitializeParams {
@@ -383,6 +463,31 @@ mod tests {
         let err = probe_mcp_initialize(&server.url()).await.unwrap_err();
 
         assert!(err.to_string().contains("MCP initialize"));
+    }
+
+    #[tokio::test]
+    async fn initialize_probe_rejects_redirect_instead_of_following() {
+        let server = spawn_redirect_server_to_valid_mcp_response();
+
+        let err = probe_mcp_initialize(&server.url()).await.unwrap_err();
+
+        assert!(err.to_string().contains("MCP initialize"));
+    }
+
+    #[tokio::test]
+    async fn initialize_probe_uses_validated_url_pinned_resolution() {
+        let server = spawn_probe_server(ProbeExpectation::ValidInitialize);
+        let url =
+            url::Url::parse(&format!("http://mcp.example.test:{}", server.addr().port())).unwrap();
+        let validated_url = ValidatedUrl {
+            url,
+            host: "mcp.example.test".to_owned(),
+            pinned_ips: vec![IpAddr::from([127, 0, 0, 1])],
+        };
+
+        probe_mcp_initialize_with_validated_url(validated_url.url.as_str(), &validated_url)
+            .await
+            .unwrap();
     }
 
     #[tokio::test]
@@ -459,12 +564,17 @@ mod tests {
 
     struct ProbeServer {
         url: String,
+        addr: std::net::SocketAddr,
         thread: Option<thread::JoinHandle<()>>,
     }
 
     impl ProbeServer {
         fn url(&self) -> String {
             self.url.clone()
+        }
+
+        fn addr(&self) -> std::net::SocketAddr {
+            self.addr
         }
     }
 
@@ -478,7 +588,8 @@ mod tests {
 
     fn spawn_probe_server(expectation: ProbeExpectation) -> ProbeServer {
         let listener = TcpListener::bind("127.0.0.1:0").unwrap();
-        let url = format!("http://{}", listener.local_addr().unwrap());
+        let addr = listener.local_addr().unwrap();
+        let url = format!("http://{addr}");
         let thread = thread::spawn(move || {
             let (mut stream, _) = listener.accept().unwrap();
             let mut buf = [0; 4096];
@@ -514,7 +625,80 @@ mod tests {
 
         ProbeServer {
             url,
+            addr,
             thread: Some(thread),
         }
+    }
+
+    fn spawn_redirect_server_to_valid_mcp_response() -> ProbeServer {
+        let target = TcpListener::bind("127.0.0.1:0").unwrap();
+        let target_addr = target.local_addr().unwrap();
+        target.set_nonblocking(true).unwrap();
+        let target_thread = thread::spawn(move || {
+            let deadline = Instant::now() + Duration::from_millis(250);
+            loop {
+                match target.accept() {
+                    Ok((mut stream, _)) => {
+                        let mut buf = [0; 4096];
+                        let _ = stream.read(&mut buf).unwrap();
+                        write_valid_initialize_response(&mut stream);
+                        break;
+                    }
+                    Err(err) if err.kind() == std::io::ErrorKind::WouldBlock => {
+                        if Instant::now() >= deadline {
+                            break;
+                        }
+                        thread::sleep(Duration::from_millis(10));
+                    }
+                    Err(err) => panic!("target accept failed: {err}"),
+                }
+            }
+        });
+
+        let redirect = TcpListener::bind("127.0.0.1:0").unwrap();
+        let addr = redirect.local_addr().unwrap();
+        let url = format!("http://{addr}");
+        let thread = thread::spawn(move || {
+            let (mut stream, _) = redirect.accept().unwrap();
+            let mut buf = [0; 4096];
+            let read = stream.read(&mut buf).unwrap();
+            let request = String::from_utf8_lossy(&buf[..read]);
+            assert!(request.contains("initialize"));
+
+            write!(
+                stream,
+                "HTTP/1.1 302 Found\r\nLocation: http://{target_addr}\r\nContent-Length: 0\r\n\r\n",
+            )
+            .unwrap();
+            target_thread
+                .join()
+                .expect("redirect target thread should finish");
+        });
+
+        ProbeServer {
+            url,
+            addr,
+            thread: Some(thread),
+        }
+    }
+
+    fn write_valid_initialize_response(stream: &mut impl Write) {
+        let body = serde_json::to_string(&json!({
+            "jsonrpc": "2.0",
+            "id": 1,
+            "result": {
+                "protocolVersion": "2024-11-05",
+                "capabilities": {},
+                "serverInfo": {"name": "mock", "version": "0.0.1"}
+            }
+        }))
+        .unwrap();
+        write!(
+            stream,
+            "HTTP/1.1 200 OK\r\nContent-Type: application/json\r\nContent-Length: {}\r\n\r\n{}",
+            body.len(),
+            body
+        )
+        .unwrap();
     }
 }

--- a/crates/drivers/context-mcp-generic/src/lib.rs
+++ b/crates/drivers/context-mcp-generic/src/lib.rs
@@ -336,9 +336,13 @@ async fn send_mcp_initialize(client: reqwest::Client, url: &str) -> DriverResult
             message: format!("MCP initialize request failed: {err}"),
         })?;
 
-    if !response.status().is_success() {
+    let status = response.status();
+    if is_auth_challenge(status) {
+        return Ok(());
+    }
+    if !status.is_success() {
         return Err(DriverError::PreflightFailed {
-            message: format!("MCP initialize returned HTTP {}", response.status()),
+            message: format!("MCP initialize returned HTTP {status}"),
         });
     }
 
@@ -388,6 +392,10 @@ fn has_non_empty_string(value: Option<&Value>) -> bool {
     value
         .and_then(Value::as_str)
         .is_some_and(|value| !value.trim().is_empty())
+}
+
+fn is_auth_challenge(status: reqwest::StatusCode) -> bool {
+    status == reqwest::StatusCode::UNAUTHORIZED || status == reqwest::StatusCode::FORBIDDEN
 }
 
 fn invalid_handle(handle: &str) -> DriverError {
@@ -497,6 +505,15 @@ mod tests {
         let err = probe_mcp_initialize(&server.url()).await.unwrap_err();
 
         assert!(err.to_string().contains("MCP initialize"));
+    }
+
+    #[tokio::test]
+    async fn initialize_probe_accepts_auth_challenges() {
+        for status in [401, 403] {
+            let server = spawn_status_server(status);
+
+            probe_mcp_initialize(&server.url()).await.unwrap();
+        }
     }
 
     #[tokio::test]
@@ -712,6 +729,31 @@ mod tests {
             target_thread
                 .join()
                 .expect("redirect target thread should finish");
+        });
+
+        ProbeServer {
+            url,
+            addr,
+            thread: Some(thread),
+        }
+    }
+
+    fn spawn_status_server(status: u16) -> ProbeServer {
+        let listener = TcpListener::bind("127.0.0.1:0").unwrap();
+        let addr = listener.local_addr().unwrap();
+        let url = format!("http://{addr}");
+        let thread = thread::spawn(move || {
+            let (mut stream, _) = listener.accept().unwrap();
+            let mut buf = [0; 4096];
+            let read = stream.read(&mut buf).unwrap();
+            let request = String::from_utf8_lossy(&buf[..read]);
+            assert!(request.contains("initialize"));
+
+            write!(
+                stream,
+                "HTTP/1.1 {status} Auth Required\r\nContent-Length: 0\r\n\r\n",
+            )
+            .unwrap();
         });
 
         ProbeServer {

--- a/crates/drivers/context-mcp-generic/src/lib.rs
+++ b/crates/drivers/context-mcp-generic/src/lib.rs
@@ -23,7 +23,7 @@ use agentenv_proto::{
     PreflightResult, RequiredNetworkRulesResult, ShutdownParams,
 };
 use async_trait::async_trait;
-use serde_json::json;
+use serde_json::{json, Value};
 
 pub const CRATE_NAME: &str = "context-mcp-generic";
 const DRIVER_NAME: &str = "mcp-generic";
@@ -34,6 +34,7 @@ const MCP_PROBE_TIMEOUT: Duration = Duration::from_secs(10);
 pub enum ProbeExpectation {
     ValidInitialize,
     InvalidInitialize,
+    EmptyInitializeResult,
 }
 
 #[derive(Debug, Clone)]
@@ -354,15 +355,39 @@ async fn send_mcp_initialize(client: reqwest::Client, url: &str) -> DriverResult
 
     if body.get("jsonrpc").and_then(serde_json::Value::as_str) != Some("2.0")
         || body.get("id") != Some(&json!(1))
-        || body.get("result").is_none()
-        || body.get("result") == Some(&serde_json::Value::Null)
+        || !body
+            .get("result")
+            .is_some_and(is_valid_mcp_initialize_result)
     {
         return Err(DriverError::PreflightFailed {
-            message: "MCP initialize response did not contain a JSON-RPC result".to_owned(),
+            message: "MCP initialize response did not contain a valid MCP initialize result"
+                .to_owned(),
         });
     }
 
     Ok(())
+}
+
+fn is_valid_mcp_initialize_result(result: &Value) -> bool {
+    let Some(result) = result.as_object() else {
+        return false;
+    };
+
+    has_non_empty_string(result.get("protocolVersion"))
+        && result.get("capabilities").is_some_and(Value::is_object)
+        && result.get("serverInfo").is_some_and(|server_info| {
+            let Some(server_info) = server_info.as_object() else {
+                return false;
+            };
+            has_non_empty_string(server_info.get("name"))
+                && has_non_empty_string(server_info.get("version"))
+        })
+}
+
+fn has_non_empty_string(value: Option<&Value>) -> bool {
+    value
+        .and_then(Value::as_str)
+        .is_some_and(|value| !value.trim().is_empty())
 }
 
 fn invalid_handle(handle: &str) -> DriverError {
@@ -459,6 +484,15 @@ mod tests {
     #[tokio::test]
     async fn initialize_probe_rejects_non_mcp_response() {
         let server = spawn_probe_server(ProbeExpectation::InvalidInitialize);
+
+        let err = probe_mcp_initialize(&server.url()).await.unwrap_err();
+
+        assert!(err.to_string().contains("MCP initialize"));
+    }
+
+    #[tokio::test]
+    async fn initialize_probe_rejects_empty_initialize_result() {
+        let server = spawn_probe_server(ProbeExpectation::EmptyInitializeResult);
 
         let err = probe_mcp_initialize(&server.url()).await.unwrap_err();
 
@@ -611,6 +645,11 @@ mod tests {
                     "jsonrpc": "2.0",
                     "id": 1,
                     "result": null
+                }),
+                ProbeExpectation::EmptyInitializeResult => json!({
+                    "jsonrpc": "2.0",
+                    "id": 1,
+                    "result": {}
                 }),
             };
             let body = serde_json::to_string(&body).unwrap();

--- a/crates/drivers/context-mcp-generic/src/lib.rs
+++ b/crates/drivers/context-mcp-generic/src/lib.rs
@@ -1,4 +1,520 @@
 #![forbid(unsafe_code)]
 
-/// Placeholder surface for the M1 workspace scaffold.
+use std::{
+    collections::{btree_map::Entry, BTreeMap},
+    sync::{Mutex, MutexGuard},
+};
+
+use agentenv_core::{
+    context_common::{
+        context_initialize, endpoint_host_rule, object_required_string,
+        remote_context_capabilities, required_object, successful_preflight,
+    },
+    driver::{ContextDriver, DriverError, DriverResult},
+    security::ssrf::{DnsResolver, SsrfOptions, SystemDnsResolver},
+};
+use agentenv_mcp::validate_mcp_endpoint;
+use agentenv_proto::{
+    ContextHandle, ContextHandleRequest, ContextSpec, ContextStatus, CredentialKind,
+    CredentialRequirement, CredentialRequirementsParams, CredentialRequirementsResult, EmptyResult,
+    InitializeParams, InitializeResult, McpEndpoint, McpTransport, PreflightParams,
+    PreflightResult, RequiredNetworkRulesResult, ShutdownParams,
+};
+use async_trait::async_trait;
+use serde_json::json;
+
 pub const CRATE_NAME: &str = "context-mcp-generic";
+const DRIVER_NAME: &str = "mcp-generic";
+
+#[cfg(test)]
+#[derive(Debug, Clone, Copy)]
+pub enum ProbeExpectation {
+    ValidInitialize,
+    InvalidInitialize,
+}
+
+#[derive(Debug, Clone)]
+struct GenericMcpState {
+    endpoint: McpEndpoint,
+}
+
+#[derive(Debug)]
+struct GenericMcpStore {
+    next_id: u64,
+    states: BTreeMap<String, GenericMcpState>,
+}
+
+#[derive(Debug, Clone, Copy)]
+struct ProbeSettings {
+    enabled: bool,
+    validate_ssrf: bool,
+}
+
+#[derive(Debug)]
+pub struct GenericMcpContextDriver {
+    store: Mutex<GenericMcpStore>,
+    probe: ProbeSettings,
+}
+
+impl Default for GenericMcpContextDriver {
+    fn default() -> Self {
+        Self {
+            store: Mutex::new(GenericMcpStore {
+                next_id: 1,
+                states: BTreeMap::new(),
+            }),
+            probe: ProbeSettings {
+                enabled: true,
+                validate_ssrf: true,
+            },
+        }
+    }
+}
+
+impl GenericMcpContextDriver {
+    pub fn new_for_tests_without_probe() -> Self {
+        Self {
+            probe: ProbeSettings {
+                enabled: false,
+                validate_ssrf: false,
+            },
+            ..Self::default()
+        }
+    }
+
+    fn state(&self, handle: &str) -> DriverResult<GenericMcpState> {
+        let store = self.store()?;
+        store
+            .states
+            .get(handle)
+            .cloned()
+            .ok_or_else(|| invalid_handle(handle))
+    }
+
+    fn store(&self) -> DriverResult<MutexGuard<'_, GenericMcpStore>> {
+        self.store.lock().map_err(|_| DriverError::CleanupFailed {
+            message: "generic MCP context store mutex poisoned".to_owned(),
+        })
+    }
+}
+
+#[async_trait]
+impl ContextDriver for GenericMcpContextDriver {
+    async fn initialize(&mut self, _params: InitializeParams) -> DriverResult<InitializeResult> {
+        Ok(context_initialize(
+            DRIVER_NAME,
+            remote_context_capabilities(),
+        ))
+    }
+
+    async fn preflight(&self, _params: PreflightParams) -> DriverResult<PreflightResult> {
+        Ok(successful_preflight())
+    }
+
+    async fn provision(&self, spec: ContextSpec) -> DriverResult<ContextHandle> {
+        let endpoint = endpoint_from_spec(&spec)?;
+        if self.probe.validate_ssrf {
+            validate_endpoint_for_driver(&endpoint, &SystemDnsResolver)?;
+        }
+
+        if self.probe.enabled
+            && matches!(
+                endpoint.transport,
+                McpTransport::Http | McpTransport::HttpSse
+            )
+        {
+            probe_mcp_initialize(&endpoint.url).await?;
+        }
+
+        let mut store = self.store()?;
+        let handle = loop {
+            let handle = format!("{DRIVER_NAME}|{}", store.next_id);
+            store.next_id += 1;
+            if let Entry::Vacant(entry) = store.states.entry(handle.clone()) {
+                entry.insert(GenericMcpState {
+                    endpoint: endpoint.clone(),
+                });
+                break handle;
+            }
+        };
+
+        Ok(ContextHandle { handle })
+    }
+
+    async fn mcp_endpoint(&self, params: ContextHandleRequest) -> DriverResult<McpEndpoint> {
+        Ok(self.state(&params.handle)?.endpoint)
+    }
+
+    async fn required_network_rules(
+        &self,
+        params: ContextHandleRequest,
+    ) -> DriverResult<RequiredNetworkRulesResult> {
+        let endpoint = self.state(&params.handle)?.endpoint;
+        Ok(RequiredNetworkRulesResult {
+            rules: vec![endpoint_host_rule(&endpoint)?],
+        })
+    }
+
+    async fn credential_requirements(
+        &self,
+        _params: CredentialRequirementsParams,
+    ) -> DriverResult<CredentialRequirementsResult> {
+        Ok(CredentialRequirementsResult {
+            requirements: vec![CredentialRequirement {
+                name: "MCP_TOKEN".to_owned(),
+                description: "Optional bearer token for generic MCP endpoints.".to_owned(),
+                kind: CredentialKind::Token,
+                required: false,
+                validator: None,
+            }],
+        })
+    }
+
+    async fn status(&self, params: ContextHandleRequest) -> DriverResult<ContextStatus> {
+        self.state(&params.handle)?;
+        Ok(ContextStatus {
+            healthy: true,
+            detail: Some("generic MCP endpoint configured".to_owned()),
+        })
+    }
+
+    async fn teardown(&self, params: ContextHandleRequest) -> DriverResult<EmptyResult> {
+        let mut store = self.store()?;
+        store
+            .states
+            .remove(&params.handle)
+            .ok_or_else(|| invalid_handle(&params.handle))?;
+        Ok(EmptyResult::default())
+    }
+
+    async fn shutdown(&mut self, _params: ShutdownParams) -> DriverResult<EmptyResult> {
+        Ok(EmptyResult::default())
+    }
+}
+
+pub fn endpoint_from_spec(spec: &ContextSpec) -> DriverResult<McpEndpoint> {
+    let endpoint = required_object(&spec.config, "endpoint")?;
+    let url = object_required_string(endpoint, "url")?;
+    let transport = match object_required_string(endpoint, "transport")?.as_str() {
+        "http" => McpTransport::Http,
+        "http+sse" => McpTransport::HttpSse,
+        "ssh+http" => McpTransport::SshHttp,
+        other => {
+            return Err(DriverError::InvalidConfig {
+                field: "endpoint.transport".to_owned(),
+                message: format!("unsupported MCP transport `{other}`"),
+            });
+        }
+    };
+
+    Ok(McpEndpoint {
+        url,
+        transport,
+        headers: BTreeMap::new(),
+    })
+}
+
+pub fn validate_endpoint_for_driver(
+    endpoint: &McpEndpoint,
+    resolver: &dyn DnsResolver,
+) -> DriverResult<()> {
+    let options = SsrfOptions {
+        allow_ssh_http: true,
+        ..SsrfOptions::default()
+    };
+
+    validate_mcp_endpoint(endpoint, options, resolver)
+        .map(|_| ())
+        .map_err(|err| DriverError::InvalidConfig {
+            field: "endpoint.url".to_owned(),
+            message: err.to_string(),
+        })
+}
+
+pub async fn probe_mcp_initialize(url: &str) -> DriverResult<()> {
+    let request_body = serde_json::to_vec(&json!({
+        "jsonrpc": "2.0",
+        "id": 1,
+        "method": "initialize",
+        "params": {
+            "protocolVersion": "2024-11-05",
+            "capabilities": {},
+            "clientInfo": {
+                "name": "agentenv",
+                "version": env!("CARGO_PKG_VERSION"),
+            },
+        },
+    }))
+    .map_err(|err| DriverError::PreflightFailed {
+        message: format!("MCP initialize request serialization failed: {err}"),
+    })?;
+
+    let response = reqwest::Client::new()
+        .post(url)
+        .header(reqwest::header::CONTENT_TYPE, "application/json")
+        .body(request_body)
+        .send()
+        .await
+        .map_err(|err| DriverError::PreflightFailed {
+            message: format!("MCP initialize request failed: {err}"),
+        })?;
+
+    if !response.status().is_success() {
+        return Err(DriverError::PreflightFailed {
+            message: format!("MCP initialize returned HTTP {}", response.status()),
+        });
+    }
+
+    let body = response
+        .text()
+        .await
+        .map_err(|err| DriverError::PreflightFailed {
+            message: format!("MCP initialize response read failed: {err}"),
+        })?;
+    let body: serde_json::Value =
+        serde_json::from_str(&body).map_err(|err| DriverError::PreflightFailed {
+            message: format!("MCP initialize response was not JSON: {err}"),
+        })?;
+
+    if body.get("jsonrpc").and_then(serde_json::Value::as_str) != Some("2.0")
+        || body.get("id") != Some(&json!(1))
+        || body.get("result").is_none()
+        || body.get("result") == Some(&serde_json::Value::Null)
+    {
+        return Err(DriverError::PreflightFailed {
+            message: "MCP initialize response did not contain a JSON-RPC result".to_owned(),
+        });
+    }
+
+    Ok(())
+}
+
+fn invalid_handle(handle: &str) -> DriverError {
+    DriverError::InvalidHandle {
+        handle: handle.to_owned(),
+        message: "unknown generic MCP context handle".to_owned(),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::{
+        collections::BTreeMap,
+        io::{Read, Write},
+        net::TcpListener,
+        thread,
+    };
+
+    use agentenv_core::{driver::ContextDriver, security::ssrf::StaticDnsResolver};
+    use agentenv_proto::{
+        Capabilities, ContextHandleRequest, ContextSpec, CredentialRequirementsParams,
+        InitializeParams, LogLevel, McpTransport, NetworkTarget, SCHEMA_VERSION,
+    };
+    use serde_json::{json, Value};
+
+    use super::{
+        endpoint_from_spec, probe_mcp_initialize, validate_endpoint_for_driver,
+        GenericMcpContextDriver, ProbeExpectation,
+    };
+
+    fn init_params() -> InitializeParams {
+        InitializeParams {
+            schema_version: SCHEMA_VERSION.to_owned(),
+            core_version: "0.0.1-alpha0".to_owned(),
+            workdir: "/tmp/agentenv-test".to_owned(),
+            log_level: LogLevel::Info,
+        }
+    }
+
+    fn spec(url: &str, transport: &str) -> ContextSpec {
+        ContextSpec {
+            config: BTreeMap::from([(
+                "endpoint".to_owned(),
+                json!({
+                    "url": url,
+                    "transport": transport,
+                }),
+            )]),
+        }
+    }
+
+    #[test]
+    fn endpoint_from_spec_accepts_http_sse() {
+        let endpoint =
+            endpoint_from_spec(&spec("https://mcp.example.com/sse", "http+sse")).unwrap();
+
+        assert_eq!(endpoint.url, "https://mcp.example.com/sse");
+        assert_eq!(endpoint.transport, McpTransport::HttpSse);
+        assert!(endpoint.headers.is_empty());
+    }
+
+    #[test]
+    fn endpoint_from_spec_rejects_unsupported_transport() {
+        let err =
+            endpoint_from_spec(&spec("https://mcp.example.com/sse", "websocket")).unwrap_err();
+
+        assert!(err.to_string().contains("unsupported MCP transport"));
+    }
+
+    #[test]
+    fn endpoint_validation_rejects_ssrf_blocked_targets() {
+        let endpoint =
+            endpoint_from_spec(&spec("https://metadata.example.test/sse", "http+sse")).unwrap();
+        let resolver =
+            StaticDnsResolver::try_from_pairs([("metadata.example.test", ["169.254.169.254"])])
+                .unwrap();
+
+        let err = validate_endpoint_for_driver(&endpoint, &resolver).unwrap_err();
+
+        assert!(err.to_string().contains("blocked"));
+    }
+
+    #[tokio::test]
+    async fn initialize_probe_accepts_mock_mcp_response() {
+        let server = spawn_probe_server(ProbeExpectation::ValidInitialize);
+
+        probe_mcp_initialize(&server.url()).await.unwrap();
+    }
+
+    #[tokio::test]
+    async fn initialize_probe_rejects_non_mcp_response() {
+        let server = spawn_probe_server(ProbeExpectation::InvalidInitialize);
+
+        let err = probe_mcp_initialize(&server.url()).await.unwrap_err();
+
+        assert!(err.to_string().contains("MCP initialize"));
+    }
+
+    #[tokio::test]
+    async fn driver_reports_remote_shared_capabilities() {
+        let mut driver = GenericMcpContextDriver::new_for_tests_without_probe();
+        let result = driver.initialize(init_params()).await.unwrap();
+
+        assert_eq!(result.driver.name, "mcp-generic");
+        let Capabilities::Context(capabilities) = result.capabilities else {
+            panic!("expected context capabilities");
+        };
+        assert!(capabilities.is_remote);
+        assert!(capabilities.is_shared);
+        assert!(!capabilities.supports_zones);
+        assert!(!capabilities.supports_snapshots);
+    }
+
+    #[tokio::test]
+    async fn provision_stores_endpoint_and_network_rule_without_query_in_handle() {
+        let driver = GenericMcpContextDriver::new_for_tests_without_probe();
+        let handle = driver
+            .provision(spec(
+                "https://mcp.example.com:8443/sse?state=abc",
+                "http+sse",
+            ))
+            .await
+            .unwrap();
+
+        assert!(!handle.handle.contains("state=abc"));
+
+        let request = ContextHandleRequest {
+            handle: handle.handle,
+        };
+        let endpoint = driver.mcp_endpoint(request.clone()).await.unwrap();
+        let rules = driver.required_network_rules(request).await.unwrap();
+
+        assert_eq!(endpoint.url, "https://mcp.example.com:8443/sse?state=abc");
+        assert_eq!(rules.rules.len(), 1);
+        let NetworkTarget::Host {
+            host, port, scheme, ..
+        } = &rules.rules[0].target
+        else {
+            panic!("expected host network rule");
+        };
+        assert_eq!(host, "mcp.example.com");
+        assert_eq!(port, &Some(8443));
+        assert_eq!(scheme.as_deref(), Some("https"));
+    }
+
+    #[tokio::test]
+    async fn credential_requirements_declare_optional_mcp_token() {
+        let driver = GenericMcpContextDriver::new_for_tests_without_probe();
+        let requirements = driver
+            .credential_requirements(CredentialRequirementsParams::default())
+            .await
+            .unwrap();
+
+        assert_eq!(requirements.requirements.len(), 1);
+        assert_eq!(requirements.requirements[0].name, "MCP_TOKEN");
+        assert!(!requirements.requirements[0].required);
+    }
+
+    #[tokio::test]
+    async fn generic_driver_satisfies_context_conformance_contract() {
+        let mut driver = GenericMcpContextDriver::new_for_tests_without_probe();
+
+        driver_conformance::assert_context_driver_contract(
+            &mut driver,
+            spec("https://mcp.example.com/sse", "http+sse"),
+        )
+        .await
+        .unwrap();
+    }
+
+    struct ProbeServer {
+        url: String,
+        thread: Option<thread::JoinHandle<()>>,
+    }
+
+    impl ProbeServer {
+        fn url(&self) -> String {
+            self.url.clone()
+        }
+    }
+
+    impl Drop for ProbeServer {
+        fn drop(&mut self) {
+            if let Some(thread) = self.thread.take() {
+                thread.join().expect("probe server thread should finish");
+            }
+        }
+    }
+
+    fn spawn_probe_server(expectation: ProbeExpectation) -> ProbeServer {
+        let listener = TcpListener::bind("127.0.0.1:0").unwrap();
+        let url = format!("http://{}", listener.local_addr().unwrap());
+        let thread = thread::spawn(move || {
+            let (mut stream, _) = listener.accept().unwrap();
+            let mut buf = [0; 4096];
+            let read = stream.read(&mut buf).unwrap();
+            let request = String::from_utf8_lossy(&buf[..read]);
+            assert!(request.contains("initialize"));
+
+            let body: Value = match expectation {
+                ProbeExpectation::ValidInitialize => json!({
+                    "jsonrpc": "2.0",
+                    "id": 1,
+                    "result": {
+                        "protocolVersion": "2024-11-05",
+                        "capabilities": {},
+                        "serverInfo": {"name": "mock", "version": "0.0.1"}
+                    }
+                }),
+                ProbeExpectation::InvalidInitialize => json!({
+                    "jsonrpc": "2.0",
+                    "id": 1,
+                    "result": null
+                }),
+            };
+            let body = serde_json::to_string(&body).unwrap();
+            write!(
+                stream,
+                "HTTP/1.1 200 OK\r\nContent-Type: application/json\r\nContent-Length: {}\r\n\r\n{}",
+                body.len(),
+                body
+            )
+            .unwrap();
+        });
+
+        ProbeServer {
+            url,
+            thread: Some(thread),
+        }
+    }
+}

--- a/crates/drivers/context-none/Cargo.toml
+++ b/crates/drivers/context-none/Cargo.toml
@@ -9,3 +9,12 @@ homepage.workspace = true
 authors.workspace = true
 readme = "README.md"
 description = "No-op context driver scaffold for agentenv"
+
+[dependencies]
+agentenv-core = { path = "../../agentenv-core" }
+agentenv-proto = { path = "../../agentenv-proto" }
+async-trait.workspace = true
+
+[dev-dependencies]
+tokio.workspace = true
+driver-conformance = { path = "../../../tests/driver-conformance" }

--- a/crates/drivers/context-none/README.md
+++ b/crates/drivers/context-none/README.md
@@ -1,3 +1,7 @@
 # context-none
 
-M1 scaffold crate for the `agentenv` workspace.
+Built-in no-op context driver for agentenv.
+
+This driver provisions no external context backend, returns no required network rules,
+declares no credentials, and exposes an empty stdio MCP endpoint sentinel. Future
+agent config assembly should skip empty endpoint URLs when rendering MCP config.

--- a/crates/drivers/context-none/src/lib.rs
+++ b/crates/drivers/context-none/src/lib.rs
@@ -1,4 +1,219 @@
 #![forbid(unsafe_code)]
 
-/// Placeholder surface for the M1 workspace scaffold.
+use std::collections::BTreeMap;
+
+use agentenv_core::{
+    context_common::{
+        context_initialize, empty_credential_requirements, empty_network_rules, empty_result,
+        local_context_capabilities, successful_preflight,
+    },
+    driver::{ContextDriver, DriverError, DriverResult},
+};
+use agentenv_proto::{
+    ContextHandle, ContextHandleRequest, ContextSpec, ContextStatus, CredentialRequirementsParams,
+    CredentialRequirementsResult, EmptyResult, InitializeParams, InitializeResult, McpEndpoint,
+    McpTransport, PreflightParams, PreflightResult, RequiredNetworkRulesResult, ShutdownParams,
+};
+use async_trait::async_trait;
+
 pub const CRATE_NAME: &str = "context-none";
+const DRIVER_NAME: &str = "none";
+const HANDLE: &str = "none|";
+
+#[derive(Debug, Default)]
+pub struct NoneContextDriver;
+
+#[async_trait]
+impl ContextDriver for NoneContextDriver {
+    async fn initialize(&mut self, _params: InitializeParams) -> DriverResult<InitializeResult> {
+        Ok(context_initialize(
+            DRIVER_NAME,
+            local_context_capabilities(),
+        ))
+    }
+
+    async fn preflight(&self, _params: PreflightParams) -> DriverResult<PreflightResult> {
+        Ok(successful_preflight())
+    }
+
+    async fn provision(&self, spec: ContextSpec) -> DriverResult<ContextHandle> {
+        if !spec.config.is_empty() {
+            return Err(DriverError::InvalidConfig {
+                field: "context".to_owned(),
+                message: "context-none does not accept configuration".to_owned(),
+            });
+        }
+
+        Ok(ContextHandle {
+            handle: HANDLE.to_owned(),
+        })
+    }
+
+    async fn mcp_endpoint(&self, params: ContextHandleRequest) -> DriverResult<McpEndpoint> {
+        validate_handle(&params.handle)?;
+
+        Ok(McpEndpoint {
+            url: String::new(),
+            transport: McpTransport::Stdio,
+            headers: BTreeMap::new(),
+        })
+    }
+
+    async fn required_network_rules(
+        &self,
+        params: ContextHandleRequest,
+    ) -> DriverResult<RequiredNetworkRulesResult> {
+        validate_handle(&params.handle)?;
+
+        Ok(empty_network_rules())
+    }
+
+    async fn credential_requirements(
+        &self,
+        _params: CredentialRequirementsParams,
+    ) -> DriverResult<CredentialRequirementsResult> {
+        Ok(empty_credential_requirements())
+    }
+
+    async fn status(&self, params: ContextHandleRequest) -> DriverResult<ContextStatus> {
+        validate_handle(&params.handle)?;
+
+        Ok(ContextStatus {
+            healthy: true,
+            detail: Some("no context configured".to_owned()),
+        })
+    }
+
+    async fn teardown(&self, params: ContextHandleRequest) -> DriverResult<EmptyResult> {
+        validate_handle(&params.handle)?;
+
+        Ok(empty_result())
+    }
+
+    async fn shutdown(&mut self, _params: ShutdownParams) -> DriverResult<EmptyResult> {
+        Ok(empty_result())
+    }
+}
+
+fn validate_handle(handle: &str) -> DriverResult<()> {
+    if handle == HANDLE {
+        Ok(())
+    } else {
+        Err(DriverError::InvalidHandle {
+            handle: handle.to_owned(),
+            message: "expected context-none handle `none|`".to_owned(),
+        })
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::collections::BTreeMap;
+
+    use agentenv_core::driver::ContextDriver;
+    use agentenv_proto::{
+        Capabilities, ContextHandleRequest, ContextSpec, CredentialRequirementsParams,
+        InitializeParams, LogLevel, McpTransport, PreflightParams, SCHEMA_VERSION,
+    };
+
+    use super::NoneContextDriver;
+
+    fn empty_context_spec() -> ContextSpec {
+        ContextSpec {
+            config: BTreeMap::new(),
+        }
+    }
+
+    #[tokio::test]
+    async fn none_driver_satisfies_context_conformance_contract() {
+        let mut driver = NoneContextDriver;
+
+        driver_conformance::assert_context_driver_contract(&mut driver, empty_context_spec())
+            .await
+            .expect("context-none should satisfy context driver conformance");
+    }
+
+    #[tokio::test]
+    async fn initialize_returns_no_context_capabilities() {
+        let mut driver = NoneContextDriver;
+
+        let result = driver
+            .initialize(InitializeParams {
+                schema_version: SCHEMA_VERSION.to_owned(),
+                core_version: "0.0.1".to_owned(),
+                workdir: "/tmp/agentenv".to_owned(),
+                log_level: LogLevel::Info,
+            })
+            .await
+            .expect("initialize should succeed");
+
+        assert_eq!(result.driver.name, "none");
+        let Capabilities::Context(capabilities) = result.capabilities else {
+            panic!("expected context capabilities");
+        };
+        assert!(!capabilities.is_remote);
+        assert!(!capabilities.is_shared);
+        assert!(!capabilities.supports_zones);
+        assert!(!capabilities.supports_snapshots);
+    }
+
+    #[tokio::test]
+    async fn provision_returns_empty_stdio_endpoint_and_no_requirements() {
+        let driver = NoneContextDriver;
+
+        let handle = driver
+            .provision(empty_context_spec())
+            .await
+            .expect("provision should succeed");
+        let endpoint = driver
+            .mcp_endpoint(ContextHandleRequest {
+                handle: handle.handle.clone(),
+            })
+            .await
+            .expect("mcp endpoint should succeed");
+        let network_rules = driver
+            .required_network_rules(ContextHandleRequest {
+                handle: handle.handle.clone(),
+            })
+            .await
+            .expect("network rules should succeed");
+        let credentials = driver
+            .credential_requirements(CredentialRequirementsParams::default())
+            .await
+            .expect("credential requirements should succeed");
+
+        assert_eq!(handle.handle, "none|");
+        assert_eq!(endpoint.url, "");
+        assert_eq!(endpoint.transport, McpTransport::Stdio);
+        assert!(endpoint.headers.is_empty());
+        assert!(network_rules.rules.is_empty());
+        assert!(credentials.requirements.is_empty());
+    }
+
+    #[tokio::test]
+    async fn invalid_handle_is_rejected() {
+        let driver = NoneContextDriver;
+
+        let err = driver
+            .mcp_endpoint(ContextHandleRequest {
+                handle: "filesystem|1".to_owned(),
+            })
+            .await
+            .expect_err("invalid handle should fail");
+
+        assert!(err.to_string().contains("invalid"));
+    }
+
+    #[tokio::test]
+    async fn preflight_succeeds() {
+        let driver = NoneContextDriver;
+
+        let result = driver
+            .preflight(PreflightParams::default())
+            .await
+            .expect("preflight should succeed");
+
+        assert!(result.ok);
+        assert!(result.issues.is_empty());
+    }
+}

--- a/docs/DRIVER_PROTOCOL.md
+++ b/docs/DRIVER_PROTOCOL.md
@@ -157,6 +157,11 @@ Agent health checks are declarative probes exported as `agent-health-check-probe
 | `status` | `{handle}` | `ContextStatus` |
 | `teardown` | `{handle}` | `{}` |
 
+For built-in context drivers, an empty `McpEndpoint.url` with `transport = stdio` is
+the no-context sentinel and should be skipped when rendering agent MCP config.
+Filesystem context endpoints encode the stdio command in `McpEndpoint.url` until a
+future protocol version splits stdio command and arguments into separate fields.
+
 #### `InferenceDriver`
 
 | Method | Params | Result |

--- a/docs/superpowers/plans/2026-04-20-m2-3-context-drivers.md
+++ b/docs/superpowers/plans/2026-04-20-m2-3-context-drivers.md
@@ -1,0 +1,2746 @@
+# M2-3 Built-In Context Drivers Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Implement built-in `ContextDriver` crates for `none`, `mcp-generic`, and `filesystem`, plus the `agentenv-fs-mcp` stdio filesystem MCP server required by issue #9.
+
+**Architecture:** Add small shared context helpers in `agentenv-core`, extend `driver-conformance` with in-process context-driver checks, and keep each driver crate thin around its protocol behavior. `context-mcp-generic` validates HTTP-like MCP endpoints with the existing SSRF helper and probes HTTP endpoints with a mockable MCP initialize client; `context-filesystem` returns a stdio endpoint for a shipped `agentenv-fs-mcp` binary whose tool engine enforces root containment and excludes.
+
+**Tech Stack:** Rust 2021, `async-trait`, `serde_json`, `thiserror`, `reqwest` with `rustls`, `tokio` tests, Cargo workspace tests, JSON-RPC framing over stdio
+
+---
+
+## File Structure
+
+### Shared Core And Conformance
+
+- Modify: `crates/agentenv-core/src/lib.rs`
+- Create: `crates/agentenv-core/src/context_common.rs`
+- Modify: `tests/driver-conformance/src/lib.rs`
+
+### Context Drivers
+
+- Modify: `crates/drivers/context-none/Cargo.toml`
+- Modify: `crates/drivers/context-none/src/lib.rs`
+- Modify: `crates/drivers/context-none/README.md`
+- Modify: `crates/drivers/context-mcp-generic/Cargo.toml`
+- Modify: `crates/drivers/context-mcp-generic/src/lib.rs`
+- Modify: `crates/drivers/context-mcp-generic/README.md`
+- Modify: `crates/drivers/context-filesystem/Cargo.toml`
+- Modify: `crates/drivers/context-filesystem/src/lib.rs`
+- Create: `crates/drivers/context-filesystem/src/bin/agentenv-fs-mcp.rs`
+- Create: `crates/drivers/context-filesystem/tests/fs_mcp_stdio.rs`
+- Modify: `crates/drivers/context-filesystem/README.md`
+
+### Docs And Verification
+
+- Modify: `docs/DRIVER_PROTOCOL.md`
+- Modify: `blueprints/claude+filesystem+openshell.yaml`
+- Modify: `blueprints/codex+mcp-generic+openshell.yaml`
+
+### Verification Commands
+
+- `cargo fmt`
+- `cargo clippy --workspace --all-targets -- -D warnings`
+- `cargo test --workspace`
+
+## Task 1: Add Shared Context Helpers
+
+**Files:**
+- Create: `crates/agentenv-core/src/context_common.rs`
+- Modify: `crates/agentenv-core/src/lib.rs`
+- Test: `crates/agentenv-core/src/context_common.rs`
+
+- [ ] **Step 1: Write the failing context helper tests**
+
+Create `crates/agentenv-core/src/context_common.rs` with only this test module:
+
+```rust
+#[cfg(test)]
+mod tests {
+    use std::collections::BTreeMap;
+
+    use agentenv_proto::{
+        Capabilities, ContextCapabilities, ContextSpec, HttpAccessLevel, McpEndpoint,
+        McpTransport, NetworkTarget,
+    };
+    use serde_json::json;
+
+    use super::{
+        context_initialize, empty_credential_requirements, empty_network_rules, endpoint_host_rule,
+        expand_tilde, local_context_capabilities, optional_bool, optional_string_list,
+        remote_context_capabilities, required_object, required_string,
+    };
+
+    #[test]
+    fn context_initialize_reports_context_driver_metadata() {
+        let result = context_initialize("filesystem", local_context_capabilities());
+
+        assert_eq!(result.driver.name, "filesystem");
+        let Capabilities::Context(capabilities) = result.capabilities else {
+            panic!("expected context capabilities");
+        };
+        assert_eq!(
+            capabilities,
+            ContextCapabilities {
+                is_remote: false,
+                is_shared: false,
+                supports_zones: false,
+                supports_snapshots: false,
+            }
+        );
+    }
+
+    #[test]
+    fn remote_context_capabilities_are_remote_and_shared() {
+        assert_eq!(
+            remote_context_capabilities(),
+            ContextCapabilities {
+                is_remote: true,
+                is_shared: true,
+                supports_zones: false,
+                supports_snapshots: false,
+            }
+        );
+    }
+
+    #[test]
+    fn config_helpers_parse_expected_types() {
+        let spec = ContextSpec {
+            config: BTreeMap::from([
+                ("mount".to_owned(), json!("/tmp/project")),
+                ("readonly".to_owned(), json!(false)),
+                ("exclude".to_owned(), json!([".git/", "target/"])),
+                ("endpoint".to_owned(), json!({"url": "https://example.com/mcp"})),
+            ]),
+        };
+
+        assert_eq!(required_string(&spec.config, "mount").unwrap(), "/tmp/project");
+        assert_eq!(optional_bool(&spec.config, "readonly").unwrap(), Some(false));
+        assert_eq!(
+            optional_string_list(&spec.config, "exclude").unwrap(),
+            vec![".git/".to_owned(), "target/".to_owned()]
+        );
+        assert_eq!(
+            required_object(&spec.config, "endpoint")
+                .unwrap()
+                .get("url")
+                .unwrap(),
+            &json!("https://example.com/mcp")
+        );
+    }
+
+    #[test]
+    fn endpoint_host_rule_preserves_host_port_scheme_and_full_access() {
+        let rule = endpoint_host_rule(&McpEndpoint {
+            url: "https://mcp.example.com:8443/sse".to_owned(),
+            transport: McpTransport::HttpSse,
+            headers: BTreeMap::new(),
+        })
+        .unwrap();
+
+        let NetworkTarget::Host {
+            host,
+            port,
+            scheme,
+            http_access,
+        } = rule.target
+        else {
+            panic!("expected host rule");
+        };
+
+        assert_eq!(host, "mcp.example.com");
+        assert_eq!(port, Some(8443));
+        assert_eq!(scheme.as_deref(), Some("https"));
+        assert_eq!(http_access, Some(HttpAccessLevel::Full));
+    }
+
+    #[test]
+    fn empty_results_are_empty() {
+        assert!(empty_network_rules().rules.is_empty());
+        assert!(empty_credential_requirements().requirements.is_empty());
+    }
+
+    #[test]
+    fn tilde_expansion_uses_home_when_available() {
+        let expanded = expand_tilde("~/project", Some("/home/alice"));
+
+        assert_eq!(expanded.to_string_lossy(), "/home/alice/project");
+    }
+}
+```
+
+- [ ] **Step 2: Run the core test and verify the expected failure**
+
+Run: `cargo test -p agentenv-core context_common`
+
+Expected: FAIL with unresolved imports for the helper functions and because `context_common` is not exported yet.
+
+- [ ] **Step 3: Implement `context_common`**
+
+Replace `crates/agentenv-core/src/context_common.rs` with:
+
+```rust
+use std::{collections::BTreeMap, path::PathBuf};
+
+use agentenv_proto::{
+    Capabilities, ContextCapabilities, CredentialRequirementsResult, DriverInfo, DriverKind,
+    EmptyResult, HttpAccessLevel, InitializeResult, McpEndpoint, NetworkRule, NetworkTarget,
+    PreflightResult, RequiredNetworkRulesResult, SCHEMA_VERSION,
+};
+use serde_json::{Map, Value};
+use url::Url;
+
+use crate::driver::{DriverError, DriverResult};
+
+pub fn context_initialize(driver_name: &str, capabilities: ContextCapabilities) -> InitializeResult {
+    InitializeResult {
+        driver: DriverInfo {
+            name: driver_name.to_owned(),
+            kind: DriverKind::Context,
+            version: env!("CARGO_PKG_VERSION").to_owned(),
+            protocol_version: SCHEMA_VERSION.to_owned(),
+        },
+        capabilities: Capabilities::Context(capabilities),
+    }
+}
+
+pub fn local_context_capabilities() -> ContextCapabilities {
+    ContextCapabilities {
+        is_remote: false,
+        is_shared: false,
+        supports_zones: false,
+        supports_snapshots: false,
+    }
+}
+
+pub fn remote_context_capabilities() -> ContextCapabilities {
+    ContextCapabilities {
+        is_remote: true,
+        is_shared: true,
+        supports_zones: false,
+        supports_snapshots: false,
+    }
+}
+
+pub fn successful_preflight() -> PreflightResult {
+    PreflightResult {
+        ok: true,
+        issues: Vec::new(),
+    }
+}
+
+pub fn empty_result() -> EmptyResult {
+    EmptyResult {}
+}
+
+pub fn empty_network_rules() -> RequiredNetworkRulesResult {
+    RequiredNetworkRulesResult { rules: Vec::new() }
+}
+
+pub fn empty_credential_requirements() -> CredentialRequirementsResult {
+    CredentialRequirementsResult {
+        requirements: Vec::new(),
+    }
+}
+
+pub fn required_string(config: &BTreeMap<String, Value>, field: &str) -> DriverResult<String> {
+    match config.get(field) {
+        Some(Value::String(value)) if !value.trim().is_empty() => Ok(value.clone()),
+        Some(Value::String(_)) => Err(invalid_config(field, "must not be empty")),
+        Some(_) => Err(invalid_config(field, "must be a string")),
+        None => Err(invalid_config(field, "is required")),
+    }
+}
+
+pub fn optional_string(config: &BTreeMap<String, Value>, field: &str) -> DriverResult<Option<String>> {
+    match config.get(field) {
+        None => Ok(None),
+        Some(Value::String(value)) if !value.trim().is_empty() => Ok(Some(value.clone())),
+        Some(Value::String(_)) => Err(invalid_config(field, "must not be empty")),
+        Some(_) => Err(invalid_config(field, "must be a string")),
+    }
+}
+
+pub fn optional_bool(config: &BTreeMap<String, Value>, field: &str) -> DriverResult<Option<bool>> {
+    match config.get(field) {
+        None => Ok(None),
+        Some(Value::Bool(value)) => Ok(Some(*value)),
+        Some(_) => Err(invalid_config(field, "must be a boolean")),
+    }
+}
+
+pub fn optional_string_list(
+    config: &BTreeMap<String, Value>,
+    field: &str,
+) -> DriverResult<Vec<String>> {
+    match config.get(field) {
+        None => Ok(Vec::new()),
+        Some(Value::Array(values)) => values
+            .iter()
+            .enumerate()
+            .map(|(index, value)| match value {
+                Value::String(item) if !item.trim().is_empty() => Ok(item.clone()),
+                Value::String(_) => Err(invalid_config(
+                    &format!("{field}[{index}]"),
+                    "must not be empty",
+                )),
+                _ => Err(invalid_config(
+                    &format!("{field}[{index}]"),
+                    "must be a string",
+                )),
+            })
+            .collect(),
+        Some(_) => Err(invalid_config(field, "must be an array of strings")),
+    }
+}
+
+pub fn required_object<'a>(
+    config: &'a BTreeMap<String, Value>,
+    field: &str,
+) -> DriverResult<&'a Map<String, Value>> {
+    match config.get(field) {
+        Some(Value::Object(value)) => Ok(value),
+        Some(_) => Err(invalid_config(field, "must be an object")),
+        None => Err(invalid_config(field, "is required")),
+    }
+}
+
+pub fn object_required_string(object: &Map<String, Value>, field: &str) -> DriverResult<String> {
+    match object.get(field) {
+        Some(Value::String(value)) if !value.trim().is_empty() => Ok(value.clone()),
+        Some(Value::String(_)) => Err(invalid_config(field, "must not be empty")),
+        Some(_) => Err(invalid_config(field, "must be a string")),
+        None => Err(invalid_config(field, "is required")),
+    }
+}
+
+pub fn endpoint_host_rule(endpoint: &McpEndpoint) -> DriverResult<NetworkRule> {
+    let parsed = Url::parse(&endpoint.url).map_err(|_| invalid_config("endpoint.url", "must be a valid URL"))?;
+    let host = parsed
+        .host_str()
+        .ok_or_else(|| invalid_config("endpoint.url", "must include a host"))?;
+
+    Ok(NetworkRule {
+        target: NetworkTarget::Host {
+            host: host.to_owned(),
+            port: parsed.port_or_known_default(),
+            scheme: Some(parsed.scheme().to_owned()),
+            http_access: Some(HttpAccessLevel::Full),
+        },
+    })
+}
+
+pub fn expand_tilde(path: &str, home: Option<&str>) -> PathBuf {
+    if path == "~" {
+        return home.map(PathBuf::from).unwrap_or_else(|| PathBuf::from(path));
+    }
+
+    if let Some(rest) = path.strip_prefix("~/") {
+        if let Some(home) = home {
+            return PathBuf::from(home).join(rest);
+        }
+    }
+
+    PathBuf::from(path)
+}
+
+pub fn invalid_config(field: &str, message: &str) -> DriverError {
+    DriverError::InvalidConfig {
+        field: field.to_owned(),
+        message: message.to_owned(),
+    }
+}
+```
+
+Add the module export to `crates/agentenv-core/src/lib.rs`:
+
+```rust
+pub mod context_common;
+```
+
+- [ ] **Step 4: Rerun the core tests**
+
+Run: `cargo test -p agentenv-core context_common`
+
+Expected: PASS.
+
+- [ ] **Step 5: Commit the shared helpers**
+
+```bash
+git add crates/agentenv-core/src/lib.rs crates/agentenv-core/src/context_common.rs
+git commit -m "feat: add shared context driver helpers"
+```
+
+## Task 2: Add Context Driver Conformance Coverage
+
+**Files:**
+- Modify: `tests/driver-conformance/src/lib.rs`
+- Test: `tests/driver-conformance/src/lib.rs`
+
+- [ ] **Step 1: Write the failing context conformance test**
+
+In `tests/driver-conformance/src/lib.rs`, update the test module imports to include `ContextDriver` and context protocol types, then add:
+
+```rust
+use agentenv_core::driver::ContextDriver;
+use agentenv_proto::{
+    ContextCapabilities, ContextHandle, ContextHandleRequest, ContextSpec, ContextStatus,
+    CredentialRequirementsParams, DriverKind, McpEndpoint, McpTransport,
+    RequiredNetworkRulesResult,
+};
+
+#[derive(Default)]
+struct FakeContextDriver {
+    init_kind: Option<DriverKind>,
+    init_capabilities: Option<Capabilities>,
+    credential_name: Option<String>,
+    preflight_ok: bool,
+}
+
+#[async_trait]
+impl ContextDriver for FakeContextDriver {
+    async fn initialize(&mut self, _params: InitializeParams) -> DriverResult<InitializeResult> {
+        Ok(InitializeResult {
+            driver: DriverInfo {
+                name: "fake-context".to_owned(),
+                kind: self.init_kind.clone().unwrap_or(DriverKind::Context),
+                version: "0.0.1".to_owned(),
+                protocol_version: SCHEMA_VERSION.to_owned(),
+            },
+            capabilities: self.init_capabilities.clone().unwrap_or_else(|| {
+                Capabilities::Context(ContextCapabilities {
+                    is_remote: false,
+                    is_shared: false,
+                    supports_zones: false,
+                    supports_snapshots: false,
+                })
+            }),
+        })
+    }
+
+    async fn preflight(&self, _params: PreflightParams) -> DriverResult<PreflightResult> {
+        Ok(PreflightResult {
+            ok: self.preflight_ok,
+            issues: Vec::new(),
+        })
+    }
+
+    async fn provision(&self, _spec: ContextSpec) -> DriverResult<ContextHandle> {
+        Ok(ContextHandle {
+            handle: "fake-context|1".to_owned(),
+        })
+    }
+
+    async fn mcp_endpoint(&self, _params: ContextHandleRequest) -> DriverResult<McpEndpoint> {
+        Ok(McpEndpoint {
+            url: "agentenv-fake-context".to_owned(),
+            transport: McpTransport::Stdio,
+            headers: BTreeMap::new(),
+        })
+    }
+
+    async fn required_network_rules(
+        &self,
+        _params: ContextHandleRequest,
+    ) -> DriverResult<RequiredNetworkRulesResult> {
+        Ok(RequiredNetworkRulesResult { rules: Vec::new() })
+    }
+
+    async fn credential_requirements(
+        &self,
+        _params: CredentialRequirementsParams,
+    ) -> DriverResult<CredentialRequirementsResult> {
+        Ok(CredentialRequirementsResult {
+            requirements: self
+                .credential_name
+                .clone()
+                .map(|name| {
+                    vec![CredentialRequirement {
+                        name,
+                        kind: CredentialKind::Token,
+                        required: false,
+                        description: "Fake context token.".to_owned(),
+                        validator: None,
+                    }]
+                })
+                .unwrap_or_default(),
+        })
+    }
+
+    async fn status(&self, _params: ContextHandleRequest) -> DriverResult<ContextStatus> {
+        Ok(ContextStatus {
+            healthy: true,
+            detail: Some("ready".to_owned()),
+        })
+    }
+
+    async fn teardown(&self, _params: ContextHandleRequest) -> DriverResult<EmptyResult> {
+        Ok(EmptyResult::default())
+    }
+
+    async fn shutdown(&mut self, _params: ShutdownParams) -> DriverResult<EmptyResult> {
+        Ok(EmptyResult::default())
+    }
+}
+
+#[tokio::test]
+async fn context_driver_contract_accepts_context_capabilities() {
+    let mut driver = FakeContextDriver::default();
+
+    assert_context_driver_contract(
+        &mut driver,
+        ContextSpec {
+            config: BTreeMap::new(),
+        },
+    )
+    .await
+    .expect("fake context should satisfy the in-process conformance contract");
+}
+
+#[tokio::test]
+async fn context_driver_contract_rejects_empty_credential_names() {
+    let mut driver = FakeContextDriver {
+        credential_name: Some(String::new()),
+        ..FakeContextDriver::default()
+    };
+
+    let err = assert_context_driver_contract(
+        &mut driver,
+        ContextSpec {
+            config: BTreeMap::new(),
+        },
+    )
+    .await
+    .expect_err("context conformance should reject empty credential names");
+
+    assert!(err.to_string().contains("credential name"));
+}
+```
+
+- [ ] **Step 2: Run the conformance tests and verify the expected failure**
+
+Run: `cargo test -p driver-conformance context_driver_contract`
+
+Expected: FAIL with `cannot find function assert_context_driver_contract`.
+
+- [ ] **Step 3: Implement `assert_context_driver_contract`**
+
+Add this public helper near the existing agent and sandbox helpers in `tests/driver-conformance/src/lib.rs`:
+
+```rust
+pub async fn assert_context_driver_contract<D: agentenv_core::driver::ContextDriver>(
+    driver: &mut D,
+    spec: agentenv_proto::ContextSpec,
+) -> anyhow::Result<()> {
+    let init = driver
+        .initialize(agentenv_proto::InitializeParams {
+            schema_version: agentenv_proto::SCHEMA_VERSION.to_owned(),
+            core_version: "0.0.1".to_owned(),
+            workdir: "/tmp/agentenv".to_owned(),
+            log_level: agentenv_proto::LogLevel::Info,
+        })
+        .await?;
+
+    agentenv_core::driver::ensure_protocol_compatible(&init)?;
+    anyhow::ensure!(
+        init.driver.kind == DriverKind::Context,
+        "initialize must report DriverKind::Context"
+    );
+    anyhow::ensure!(
+        matches!(init.capabilities, Capabilities::Context(_)),
+        "initialize must report Capabilities::Context"
+    );
+
+    let preflight = driver
+        .preflight(agentenv_proto::PreflightParams::default())
+        .await?;
+    anyhow::ensure!(preflight.ok, "preflight must pass");
+
+    let handle = driver.provision(spec).await?;
+    anyhow::ensure!(
+        !handle.handle.trim().is_empty(),
+        "context handle must not be empty"
+    );
+
+    let request = agentenv_proto::ContextHandleRequest {
+        handle: handle.handle,
+    };
+    let _endpoint = driver.mcp_endpoint(request.clone()).await?;
+    let network_rules = driver.required_network_rules(request.clone()).await?;
+    for rule in network_rules.rules {
+        if let agentenv_proto::NetworkTarget::Host { host, .. } = rule.target {
+            anyhow::ensure!(!host.trim().is_empty(), "network host must not be empty");
+        }
+    }
+
+    let credentials = driver
+        .credential_requirements(agentenv_proto::CredentialRequirementsParams::default())
+        .await?;
+    anyhow::ensure!(
+        credentials
+            .requirements
+            .iter()
+            .all(|requirement| !requirement.name.trim().is_empty()),
+        "credential name must not be empty"
+    );
+
+    let status = driver.status(request.clone()).await?;
+    anyhow::ensure!(status.healthy, "context status must be healthy");
+    driver.teardown(request).await?;
+
+    Ok(())
+}
+```
+
+- [ ] **Step 4: Rerun the conformance tests**
+
+Run: `cargo test -p driver-conformance context_driver_contract`
+
+Expected: PASS.
+
+- [ ] **Step 5: Commit context conformance coverage**
+
+```bash
+git add tests/driver-conformance/src/lib.rs
+git commit -m "test: add context driver conformance checks"
+```
+
+## Task 3: Implement `context-none`
+
+**Files:**
+- Modify: `crates/drivers/context-none/Cargo.toml`
+- Modify: `crates/drivers/context-none/src/lib.rs`
+- Modify: `crates/drivers/context-none/README.md`
+- Test: `crates/drivers/context-none/src/lib.rs`
+
+- [ ] **Step 1: Add dependencies**
+
+Update `crates/drivers/context-none/Cargo.toml`:
+
+```toml
+[dependencies]
+agentenv-core = { path = "../../agentenv-core" }
+agentenv-proto = { path = "../../agentenv-proto" }
+async-trait.workspace = true
+
+[dev-dependencies]
+tokio.workspace = true
+driver-conformance = { path = "../../../tests/driver-conformance" }
+```
+
+- [ ] **Step 2: Write the failing `context-none` tests**
+
+Replace the placeholder tests in `crates/drivers/context-none/src/lib.rs` with:
+
+```rust
+#[cfg(test)]
+mod tests {
+    use std::collections::BTreeMap;
+
+    use agentenv_core::driver::ContextDriver;
+    use agentenv_proto::{
+        Capabilities, ContextHandleRequest, ContextSpec, CredentialRequirementsParams,
+        InitializeParams, LogLevel, McpTransport, PreflightParams, SCHEMA_VERSION,
+    };
+
+    use super::NoneContextDriver;
+
+    fn init_params() -> InitializeParams {
+        InitializeParams {
+            schema_version: SCHEMA_VERSION.to_owned(),
+            core_version: "0.0.1-alpha0".to_owned(),
+            workdir: "/tmp/agentenv-test".to_owned(),
+            log_level: LogLevel::Info,
+        }
+    }
+
+    #[tokio::test]
+    async fn none_driver_satisfies_context_conformance_contract() {
+        let mut driver = NoneContextDriver;
+
+        driver_conformance::assert_context_driver_contract(
+            &mut driver,
+            ContextSpec {
+                config: BTreeMap::new(),
+            },
+        )
+        .await
+        .unwrap();
+    }
+
+    #[tokio::test]
+    async fn initialize_returns_no_context_capabilities() {
+        let mut driver = NoneContextDriver;
+        let result = driver.initialize(init_params()).await.unwrap();
+
+        assert_eq!(result.driver.name, "none");
+        let Capabilities::Context(capabilities) = result.capabilities else {
+            panic!("expected context capabilities");
+        };
+        assert!(!capabilities.is_remote);
+        assert!(!capabilities.is_shared);
+        assert!(!capabilities.supports_zones);
+        assert!(!capabilities.supports_snapshots);
+    }
+
+    #[tokio::test]
+    async fn provision_returns_empty_stdio_endpoint_and_no_requirements() {
+        let driver = NoneContextDriver;
+        let handle = driver
+            .provision(ContextSpec {
+                config: BTreeMap::new(),
+            })
+            .await
+            .unwrap();
+
+        let endpoint = driver
+            .mcp_endpoint(ContextHandleRequest {
+                handle: handle.handle.clone(),
+            })
+            .await
+            .unwrap();
+        let rules = driver
+            .required_network_rules(ContextHandleRequest {
+                handle: handle.handle.clone(),
+            })
+            .await
+            .unwrap();
+        let credentials = driver
+            .credential_requirements(CredentialRequirementsParams::default())
+            .await
+            .unwrap();
+
+        assert_eq!(endpoint.url, "");
+        assert_eq!(endpoint.transport, McpTransport::Stdio);
+        assert!(endpoint.headers.is_empty());
+        assert!(rules.rules.is_empty());
+        assert!(credentials.requirements.is_empty());
+    }
+
+    #[tokio::test]
+    async fn invalid_handle_is_rejected() {
+        let driver = NoneContextDriver;
+
+        let err = driver
+            .mcp_endpoint(ContextHandleRequest {
+                handle: "filesystem|1".to_owned(),
+            })
+            .await
+            .unwrap_err();
+
+        assert!(err.to_string().contains("invalid"));
+    }
+
+    #[tokio::test]
+    async fn preflight_succeeds() {
+        let driver = NoneContextDriver;
+        let result = driver.preflight(PreflightParams::default()).await.unwrap();
+
+        assert!(result.ok);
+        assert!(result.issues.is_empty());
+    }
+}
+```
+
+- [ ] **Step 3: Run the `context-none` tests and verify the expected failure**
+
+Run: `cargo test -p context-none`
+
+Expected: FAIL with missing `NoneContextDriver`.
+
+- [ ] **Step 4: Implement `NoneContextDriver`**
+
+Replace `crates/drivers/context-none/src/lib.rs` with:
+
+```rust
+#![forbid(unsafe_code)]
+
+use std::collections::BTreeMap;
+
+use agentenv_core::{
+    context_common::{
+        context_initialize, empty_credential_requirements, empty_network_rules, empty_result,
+        local_context_capabilities, successful_preflight,
+    },
+    driver::{ContextDriver, DriverError, DriverResult},
+};
+use agentenv_proto::{
+    ContextHandle, ContextHandleRequest, ContextSpec, ContextStatus, CredentialRequirementsParams,
+    CredentialRequirementsResult, EmptyResult, InitializeParams, InitializeResult, McpEndpoint,
+    McpTransport, PreflightParams, PreflightResult, RequiredNetworkRulesResult, ShutdownParams,
+};
+use async_trait::async_trait;
+
+pub const CRATE_NAME: &str = "context-none";
+const DRIVER_NAME: &str = "none";
+const HANDLE: &str = "none|";
+
+#[derive(Debug, Default)]
+pub struct NoneContextDriver;
+
+#[async_trait]
+impl ContextDriver for NoneContextDriver {
+    async fn initialize(&mut self, _params: InitializeParams) -> DriverResult<InitializeResult> {
+        Ok(context_initialize(DRIVER_NAME, local_context_capabilities()))
+    }
+
+    async fn preflight(&self, _params: PreflightParams) -> DriverResult<PreflightResult> {
+        Ok(successful_preflight())
+    }
+
+    async fn provision(&self, spec: ContextSpec) -> DriverResult<ContextHandle> {
+        if !spec.config.is_empty() {
+            return Err(DriverError::InvalidConfig {
+                field: "context".to_owned(),
+                message: "context-none does not accept configuration".to_owned(),
+            });
+        }
+
+        Ok(ContextHandle {
+            handle: HANDLE.to_owned(),
+        })
+    }
+
+    async fn mcp_endpoint(&self, params: ContextHandleRequest) -> DriverResult<McpEndpoint> {
+        validate_handle(&params.handle)?;
+        Ok(McpEndpoint {
+            url: String::new(),
+            transport: McpTransport::Stdio,
+            headers: BTreeMap::new(),
+        })
+    }
+
+    async fn required_network_rules(
+        &self,
+        params: ContextHandleRequest,
+    ) -> DriverResult<RequiredNetworkRulesResult> {
+        validate_handle(&params.handle)?;
+        Ok(empty_network_rules())
+    }
+
+    async fn credential_requirements(
+        &self,
+        _params: CredentialRequirementsParams,
+    ) -> DriverResult<CredentialRequirementsResult> {
+        Ok(empty_credential_requirements())
+    }
+
+    async fn status(&self, params: ContextHandleRequest) -> DriverResult<ContextStatus> {
+        validate_handle(&params.handle)?;
+        Ok(ContextStatus {
+            healthy: true,
+            detail: Some("no context configured".to_owned()),
+        })
+    }
+
+    async fn teardown(&self, params: ContextHandleRequest) -> DriverResult<EmptyResult> {
+        validate_handle(&params.handle)?;
+        Ok(empty_result())
+    }
+
+    async fn shutdown(&mut self, _params: ShutdownParams) -> DriverResult<EmptyResult> {
+        Ok(empty_result())
+    }
+}
+
+fn validate_handle(handle: &str) -> DriverResult<()> {
+    if handle == HANDLE {
+        Ok(())
+    } else {
+        Err(DriverError::InvalidHandle {
+            handle: handle.to_owned(),
+            message: "expected context-none handle `none|`".to_owned(),
+        })
+    }
+}
+```
+
+- [ ] **Step 5: Restore the tests and rerun**
+
+Keep the test module from Step 2 at the bottom of `crates/drivers/context-none/src/lib.rs`.
+
+Run: `cargo test -p context-none`
+
+Expected: PASS.
+
+- [ ] **Step 6: Update the README**
+
+Replace `crates/drivers/context-none/README.md` with:
+
+```markdown
+# context-none
+
+Built-in no-op context driver for agentenv.
+
+This driver provisions no external context backend, returns no required network rules,
+declares no credentials, and exposes an empty stdio MCP endpoint sentinel. Future
+agent config assembly should skip empty endpoint URLs when rendering MCP config.
+```
+
+- [ ] **Step 7: Commit `context-none`**
+
+```bash
+git add crates/drivers/context-none/Cargo.toml \
+        crates/drivers/context-none/src/lib.rs \
+        crates/drivers/context-none/README.md
+git commit -m "feat: implement context-none driver"
+```
+
+## Task 4: Implement `context-mcp-generic`
+
+**Files:**
+- Modify: `crates/drivers/context-mcp-generic/Cargo.toml`
+- Modify: `crates/drivers/context-mcp-generic/src/lib.rs`
+- Modify: `crates/drivers/context-mcp-generic/README.md`
+- Test: `crates/drivers/context-mcp-generic/src/lib.rs`
+
+- [ ] **Step 1: Add dependencies**
+
+Update `crates/drivers/context-mcp-generic/Cargo.toml`:
+
+```toml
+[dependencies]
+agentenv-core = { path = "../../agentenv-core" }
+agentenv-mcp = { path = "../../agentenv-mcp" }
+agentenv-proto = { path = "../../agentenv-proto" }
+async-trait.workspace = true
+reqwest.workspace = true
+serde_json.workspace = true
+url.workspace = true
+
+[dev-dependencies]
+driver-conformance = { path = "../../../tests/driver-conformance" }
+tokio.workspace = true
+```
+
+- [ ] **Step 2: Write failing endpoint parsing and probe tests**
+
+Replace `crates/drivers/context-mcp-generic/src/lib.rs` with the test module scaffold below. It intentionally references missing public items.
+
+```rust
+#![forbid(unsafe_code)]
+
+#[cfg(test)]
+mod tests {
+    use std::{
+        collections::BTreeMap,
+        io::{Read, Write},
+        net::TcpListener,
+        thread,
+    };
+
+    use agentenv_core::{
+        driver::ContextDriver,
+        security::ssrf::StaticDnsResolver,
+    };
+    use agentenv_proto::{
+        Capabilities, ContextHandleRequest, ContextSpec, CredentialRequirementsParams,
+        InitializeParams, LogLevel, McpTransport, NetworkTarget, SCHEMA_VERSION,
+    };
+    use serde_json::{json, Value};
+
+    use super::{
+        endpoint_from_spec, probe_mcp_initialize, validate_endpoint_for_driver,
+        GenericMcpContextDriver,
+        ProbeExpectation,
+    };
+
+    fn init_params() -> InitializeParams {
+        InitializeParams {
+            schema_version: SCHEMA_VERSION.to_owned(),
+            core_version: "0.0.1-alpha0".to_owned(),
+            workdir: "/tmp/agentenv-test".to_owned(),
+            log_level: LogLevel::Info,
+        }
+    }
+
+    fn spec(url: &str, transport: &str) -> ContextSpec {
+        ContextSpec {
+            config: BTreeMap::from([(
+                "endpoint".to_owned(),
+                json!({
+                    "url": url,
+                    "transport": transport,
+                }),
+            )]),
+        }
+    }
+
+    #[test]
+    fn endpoint_from_spec_accepts_http_sse() {
+        let endpoint = endpoint_from_spec(&spec("https://mcp.example.com/sse", "http+sse"))
+            .unwrap();
+
+        assert_eq!(endpoint.url, "https://mcp.example.com/sse");
+        assert_eq!(endpoint.transport, McpTransport::HttpSse);
+        assert!(endpoint.headers.is_empty());
+    }
+
+    #[test]
+    fn endpoint_from_spec_rejects_unsupported_transport() {
+        let err = endpoint_from_spec(&spec("https://mcp.example.com/sse", "websocket"))
+            .unwrap_err();
+
+        assert!(err.to_string().contains("unsupported MCP transport"));
+    }
+
+    #[test]
+    fn endpoint_validation_rejects_ssrf_blocked_targets() {
+        let endpoint = endpoint_from_spec(&spec("https://metadata.example.test/sse", "http+sse"))
+            .unwrap();
+        let resolver =
+            StaticDnsResolver::try_from_pairs([("metadata.example.test", ["169.254.169.254"])])
+                .unwrap();
+
+        let err = validate_endpoint_for_driver(&endpoint, &resolver).unwrap_err();
+
+        assert!(err.to_string().contains("blocked"));
+    }
+
+    #[tokio::test]
+    async fn initialize_probe_accepts_mock_mcp_response() {
+        let server = spawn_probe_server(ProbeExpectation::ValidInitialize);
+
+        probe_mcp_initialize(&server.url()).await.unwrap();
+    }
+
+    #[tokio::test]
+    async fn initialize_probe_rejects_non_mcp_response() {
+        let server = spawn_probe_server(ProbeExpectation::InvalidInitialize);
+
+        let err = probe_mcp_initialize(&server.url()).await.unwrap_err();
+
+        assert!(err.to_string().contains("MCP initialize"));
+    }
+
+    #[tokio::test]
+    async fn driver_reports_remote_shared_capabilities() {
+        let mut driver = GenericMcpContextDriver::new_for_tests_without_probe();
+        let result = driver.initialize(init_params()).await.unwrap();
+
+        assert_eq!(result.driver.name, "mcp-generic");
+        let Capabilities::Context(capabilities) = result.capabilities else {
+            panic!("expected context capabilities");
+        };
+        assert!(capabilities.is_remote);
+        assert!(capabilities.is_shared);
+        assert!(!capabilities.supports_zones);
+        assert!(!capabilities.supports_snapshots);
+    }
+
+    #[tokio::test]
+    async fn provision_stores_endpoint_and_network_rule_without_query_in_handle() {
+        let driver = GenericMcpContextDriver::new_for_tests_without_probe();
+        let handle = driver
+            .provision(spec("https://mcp.example.com:8443/sse?state=abc", "http+sse"))
+            .await
+            .unwrap();
+
+        assert!(!handle.handle.contains("state=abc"));
+
+        let request = ContextHandleRequest {
+            handle: handle.handle,
+        };
+        let endpoint = driver.mcp_endpoint(request.clone()).await.unwrap();
+        let rules = driver.required_network_rules(request).await.unwrap();
+
+        assert_eq!(endpoint.url, "https://mcp.example.com:8443/sse?state=abc");
+        assert_eq!(rules.rules.len(), 1);
+        let NetworkTarget::Host {
+            host,
+            port,
+            scheme,
+            ..
+        } = &rules.rules[0].target
+        else {
+            panic!("expected host network rule");
+        };
+        assert_eq!(host, "mcp.example.com");
+        assert_eq!(*port, Some(8443));
+        assert_eq!(scheme.as_deref(), Some("https"));
+    }
+
+    #[tokio::test]
+    async fn credential_requirements_declare_optional_mcp_token() {
+        let driver = GenericMcpContextDriver::new_for_tests_without_probe();
+        let requirements = driver
+            .credential_requirements(CredentialRequirementsParams::default())
+            .await
+            .unwrap();
+
+        assert_eq!(requirements.requirements.len(), 1);
+        assert_eq!(requirements.requirements[0].name, "MCP_TOKEN");
+        assert!(!requirements.requirements[0].required);
+    }
+
+    #[tokio::test]
+    async fn generic_driver_satisfies_context_conformance_contract() {
+        let mut driver = GenericMcpContextDriver::new_for_tests_without_probe();
+
+        driver_conformance::assert_context_driver_contract(
+            &mut driver,
+            spec("https://mcp.example.com/sse", "http+sse"),
+        )
+        .await
+        .unwrap();
+    }
+
+    struct ProbeServer {
+        url: String,
+        thread: Option<thread::JoinHandle<()>>,
+    }
+
+    impl ProbeServer {
+        fn url(&self) -> String {
+            self.url.clone()
+        }
+    }
+
+    impl Drop for ProbeServer {
+        fn drop(&mut self) {
+            if let Some(thread) = self.thread.take() {
+                thread.join().expect("probe server thread should finish");
+            }
+        }
+    }
+
+    fn spawn_probe_server(expectation: ProbeExpectation) -> ProbeServer {
+        let listener = TcpListener::bind("127.0.0.1:0").unwrap();
+        let url = format!("http://{}", listener.local_addr().unwrap());
+        let thread = thread::spawn(move || {
+            let (mut stream, _) = listener.accept().unwrap();
+            let mut buf = [0; 4096];
+            let read = stream.read(&mut buf).unwrap();
+            let request = String::from_utf8_lossy(&buf[..read]);
+            assert!(request.contains("initialize"));
+
+            let body: Value = match expectation {
+                ProbeExpectation::ValidInitialize => json!({
+                    "jsonrpc": "2.0",
+                    "id": 1,
+                    "result": {
+                        "protocolVersion": "2024-11-05",
+                        "capabilities": {},
+                        "serverInfo": {"name": "mock", "version": "0.0.1"}
+                    }
+                }),
+                ProbeExpectation::InvalidInitialize => json!({
+                    "jsonrpc": "2.0",
+                    "id": 1,
+                    "result": null
+                }),
+            };
+            let body = serde_json::to_string(&body).unwrap();
+            write!(
+                stream,
+                "HTTP/1.1 200 OK\r\nContent-Type: application/json\r\nContent-Length: {}\r\n\r\n{}",
+                body.len(),
+                body
+            )
+            .unwrap();
+        });
+
+        ProbeServer {
+            url,
+            thread: Some(thread),
+        }
+    }
+}
+```
+
+- [ ] **Step 3: Run the `context-mcp-generic` tests and verify the expected failure**
+
+Run: `cargo test -p context-mcp-generic`
+
+Expected: FAIL with missing `GenericMcpContextDriver`, `endpoint_from_spec`, and `probe_mcp_initialize`.
+
+- [ ] **Step 4: Implement endpoint parsing, probing, and the driver**
+
+Replace `crates/drivers/context-mcp-generic/src/lib.rs` with an implementation containing these items:
+
+```rust
+#![forbid(unsafe_code)]
+
+use std::{
+    collections::BTreeMap,
+    sync::Mutex,
+};
+
+use agentenv_core::{
+    context_common::{
+        context_initialize, endpoint_host_rule, object_required_string, remote_context_capabilities,
+        required_object, successful_preflight,
+    },
+    driver::{ContextDriver, DriverError, DriverResult},
+    security::ssrf::{DnsResolver, SsrfOptions, SystemDnsResolver},
+};
+use agentenv_mcp::validate_mcp_endpoint;
+use agentenv_proto::{
+    ContextHandle, ContextHandleRequest, ContextSpec, ContextStatus, CredentialKind,
+    CredentialRequirement, CredentialRequirementsParams, CredentialRequirementsResult,
+    EmptyResult, InitializeParams, InitializeResult, McpEndpoint, McpTransport, PreflightParams,
+    PreflightResult, RequiredNetworkRulesResult, ShutdownParams,
+};
+use async_trait::async_trait;
+use serde_json::json;
+
+pub const CRATE_NAME: &str = "context-mcp-generic";
+const DRIVER_NAME: &str = "mcp-generic";
+
+#[derive(Debug, Clone, Copy)]
+pub enum ProbeExpectation {
+    ValidInitialize,
+    InvalidInitialize,
+}
+
+#[derive(Debug, Clone)]
+struct GenericMcpState {
+    endpoint: McpEndpoint,
+}
+
+#[derive(Debug)]
+struct GenericMcpStore {
+    next_id: u64,
+    states: BTreeMap<String, GenericMcpState>,
+}
+
+#[derive(Clone)]
+struct ProbeSettings {
+    enabled: bool,
+    validate_ssrf: bool,
+}
+
+pub struct GenericMcpContextDriver {
+    store: Mutex<GenericMcpStore>,
+    probe: ProbeSettings,
+}
+
+impl Default for GenericMcpContextDriver {
+    fn default() -> Self {
+        Self {
+            store: Mutex::new(GenericMcpStore {
+                next_id: 1,
+                states: BTreeMap::new(),
+            }),
+            probe: ProbeSettings {
+                enabled: true,
+                validate_ssrf: true,
+            },
+        }
+    }
+}
+
+impl GenericMcpContextDriver {
+    pub fn new_for_tests_without_probe() -> Self {
+        Self {
+            probe: ProbeSettings {
+                enabled: false,
+                validate_ssrf: false,
+            },
+            ..Self::default()
+        }
+    }
+}
+
+#[async_trait]
+impl ContextDriver for GenericMcpContextDriver {
+    async fn initialize(&mut self, _params: InitializeParams) -> DriverResult<InitializeResult> {
+        Ok(context_initialize(DRIVER_NAME, remote_context_capabilities()))
+    }
+
+    async fn preflight(&self, _params: PreflightParams) -> DriverResult<PreflightResult> {
+        Ok(successful_preflight())
+    }
+
+    async fn provision(&self, spec: ContextSpec) -> DriverResult<ContextHandle> {
+        let endpoint = endpoint_from_spec(&spec)?;
+        if self.probe.validate_ssrf {
+            validate_endpoint_for_driver(&endpoint, &SystemDnsResolver)?;
+        }
+
+        if self.probe.enabled && matches!(endpoint.transport, McpTransport::Http | McpTransport::HttpSse) {
+            probe_mcp_initialize(&endpoint.url).await?;
+        }
+
+        let mut store = self.store.lock().expect("generic MCP store mutex");
+        let handle = format!("{DRIVER_NAME}|{}", store.next_id);
+        store.next_id += 1;
+        store.states.insert(
+            handle.clone(),
+            GenericMcpState {
+                endpoint: endpoint.clone(),
+            },
+        );
+
+        Ok(ContextHandle { handle })
+    }
+
+    async fn mcp_endpoint(&self, params: ContextHandleRequest) -> DriverResult<McpEndpoint> {
+        Ok(self.state(&params.handle)?.endpoint)
+    }
+
+    async fn required_network_rules(
+        &self,
+        params: ContextHandleRequest,
+    ) -> DriverResult<RequiredNetworkRulesResult> {
+        let endpoint = self.state(&params.handle)?.endpoint;
+        Ok(RequiredNetworkRulesResult {
+            rules: vec![endpoint_host_rule(&endpoint)?],
+        })
+    }
+
+    async fn credential_requirements(
+        &self,
+        _params: CredentialRequirementsParams,
+    ) -> DriverResult<CredentialRequirementsResult> {
+        Ok(CredentialRequirementsResult {
+            requirements: vec![CredentialRequirement {
+                name: "MCP_TOKEN".to_owned(),
+                description: "Optional bearer token for generic MCP endpoints.".to_owned(),
+                kind: CredentialKind::Token,
+                required: false,
+                validator: None,
+            }],
+        })
+    }
+
+    async fn status(&self, params: ContextHandleRequest) -> DriverResult<ContextStatus> {
+        self.state(&params.handle)?;
+        Ok(ContextStatus {
+            healthy: true,
+            detail: Some("generic MCP endpoint configured".to_owned()),
+        })
+    }
+
+    async fn teardown(&self, params: ContextHandleRequest) -> DriverResult<EmptyResult> {
+        let mut store = self.store.lock().expect("generic MCP store mutex");
+        store.states.remove(&params.handle).ok_or_else(|| invalid_handle(&params.handle))?;
+        Ok(EmptyResult::default())
+    }
+
+    async fn shutdown(&mut self, _params: ShutdownParams) -> DriverResult<EmptyResult> {
+        Ok(EmptyResult::default())
+    }
+}
+
+impl GenericMcpContextDriver {
+    fn state(&self, handle: &str) -> DriverResult<GenericMcpState> {
+        let store = self.store.lock().expect("generic MCP store mutex");
+        store
+            .states
+            .get(handle)
+            .cloned()
+            .ok_or_else(|| invalid_handle(handle))
+    }
+}
+
+pub fn endpoint_from_spec(spec: &ContextSpec) -> DriverResult<McpEndpoint> {
+    let endpoint = required_object(&spec.config, "endpoint")?;
+    let url = object_required_string(endpoint, "url")?;
+    let transport = match object_required_string(endpoint, "transport")?.as_str() {
+        "http" => McpTransport::Http,
+        "http+sse" => McpTransport::HttpSse,
+        "ssh+http" => McpTransport::SshHttp,
+        other => {
+            return Err(DriverError::InvalidConfig {
+                field: "endpoint.transport".to_owned(),
+                message: format!("unsupported MCP transport `{other}`"),
+            })
+        }
+    };
+
+    Ok(McpEndpoint {
+        url,
+        transport,
+        headers: BTreeMap::new(),
+    })
+}
+
+pub fn validate_endpoint_for_driver(
+    endpoint: &McpEndpoint,
+    resolver: &dyn DnsResolver,
+) -> DriverResult<()> {
+    let options = SsrfOptions {
+        allow_ssh_http: true,
+        ..SsrfOptions::default()
+    };
+    validate_mcp_endpoint(endpoint, options, resolver)
+        .map(|_| ())
+        .map_err(|err| DriverError::InvalidConfig {
+            field: "endpoint.url".to_owned(),
+            message: err.to_string(),
+        })
+}
+
+pub async fn probe_mcp_initialize(url: &str) -> DriverResult<()> {
+    let response = reqwest::Client::new()
+        .post(url)
+        .json(&json!({
+            "jsonrpc": "2.0",
+            "id": 1,
+            "method": "initialize",
+            "params": {
+                "protocolVersion": "2024-11-05",
+                "capabilities": {},
+                "clientInfo": {"name": "agentenv", "version": env!("CARGO_PKG_VERSION")}
+            }
+        }))
+        .send()
+        .await
+        .map_err(|err| DriverError::PreflightFailed {
+            message: format!("MCP initialize request failed: {err}"),
+        })?;
+
+    if !response.status().is_success() {
+        return Err(DriverError::PreflightFailed {
+            message: format!("MCP initialize returned HTTP {}", response.status()),
+        });
+    }
+
+    let body: serde_json::Value = response.json().await.map_err(|err| DriverError::PreflightFailed {
+        message: format!("MCP initialize response was not JSON: {err}"),
+    })?;
+    if body.get("jsonrpc").and_then(serde_json::Value::as_str) != Some("2.0")
+        || body.get("id") != Some(&json!(1))
+        || body.get("result").is_none()
+        || body.get("result") == Some(&serde_json::Value::Null)
+    {
+        return Err(DriverError::PreflightFailed {
+            message: "MCP initialize response did not contain a JSON-RPC result".to_owned(),
+        });
+    }
+
+    Ok(())
+}
+
+fn invalid_handle(handle: &str) -> DriverError {
+    DriverError::InvalidHandle {
+        handle: handle.to_owned(),
+        message: "unknown generic MCP context handle".to_owned(),
+    }
+}
+```
+
+- [ ] **Step 5: Restore the tests and rerun**
+
+Keep the test module from Step 2 at the bottom of `crates/drivers/context-mcp-generic/src/lib.rs`.
+
+Run: `cargo test -p context-mcp-generic`
+
+Expected: PASS.
+
+- [ ] **Step 6: Update the README**
+
+Replace `crates/drivers/context-mcp-generic/README.md` with:
+
+````markdown
+# context-mcp-generic
+
+Built-in context driver for existing MCP HTTP endpoints.
+
+Supported config:
+
+```yaml
+context:
+  driver: mcp-generic
+  endpoint:
+    url: https://mcp.example.com/sse
+    transport: http+sse
+  credentials:
+    MCP_TOKEN:
+      source: env
+```
+
+The driver validates outbound endpoint URLs through the shared SSRF validator,
+declares an optional `MCP_TOKEN` credential name, returns one network allow rule for
+the endpoint host, and never stores credential values.
+````
+
+- [ ] **Step 7: Commit `context-mcp-generic`**
+
+```bash
+git add crates/drivers/context-mcp-generic/Cargo.toml \
+        crates/drivers/context-mcp-generic/src/lib.rs \
+        crates/drivers/context-mcp-generic/README.md
+git commit -m "feat: implement generic MCP context driver"
+```
+
+## Task 5: Implement `context-filesystem` Driver Surface
+
+**Files:**
+- Modify: `crates/drivers/context-filesystem/Cargo.toml`
+- Modify: `crates/drivers/context-filesystem/src/lib.rs`
+- Test: `crates/drivers/context-filesystem/src/lib.rs`
+
+- [ ] **Step 1: Add dependencies**
+
+Update `crates/drivers/context-filesystem/Cargo.toml`:
+
+```toml
+[dependencies]
+agentenv-core = { path = "../../agentenv-core" }
+agentenv-proto = { path = "../../agentenv-proto" }
+async-trait.workspace = true
+serde.workspace = true
+serde_json.workspace = true
+thiserror.workspace = true
+tracing.workspace = true
+
+[dev-dependencies]
+driver-conformance = { path = "../../../tests/driver-conformance" }
+tempfile = "=3.16.0"
+tokio.workspace = true
+```
+
+- [ ] **Step 2: Write the failing filesystem driver tests**
+
+Replace `crates/drivers/context-filesystem/src/lib.rs` with a test module scaffold that references missing driver items:
+
+```rust
+#![forbid(unsafe_code)]
+
+#[cfg(test)]
+mod tests {
+    use std::{collections::BTreeMap, fs};
+
+    use agentenv_core::driver::ContextDriver;
+    use agentenv_proto::{
+        Capabilities, ContextHandleRequest, ContextSpec, CredentialRequirementsParams,
+        InitializeParams, LogLevel, McpTransport, SCHEMA_VERSION,
+    };
+    use serde_json::json;
+
+    use super::{filesystem_config_from_spec, FilesystemContextDriver};
+
+    fn init_params() -> InitializeParams {
+        InitializeParams {
+            schema_version: SCHEMA_VERSION.to_owned(),
+            core_version: "0.0.1-alpha0".to_owned(),
+            workdir: "/tmp/agentenv-test".to_owned(),
+            log_level: LogLevel::Info,
+        }
+    }
+
+    fn spec(root: &std::path::Path) -> ContextSpec {
+        ContextSpec {
+            config: BTreeMap::from([
+                ("mount".to_owned(), json!(root.to_string_lossy())),
+                ("readonly".to_owned(), json!(false)),
+                ("exclude".to_owned(), json!([".git/", "target/"])),
+            ]),
+        }
+    }
+
+    #[test]
+    fn filesystem_config_parses_mount_readonly_and_excludes() {
+        let tmp = tempfile::tempdir().unwrap();
+        let config = filesystem_config_from_spec(&spec(tmp.path())).unwrap();
+
+        assert_eq!(config.root, tmp.path().canonicalize().unwrap());
+        assert!(!config.readonly);
+        assert_eq!(config.exclude, vec![".git/".to_owned(), "target/".to_owned()]);
+    }
+
+    #[test]
+    fn filesystem_config_rejects_missing_mount() {
+        let err = filesystem_config_from_spec(&ContextSpec {
+            config: BTreeMap::new(),
+        })
+        .unwrap_err();
+
+        assert!(err.to_string().contains("mount"));
+    }
+
+    #[test]
+    fn filesystem_config_rejects_file_mount() {
+        let tmp = tempfile::tempdir().unwrap();
+        let file = tmp.path().join("file.txt");
+        fs::write(&file, "not a directory").unwrap();
+
+        let err = filesystem_config_from_spec(&spec(&file)).unwrap_err();
+
+        assert!(err.to_string().contains("directory"));
+    }
+
+    #[tokio::test]
+    async fn initialize_returns_local_capabilities() {
+        let mut driver = FilesystemContextDriver::default();
+        let result = driver.initialize(init_params()).await.unwrap();
+
+        assert_eq!(result.driver.name, "filesystem");
+        let Capabilities::Context(capabilities) = result.capabilities else {
+            panic!("expected context capabilities");
+        };
+        assert!(!capabilities.is_remote);
+        assert!(!capabilities.is_shared);
+        assert!(!capabilities.supports_zones);
+        assert!(!capabilities.supports_snapshots);
+    }
+
+    #[tokio::test]
+    async fn provision_returns_stdio_endpoint_and_empty_rules() {
+        let tmp = tempfile::tempdir().unwrap();
+        let driver = FilesystemContextDriver::default();
+        let handle = driver.provision(spec(tmp.path())).await.unwrap();
+        let request = ContextHandleRequest {
+            handle: handle.handle.clone(),
+        };
+
+        let endpoint = driver.mcp_endpoint(request.clone()).await.unwrap();
+        let rules = driver.required_network_rules(request.clone()).await.unwrap();
+        let credentials = driver
+            .credential_requirements(CredentialRequirementsParams::default())
+            .await
+            .unwrap();
+
+        assert_eq!(endpoint.transport, McpTransport::Stdio);
+        assert!(endpoint.url.contains("agentenv-fs-mcp"));
+        assert!(endpoint.url.contains("--root"));
+        assert!(endpoint.url.contains("--exclude"));
+        assert!(rules.rules.is_empty());
+        assert!(credentials.requirements.is_empty());
+    }
+
+    #[tokio::test]
+    async fn status_reports_unhealthy_when_mount_disappears() {
+        let tmp = tempfile::tempdir().unwrap();
+        let driver = FilesystemContextDriver::default();
+        let handle = driver.provision(spec(tmp.path())).await.unwrap();
+        let mount = tmp.into_path();
+        fs::remove_dir_all(&mount).unwrap();
+
+        let status = driver
+            .status(ContextHandleRequest {
+                handle: handle.handle,
+            })
+            .await
+            .unwrap();
+
+        assert!(!status.healthy);
+        assert!(status.detail.unwrap().contains("not a directory"));
+    }
+
+    #[tokio::test]
+    async fn filesystem_driver_satisfies_context_conformance_contract() {
+        let tmp = tempfile::tempdir().unwrap();
+        let mut driver = FilesystemContextDriver::default();
+
+        driver_conformance::assert_context_driver_contract(&mut driver, spec(tmp.path()))
+            .await
+            .unwrap();
+    }
+}
+```
+
+- [ ] **Step 3: Run the filesystem driver tests and verify the expected failure**
+
+Run: `cargo test -p context-filesystem filesystem_config`
+
+Expected: FAIL with missing `FilesystemContextDriver` and `filesystem_config_from_spec`.
+
+- [ ] **Step 4: Implement filesystem config parsing and driver methods**
+
+Add this driver surface to `crates/drivers/context-filesystem/src/lib.rs` above the test module:
+
+```rust
+#![forbid(unsafe_code)]
+
+use std::{
+    collections::BTreeMap,
+    fs,
+    path::PathBuf,
+    sync::Mutex,
+};
+
+use agentenv_core::{
+    context_common::{
+        context_initialize, empty_credential_requirements, empty_network_rules, empty_result,
+        expand_tilde, local_context_capabilities, optional_bool, optional_string_list,
+        required_string, successful_preflight,
+    },
+    driver::{ContextDriver, DriverError, DriverResult},
+};
+use agentenv_proto::{
+    ContextHandle, ContextHandleRequest, ContextSpec, ContextStatus, CredentialRequirementsParams,
+    CredentialRequirementsResult, EmptyResult, InitializeParams, InitializeResult, McpEndpoint,
+    McpTransport, PreflightParams, PreflightResult, RequiredNetworkRulesResult, ShutdownParams,
+};
+use async_trait::async_trait;
+
+pub const CRATE_NAME: &str = "context-filesystem";
+const DRIVER_NAME: &str = "filesystem";
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct FilesystemConfig {
+    pub root: PathBuf,
+    pub readonly: bool,
+    pub exclude: Vec<String>,
+}
+
+#[derive(Debug, Clone)]
+struct FilesystemState {
+    config: FilesystemConfig,
+}
+
+#[derive(Debug, Default)]
+struct FilesystemStore {
+    next_id: u64,
+    states: BTreeMap<String, FilesystemState>,
+}
+
+#[derive(Debug, Default)]
+pub struct FilesystemContextDriver {
+    store: Mutex<FilesystemStore>,
+}
+
+#[async_trait]
+impl ContextDriver for FilesystemContextDriver {
+    async fn initialize(&mut self, _params: InitializeParams) -> DriverResult<InitializeResult> {
+        Ok(context_initialize(DRIVER_NAME, local_context_capabilities()))
+    }
+
+    async fn preflight(&self, _params: PreflightParams) -> DriverResult<PreflightResult> {
+        Ok(successful_preflight())
+    }
+
+    async fn provision(&self, spec: ContextSpec) -> DriverResult<ContextHandle> {
+        let config = filesystem_config_from_spec(&spec)?;
+        let mut store = self.store.lock().expect("filesystem context store mutex");
+        store.next_id += 1;
+        let handle = format!("{DRIVER_NAME}|{}", store.next_id);
+        store.states.insert(handle.clone(), FilesystemState { config });
+
+        Ok(ContextHandle { handle })
+    }
+
+    async fn mcp_endpoint(&self, params: ContextHandleRequest) -> DriverResult<McpEndpoint> {
+        let state = self.state(&params.handle)?;
+        Ok(McpEndpoint {
+            url: filesystem_endpoint_command(&state.config),
+            transport: McpTransport::Stdio,
+            headers: BTreeMap::new(),
+        })
+    }
+
+    async fn required_network_rules(
+        &self,
+        params: ContextHandleRequest,
+    ) -> DriverResult<RequiredNetworkRulesResult> {
+        self.state(&params.handle)?;
+        Ok(empty_network_rules())
+    }
+
+    async fn credential_requirements(
+        &self,
+        _params: CredentialRequirementsParams,
+    ) -> DriverResult<CredentialRequirementsResult> {
+        Ok(empty_credential_requirements())
+    }
+
+    async fn status(&self, params: ContextHandleRequest) -> DriverResult<ContextStatus> {
+        let state = self.state(&params.handle)?;
+        let healthy = state.config.root.is_dir();
+        let detail = if healthy {
+            Some(format!("mounted {}", state.config.root.display()))
+        } else {
+            Some(format!("{} is not a directory", state.config.root.display()))
+        };
+
+        Ok(ContextStatus { healthy, detail })
+    }
+
+    async fn teardown(&self, params: ContextHandleRequest) -> DriverResult<EmptyResult> {
+        let mut store = self.store.lock().expect("filesystem context store mutex");
+        store.states.remove(&params.handle).ok_or_else(|| invalid_handle(&params.handle))?;
+        Ok(empty_result())
+    }
+
+    async fn shutdown(&mut self, _params: ShutdownParams) -> DriverResult<EmptyResult> {
+        Ok(empty_result())
+    }
+}
+
+impl FilesystemContextDriver {
+    fn state(&self, handle: &str) -> DriverResult<FilesystemState> {
+        let store = self.store.lock().expect("filesystem context store mutex");
+        store
+            .states
+            .get(handle)
+            .cloned()
+            .ok_or_else(|| invalid_handle(handle))
+    }
+}
+
+pub fn filesystem_config_from_spec(spec: &ContextSpec) -> DriverResult<FilesystemConfig> {
+    let mount = required_string(&spec.config, "mount")?;
+    let home = std::env::var("HOME").ok();
+    let expanded = expand_tilde(&mount, home.as_deref());
+    let root = fs::canonicalize(&expanded).map_err(|err| DriverError::InvalidConfig {
+        field: "mount".to_owned(),
+        message: format!("failed to canonicalize `{}`: {err}", expanded.display()),
+    })?;
+    if !root.is_dir() {
+        return Err(DriverError::InvalidConfig {
+            field: "mount".to_owned(),
+            message: format!("{} is not a directory", root.display()),
+        });
+    }
+
+    Ok(FilesystemConfig {
+        root,
+        readonly: optional_bool(&spec.config, "readonly")?.unwrap_or(true),
+        exclude: optional_string_list(&spec.config, "exclude")?,
+    })
+}
+
+pub fn filesystem_endpoint_command(config: &FilesystemConfig) -> String {
+    let mut parts = vec![
+        "agentenv-fs-mcp".to_owned(),
+        "--root".to_owned(),
+        shell_quote(&config.root.to_string_lossy()),
+    ];
+    if config.readonly {
+        parts.push("--readonly".to_owned());
+    }
+    for pattern in &config.exclude {
+        parts.push("--exclude".to_owned());
+        parts.push(shell_quote(pattern));
+    }
+
+    parts.join(" ")
+}
+
+fn shell_quote(value: &str) -> String {
+    if value.chars().all(|ch| ch.is_ascii_alphanumeric() || matches!(ch, '/' | '.' | '_' | '-' | ':')) {
+        value.to_owned()
+    } else {
+        format!("'{}'", value.replace('\'', "'\\''"))
+    }
+}
+
+fn invalid_handle(handle: &str) -> DriverError {
+    DriverError::InvalidHandle {
+        handle: handle.to_owned(),
+        message: "unknown filesystem context handle".to_owned(),
+    }
+}
+```
+
+- [ ] **Step 5: Restore the tests and rerun**
+
+Keep the test module from Step 2 at the bottom of `crates/drivers/context-filesystem/src/lib.rs`.
+
+Run: `cargo test -p context-filesystem filesystem`
+
+Expected: PASS.
+
+- [ ] **Step 6: Commit the filesystem driver surface**
+
+```bash
+git add crates/drivers/context-filesystem/Cargo.toml \
+        crates/drivers/context-filesystem/src/lib.rs
+git commit -m "feat: implement filesystem context driver"
+```
+
+## Task 6: Implement Filesystem MCP Tool Engine
+
+**Files:**
+- Modify: `crates/drivers/context-filesystem/src/lib.rs`
+- Test: `crates/drivers/context-filesystem/src/lib.rs`
+
+- [ ] **Step 1: Write failing tool-engine tests**
+
+Append this test module inside `crates/drivers/context-filesystem/src/lib.rs`:
+
+```rust
+#[cfg(test)]
+mod mcp_tool_tests {
+    use std::fs;
+
+    use serde_json::json;
+
+    use super::{FilesystemMcpServer, ToolCall};
+
+    #[test]
+    fn tools_list_advertises_expected_tools() {
+        let tmp = tempfile::tempdir().unwrap();
+        let server = FilesystemMcpServer::new(tmp.path().to_path_buf(), true, Vec::new()).unwrap();
+        let tools = server.tools_list();
+
+        let names: Vec<_> = tools
+            .as_array()
+            .unwrap()
+            .iter()
+            .map(|tool| tool.get("name").unwrap().as_str().unwrap())
+            .collect();
+        assert_eq!(names, vec!["fs_grep", "fs_list", "fs_read", "fs_search"]);
+    }
+
+    #[test]
+    fn fs_read_reads_utf8_file_under_root() {
+        let tmp = tempfile::tempdir().unwrap();
+        fs::write(tmp.path().join("README.md"), "hello\n").unwrap();
+        let server = FilesystemMcpServer::new(tmp.path().to_path_buf(), true, Vec::new()).unwrap();
+
+        let result = server
+            .call_tool(ToolCall {
+                name: "fs_read".to_owned(),
+                arguments: json!({"path": "README.md"}),
+            })
+            .unwrap();
+
+        assert_eq!(result, json!({"content": "hello\n"}));
+    }
+
+    #[test]
+    fn fs_read_rejects_traversal_and_excluded_paths() {
+        let tmp = tempfile::tempdir().unwrap();
+        fs::create_dir(tmp.path().join(".git")).unwrap();
+        fs::write(tmp.path().join(".git/config"), "secret").unwrap();
+        let server =
+            FilesystemMcpServer::new(tmp.path().to_path_buf(), true, vec![".git/".to_owned()])
+                .unwrap();
+
+        assert!(server
+            .call_tool(ToolCall {
+                name: "fs_read".to_owned(),
+                arguments: json!({"path": "../outside"}),
+            })
+            .unwrap_err()
+            .to_string()
+            .contains("outside root"));
+        assert!(server
+            .call_tool(ToolCall {
+                name: "fs_read".to_owned(),
+                arguments: json!({"path": ".git/config"}),
+            })
+            .unwrap_err()
+            .to_string()
+            .contains("excluded"));
+    }
+
+    #[test]
+    fn fs_list_search_and_grep_skip_excluded_paths_and_sort_results() {
+        let tmp = tempfile::tempdir().unwrap();
+        fs::create_dir_all(tmp.path().join("src")).unwrap();
+        fs::create_dir_all(tmp.path().join("target")).unwrap();
+        fs::write(tmp.path().join("src/lib.rs"), "pub fn alpha() {}\n").unwrap();
+        fs::write(tmp.path().join("src/main.rs"), "fn main() {}\nalpha();\n").unwrap();
+        fs::write(tmp.path().join("target/cache.txt"), "alpha\n").unwrap();
+        let server =
+            FilesystemMcpServer::new(tmp.path().to_path_buf(), true, vec!["target/".to_owned()])
+                .unwrap();
+
+        let listed = server
+            .call_tool(ToolCall {
+                name: "fs_list".to_owned(),
+                arguments: json!({"path": ".", "recursive": true}),
+            })
+            .unwrap();
+        assert_eq!(listed, json!({"paths": ["src/lib.rs", "src/main.rs"]}));
+
+        let searched = server
+            .call_tool(ToolCall {
+                name: "fs_search".to_owned(),
+                arguments: json!({"query": "main"}),
+            })
+            .unwrap();
+        assert_eq!(searched, json!({"paths": ["src/main.rs"]}));
+
+        let grep = server
+            .call_tool(ToolCall {
+                name: "fs_grep".to_owned(),
+                arguments: json!({"pattern": "alpha"}),
+            })
+            .unwrap();
+        assert_eq!(
+            grep,
+            json!({
+                "matches": [
+                    {"path": "src/lib.rs", "line": 1, "text": "pub fn alpha() {}"},
+                    {"path": "src/main.rs", "line": 2, "text": "alpha();"}
+                ]
+            })
+        );
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn symlink_escaping_root_is_rejected() {
+        use std::os::unix::fs::symlink;
+
+        let tmp = tempfile::tempdir().unwrap();
+        let outside = tempfile::tempdir().unwrap();
+        fs::write(outside.path().join("secret.txt"), "secret").unwrap();
+        symlink(outside.path().join("secret.txt"), tmp.path().join("link.txt")).unwrap();
+        let server = FilesystemMcpServer::new(tmp.path().to_path_buf(), true, Vec::new()).unwrap();
+
+        let err = server
+            .call_tool(ToolCall {
+                name: "fs_read".to_owned(),
+                arguments: json!({"path": "link.txt"}),
+            })
+            .unwrap_err();
+
+        assert!(err.to_string().contains("outside root"));
+    }
+}
+```
+
+- [ ] **Step 2: Run the tool tests and verify the expected failure**
+
+Run: `cargo test -p context-filesystem mcp_tool_tests`
+
+Expected: FAIL with missing `FilesystemMcpServer` and `ToolCall`.
+
+- [ ] **Step 3: Implement tool engine types and handlers**
+
+Add these public types and constants to `crates/drivers/context-filesystem/src/lib.rs`:
+
+```rust
+use serde_json::{json, Value};
+use thiserror::Error;
+
+const MAX_READ_BYTES: u64 = 1024 * 1024;
+const DEFAULT_LIMIT: usize = 100;
+const MAX_LIMIT: usize = 1000;
+
+#[derive(Debug, Clone)]
+pub struct ToolCall {
+    pub name: String,
+    pub arguments: Value,
+}
+
+#[derive(Debug, Error)]
+pub enum FsMcpError {
+    #[error("invalid params: {0}")]
+    InvalidParams(String),
+    #[error("path `{0}` is outside root")]
+    OutsideRoot(String),
+    #[error("path `{0}` is excluded")]
+    Excluded(String),
+    #[error("path `{0}` is a directory")]
+    Directory(String),
+    #[error("file `{0}` is too large")]
+    FileTooLarge(String),
+    #[error("file `{0}` is not UTF-8 text")]
+    Binary(String),
+    #[error("unknown tool `{0}`")]
+    UnknownTool(String),
+    #[error("filesystem error for `{path}`: {source}")]
+    Io {
+        path: String,
+        #[source]
+        source: std::io::Error,
+    },
+}
+
+#[derive(Debug, Clone)]
+pub struct FilesystemMcpServer {
+    root: PathBuf,
+    readonly: bool,
+    exclude: Vec<String>,
+}
+```
+
+Implement these methods in the same file:
+
+```rust
+impl FilesystemMcpServer {
+    pub fn new(root: PathBuf, readonly: bool, exclude: Vec<String>) -> Result<Self, FsMcpError> {
+        let root = fs::canonicalize(&root).map_err(|source| FsMcpError::Io {
+            path: root.display().to_string(),
+            source,
+        })?;
+        if !root.is_dir() {
+            return Err(FsMcpError::InvalidParams(format!(
+                "{} is not a directory",
+                root.display()
+            )));
+        }
+
+        Ok(Self {
+            root,
+            readonly,
+            exclude,
+        })
+    }
+
+    pub fn tools_list(&self) -> Value {
+        let readonly = self.readonly;
+        json!([
+            {"name": "fs_grep", "description": "Search file contents under the mounted root", "readOnly": readonly},
+            {"name": "fs_list", "description": "List files under the mounted root", "readOnly": readonly},
+            {"name": "fs_read", "description": "Read a UTF-8 text file under the mounted root", "readOnly": readonly},
+            {"name": "fs_search", "description": "Search filenames under the mounted root", "readOnly": readonly}
+        ])
+    }
+
+    pub fn call_tool(&self, call: ToolCall) -> Result<Value, FsMcpError> {
+        match call.name.as_str() {
+            "fs_read" => self.fs_read(&call.arguments),
+            "fs_list" => self.fs_list(&call.arguments),
+            "fs_search" => self.fs_search(&call.arguments),
+            "fs_grep" => self.fs_grep(&call.arguments),
+            other => Err(FsMcpError::UnknownTool(other.to_owned())),
+        }
+    }
+
+    fn fs_read(&self, args: &Value) -> Result<Value, FsMcpError> {
+        let path = self.required_arg(args, "path")?;
+        let resolved = self.resolve_path(path)?;
+        let metadata = fs::metadata(&resolved).map_err(|source| FsMcpError::Io {
+            path: path.to_owned(),
+            source,
+        })?;
+        if metadata.is_dir() {
+            return Err(FsMcpError::Directory(path.to_owned()));
+        }
+        if metadata.len() > MAX_READ_BYTES {
+            return Err(FsMcpError::FileTooLarge(path.to_owned()));
+        }
+        let bytes = fs::read(&resolved).map_err(|source| FsMcpError::Io {
+            path: path.to_owned(),
+            source,
+        })?;
+        let content = String::from_utf8(bytes).map_err(|_| FsMcpError::Binary(path.to_owned()))?;
+        Ok(json!({ "content": content }))
+    }
+
+    fn fs_list(&self, args: &Value) -> Result<Value, FsMcpError> {
+        let path = self.optional_arg(args, "path").unwrap_or(".");
+        let recursive = args.get("recursive").and_then(Value::as_bool).unwrap_or(false);
+        let root = self.resolve_path(path)?;
+        let mut paths = Vec::new();
+        self.collect_paths(&root, recursive, &mut paths)?;
+        paths.sort();
+        Ok(json!({ "paths": paths }))
+    }
+
+    fn fs_search(&self, args: &Value) -> Result<Value, FsMcpError> {
+        let query = self.required_arg(args, "query")?;
+        let path = self.optional_arg(args, "path").unwrap_or(".");
+        let limit = self.limit(args);
+        let root = self.resolve_path(path)?;
+        let mut paths = Vec::new();
+        self.collect_paths(&root, true, &mut paths)?;
+        paths.retain(|path| path.rsplit('/').next().unwrap_or(path).contains(query));
+        paths.sort();
+        paths.truncate(limit);
+        Ok(json!({ "paths": paths }))
+    }
+
+    fn fs_grep(&self, args: &Value) -> Result<Value, FsMcpError> {
+        let pattern = self.required_arg(args, "pattern")?;
+        let path = self.optional_arg(args, "path").unwrap_or(".");
+        let limit = self.limit(args);
+        let root = self.resolve_path(path)?;
+        let mut paths = Vec::new();
+        self.collect_paths(&root, true, &mut paths)?;
+        paths.sort();
+
+        let mut matches = Vec::new();
+        for relative in paths {
+            let full = self.root.join(&relative);
+            if fs::metadata(&full).map(|metadata| metadata.is_dir()).unwrap_or(true) {
+                continue;
+            }
+            let Ok(content) = fs::read_to_string(&full) else {
+                continue;
+            };
+            for (index, line) in content.lines().enumerate() {
+                if line.contains(pattern) {
+                    matches.push(json!({
+                        "path": relative,
+                        "line": index + 1,
+                        "text": line,
+                    }));
+                    if matches.len() == limit {
+                        return Ok(json!({ "matches": matches }));
+                    }
+                }
+            }
+        }
+
+        Ok(json!({ "matches": matches }))
+    }
+}
+```
+
+Add the path helper methods:
+
+```rust
+impl FilesystemMcpServer {
+    fn required_arg<'a>(&self, args: &'a Value, field: &str) -> Result<&'a str, FsMcpError> {
+        self.optional_arg(args, field)
+            .ok_or_else(|| FsMcpError::InvalidParams(format!("missing `{field}`")))
+    }
+
+    fn optional_arg<'a>(&self, args: &'a Value, field: &str) -> Option<&'a str> {
+        args.get(field).and_then(Value::as_str).filter(|value| !value.trim().is_empty())
+    }
+
+    fn limit(&self, args: &Value) -> usize {
+        args.get("limit")
+            .and_then(Value::as_u64)
+            .map(|value| value as usize)
+            .unwrap_or(DEFAULT_LIMIT)
+            .clamp(1, MAX_LIMIT)
+    }
+
+    fn resolve_path(&self, path: &str) -> Result<PathBuf, FsMcpError> {
+        let relative = std::path::Path::new(path);
+        if relative.is_absolute() {
+            return Err(FsMcpError::OutsideRoot(path.to_owned()));
+        }
+        if relative.components().any(|component| matches!(component, std::path::Component::ParentDir)) {
+            return Err(FsMcpError::OutsideRoot(path.to_owned()));
+        }
+        if self.is_excluded(path) {
+            return Err(FsMcpError::Excluded(path.to_owned()));
+        }
+
+        let joined = self.root.join(relative);
+        let canonical = fs::canonicalize(&joined).map_err(|source| FsMcpError::Io {
+            path: path.to_owned(),
+            source,
+        })?;
+        if !canonical.starts_with(&self.root) {
+            return Err(FsMcpError::OutsideRoot(path.to_owned()));
+        }
+        Ok(canonical)
+    }
+
+    fn collect_paths(
+        &self,
+        root: &std::path::Path,
+        recursive: bool,
+        paths: &mut Vec<String>,
+    ) -> Result<(), FsMcpError> {
+        for entry in fs::read_dir(root).map_err(|source| FsMcpError::Io {
+            path: root.display().to_string(),
+            source,
+        })? {
+            let entry = entry.map_err(|source| FsMcpError::Io {
+                path: root.display().to_string(),
+                source,
+            })?;
+            let path = entry.path();
+            let relative = path
+                .strip_prefix(&self.root)
+                .map_err(|_| FsMcpError::OutsideRoot(path.display().to_string()))?
+                .to_string_lossy()
+                .replace('\\', "/");
+            if self.is_excluded(&relative) {
+                continue;
+            }
+            let Ok(canonical) = fs::canonicalize(&path) else {
+                continue;
+            };
+            if !canonical.starts_with(&self.root) {
+                continue;
+            }
+            if fs::metadata(&canonical).map(|metadata| metadata.is_dir()).unwrap_or(false) {
+                if recursive {
+                    self.collect_paths(&canonical, recursive, paths)?;
+                }
+            } else {
+                paths.push(relative);
+            }
+        }
+        Ok(())
+    }
+
+    fn is_excluded(&self, relative: &str) -> bool {
+        let normalized = relative.trim_start_matches("./");
+        self.exclude.iter().any(|pattern| {
+            if let Some(prefix) = pattern.strip_suffix('/') {
+                normalized == prefix || normalized.starts_with(&format!("{prefix}/"))
+            } else {
+                normalized == pattern
+                    || normalized
+                        .split('/')
+                        .any(|segment| segment == pattern || segment.contains(pattern))
+            }
+        })
+    }
+}
+```
+
+- [ ] **Step 4: Rerun the tool tests**
+
+Run: `cargo test -p context-filesystem mcp_tool_tests`
+
+Expected: PASS.
+
+- [ ] **Step 5: Commit the tool engine**
+
+```bash
+git add crates/drivers/context-filesystem/src/lib.rs
+git commit -m "feat: add filesystem MCP tool engine"
+```
+
+## Task 7: Add `agentenv-fs-mcp` Stdio Binary
+
+**Files:**
+- Create: `crates/drivers/context-filesystem/src/bin/agentenv-fs-mcp.rs`
+- Modify: `crates/drivers/context-filesystem/src/lib.rs`
+- Test: `crates/drivers/context-filesystem/src/bin/agentenv-fs-mcp.rs`
+
+- [ ] **Step 1: Write failing JSON-RPC smoke tests**
+
+Create `crates/drivers/context-filesystem/src/bin/agentenv-fs-mcp.rs` with this test module first:
+
+```rust
+#[cfg(test)]
+mod tests {
+    use std::io::{BufReader, Cursor};
+
+    use serde_json::json;
+
+    use super::{handle_request, read_framed_json, write_framed_json};
+
+    #[test]
+    fn framed_json_round_trips() {
+        let mut bytes = Vec::new();
+        write_framed_json(&mut bytes, &json!({"jsonrpc": "2.0", "id": 1})).unwrap();
+        let mut reader = BufReader::new(Cursor::new(bytes));
+
+        let value = read_framed_json(&mut reader).unwrap();
+
+        assert_eq!(value, json!({"jsonrpc": "2.0", "id": 1}));
+    }
+
+    #[test]
+    fn initialize_request_returns_server_info() {
+        let tmp = tempfile::tempdir().unwrap();
+        let response = handle_request(
+            tmp.path().to_path_buf(),
+            true,
+            Vec::new(),
+            json!({
+                "jsonrpc": "2.0",
+                "id": 1,
+                "method": "initialize",
+                "params": {}
+            }),
+        );
+
+        assert_eq!(response["jsonrpc"], "2.0");
+        assert_eq!(response["id"], 1);
+        assert_eq!(response["result"]["serverInfo"]["name"], "agentenv-fs-mcp");
+    }
+
+    #[test]
+    fn tools_call_fs_read_returns_json_rpc_result() {
+        let tmp = tempfile::tempdir().unwrap();
+        std::fs::write(tmp.path().join("note.txt"), "hello").unwrap();
+        let response = handle_request(
+            tmp.path().to_path_buf(),
+            true,
+            Vec::new(),
+            json!({
+                "jsonrpc": "2.0",
+                "id": 2,
+                "method": "tools/call",
+                "params": {
+                    "name": "fs_read",
+                    "arguments": {"path": "note.txt"}
+                }
+            }),
+        );
+
+        assert_eq!(response["jsonrpc"], "2.0");
+        assert_eq!(response["id"], 2);
+        assert_eq!(response["result"], json!({"content": "hello"}));
+    }
+}
+```
+
+- [ ] **Step 2: Run the binary tests and verify the expected failure**
+
+Run: `cargo test -p context-filesystem --bin agentenv-fs-mcp`
+
+Expected: FAIL with missing `main`, `handle_request`, and framing functions.
+
+- [ ] **Step 3: Implement the stdio binary**
+
+Replace `crates/drivers/context-filesystem/src/bin/agentenv-fs-mcp.rs` with:
+
+```rust
+use std::{
+    env,
+    io::{self, BufRead, BufReader, Read, Write},
+    path::PathBuf,
+};
+
+use context_filesystem::{FilesystemMcpServer, ToolCall};
+use serde_json::{json, Value};
+
+fn main() {
+    let args: Vec<String> = env::args().collect();
+    let Ok(config) = parse_args(&args) else {
+        eprintln!("usage: agentenv-fs-mcp --root <path> [--readonly] [--exclude <pattern>]...");
+        std::process::exit(2);
+    };
+
+    let stdin = io::stdin();
+    let stdout = io::stdout();
+    let mut reader = BufReader::new(stdin.lock());
+    let mut writer = stdout.lock();
+
+    loop {
+        match read_framed_json(&mut reader) {
+            Ok(request) => {
+                let response = handle_request(
+                    config.root.clone(),
+                    config.readonly,
+                    config.exclude.clone(),
+                    request,
+                );
+                if write_framed_json(&mut writer, &response).is_err() {
+                    break;
+                }
+            }
+            Err(_) => break,
+        }
+    }
+}
+
+#[derive(Debug, Clone)]
+struct CliConfig {
+    root: PathBuf,
+    readonly: bool,
+    exclude: Vec<String>,
+}
+
+fn parse_args(args: &[String]) -> Result<CliConfig, String> {
+    let mut root = None;
+    let mut readonly = false;
+    let mut exclude = Vec::new();
+    let mut index = 1;
+    while index < args.len() {
+        match args[index].as_str() {
+            "--root" => {
+                index += 1;
+                root = args.get(index).map(PathBuf::from);
+            }
+            "--readonly" => readonly = true,
+            "--exclude" => {
+                index += 1;
+                let value = args
+                    .get(index)
+                    .filter(|value| !value.trim().is_empty())
+                    .ok_or_else(|| "--exclude requires a value".to_owned())?;
+                exclude.push(value.clone());
+            }
+            other => return Err(format!("unknown argument `{other}`")),
+        }
+        index += 1;
+    }
+
+    Ok(CliConfig {
+        root: root.ok_or_else(|| "--root is required".to_owned())?,
+        readonly,
+        exclude,
+    })
+}
+
+pub fn handle_request(root: PathBuf, readonly: bool, exclude: Vec<String>, request: Value) -> Value {
+    let id = request.get("id").cloned().unwrap_or(Value::Null);
+    let method = request.get("method").and_then(Value::as_str).unwrap_or("");
+
+    match method {
+        "initialize" => success(
+            id,
+            json!({
+                "protocolVersion": "2024-11-05",
+                "capabilities": {"tools": {}},
+                "serverInfo": {"name": "agentenv-fs-mcp", "version": env!("CARGO_PKG_VERSION")}
+            }),
+        ),
+        "tools/list" => match FilesystemMcpServer::new(root, readonly, exclude) {
+            Ok(server) => success(id, json!({"tools": server.tools_list()})),
+            Err(err) => error(id, -32603, err.to_string()),
+        },
+        "tools/call" => {
+            let Some(params) = request.get("params") else {
+                return error(id, -32602, "missing params".to_owned());
+            };
+            let Some(name) = params.get("name").and_then(Value::as_str) else {
+                return error(id, -32602, "missing tool name".to_owned());
+            };
+            let arguments = params.get("arguments").cloned().unwrap_or_else(|| json!({}));
+            match FilesystemMcpServer::new(root, readonly, exclude)
+                .and_then(|server| server.call_tool(ToolCall {
+                    name: name.to_owned(),
+                    arguments,
+                }))
+            {
+                Ok(result) => success(id, result),
+                Err(err) => error(id, -32602, err.to_string()),
+            }
+        }
+        _ => error(id, -32601, format!("unknown method `{method}`")),
+    }
+}
+
+fn success(id: Value, result: Value) -> Value {
+    json!({"jsonrpc": "2.0", "id": id, "result": result})
+}
+
+fn error(id: Value, code: i64, message: String) -> Value {
+    json!({"jsonrpc": "2.0", "id": id, "error": {"code": code, "message": message}})
+}
+
+pub fn write_framed_json<W: Write>(writer: &mut W, message: &Value) -> io::Result<()> {
+    let payload = serde_json::to_vec(message).map_err(|err| {
+        io::Error::new(io::ErrorKind::InvalidData, format!("serialize JSON: {err}"))
+    })?;
+    write!(writer, "Content-Length: {}\r\n\r\n", payload.len())?;
+    writer.write_all(&payload)?;
+    writer.flush()
+}
+
+pub fn read_framed_json<R: BufRead>(reader: &mut R) -> io::Result<Value> {
+    let mut content_length = None;
+    loop {
+        let mut line = String::new();
+        if reader.read_line(&mut line)? == 0 {
+            return Err(io::Error::new(io::ErrorKind::UnexpectedEof, "missing JSON-RPC header"));
+        }
+        if line == "\r\n" {
+            break;
+        }
+        if let Some(raw) = line.strip_prefix("Content-Length: ") {
+            content_length = Some(raw.trim().parse::<usize>().map_err(|err| {
+                io::Error::new(io::ErrorKind::InvalidData, format!("invalid Content-Length: {err}"))
+            })?);
+        }
+    }
+
+    let length = content_length.ok_or_else(|| {
+        io::Error::new(io::ErrorKind::InvalidData, "missing Content-Length header")
+    })?;
+    let mut payload = vec![0; length];
+    reader.read_exact(&mut payload)?;
+    serde_json::from_slice(&payload).map_err(|err| {
+        io::Error::new(io::ErrorKind::InvalidData, format!("invalid JSON payload: {err}"))
+    })
+}
+```
+
+Keep the tests from Step 1 at the bottom of the file.
+
+- [ ] **Step 4: Run the binary tests**
+
+Run: `cargo test -p context-filesystem --bin agentenv-fs-mcp`
+
+Expected: PASS.
+
+- [ ] **Step 5: Add a process-level smoke test**
+
+Create `crates/drivers/context-filesystem/tests/fs_mcp_stdio.rs`:
+
+```rust
+use std::io::{self, BufRead, BufReader, Read, Write};
+
+use serde_json::{json, Value};
+
+#[test]
+fn process_smoke_reads_file_over_stdio() {
+    let tmp = tempfile::tempdir().unwrap();
+    std::fs::write(tmp.path().join("note.txt"), "hello").unwrap();
+    let binary = env!("CARGO_BIN_EXE_agentenv-fs-mcp");
+    let mut child = std::process::Command::new(binary)
+        .arg("--root")
+        .arg(tmp.path())
+        .arg("--readonly")
+        .stdin(std::process::Stdio::piped())
+        .stdout(std::process::Stdio::piped())
+        .spawn()
+        .unwrap();
+
+    let request = serde_json::json!({
+        "jsonrpc": "2.0",
+        "id": 7,
+        "method": "tools/call",
+        "params": {"name": "fs_read", "arguments": {"path": "note.txt"}}
+    });
+    write_framed_json(child.stdin.as_mut().unwrap(), &request).unwrap();
+    drop(child.stdin.take());
+
+    let mut reader = std::io::BufReader::new(child.stdout.take().unwrap());
+    let response = read_framed_json(&mut reader).unwrap();
+    let status = child.wait().unwrap();
+
+    assert!(status.success());
+    assert_eq!(response["result"], serde_json::json!({"content": "hello"}));
+}
+
+fn write_framed_json<W: Write>(writer: &mut W, message: &Value) -> io::Result<()> {
+    let payload = serde_json::to_vec(message).map_err(|err| {
+        io::Error::new(io::ErrorKind::InvalidData, format!("serialize JSON: {err}"))
+    })?;
+    write!(writer, "Content-Length: {}\r\n\r\n", payload.len())?;
+    writer.write_all(&payload)?;
+    writer.flush()
+}
+
+fn read_framed_json<R: BufRead>(reader: &mut R) -> io::Result<Value> {
+    let mut content_length = None;
+    loop {
+        let mut line = String::new();
+        if reader.read_line(&mut line)? == 0 {
+            return Err(io::Error::new(io::ErrorKind::UnexpectedEof, "missing JSON-RPC header"));
+        }
+        if line == "\r\n" {
+            break;
+        }
+        if let Some(raw) = line.strip_prefix("Content-Length: ") {
+            content_length = Some(raw.trim().parse::<usize>().map_err(|err| {
+                io::Error::new(io::ErrorKind::InvalidData, format!("invalid Content-Length: {err}"))
+            })?);
+        }
+    }
+
+    let length = content_length.ok_or_else(|| {
+        io::Error::new(io::ErrorKind::InvalidData, "missing Content-Length header")
+    })?;
+    let mut payload = vec![0; length];
+    reader.read_exact(&mut payload)?;
+    serde_json::from_slice(&payload).map_err(|err| {
+        io::Error::new(io::ErrorKind::InvalidData, format!("invalid JSON payload: {err}"))
+    })
+}
+```
+
+- [ ] **Step 6: Run the binary smoke test**
+
+Run: `cargo test -p context-filesystem process_smoke_reads_file_over_stdio`
+
+Expected: PASS.
+
+- [ ] **Step 7: Commit the stdio binary**
+
+```bash
+git add crates/drivers/context-filesystem/src/bin/agentenv-fs-mcp.rs \
+        crates/drivers/context-filesystem/tests/fs_mcp_stdio.rs
+git commit -m "feat: add filesystem MCP stdio server"
+```
+
+## Task 8: Update Documentation And Run Workspace Verification
+
+**Files:**
+- Modify: `crates/drivers/context-filesystem/README.md`
+- Modify: `docs/DRIVER_PROTOCOL.md`
+- Modify: `blueprints/claude+filesystem+openshell.yaml`
+- Modify: `blueprints/codex+mcp-generic+openshell.yaml`
+
+- [ ] **Step 1: Update filesystem README**
+
+Replace `crates/drivers/context-filesystem/README.md` with:
+
+````markdown
+# context-filesystem
+
+Built-in filesystem context driver for agentenv.
+
+Supported config:
+
+```yaml
+context:
+  driver: filesystem
+  mount: ~/projects/myapp
+  readonly: false
+  exclude:
+    - ".git/"
+    - "node_modules/"
+```
+
+The driver validates the mount, stores an opaque context handle, and exposes a stdio
+MCP endpoint command for `agentenv-fs-mcp`. The server exposes read-only tools:
+`fs_read`, `fs_grep`, `fs_list`, and `fs_search`.
+
+Exclude patterns are intentionally simple. Values ending in `/` match path prefixes.
+Other values match exact path segments or filename substrings.
+````
+
+- [ ] **Step 2: Update protocol docs**
+
+In `docs/DRIVER_PROTOCOL.md`, add this paragraph under the `ContextDriver` table:
+
+```markdown
+For built-in context drivers, an empty `McpEndpoint.url` with `transport = stdio` is
+the no-context sentinel and should be skipped when rendering agent MCP config.
+Filesystem context endpoints encode the stdio command in `McpEndpoint.url` until a
+future protocol version splits stdio command and arguments into separate fields.
+```
+
+- [ ] **Step 3: Update blueprint comments**
+
+In `blueprints/claude+filesystem+openshell.yaml`, update the filesystem context block comment to mention that `exclude` can be added:
+
+```yaml
+context:
+  driver: filesystem
+  mount: ~/projects            # mounted read-write into the sandbox; exposed as MCP
+  # exclude:
+  #   - ".git/"
+  #   - "node_modules/"
+```
+
+In `blueprints/codex+mcp-generic+openshell.yaml`, update the context comment to name the optional token:
+
+```yaml
+context:
+  driver: mcp-generic
+  endpoint:
+    url: ${MCP_URL}
+    transport: http+sse
+  credentials:
+    MCP_TOKEN:
+      source: env
+      required: true
+```
+
+- [ ] **Step 4: Run formatting**
+
+Run: `cargo fmt`
+
+Expected: command exits with status 0 and no output indicating errors.
+
+- [ ] **Step 5: Run clippy**
+
+Run: `cargo clippy --workspace --all-targets -- -D warnings`
+
+Expected: PASS with no warnings.
+
+- [ ] **Step 6: Run the full workspace test suite**
+
+Run: `cargo test --workspace`
+
+Expected: PASS.
+
+- [ ] **Step 7: Commit docs and verification fixes**
+
+If formatting or lint fixes changed code, include those files in this commit. Then run:
+
+```bash
+git add crates/drivers/context-filesystem/README.md \
+        docs/DRIVER_PROTOCOL.md \
+        blueprints/claude+filesystem+openshell.yaml \
+        blueprints/codex+mcp-generic+openshell.yaml
+git commit -m "docs: document built-in context drivers"
+```
+
+## Self-Review Checklist
+
+- [ ] Issue #9 driver scope is covered by Tasks 3, 4, and 5.
+- [ ] Filesystem MCP server scope is covered by Tasks 6 and 7.
+- [ ] Shared conformance coverage is covered by Task 2.
+- [ ] No schema-version bump is required because `ContextDriver` signatures remain unchanged.
+- [ ] SSRF validation is preserved for `context-mcp-generic`.
+- [ ] Credential values never enter `ContextSpec`, handles, or status strings.
+- [ ] Verification commands are listed and expected outputs are explicit.

--- a/docs/superpowers/specs/2026-04-20-m2-3-context-drivers-design.md
+++ b/docs/superpowers/specs/2026-04-20-m2-3-context-drivers-design.md
@@ -1,0 +1,433 @@
+# M2-3 Built-In Context Drivers Design
+
+Date: 2026-04-20
+Issue: [#9](https://github.com/windoliver/agentenv/issues/9)
+Milestone: M2 - Built-in drivers
+Status: Draft for review
+
+## Summary
+
+Implement the full built-in context-driver issue scope in one pass: `context-none`,
+`context-mcp-generic`, `context-filesystem`, and the embedded filesystem MCP server
+binary. The implementation will make the three built-in `ContextDriver` crates real,
+extend shared conformance coverage for context drivers, validate outbound MCP URLs
+through the existing SSRF helpers, and ship a small `agentenv-fs-mcp` stdio server
+that exposes `fs_read`, `fs_grep`, `fs_list`, and `fs_search` against a configured
+mount.
+
+The design keeps MCP as the only agent-to-context protocol and keeps JSON-RPC driver
+traits as the core-to-driver contract. It does not add a new pluggable axis or a new
+serialization format.
+
+## Context And Constraints
+
+- `docs/ARCHITECTURE.md` defines `ContextDriver` as the knowledge-backend axis. It
+  provisions context, exposes an `MCPEndpoint`, declares network rules and credential
+  requirements, and reports capabilities.
+- `docs/DRIVER_PROTOCOL.md` already defines the `ContextDriver` method surface:
+  `provision`, `mcp_endpoint`, `required_network_rules`, `credential_requirements`,
+  `status`, and `teardown`.
+- The current context crates are M1 scaffolds, while the registry and reference
+  blueprints already recognize `filesystem`, `mcp-generic`, and `none`.
+- `agentenv-mcp` already has SSRF-aware MCP endpoint validation for HTTP-like
+  transports.
+- There is no M4 create lifecycle yet that can install sidecars inside a sandbox. The
+  filesystem MCP binary must therefore be directly testable as a crate binary and
+  returned as an endpoint plan by the driver, while final sandbox materialization can
+  use it later.
+- Credentials must not flow through generic driver RPC. Drivers may declare credential
+  names and header templates, but they must not store or expose credential values.
+
+## Affected Crates And Docs
+
+- `crates/agentenv-core`
+- `crates/agentenv-mcp`
+- `crates/drivers/context-none`
+- `crates/drivers/context-mcp-generic`
+- `crates/drivers/context-filesystem`
+- `tests/driver-conformance`
+- `docs/DRIVER_PROTOCOL.md`
+- `blueprints/claude+filesystem+openshell.yaml`
+- `blueprints/codex+mcp-generic+openshell.yaml`
+
+`agentenv-proto` is not expected to need a schema-version bump because the existing
+context-driver method signatures are sufficient. If implementation finds that MCP
+stdio arguments cannot be represented safely in the current `McpEndpoint`, the
+preferred fallback is to encode the command and arguments as a single stdio command
+string for the current schema and document the limitation rather than changing the
+protocol during this issue.
+
+## Goals
+
+- Implement honest context capabilities for all three built-in context drivers.
+- Make `context-none` compose cleanly with no external MCP configuration.
+- Make `context-mcp-generic` validate and expose external MCP HTTP/SSE endpoints.
+- Make `context-filesystem` validate filesystem config and expose a local stdio MCP
+  endpoint backed by a shipped Rust binary.
+- Implement the filesystem MCP server tools required by issue #9.
+- Add shared context-driver conformance checks and crate-level behavior tests.
+- Preserve the security model: SSRF checks for outbound URLs, path containment for
+  filesystem access, no credential values in handles or endpoints.
+
+## Non-Goals
+
+- Implementing the full M4 `agentenv create` orchestration pipeline.
+- Adding a second context protocol besides MCP.
+- Adding a second serialization format besides JSON-RPC/JSON for protocol and YAML
+  for blueprints.
+- Implementing remote filesystem sharing, context zones, or snapshots.
+- Supporting writes through the filesystem MCP server. The issue only requires grep,
+  read, list, and search tools; `readonly` is still parsed and preserved so future
+  write tools can use it.
+
+## Architecture
+
+### 1. Shared Context Helpers
+
+Add `agentenv-core::context_common` for small, deterministic helpers shared by the
+three built-in context crates. It should own:
+
+- context `InitializeResult` builders
+- successful preflight and empty result helpers
+- context capability constructors
+- opaque handle construction and validation helpers backed by per-driver in-memory
+  state maps
+- small config parsing helpers for strings, booleans, string arrays, and nested maps
+- filesystem mount normalization and path expansion for `~`
+- endpoint host-to-network-rule conversion for `mcp-generic`
+
+This mirrors the recent inference-driver shape and keeps per-driver crates thin.
+Driver crates should still own behavior-specific structs, public driver types, and
+tests.
+
+### 2. `context-none`
+
+`context-none` is a true no-op driver for agents that run without external context.
+
+Behavior:
+
+- Driver name: `none`.
+- Capabilities: `is_remote = false`, `is_shared = false`, `supports_zones = false`,
+  `supports_snapshots = false`.
+- `preflight` succeeds without host checks.
+- `provision` accepts an empty config and returns a stable `none|` handle.
+- `mcp_endpoint` rejects invalid handles and otherwise returns an empty `stdio`
+  endpoint as the protocol-compatible "no MCP config" sentinel.
+- `required_network_rules` and `credential_requirements` return empty lists.
+- `status` reports healthy with a short no-context detail.
+- `teardown` and `shutdown` are no-ops.
+
+The downstream lifecycle should treat an empty endpoint URL as "do not render an MCP
+server entry." That filtering belongs in future orchestration or agent config assembly
+instead of in this driver issue.
+
+### 3. `context-mcp-generic`
+
+`context-mcp-generic` points at an external MCP endpoint and does not own the
+upstream service.
+
+Supported blueprint shape:
+
+```yaml
+context:
+  driver: mcp-generic
+  endpoint:
+    url: https://mcp.internal.company.com
+    transport: http+sse
+  credentials:
+    MCP_TOKEN:
+      source: env
+```
+
+Driver config comes through `ContextSpec.config` as:
+
+- `endpoint.url`: required string
+- `endpoint.transport`: required string, one of `http`, `http+sse`, or `ssh+http`
+
+Credential declarations in the blueprint already live outside `ContextSpec.config`,
+and the context credential method is intentionally config-independent in the current
+driver protocol. The driver therefore declares a conventional optional `MCP_TOKEN`
+credential requirement by name only. Blueprints remain the source of truth for whether
+that token is required for a specific endpoint.
+
+Security and behavior:
+
+- `provision` parses the endpoint, validates it with `agentenv-mcp::validate_mcp_endpoint`,
+  probes the endpoint with an MCP `initialize` request for `http` and `http+sse`
+  transports, and returns an opaque handle.
+- URL validation uses SSRF defaults with `allow_ssh_http = true` for MCP transports,
+  matching blueprint verification.
+- `mcp_endpoint` returns the stored endpoint for a valid handle.
+- `required_network_rules` returns one `NetworkRule::Host` for the endpoint host,
+  preserving scheme and port when present.
+- Capabilities: `is_remote = true`, `is_shared = true`, `supports_zones = false`,
+  `supports_snapshots = false`.
+- `status` reports healthy after config validation succeeds.
+
+The endpoint probe is implemented as a small crate-local helper using `reqwest` over
+`rustls`. Unit tests should run it against a mock HTTP server built with `tokio` TCP
+listeners so no external service is required. `ssh+http` is validated for URL safety
+but not live-probed in this issue because it requires an SSH transport adapter that is
+not part of M2-3.
+
+### 4. `context-filesystem`
+
+`context-filesystem` mounts a host directory and exposes it through a local stdio MCP
+server.
+
+Supported blueprint shape:
+
+```yaml
+context:
+  driver: filesystem
+  mount: ~/projects/myapp
+  readonly: false
+  exclude:
+    - ".git/"
+    - "node_modules/"
+```
+
+Driver config comes through `ContextSpec.config` as:
+
+- `mount`: required string
+- `readonly`: optional boolean, default `true`
+- `exclude`: optional array of non-empty strings
+
+Behavior:
+
+- `provision` expands `~`, canonicalizes existing mounts when possible, rejects empty
+  mounts, rejects non-directory mounts, stores the resolved config in the driver's
+  in-memory state map, and returns an opaque filesystem handle.
+- `mcp_endpoint` returns a `stdio` endpoint command invoking `agentenv-fs-mcp` with
+  `--root`, `--readonly`, and repeated `--exclude` flags encoded in a single command
+  string for the current `McpEndpoint` schema.
+- `required_network_rules` returns no network rules.
+- `credential_requirements` returns no credentials.
+- Capabilities: `is_remote = false`, `is_shared = false`, `supports_zones = false`,
+  `supports_snapshots = false`.
+- `status` reports healthy when the mount still exists and is a directory.
+- `teardown` and `shutdown` are no-ops because the stdio MCP process is owned by the
+  agent runtime that launches it.
+
+`readonly` is parsed, encoded in the endpoint command, and enforced by the server by
+not exposing write tools. Because the initial tool set is read-only, `readonly: false`
+does not create write access in this issue.
+
+### 5. Filesystem MCP Server Binary
+
+Add a binary target named `agentenv-fs-mcp` in the `context-filesystem` crate. It
+speaks MCP over stdio using JSON-RPC framing compatible with MCP-style requests.
+
+CLI flags:
+
+```text
+agentenv-fs-mcp --root <path> [--readonly] [--exclude <pattern>]...
+```
+
+Server methods:
+
+- `initialize`
+- `tools/list`
+- `tools/call`
+
+Tools:
+
+- `fs_read`
+  - input: `path`
+  - output: UTF-8 file content
+  - rejects directories, binary content, excluded paths, and paths outside root
+- `fs_list`
+  - input: optional `path`, optional `recursive`
+  - output: sorted relative paths
+  - skips excluded entries
+- `fs_search`
+  - input: `query`, optional `path`, optional `limit`
+  - output: sorted relative paths whose filenames contain `query`
+  - skips excluded entries
+- `fs_grep`
+  - input: `pattern`, optional `path`, optional `limit`
+  - output: matches with relative path, 1-based line number, and line text
+  - skips excluded entries and binary/unreadable files
+
+Path rules:
+
+- All tool paths are interpreted as relative to `--root`.
+- Absolute paths are rejected.
+- `.` is allowed and means the root.
+- `..` traversal is rejected before any filesystem access.
+- Symlinks are resolved; resolved paths must remain under the root.
+- Exclude patterns are path-prefix style for entries ending in `/` and substring or
+  exact segment style for other simple patterns. This is intentionally smaller than
+  gitignore syntax and should be documented as such.
+
+Limits:
+
+- `fs_read` should cap returned content to a conservative size, for example 1 MiB.
+- `fs_list`, `fs_search`, and `fs_grep` should honor `limit` with a default and a
+  maximum to prevent unbounded output.
+- The server should return structured JSON-RPC errors for invalid input and access
+  denial, not panic.
+
+This binary can live in `src/bin/agentenv-fs-mcp.rs` with reusable logic in
+`context-filesystem/src/lib.rs` or sibling modules. The binary should use `tracing`
+for diagnostics and avoid `println!` outside protocol stdout writes.
+
+## Error Handling
+
+Use `thiserror` in library code and map errors to `DriverError` at driver boundaries.
+
+Driver errors should be specific for:
+
+- missing required config keys
+- config keys with the wrong type
+- unsupported MCP transport strings
+- blocked SSRF endpoint URLs
+- invalid or stale handles
+- mount paths that are empty, nonexistent, or not directories
+- invalid excludes
+
+Filesystem MCP server errors should distinguish:
+
+- invalid params
+- path outside root
+- excluded path
+- file too large
+- unsupported binary content
+- tool not found
+- method not found
+
+No `.unwrap()` should appear outside tests.
+
+## Credential Handling
+
+`context-none` and `context-filesystem` declare no credentials.
+
+`context-mcp-generic` must not receive credential values through `ContextSpec`. The
+normal blueprint credential references remain owned by core credential collection and
+future sandbox injection. Endpoint headers are out of scope for this issue because the
+current driver protocol has no safe path for credential values. Handles and status
+strings must not include credential names, credential values, or endpoint query strings.
+
+## Testing Strategy
+
+Follow TDD for behavior changes.
+
+### 1. Shared context conformance
+
+Extend `tests/driver-conformance` with `assert_context_driver_contract`. It should
+exercise:
+
+- `initialize` reports `DriverKind::Context`
+- capabilities use `Capabilities::Context`
+- `preflight` succeeds
+- `provision` returns a non-empty handle for valid specs
+- `mcp_endpoint` accepts that handle
+- `required_network_rules` and `credential_requirements` do not contain empty names or
+  malformed host rules
+- `status` reports healthy
+- `teardown` succeeds
+
+Each built-in context crate should have a test that passes this contract.
+
+### 2. Driver unit tests
+
+`context-none` tests:
+
+- initializes with no-context capabilities
+- provisions and returns the no-context sentinel endpoint
+- rejects invalid handles
+- returns no network rules and no credentials
+
+`context-mcp-generic` tests:
+
+- parses `http` and `http+sse` endpoint config
+- rejects malformed, unsupported, and SSRF-blocked URLs
+- connects to a mock MCP HTTP endpoint and accepts a valid initialize response
+- reports a failed probe when the mock endpoint returns a non-MCP response
+- returns remote/shared capabilities
+- returns a network allow rule for the endpoint host
+- declares optional `MCP_TOKEN` without storing a value
+- never includes credential values or endpoint query strings in handles
+
+`context-filesystem` tests:
+
+- parses mount, readonly, and excludes
+- rejects missing mount and non-directory mount
+- returns local non-shared capabilities
+- returns a stdio endpoint command for `agentenv-fs-mcp`
+- returns no network rules and no credentials
+- status detects when the mount disappears
+
+### 3. Filesystem MCP server tests
+
+Use temp directories and direct server handler functions rather than shelling out for
+every case.
+
+Tests should cover:
+
+- `tools/list` advertises exactly `fs_read`, `fs_grep`, `fs_list`, and `fs_search`
+- `fs_read` reads UTF-8 files under root
+- `fs_read` rejects traversal, absolute paths, directories, binary files, excluded
+  paths, and oversized files
+- `fs_list` returns sorted relative paths and skips excluded directories
+- `fs_search` finds filenames and respects limits
+- `fs_grep` returns line-numbered matches and respects limits
+- symlinks escaping the root are rejected
+- JSON-RPC unknown methods and unknown tools return protocol errors
+
+### 4. Integration smoke tests
+
+Add a binary smoke test that starts `agentenv-fs-mcp` with a temp root, sends framed
+JSON-RPC requests over stdio, and verifies `initialize`, `tools/list`, and one
+`fs_read` call. This proves the stdio transport works without needing a full agent
+or sandbox.
+
+### 5. Verification commands
+
+Run:
+
+```bash
+cargo fmt
+cargo clippy --workspace --all-targets -- -D warnings
+cargo test --workspace
+```
+
+## Acceptance Mapping
+
+- All three drivers pass the protocol conformance suite: covered by shared context
+  conformance and per-crate tests.
+- `context-filesystem` serves grep/read/list tools against a host-mounted dir: covered
+  by filesystem MCP server unit and stdio smoke tests.
+- `context-mcp-generic` validates URL, passes SSRF check, and connects to a mock MCP
+  server: covered by SSRF validation and MCP initialize probe tests.
+- `context-none` composes cleanly and the agent starts without MCP config entries:
+  covered by no-context sentinel endpoint and future lifecycle filtering contract.
+- Honest capability reporting: covered by driver initialization tests and conformance.
+
+## Trade-Offs
+
+- Implementing the filesystem MCP binary now gives issue #9 real user-facing value,
+  but it makes the change larger than the recent inference-driver MVP. The mitigation
+  is to keep server logic local to `context-filesystem` and test it independently.
+- Encoding stdio command arguments into `McpEndpoint.url` is not ideal, but it avoids a
+  protocol change while the current schema only has `url`, `transport`, and `headers`.
+  A future protocol revision can split stdio command and args.
+- The exclude model is intentionally simpler than gitignore syntax. That keeps the
+  server predictable and avoids adding a new pattern language dependency in this
+  milestone.
+- Live end-to-end testing with Claude in a sandbox depends on M4 lifecycle and agent
+  orchestration. This issue will prove the binary and driver contracts locally, then
+  leave full create/enter composition to the lifecycle milestone.
+
+## Implementation Order
+
+1. Add shared context-driver conformance tests.
+2. Implement `context-none`.
+3. Implement `context-mcp-generic` config parsing, SSRF validation, endpoint handling,
+   and network rules.
+4. Implement `context-filesystem` config parsing, mount validation, endpoint handling,
+   and status checks.
+5. Implement filesystem MCP server core path policy and tool handlers.
+6. Add stdio JSON-RPC smoke coverage for `agentenv-fs-mcp`.
+7. Update README/docs and any reference blueprint comments that need clarification.
+8. Run formatting, clippy, and full workspace tests.

--- a/tests/driver-conformance/src/lib.rs
+++ b/tests/driver-conformance/src/lib.rs
@@ -312,6 +312,69 @@ pub async fn assert_agent_driver_contract<D: agentenv_core::driver::AgentDriver>
     Ok(())
 }
 
+pub async fn assert_context_driver_contract<D: agentenv_core::driver::ContextDriver>(
+    driver: &mut D,
+    spec: agentenv_proto::ContextSpec,
+) -> anyhow::Result<()> {
+    let init = driver
+        .initialize(agentenv_proto::InitializeParams {
+            schema_version: agentenv_proto::SCHEMA_VERSION.to_owned(),
+            core_version: "0.0.1".to_owned(),
+            workdir: "/tmp/agentenv".to_owned(),
+            log_level: agentenv_proto::LogLevel::Info,
+        })
+        .await?;
+
+    agentenv_core::driver::ensure_protocol_compatible(&init)?;
+    anyhow::ensure!(
+        init.driver.kind == DriverKind::Context,
+        "initialize must report DriverKind::Context"
+    );
+    anyhow::ensure!(
+        matches!(init.capabilities, Capabilities::Context(_)),
+        "initialize must report Capabilities::Context"
+    );
+
+    let preflight = driver
+        .preflight(agentenv_proto::PreflightParams::default())
+        .await?;
+    anyhow::ensure!(preflight.ok, "preflight must pass");
+
+    let handle = driver.provision(spec).await?;
+    anyhow::ensure!(
+        !handle.handle.trim().is_empty(),
+        "context handle must not be empty"
+    );
+
+    let request = agentenv_proto::ContextHandleRequest {
+        handle: handle.handle,
+    };
+    let _endpoint = driver.mcp_endpoint(request.clone()).await?;
+    let network_rules = driver.required_network_rules(request.clone()).await?;
+    for rule in network_rules.rules {
+        if let agentenv_proto::NetworkTarget::Host { host, .. } = rule.target {
+            anyhow::ensure!(!host.trim().is_empty(), "network host must not be empty");
+        }
+    }
+
+    let credentials = driver
+        .credential_requirements(agentenv_proto::CredentialRequirementsParams::default())
+        .await?;
+    anyhow::ensure!(
+        credentials
+            .requirements
+            .iter()
+            .all(|requirement| !requirement.name.trim().is_empty()),
+        "credential name must not be empty"
+    );
+
+    let status = driver.status(request.clone()).await?;
+    anyhow::ensure!(status.healthy, "context status must be healthy");
+    driver.teardown(request).await?;
+
+    Ok(())
+}
+
 pub async fn assert_sandbox_driver_contract<D: agentenv_core::driver::SandboxDriver>(
     driver: &mut D,
 ) -> anyhow::Result<()> {
@@ -380,20 +443,22 @@ mod tests {
     use std::io::{BufReader, Cursor};
     use std::sync::Mutex;
 
-    use agentenv_core::driver::{AgentDriver, DriverResult, SandboxDriver};
+    use agentenv_core::driver::{AgentDriver, ContextDriver, DriverResult, SandboxDriver};
     use agentenv_proto::{
-        AgentCapabilities, AgentHealthCheckProbe, AgentSpec, Capabilities, CredentialKind,
-        CredentialRequirement, CredentialRequirementsResult, DriverInfo, DriverKind, EmptyResult,
-        InitializeParams, InitializeResult, InstallStepsResult, McpConfigPathParams,
-        McpConfigPathResult, PreflightParams, PreflightResult, RenderEntrypointResult,
-        RenderMcpConfigParams, RenderMcpConfigResult, SandboxCapabilities, ShutdownParams,
+        AgentCapabilities, AgentHealthCheckProbe, AgentSpec, Capabilities, ContextCapabilities,
+        ContextHandle, ContextHandleRequest, ContextSpec, ContextStatus, CredentialKind,
+        CredentialRequirement, CredentialRequirementsParams, CredentialRequirementsResult,
+        DriverInfo, DriverKind, EmptyResult, InitializeParams, InitializeResult,
+        InstallStepsResult, McpConfigPathParams, McpConfigPathResult, McpEndpoint, McpTransport,
+        PreflightParams, PreflightResult, RenderEntrypointResult, RenderMcpConfigParams,
+        RenderMcpConfigResult, RequiredNetworkRulesResult, SandboxCapabilities, ShutdownParams,
         SCHEMA_VERSION,
     };
     use async_trait::async_trait;
 
     use super::{
-        assert_agent_driver_contract, assert_sandbox_driver_contract, read_response_envelope,
-        write_framed_json,
+        assert_agent_driver_contract, assert_context_driver_contract,
+        assert_sandbox_driver_contract, read_response_envelope, write_framed_json,
     };
     use serde_json::json;
 
@@ -970,5 +1035,169 @@ mod tests {
             .expect_err("sandbox conformance should reject failed preflight");
 
         assert!(err.to_string().contains("preflight"));
+    }
+
+    #[derive(Default)]
+    struct FakeContextDriver {
+        calls: Mutex<FakeContextDriverCalls>,
+        credential_name: Option<String>,
+    }
+
+    #[derive(Default)]
+    struct FakeContextDriverCalls {
+        initialized: bool,
+        preflight_checked: bool,
+        provisioned: bool,
+        endpoint_checked: bool,
+        network_rules_checked: bool,
+        credential_requirements_checked: bool,
+        status_checked: bool,
+        torn_down: bool,
+    }
+
+    #[async_trait]
+    impl ContextDriver for FakeContextDriver {
+        async fn initialize(
+            &mut self,
+            _params: InitializeParams,
+        ) -> DriverResult<InitializeResult> {
+            self.calls.lock().unwrap().initialized = true;
+
+            Ok(InitializeResult {
+                driver: DriverInfo {
+                    name: "fake-context".to_owned(),
+                    kind: DriverKind::Context,
+                    version: "0.0.1".to_owned(),
+                    protocol_version: SCHEMA_VERSION.to_owned(),
+                },
+                capabilities: Capabilities::Context(ContextCapabilities {
+                    is_remote: false,
+                    is_shared: false,
+                    supports_zones: false,
+                    supports_snapshots: false,
+                }),
+            })
+        }
+
+        async fn preflight(&self, _params: PreflightParams) -> DriverResult<PreflightResult> {
+            self.calls.lock().unwrap().preflight_checked = true;
+
+            Ok(PreflightResult {
+                ok: true,
+                issues: Vec::new(),
+            })
+        }
+
+        async fn provision(&self, _spec: ContextSpec) -> DriverResult<ContextHandle> {
+            self.calls.lock().unwrap().provisioned = true;
+
+            Ok(ContextHandle {
+                handle: "fake-context".to_owned(),
+            })
+        }
+
+        async fn mcp_endpoint(&self, _params: ContextHandleRequest) -> DriverResult<McpEndpoint> {
+            self.calls.lock().unwrap().endpoint_checked = true;
+
+            Ok(McpEndpoint {
+                url: "http://127.0.0.1:9000/mcp".to_owned(),
+                transport: McpTransport::Http,
+                headers: BTreeMap::new(),
+            })
+        }
+
+        async fn required_network_rules(
+            &self,
+            _params: ContextHandleRequest,
+        ) -> DriverResult<RequiredNetworkRulesResult> {
+            self.calls.lock().unwrap().network_rules_checked = true;
+
+            Ok(RequiredNetworkRulesResult { rules: Vec::new() })
+        }
+
+        async fn credential_requirements(
+            &self,
+            _params: CredentialRequirementsParams,
+        ) -> DriverResult<CredentialRequirementsResult> {
+            self.calls.lock().unwrap().credential_requirements_checked = true;
+
+            Ok(CredentialRequirementsResult {
+                requirements: self
+                    .credential_name
+                    .clone()
+                    .map(|name| {
+                        vec![CredentialRequirement {
+                            name,
+                            kind: CredentialKind::ApiKey,
+                            required: true,
+                            description: "Fake context credential.".to_owned(),
+                            validator: None,
+                        }]
+                    })
+                    .unwrap_or_default(),
+            })
+        }
+
+        async fn status(&self, _params: ContextHandleRequest) -> DriverResult<ContextStatus> {
+            self.calls.lock().unwrap().status_checked = true;
+
+            Ok(ContextStatus {
+                healthy: true,
+                detail: None,
+            })
+        }
+
+        async fn teardown(&self, _params: ContextHandleRequest) -> DriverResult<EmptyResult> {
+            self.calls.lock().unwrap().torn_down = true;
+
+            Ok(EmptyResult::default())
+        }
+
+        async fn shutdown(&mut self, _params: ShutdownParams) -> DriverResult<EmptyResult> {
+            Ok(EmptyResult::default())
+        }
+    }
+
+    #[tokio::test]
+    async fn context_driver_contract_accepts_context_capabilities() {
+        let mut driver = FakeContextDriver::default();
+
+        assert_context_driver_contract(
+            &mut driver,
+            ContextSpec {
+                config: BTreeMap::new(),
+            },
+        )
+        .await
+        .expect("fake context should satisfy the in-process conformance contract");
+
+        let calls = driver.calls.lock().unwrap();
+        assert!(calls.initialized);
+        assert!(calls.preflight_checked);
+        assert!(calls.provisioned);
+        assert!(calls.endpoint_checked);
+        assert!(calls.network_rules_checked);
+        assert!(calls.credential_requirements_checked);
+        assert!(calls.status_checked);
+        assert!(calls.torn_down);
+    }
+
+    #[tokio::test]
+    async fn context_driver_contract_rejects_empty_credential_names() {
+        let mut driver = FakeContextDriver {
+            credential_name: Some(String::new()),
+            ..FakeContextDriver::default()
+        };
+
+        let err = assert_context_driver_contract(
+            &mut driver,
+            ContextSpec {
+                config: BTreeMap::new(),
+            },
+        )
+        .await
+        .expect_err("context conformance should reject empty credential names");
+
+        assert!(err.to_string().contains("credential name"));
     }
 }

--- a/tests/driver-conformance/src/lib.rs
+++ b/tests/driver-conformance/src/lib.rs
@@ -349,12 +349,11 @@ pub async fn assert_context_driver_contract<D: agentenv_core::driver::ContextDri
     let request = agentenv_proto::ContextHandleRequest {
         handle: handle.handle,
     };
-    let _endpoint = driver.mcp_endpoint(request.clone()).await?;
+    let endpoint = driver.mcp_endpoint(request.clone()).await?;
+    ensure_valid_mcp_endpoint(&endpoint)?;
     let network_rules = driver.required_network_rules(request.clone()).await?;
     for rule in network_rules.rules {
-        if let agentenv_proto::NetworkTarget::Host { host, .. } = rule.target {
-            anyhow::ensure!(!host.trim().is_empty(), "network host must not be empty");
-        }
+        ensure_valid_network_target(&rule.target)?;
     }
 
     let credentials = driver
@@ -371,6 +370,72 @@ pub async fn assert_context_driver_contract<D: agentenv_core::driver::ContextDri
     let status = driver.status(request.clone()).await?;
     anyhow::ensure!(status.healthy, "context status must be healthy");
     driver.teardown(request).await?;
+
+    Ok(())
+}
+
+fn ensure_valid_mcp_endpoint(endpoint: &agentenv_proto::McpEndpoint) -> anyhow::Result<()> {
+    match endpoint.transport {
+        agentenv_proto::McpTransport::Stdio => Ok(()),
+        agentenv_proto::McpTransport::Http
+        | agentenv_proto::McpTransport::HttpSse
+        | agentenv_proto::McpTransport::SshHttp => {
+            anyhow::ensure!(
+                !endpoint.url.trim().is_empty(),
+                "MCP endpoint URL must not be empty for URL-based transports"
+            );
+            agentenv_core::context_common::endpoint_host_rule(endpoint)
+                .context("MCP endpoint URL must parse and include a host")?;
+            Ok(())
+        }
+    }
+}
+
+fn ensure_valid_network_target(target: &agentenv_proto::NetworkTarget) -> anyhow::Result<()> {
+    match target {
+        agentenv_proto::NetworkTarget::Host { host, scheme, .. } => {
+            anyhow::ensure!(!host.trim().is_empty(), "network host must not be empty");
+            if let Some(scheme) = scheme {
+                anyhow::ensure!(
+                    !scheme.trim().is_empty(),
+                    "network host scheme must not be empty"
+                );
+            }
+        }
+        agentenv_proto::NetworkTarget::Cidr { cidr } => {
+            anyhow::ensure!(!cidr.trim().is_empty(), "network CIDR must not be empty");
+        }
+        agentenv_proto::NetworkTarget::Port { protocol, .. } => {
+            if let Some(protocol) = protocol {
+                anyhow::ensure!(
+                    !protocol.trim().is_empty(),
+                    "network port protocol must not be empty"
+                );
+            }
+        }
+        agentenv_proto::NetworkTarget::UrlPattern { pattern } => {
+            anyhow::ensure!(
+                !pattern.trim().is_empty(),
+                "network URL pattern must not be empty"
+            );
+        }
+        agentenv_proto::NetworkTarget::HttpMethodPath { host, method, path } => {
+            if let Some(host) = host {
+                anyhow::ensure!(
+                    !host.trim().is_empty(),
+                    "network HTTP method path host must not be empty"
+                );
+            }
+            anyhow::ensure!(
+                !method.trim().is_empty(),
+                "network HTTP method path method must not be empty"
+            );
+            anyhow::ensure!(
+                !path.trim().is_empty(),
+                "network HTTP method path path must not be empty"
+            );
+        }
+    }
 
     Ok(())
 }
@@ -450,9 +515,9 @@ mod tests {
         CredentialRequirement, CredentialRequirementsParams, CredentialRequirementsResult,
         DriverInfo, DriverKind, EmptyResult, InitializeParams, InitializeResult,
         InstallStepsResult, McpConfigPathParams, McpConfigPathResult, McpEndpoint, McpTransport,
-        PreflightParams, PreflightResult, RenderEntrypointResult, RenderMcpConfigParams,
-        RenderMcpConfigResult, RequiredNetworkRulesResult, SandboxCapabilities, ShutdownParams,
-        SCHEMA_VERSION,
+        NetworkRule, NetworkTarget, PreflightParams, PreflightResult, RenderEntrypointResult,
+        RenderMcpConfigParams, RenderMcpConfigResult, RequiredNetworkRulesResult,
+        SandboxCapabilities, ShutdownParams, SCHEMA_VERSION,
     };
     use async_trait::async_trait;
 
@@ -1040,6 +1105,8 @@ mod tests {
     #[derive(Default)]
     struct FakeContextDriver {
         calls: Mutex<FakeContextDriverCalls>,
+        endpoint: Option<McpEndpoint>,
+        network_rules: Vec<NetworkRule>,
         credential_name: Option<String>,
     }
 
@@ -1099,11 +1166,11 @@ mod tests {
         async fn mcp_endpoint(&self, _params: ContextHandleRequest) -> DriverResult<McpEndpoint> {
             self.calls.lock().unwrap().endpoint_checked = true;
 
-            Ok(McpEndpoint {
+            Ok(self.endpoint.clone().unwrap_or_else(|| McpEndpoint {
                 url: "http://127.0.0.1:9000/mcp".to_owned(),
                 transport: McpTransport::Http,
                 headers: BTreeMap::new(),
-            })
+            }))
         }
 
         async fn required_network_rules(
@@ -1112,7 +1179,9 @@ mod tests {
         ) -> DriverResult<RequiredNetworkRulesResult> {
             self.calls.lock().unwrap().network_rules_checked = true;
 
-            Ok(RequiredNetworkRulesResult { rules: Vec::new() })
+            Ok(RequiredNetworkRulesResult {
+                rules: self.network_rules.clone(),
+            })
         }
 
         async fn credential_requirements(
@@ -1199,5 +1268,72 @@ mod tests {
         .expect_err("context conformance should reject empty credential names");
 
         assert!(err.to_string().contains("credential name"));
+    }
+
+    #[tokio::test]
+    async fn context_driver_contract_rejects_url_transport_with_malformed_url() {
+        let mut driver = FakeContextDriver {
+            endpoint: Some(McpEndpoint {
+                url: "not a url".to_owned(),
+                transport: McpTransport::Http,
+                headers: BTreeMap::new(),
+            }),
+            ..FakeContextDriver::default()
+        };
+
+        let err = assert_context_driver_contract(
+            &mut driver,
+            ContextSpec {
+                config: BTreeMap::new(),
+            },
+        )
+        .await
+        .expect_err("context conformance should reject malformed URL endpoints");
+
+        assert!(err.to_string().contains("endpoint"));
+    }
+
+    #[tokio::test]
+    async fn context_driver_contract_allows_stdio_endpoint_with_empty_url() {
+        let mut driver = FakeContextDriver {
+            endpoint: Some(McpEndpoint {
+                url: String::new(),
+                transport: McpTransport::Stdio,
+                headers: BTreeMap::new(),
+            }),
+            ..FakeContextDriver::default()
+        };
+
+        assert_context_driver_contract(
+            &mut driver,
+            ContextSpec {
+                config: BTreeMap::new(),
+            },
+        )
+        .await
+        .expect("stdio context endpoints may use an empty URL sentinel");
+    }
+
+    #[tokio::test]
+    async fn context_driver_contract_rejects_empty_url_pattern_network_rule() {
+        let mut driver = FakeContextDriver {
+            network_rules: vec![NetworkRule {
+                target: NetworkTarget::UrlPattern {
+                    pattern: String::new(),
+                },
+            }],
+            ..FakeContextDriver::default()
+        };
+
+        let err = assert_context_driver_contract(
+            &mut driver,
+            ContextSpec {
+                config: BTreeMap::new(),
+            },
+        )
+        .await
+        .expect_err("context conformance should reject empty URL pattern network rules");
+
+        assert!(err.to_string().contains("network"));
     }
 }


### PR DESCRIPTION
## Summary

Implements the M2-3 built-in context driver work for issue #9:

- Adds `context-none`, `context-mcp-generic`, and `context-filesystem` drivers.
- Adds the filesystem MCP stdio server and shared context-driver helpers.
- Hardens filesystem traversal, listing limits, MCP stdio framing, and generic MCP endpoint probing.
- Documents the built-in context drivers and updates reference blueprints.
- Addresses review feedback for authenticated MCP endpoint probes and no-context MCP rendering.

## Impact

Agents can now run with no context, a remote/generic MCP context endpoint, or a local filesystem-backed MCP context endpoint while preserving the driver protocol boundary and existing credential handling rules.

## Validation

Fresh verification on Rust 1.95.0:

- `cargo fmt --check`
- `cargo clippy --workspace --all-targets -- -D warnings`
- `cargo test --workspace`

Closes #9.
