### PR TITLE
[codex] Add reference blueprints and sample projects

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -578,6 +578,13 @@ dependencies = [
 ]
 
 [[package]]
+name = "blueprint-integration"
+version = "0.0.1-alpha0"
+dependencies = [
+ "uuid",
+]
+
+[[package]]
 name = "bstr"
 version = "1.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -23,6 +23,7 @@ members = [
     "crates/drivers/inference-anthropic",
     "crates/drivers/inference-ollama",
     "tests/driver-conformance",
+    "tests/blueprint-integration",
 ]
 
 [workspace.package]

--- a/blueprints/claude+filesystem+openshell.yaml
+++ b/blueprints/claude+filesystem+openshell.yaml
@@ -1,5 +1,8 @@
-# Reference blueprint — Claude Code in OpenShell with a local filesystem context.
-# The simplest viable agentenv composition. No remote context backend, no hub.
+# Reference blueprint - Claude Code in OpenShell with a local filesystem context.
+# Good for: getting started with Claude against a local project tree.
+#
+# Prerequisites:
+#   export ANTHROPIC_API_KEY=sk-ant-example
 #
 # Usage:
 #   agentenv create myapp --blueprint blueprints/claude+filesystem+openshell.yaml

--- a/blueprints/claude+mcp-generic+openshell.yaml
+++ b/blueprints/claude+mcp-generic+openshell.yaml
@@ -1,14 +1,14 @@
-# Reference blueprint - OpenAI Codex in OpenShell with a generic MCP context server.
-# Good for: connecting Codex to any MCP-compatible knowledge service.
+# Reference blueprint - Claude Code in OpenShell with a generic MCP context server.
+# Good for: connecting Claude to any MCP-compatible knowledge service.
 #
 # Prerequisites:
-#   export OPENAI_API_KEY=sk-openai-example
+#   export ANTHROPIC_API_KEY=sk-ant-example
 #   export MCP_URL=https://mcp.internal.company.com
 #   export MCP_TOKEN=mcp-token-example
 #
 # Usage:
-#   agentenv create legal --blueprint blueprints/codex+mcp-generic+openshell.yaml
-#   agentenv enter legal
+#   agentenv create docs --blueprint blueprints/claude+mcp-generic+openshell.yaml
+#   agentenv enter docs
 
 version: 0.1.0
 min_agentenv_version: 0.0.1-alpha0
@@ -18,9 +18,9 @@ sandbox:
   version: ">=0.0.1-alpha0,<0.1"
 
 agent:
-  driver: codex
+  driver: claude
   credentials:
-    OPENAI_API_KEY:
+    ANTHROPIC_API_KEY:
       source: env
       required: true
 
@@ -38,7 +38,10 @@ inference:
   driver: passthrough
 
 policy:
-  tier: restricted              # legal work — tight default
+  tier: restricted
   presets: []
   overrides:
     - allow: "${MCP_URL}"
+
+state:
+  persist_home: true

--- a/blueprints/claude+mcp-generic+openshell.yaml
+++ b/blueprints/claude+mcp-generic+openshell.yaml
@@ -3,7 +3,7 @@
 #
 # Prerequisites:
 #   export ANTHROPIC_API_KEY=sk-ant-example
-#   export MCP_URL=https://mcp.internal.company.com
+#   export MCP_URL=https://example.com/mcp
 #   export MCP_TOKEN=mcp-token-example
 #
 # Usage:

--- a/blueprints/claude+nexus+openshell.yaml
+++ b/blueprints/claude+nexus+openshell.yaml
@@ -1,15 +1,15 @@
-# Reference blueprint - OpenClaw in OpenShell with a shared Nexus hub.
-# Good for: enterprise teams using OpenClaw with shared company context.
+# Reference blueprint - Claude Code in OpenShell with a shared Nexus hub.
+# Good for: enterprise teams using Claude with shared company context.
 #
 # Prerequisites:
-#   export OPENAI_API_KEY=sk-openai-example
+#   export ANTHROPIC_API_KEY=sk-ant-example
 #   export NEXUS_HUB_URL=https://nexus.company.com
 #   export NEXUS_TOKEN=nexus-token-example
 #   agentenv drivers list   # confirm the nexus context driver is installed
 #
 # Usage:
-#   agentenv create assistant --blueprint blueprints/openclaw+nexus+openshell.yaml
-#   agentenv enter assistant
+#   agentenv create enterprise --blueprint blueprints/claude+nexus+openshell.yaml
+#   agentenv enter enterprise
 
 version: 0.1.0
 min_agentenv_version: 0.0.1-alpha0
@@ -19,17 +19,14 @@ sandbox:
   version: ">=0.0.1-alpha0,<0.1"
 
 agent:
-  driver: openclaw
-  config:
-    provider: openai
+  driver: claude
   credentials:
-    OPENAI_API_KEY:
+    ANTHROPIC_API_KEY:
       source: env
       required: true
 
 context:
   driver: nexus
-  # External subprocess driver installed at ~/.agentenv/drivers/context-nexus/.
   mode: hub
   hub_url: ${NEXUS_HUB_URL}
   credentials:
@@ -49,4 +46,4 @@ policy:
     - allow: "${NEXUS_HUB_URL}"
 
 state:
-  persist_home: true            # OpenClaw's always-on assistant state lives here
+  persist_home: true

--- a/blueprints/claude+nexus+openshell.yaml
+++ b/blueprints/claude+nexus+openshell.yaml
@@ -3,7 +3,7 @@
 #
 # Prerequisites:
 #   export ANTHROPIC_API_KEY=sk-ant-example
-#   export NEXUS_HUB_URL=https://nexus.company.com
+#   export NEXUS_HUB_URL=https://example.com/nexus
 #   export NEXUS_TOKEN=nexus-token-example
 #   agentenv drivers list   # confirm the nexus context driver is installed
 #

--- a/blueprints/codex+filesystem+openshell.yaml
+++ b/blueprints/codex+filesystem+openshell.yaml
@@ -1,0 +1,39 @@
+# Reference blueprint - OpenAI Codex in OpenShell with a local filesystem context.
+# Good for: getting started with Codex against a local project tree.
+#
+# Prerequisites:
+#   export OPENAI_API_KEY=sk-openai-example
+#
+# Usage:
+#   agentenv create myapp --blueprint blueprints/codex+filesystem+openshell.yaml
+#   agentenv enter myapp
+
+version: 0.1.0
+min_agentenv_version: 0.0.1-alpha0
+
+sandbox:
+  driver: openshell
+  version: ">=0.0.1-alpha0,<0.1"
+
+agent:
+  driver: codex
+  credentials:
+    OPENAI_API_KEY:
+      source: env
+      required: true
+
+context:
+  driver: filesystem
+  mount: ~/projects
+
+inference:
+  driver: passthrough
+
+policy:
+  tier: balanced
+  presets:
+    - github_read
+    - npm_read
+
+state:
+  persist_home: true

--- a/blueprints/codex+mcp-generic+openshell.yaml
+++ b/blueprints/codex+mcp-generic+openshell.yaml
@@ -3,7 +3,7 @@
 #
 # Prerequisites:
 #   export OPENAI_API_KEY=sk-openai-example
-#   export MCP_URL=https://mcp.internal.company.com
+#   export MCP_URL=https://example.com/mcp
 #   export MCP_TOKEN=mcp-token-example
 #
 # Usage:

--- a/blueprints/hermes+filesystem+openshell.yaml
+++ b/blueprints/hermes+filesystem+openshell.yaml
@@ -1,0 +1,36 @@
+# Reference blueprint - Hermes subprocess agent in OpenShell with a local filesystem context.
+# Good for: demonstrating an external polyglot agent driver against local code.
+#
+# Prerequisites:
+#   export OPENAI_API_KEY=sk-openai-example
+#   agentenv drivers list   # confirm the hermes agent driver is installed
+#
+# Usage:
+#   agentenv create research --blueprint blueprints/hermes+filesystem+openshell.yaml
+#   agentenv enter research
+
+version: 0.1.0
+min_agentenv_version: 0.0.1-alpha0
+
+sandbox:
+  driver: openshell
+  version: ">=0.0.1-alpha0,<0.1"
+
+agent:
+  driver: hermes
+  credentials:
+    OPENAI_API_KEY:
+      source: env
+      required: true
+
+context:
+  driver: filesystem
+  mount: ~/projects
+
+inference:
+  driver: passthrough
+
+policy:
+  tier: balanced
+  presets:
+    - github_read

--- a/blueprints/hermes+nexus+openshell.yaml
+++ b/blueprints/hermes+nexus+openshell.yaml
@@ -1,11 +1,15 @@
-# Reference blueprint — Nous Research Hermes agent in OpenShell with a shared Nexus hub.
-# Uses two subprocess (Python) drivers: agent-hermes and context-nexus.
-# Installed driver directories are expected at ~/.agentenv/drivers/agent-hermes/
-# and ~/.agentenv/drivers/context-nexus/.
-# Supported flows:
-#   agentenv drivers list
+# Reference blueprint - Hermes subprocess agent in OpenShell with a shared Nexus hub.
+# Good for: demonstrating external Hermes and Nexus subprocess drivers together.
+#
+# Prerequisites:
+#   export OPENAI_API_KEY=sk-openai-example
+#   export NEXUS_HUB_URL=https://nexus.company.com
+#   export NEXUS_TOKEN=nexus-token-example
+#   agentenv drivers list   # confirm hermes and nexus drivers are installed
+#
+# Usage:
 #   agentenv create research --blueprint blueprints/hermes+nexus+openshell.yaml
-#   agentenv status research
+#   agentenv enter research
 #   agentenv destroy research --yes
 
 version: 0.1.0

--- a/blueprints/hermes+nexus+openshell.yaml
+++ b/blueprints/hermes+nexus+openshell.yaml
@@ -3,7 +3,7 @@
 #
 # Prerequisites:
 #   export OPENAI_API_KEY=sk-openai-example
-#   export NEXUS_HUB_URL=https://nexus.company.com
+#   export NEXUS_HUB_URL=https://example.com/nexus
 #   export NEXUS_TOKEN=nexus-token-example
 #   agentenv drivers list   # confirm hermes and nexus drivers are installed
 #

--- a/blueprints/openclaw+filesystem+openshell.yaml
+++ b/blueprints/openclaw+filesystem+openshell.yaml
@@ -1,0 +1,41 @@
+# Reference blueprint - OpenClaw in OpenShell with a local filesystem context.
+# Good for: getting started with an always-on OpenClaw assistant over local code.
+#
+# Prerequisites:
+#   export OPENAI_API_KEY=sk-openai-example
+#
+# Usage:
+#   agentenv create assistant --blueprint blueprints/openclaw+filesystem+openshell.yaml
+#   agentenv enter assistant
+
+version: 0.1.0
+min_agentenv_version: 0.0.1-alpha0
+
+sandbox:
+  driver: openshell
+  version: ">=0.0.1-alpha0,<0.1"
+
+agent:
+  driver: openclaw
+  config:
+    provider: openai
+  credentials:
+    OPENAI_API_KEY:
+      source: env
+      required: true
+
+context:
+  driver: filesystem
+  mount: ~/projects
+
+inference:
+  driver: passthrough
+
+policy:
+  tier: balanced
+  presets:
+    - github_read
+    - npm_read
+
+state:
+  persist_home: true

--- a/blueprints/openclaw+nexus+openshell.yaml
+++ b/blueprints/openclaw+nexus+openshell.yaml
@@ -3,7 +3,7 @@
 #
 # Prerequisites:
 #   export OPENAI_API_KEY=sk-openai-example
-#   export NEXUS_HUB_URL=https://nexus.company.com
+#   export NEXUS_HUB_URL=https://example.com/nexus
 #   export NEXUS_TOKEN=nexus-token-example
 #   agentenv drivers list   # confirm the nexus context driver is installed
 #

--- a/crates/agentenv-core/tests/reference_blueprints.rs
+++ b/crates/agentenv-core/tests/reference_blueprints.rs
@@ -226,6 +226,47 @@ fn all_reference_blueprints_parse() {
 }
 
 #[test]
+fn docs_catalog_mentions_every_reference_blueprint() {
+    let docs = std::fs::read_to_string(workspace_path("docs/BLUEPRINTS.md")).unwrap();
+
+    for case in reference_blueprints() {
+        let file_name = case.path.strip_prefix("blueprints/").unwrap();
+        assert!(
+            docs.contains(file_name),
+            "docs/BLUEPRINTS.md must mention {file_name}"
+        );
+    }
+}
+
+#[test]
+fn sample_project_blueprints_parse() {
+    {
+        let _guard = env_lock().lock().unwrap();
+        std::env::set_var("NEXUS_HUB_URL", "https://93.184.216.35");
+    }
+
+    for path in [
+        "examples/quickstart/agentenv.yaml",
+        "examples/enterprise-hub/agentenv.yaml",
+        "examples/headless-ci/agentenv.yaml",
+    ] {
+        let doc = std::fs::read_to_string(workspace_path(path)).unwrap();
+        let blueprint = Blueprint::from_yaml(&doc).unwrap();
+
+        assert_eq!(blueprint.version, "0.1.0", "{path}");
+        assert_eq!(blueprint.sandbox.driver, "openshell", "{path}");
+        assert_eq!(
+            blueprint
+                .inference
+                .as_ref()
+                .map(|section| section.driver.as_str()),
+            Some("passthrough"),
+            "{path}"
+        );
+    }
+}
+
+#[test]
 fn interpolation_resolves_env_variable() {
     let _guard = env_lock().lock().unwrap();
     std::env::set_var("MCP_URL", "https://93.184.216.34");

--- a/crates/agentenv-core/tests/reference_blueprints.rs
+++ b/crates/agentenv-core/tests/reference_blueprints.rs
@@ -240,18 +240,18 @@ fn docs_catalog_mentions_every_reference_blueprint() {
 
 #[test]
 fn sample_project_blueprints_parse() {
-    {
-        let _guard = env_lock().lock().unwrap();
-        std::env::set_var("NEXUS_HUB_URL", "https://93.184.216.35");
-    }
+    let _guard = env_lock().lock().unwrap();
+
+    std::env::set_var("NEXUS_HUB_URL", "https://93.184.216.35");
 
     for path in [
         "examples/quickstart/agentenv.yaml",
         "examples/enterprise-hub/agentenv.yaml",
         "examples/headless-ci/agentenv.yaml",
     ] {
-        let doc = std::fs::read_to_string(workspace_path(path)).unwrap();
-        let blueprint = Blueprint::from_yaml(&doc).unwrap();
+        let doc = std::fs::read_to_string(workspace_path(path))
+            .unwrap_or_else(|err| panic!("{path}: {err}"));
+        let blueprint = Blueprint::from_yaml(&doc).unwrap_or_else(|err| panic!("{path}: {err}"));
 
         assert_eq!(blueprint.version, "0.1.0", "{path}");
         assert_eq!(blueprint.sandbox.driver, "openshell", "{path}");

--- a/crates/agentenv-core/tests/reference_blueprints.rs
+++ b/crates/agentenv-core/tests/reference_blueprints.rs
@@ -1,6 +1,8 @@
 use std::sync::{Mutex, OnceLock};
 
-use agentenv_core::{blueprint::Blueprint, error::BlueprintError};
+use agentenv_core::{
+    blueprint::Blueprint, error::BlueprintError, lifecycle::verify_blueprint_yaml,
+};
 
 fn env_lock() -> &'static Mutex<()> {
     static LOCK: OnceLock<Mutex<()>> = OnceLock::new();
@@ -252,6 +254,7 @@ fn sample_project_blueprints_parse() {
         let doc = std::fs::read_to_string(workspace_path(path))
             .unwrap_or_else(|err| panic!("{path}: {err}"));
         let blueprint = Blueprint::from_yaml(&doc).unwrap_or_else(|err| panic!("{path}: {err}"));
+        verify_blueprint_yaml(&doc).unwrap_or_else(|err| panic!("{path}: {err}"));
 
         assert_eq!(blueprint.version, "0.1.0", "{path}");
         assert_eq!(blueprint.sandbox.driver, "openshell", "{path}");

--- a/crates/agentenv-core/tests/reference_blueprints.rs
+++ b/crates/agentenv-core/tests/reference_blueprints.rs
@@ -13,6 +13,125 @@ fn workspace_path(path: &str) -> std::path::PathBuf {
         .join(path)
 }
 
+struct ReferenceBlueprint {
+    path: &'static str,
+    agent_driver: &'static str,
+    context_driver: &'static str,
+    tier: &'static str,
+    persists_home: Option<bool>,
+    context: ContextExpectation,
+}
+
+enum ContextExpectation {
+    Filesystem {
+        mount: &'static str,
+    },
+    GenericMcp {
+        url: &'static str,
+        transport: &'static str,
+    },
+    Nexus {
+        hub_url: &'static str,
+    },
+}
+
+fn reference_blueprints() -> Vec<ReferenceBlueprint> {
+    vec![
+        ReferenceBlueprint {
+            path: "blueprints/claude+filesystem+openshell.yaml",
+            agent_driver: "claude",
+            context_driver: "filesystem",
+            tier: "balanced",
+            persists_home: Some(true),
+            context: ContextExpectation::Filesystem {
+                mount: "~/projects",
+            },
+        },
+        ReferenceBlueprint {
+            path: "blueprints/codex+filesystem+openshell.yaml",
+            agent_driver: "codex",
+            context_driver: "filesystem",
+            tier: "balanced",
+            persists_home: Some(true),
+            context: ContextExpectation::Filesystem {
+                mount: "~/projects",
+            },
+        },
+        ReferenceBlueprint {
+            path: "blueprints/openclaw+filesystem+openshell.yaml",
+            agent_driver: "openclaw",
+            context_driver: "filesystem",
+            tier: "balanced",
+            persists_home: Some(true),
+            context: ContextExpectation::Filesystem {
+                mount: "~/projects",
+            },
+        },
+        ReferenceBlueprint {
+            path: "blueprints/claude+mcp-generic+openshell.yaml",
+            agent_driver: "claude",
+            context_driver: "mcp-generic",
+            tier: "restricted",
+            persists_home: Some(true),
+            context: ContextExpectation::GenericMcp {
+                url: "https://93.184.216.34",
+                transport: "http+sse",
+            },
+        },
+        ReferenceBlueprint {
+            path: "blueprints/hermes+filesystem+openshell.yaml",
+            agent_driver: "hermes",
+            context_driver: "filesystem",
+            tier: "balanced",
+            persists_home: None,
+            context: ContextExpectation::Filesystem {
+                mount: "~/projects",
+            },
+        },
+        ReferenceBlueprint {
+            path: "blueprints/claude+nexus+openshell.yaml",
+            agent_driver: "claude",
+            context_driver: "nexus",
+            tier: "balanced",
+            persists_home: Some(true),
+            context: ContextExpectation::Nexus {
+                hub_url: "https://93.184.216.35",
+            },
+        },
+        ReferenceBlueprint {
+            path: "blueprints/codex+mcp-generic+openshell.yaml",
+            agent_driver: "codex",
+            context_driver: "mcp-generic",
+            tier: "restricted",
+            persists_home: None,
+            context: ContextExpectation::GenericMcp {
+                url: "https://93.184.216.34",
+                transport: "http+sse",
+            },
+        },
+        ReferenceBlueprint {
+            path: "blueprints/hermes+nexus+openshell.yaml",
+            agent_driver: "hermes",
+            context_driver: "nexus",
+            tier: "balanced",
+            persists_home: None,
+            context: ContextExpectation::Nexus {
+                hub_url: "https://93.184.216.35",
+            },
+        },
+        ReferenceBlueprint {
+            path: "blueprints/openclaw+nexus+openshell.yaml",
+            agent_driver: "openclaw",
+            context_driver: "nexus",
+            tier: "balanced",
+            persists_home: Some(true),
+            context: ContextExpectation::Nexus {
+                hub_url: "https://93.184.216.35",
+            },
+        },
+    ]
+}
+
 #[test]
 fn all_reference_blueprints_parse() {
     let _guard = env_lock().lock().unwrap();
@@ -20,37 +139,10 @@ fn all_reference_blueprints_parse() {
     std::env::set_var("MCP_URL", "https://93.184.216.34");
     std::env::set_var("NEXUS_HUB_URL", "https://93.184.216.35");
 
-    for (path, agent_driver, context_driver, tier, persists_home) in [
-        (
-            "blueprints/claude+filesystem+openshell.yaml",
-            "claude",
-            "filesystem",
-            "balanced",
-            Some(true),
-        ),
-        (
-            "blueprints/codex+mcp-generic+openshell.yaml",
-            "codex",
-            "mcp-generic",
-            "restricted",
-            None,
-        ),
-        (
-            "blueprints/hermes+nexus+openshell.yaml",
-            "hermes",
-            "nexus",
-            "balanced",
-            None,
-        ),
-        (
-            "blueprints/openclaw+nexus+openshell.yaml",
-            "openclaw",
-            "nexus",
-            "balanced",
-            Some(true),
-        ),
-    ] {
-        let doc = std::fs::read_to_string(workspace_path(path)).unwrap();
+    for expected in reference_blueprints() {
+        let path = expected.path;
+        let doc = std::fs::read_to_string(workspace_path(path))
+            .unwrap_or_else(|err| panic!("{path}: {err}"));
         let blueprint = Blueprint::from_yaml(&doc).unwrap();
 
         assert_eq!(blueprint.version, "0.1.0", "{path}");
@@ -60,9 +152,9 @@ fn all_reference_blueprints_parse() {
             "{path}"
         );
         assert_eq!(blueprint.sandbox.driver, "openshell", "{path}");
-        assert_eq!(blueprint.agent.driver, agent_driver, "{path}");
-        assert_eq!(blueprint.context.driver, context_driver, "{path}");
-        assert_eq!(blueprint.policy.tier, tier, "{path}");
+        assert_eq!(blueprint.agent.driver, expected.agent_driver, "{path}");
+        assert_eq!(blueprint.context.driver, expected.context_driver, "{path}");
+        assert_eq!(blueprint.policy.tier, expected.tier, "{path}");
         assert_eq!(
             blueprint
                 .inference
@@ -76,12 +168,14 @@ fn all_reference_blueprints_parse() {
                 .state
                 .as_ref()
                 .and_then(|state| state.persist_home),
-            persists_home,
+            expected.persists_home,
             "{path}"
         );
 
-        match context_driver {
-            "filesystem" => {
+        match expected.context {
+            ContextExpectation::Filesystem {
+                mount: expected_mount,
+            } => {
                 let mount = blueprint
                     .context
                     .extra
@@ -89,16 +183,21 @@ fn all_reference_blueprints_parse() {
                     .unwrap()
                     .as_str()
                     .unwrap();
-                assert_eq!(mount, "~/projects", "{path}");
+                assert_eq!(mount, expected_mount, "{path}");
             }
-            "mcp-generic" => {
+            ContextExpectation::GenericMcp {
+                url: expected_url,
+                transport: expected_transport,
+            } => {
                 let endpoint = blueprint.context.extra.get("endpoint").unwrap();
                 let url = yaml_string_field(endpoint, "url");
                 let transport = yaml_string_field(endpoint, "transport");
-                assert_eq!(url, "https://93.184.216.34", "{path}");
-                assert_eq!(transport, "http+sse", "{path}");
+                assert_eq!(url, expected_url, "{path}");
+                assert_eq!(transport, expected_transport, "{path}");
             }
-            "nexus" => {
+            ContextExpectation::Nexus {
+                hub_url: expected_hub_url,
+            } => {
                 assert_eq!(
                     blueprint
                         .context
@@ -118,11 +217,10 @@ fn all_reference_blueprints_parse() {
                         .unwrap()
                         .as_str()
                         .unwrap(),
-                    "https://93.184.216.35",
+                    expected_hub_url,
                     "{path}"
                 );
             }
-            _ => unreachable!(),
         }
     }
 }

--- a/crates/agentenv-core/tests/reference_blueprints.rs
+++ b/crates/agentenv-core/tests/reference_blueprints.rs
@@ -146,6 +146,7 @@ fn all_reference_blueprints_parse() {
         let doc = std::fs::read_to_string(workspace_path(path))
             .unwrap_or_else(|err| panic!("{path}: {err}"));
         let blueprint = Blueprint::from_yaml(&doc).unwrap();
+        verify_blueprint_yaml(&doc).unwrap_or_else(|err| panic!("{path}: {err}"));
 
         assert_eq!(blueprint.version, "0.1.0", "{path}");
         assert_eq!(

--- a/crates/agentenv-plugin/src/jsonrpc.rs
+++ b/crates/agentenv-plugin/src/jsonrpc.rs
@@ -1462,18 +1462,28 @@ mod async_client_tests {
     use std::os::unix::fs::PermissionsExt;
     use std::path::{Path, PathBuf};
     use std::sync::atomic::{AtomicU64, Ordering};
-    use std::sync::Arc;
+    use std::sync::{Arc, OnceLock};
     use std::time::Duration;
     use std::time::{SystemTime, UNIX_EPOCH};
 
     use serde_json::json;
+    use tokio::sync::{Mutex, MutexGuard};
 
     use super::{JsonRpcClient, JsonRpcClientConfig};
 
     static FIXTURE_COUNTER: AtomicU64 = AtomicU64::new(0);
+    static FIXTURE_TEST_LOCK: OnceLock<Mutex<()>> = OnceLock::new();
+
+    async fn fixture_test_guard() -> MutexGuard<'static, ()> {
+        FIXTURE_TEST_LOCK
+            .get_or_init(|| Mutex::new(()))
+            .lock()
+            .await
+    }
 
     #[tokio::test]
     async fn jsonrpc_client_returns_method_result() {
+        let _guard = fixture_test_guard().await;
         let mut client = spawn_fixture_client("normal", Duration::from_secs(5), &[]).await;
 
         let result: agentenv_proto::PreflightResult = client
@@ -1487,6 +1497,7 @@ mod async_client_tests {
 
     #[tokio::test]
     async fn jsonrpc_client_surfaces_driver_error_code() {
+        let _guard = fixture_test_guard().await;
         let mut client = spawn_fixture_client("normal", Duration::from_secs(5), &[]).await;
 
         let err = client
@@ -1500,6 +1511,7 @@ mod async_client_tests {
 
     #[tokio::test]
     async fn jsonrpc_client_drops_child_process_on_drop() {
+        let _guard = fixture_test_guard().await;
         let pid_file = temp_fixture_path("drop");
         let client = spawn_fixture_client(
             "idle",
@@ -1520,6 +1532,7 @@ mod async_client_tests {
 
     #[tokio::test]
     async fn jsonrpc_client_poisons_after_request_timeout() {
+        let _guard = fixture_test_guard().await;
         let client = spawn_fixture_client("slow_preflight", Duration::from_millis(100), &[]).await;
 
         let err = client
@@ -1545,6 +1558,7 @@ mod async_client_tests {
 
     #[tokio::test]
     async fn jsonrpc_client_shutdown_timeout_kills_and_reaps_child() {
+        let _guard = fixture_test_guard().await;
         let pid_file = temp_fixture_path("shutdown-timeout");
         let mut client = spawn_fixture_client(
             "shutdown_hang",
@@ -1565,6 +1579,7 @@ mod async_client_tests {
 
     #[tokio::test]
     async fn jsonrpc_client_shutdown_reports_nonzero_exit_status() {
+        let _guard = fixture_test_guard().await;
         let mut client =
             spawn_fixture_client("shutdown_nonzero", Duration::from_secs(5), &[]).await;
         let err = client.shutdown().await.unwrap_err();
@@ -1574,6 +1589,7 @@ mod async_client_tests {
 
     #[tokio::test]
     async fn jsonrpc_client_shutdown_reaps_child_on_shutdown_rpc_failure() {
+        let _guard = fixture_test_guard().await;
         let pid_file = temp_fixture_path("shutdown-rpc-failure");
         let mut client = spawn_fixture_client(
             "shutdown_invalid_then_hang",
@@ -1608,6 +1624,7 @@ mod async_client_tests {
 
     #[tokio::test]
     async fn jsonrpc_client_serializes_concurrent_calls() {
+        let _guard = fixture_test_guard().await;
         let driver = write_racy_driver_script();
 
         let client = Arc::new(
@@ -1652,6 +1669,7 @@ mod async_client_tests {
 
     #[tokio::test]
     async fn jsonrpc_client_emits_notification_seen_before_response() {
+        let _guard = fixture_test_guard().await;
         let mut client =
             spawn_fixture_client("notification_before_preflight", Duration::from_secs(5), &[])
                 .await;
@@ -1674,6 +1692,7 @@ mod async_client_tests {
 
     #[tokio::test]
     async fn approval_requested_notification_waits_and_sends_decision() {
+        let _guard = fixture_test_guard().await;
         let store_path = temp_fixture_artifact_path("approvals", "db");
         let store = agentenv_approvals::ApprovalStore::open(&store_path).unwrap();
         let emitter = agentenv_events::RecordingEventEmitter::default();
@@ -1745,6 +1764,7 @@ mod async_client_tests {
 
     #[tokio::test]
     async fn approval_decision_round_trips_same_request_id_before_original_response() {
+        let _guard = fixture_test_guard().await;
         let store_path = temp_fixture_artifact_path("approvals-dynamic-request-id", "db");
         let store = agentenv_approvals::ApprovalStore::open(&store_path).unwrap();
         let coordinator = agentenv_approvals::ApprovalCoordinator::new(
@@ -1811,6 +1831,7 @@ mod async_client_tests {
 
     #[tokio::test]
     async fn approval_requested_notification_auto_denies_before_client_timeout() {
+        let _guard = fixture_test_guard().await;
         let store_path = temp_fixture_artifact_path("approvals-auto-deny", "db");
         let store = agentenv_approvals::ApprovalStore::open(&store_path).unwrap();
         let coordinator = agentenv_approvals::ApprovalCoordinator::new(
@@ -1826,7 +1847,7 @@ mod async_client_tests {
         let decision_file = temp_fixture_path("approval-auto-deny");
         let mut client = spawn_fixture_client(
             "approval_before_preflight",
-            Duration::from_secs(2),
+            Duration::from_secs(3),
             &[(
                 "JSONRPC_FIXTURE_DECISION_FILE",
                 decision_file.to_string_lossy().as_ref(),
@@ -1856,6 +1877,7 @@ mod async_client_tests {
 
     #[tokio::test]
     async fn delayed_approval_requested_notification_auto_denies_before_client_timeout() {
+        let _guard = fixture_test_guard().await;
         let store_path = temp_fixture_artifact_path("approvals-delayed-auto-deny", "db");
         let store = agentenv_approvals::ApprovalStore::open(&store_path).unwrap();
         let coordinator = agentenv_approvals::ApprovalCoordinator::new(
@@ -1871,7 +1893,7 @@ mod async_client_tests {
         let decision_file = temp_fixture_path("approval-delayed-auto-deny");
         let mut client = spawn_fixture_client(
             "delayed_approval_before_preflight",
-            Duration::from_secs(2),
+            Duration::from_secs(3),
             &[(
                 "JSONRPC_FIXTURE_DECISION_FILE",
                 decision_file.to_string_lossy().as_ref(),

--- a/docs/BLUEPRINTS.md
+++ b/docs/BLUEPRINTS.md
@@ -45,10 +45,12 @@ Required environment:
 Usage:
 
 ```sh
-export MCP_URL=https://mcp.internal.company.com
+export MCP_URL=https://example.com/mcp
 export MCP_TOKEN=mcp-token-example
 agentenv create docs --blueprint blueprints/codex+mcp-generic+openshell.yaml
 ```
+
+Note: the templates collect `MCP_TOKEN` as a credential reference, but the current generic MCP driver does not attach it to endpoint headers yet. Use endpoints that do not require header auth, or add driver support before relying on token auth.
 
 Trade-off: the `restricted` policy keeps egress narrow and allows only the configured MCP endpoint by default.
 
@@ -80,7 +82,7 @@ Required environment:
 Usage:
 
 ```sh
-export NEXUS_HUB_URL=https://nexus.company.com
+export NEXUS_HUB_URL=https://example.com/nexus
 export NEXUS_TOKEN=nexus-token-example
 agentenv create enterprise --blueprint blueprints/claude+nexus+openshell.yaml
 ```

--- a/docs/BLUEPRINTS.md
+++ b/docs/BLUEPRINTS.md
@@ -1,0 +1,94 @@
+# Reference Blueprints
+
+Reference blueprints are checked-in `agentenv.yaml` compositions that double as starter templates. Each file is runnable as-is after its listed credentials, URLs, and external drivers are available.
+
+| Blueprint | Audience | Context | Policy | Pick it when |
+|---|---|---|---|---|
+| `claude+filesystem+openshell.yaml` | Getting started | Local filesystem | `balanced` | You want Claude Code over local projects. |
+| `codex+filesystem+openshell.yaml` | Getting started | Local filesystem | `balanced` | You want Codex over local projects. |
+| `openclaw+filesystem+openshell.yaml` | Getting started | Local filesystem | `balanced` | You want an OpenClaw assistant with persistent home state. |
+| `claude+mcp-generic+openshell.yaml` | Integrators | Generic MCP endpoint | `restricted` | You have an MCP service and want Claude as the agent. |
+| `hermes+filesystem+openshell.yaml` | Polyglot demos | Local filesystem | `balanced` | You want to exercise an external Hermes agent driver. |
+| `claude+nexus+openshell.yaml` | Enterprise reference | Nexus hub | `balanced` | You use Claude with shared company context. |
+| `codex+mcp-generic+openshell.yaml` | Integrators | Generic MCP endpoint | `restricted` | You have an MCP service and want Codex as the agent. |
+| `hermes+nexus+openshell.yaml` | Polyglot enterprise demos | Nexus hub | `balanced` | You want Hermes through subprocess drivers with Nexus context. |
+| `openclaw+nexus+openshell.yaml` | Enterprise reference | Nexus hub | `balanced` | You want OpenClaw with shared company context. |
+
+## Getting-Started Filesystem Blueprints
+
+`claude+filesystem+openshell.yaml`, `codex+filesystem+openshell.yaml`, and `openclaw+filesystem+openshell.yaml` mount `~/projects` through the filesystem context driver and expose it over MCP inside OpenShell. They are the lowest-friction templates because they do not require remote context infrastructure.
+
+Required credentials:
+
+- Claude: `ANTHROPIC_API_KEY`
+- Codex and OpenClaw: `OPENAI_API_KEY`
+
+Usage:
+
+```sh
+agentenv create myapp --blueprint blueprints/claude+filesystem+openshell.yaml
+agentenv enter myapp
+```
+
+Trade-off: `balanced` policy includes common package and GitHub read presets, so these are better for local development than for tightly regulated data.
+
+## Generic MCP Blueprints
+
+`claude+mcp-generic+openshell.yaml` and `codex+mcp-generic+openshell.yaml` connect agents to any MCP-compatible HTTP+SSE endpoint.
+
+Required environment:
+
+- `MCP_URL`
+- `MCP_TOKEN`
+- agent API key for the selected agent
+
+Usage:
+
+```sh
+export MCP_URL=https://mcp.internal.company.com
+export MCP_TOKEN=mcp-token-example
+agentenv create docs --blueprint blueprints/codex+mcp-generic+openshell.yaml
+```
+
+Trade-off: the `restricted` policy keeps egress narrow and allows only the configured MCP endpoint by default.
+
+## Hermes Blueprints
+
+`hermes+filesystem+openshell.yaml` and `hermes+nexus+openshell.yaml` use the external Hermes subprocess agent driver. Confirm it is installed before creating the env:
+
+```sh
+agentenv drivers list
+```
+
+Required environment:
+
+- `OPENAI_API_KEY`
+- `NEXUS_HUB_URL` and `NEXUS_TOKEN` for the Nexus variant
+
+Trade-off: these blueprints demonstrate third-party driver composition, so they depend on driver installation in addition to normal credentials.
+
+## Nexus Blueprints
+
+`claude+nexus+openshell.yaml`, `hermes+nexus+openshell.yaml`, and `openclaw+nexus+openshell.yaml` connect to a shared Nexus hub.
+
+Required environment:
+
+- `NEXUS_HUB_URL`
+- `NEXUS_TOKEN`
+- agent API key for the selected agent
+
+Usage:
+
+```sh
+export NEXUS_HUB_URL=https://nexus.company.com
+export NEXUS_TOKEN=nexus-token-example
+agentenv create enterprise --blueprint blueprints/claude+nexus+openshell.yaml
+```
+
+Trade-off: Nexus blueprints are the best fit for shared enterprise context, but they require a reachable hub and installed Nexus context driver.
+
+## Sample Projects
+
+- `examples/quickstart/` shows the smallest local project flow.
+- `examples/enterprise-hub/` shows a Nexus hub template with company CA and internal base-image conventions.
+- `examples/headless-ci/` shows a non-interactive CI template for automated code maintenance.

--- a/docs/superpowers/plans/2026-05-02-m5-4-reference-blueprints.md
+++ b/docs/superpowers/plans/2026-05-02-m5-4-reference-blueprints.md
@@ -1,0 +1,1469 @@
+# M5-4 Reference Blueprints Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Expand agentenv's reference blueprints into a documented nine-blueprint starter set with sample projects and an optional live integration harness.
+
+**Architecture:** Keep fast YAML parse, validate, and resolve checks in `agentenv-core` so normal test runs stay deterministic. Add human-facing docs and examples beside the blueprint files, then place live `create -> exec -> destroy` validation in a dedicated `tests/blueprint-integration/` workspace crate gated by an `integration` feature and explicit ignored tests.
+
+**Tech Stack:** Rust 2021, Cargo workspace integration tests, `serde_yaml`, `serde_json`, `uuid`, existing `agentenv` CLI, existing `agentenv-core` blueprint parser and lifecycle verification, YAML reference files.
+
+---
+
+## File Structure
+
+Create:
+
+- `blueprints/codex+filesystem+openshell.yaml`: getting-started Codex blueprint with local filesystem context.
+- `blueprints/openclaw+filesystem+openshell.yaml`: getting-started OpenClaw blueprint with local filesystem context.
+- `blueprints/claude+mcp-generic+openshell.yaml`: Claude blueprint for arbitrary MCP endpoints.
+- `blueprints/hermes+filesystem+openshell.yaml`: Hermes subprocess-agent blueprint with local filesystem context.
+- `blueprints/claude+nexus+openshell.yaml`: Claude enterprise blueprint for Nexus hub context.
+- `docs/BLUEPRINTS.md`: catalog of all nine blueprints, prerequisites, trade-offs, and usage.
+- `examples/quickstart/agentenv.yaml`: minimal quickstart project blueprint.
+- `examples/quickstart/README.md`: quickstart lifecycle walkthrough.
+- `examples/enterprise-hub/agentenv.yaml`: Nexus hub template.
+- `examples/enterprise-hub/Dockerfile`: company base-image example used by the README.
+- `examples/enterprise-hub/certs/company-ca.pem`: non-secret example CA certificate text.
+- `examples/enterprise-hub/README.md`: enterprise hub setup and lifecycle walkthrough.
+- `examples/headless-ci/agentenv.yaml`: non-interactive CI template.
+- `examples/headless-ci/README.md`: headless CI workflow.
+- `tests/blueprint-integration/Cargo.toml`: dedicated integration test package.
+- `tests/blueprint-integration/tests/reference_blueprints.rs`: live blueprint harness.
+
+Modify:
+
+- `Cargo.toml`: add `tests/blueprint-integration` as a workspace member.
+- `crates/agentenv-core/tests/reference_blueprints.rs`: expand fast reference blueprint coverage and add docs/example coverage.
+
+Test:
+
+- `crates/agentenv-core/tests/reference_blueprints.rs`: default fast checks for all blueprints, docs catalog entries, and sample project blueprint parsing.
+- `tests/blueprint-integration/tests/reference_blueprints.rs`: ignored live checks for create, exec, and destroy when driver prerequisites exist.
+
+---
+
+### Task 1: Fast Coverage For All Nine Reference Blueprints
+
+**Files:**
+- Modify: `crates/agentenv-core/tests/reference_blueprints.rs`
+
+- [ ] **Step 1: Write the failing all-blueprints test**
+
+In `crates/agentenv-core/tests/reference_blueprints.rs`, add these definitions after `workspace_path`:
+
+```rust
+struct ReferenceBlueprint {
+    path: &'static str,
+    agent_driver: &'static str,
+    context_driver: &'static str,
+    tier: &'static str,
+    persists_home: Option<bool>,
+    context: ContextExpectation,
+}
+
+enum ContextExpectation {
+    Filesystem { mount: &'static str },
+    GenericMcp {
+        url: &'static str,
+        transport: &'static str,
+    },
+    Nexus { hub_url: &'static str },
+}
+
+fn reference_blueprints() -> Vec<ReferenceBlueprint> {
+    vec![
+        ReferenceBlueprint {
+            path: "blueprints/claude+filesystem+openshell.yaml",
+            agent_driver: "claude",
+            context_driver: "filesystem",
+            tier: "balanced",
+            persists_home: Some(true),
+            context: ContextExpectation::Filesystem {
+                mount: "~/projects",
+            },
+        },
+        ReferenceBlueprint {
+            path: "blueprints/codex+filesystem+openshell.yaml",
+            agent_driver: "codex",
+            context_driver: "filesystem",
+            tier: "balanced",
+            persists_home: Some(true),
+            context: ContextExpectation::Filesystem {
+                mount: "~/projects",
+            },
+        },
+        ReferenceBlueprint {
+            path: "blueprints/openclaw+filesystem+openshell.yaml",
+            agent_driver: "openclaw",
+            context_driver: "filesystem",
+            tier: "balanced",
+            persists_home: Some(true),
+            context: ContextExpectation::Filesystem {
+                mount: "~/projects",
+            },
+        },
+        ReferenceBlueprint {
+            path: "blueprints/claude+mcp-generic+openshell.yaml",
+            agent_driver: "claude",
+            context_driver: "mcp-generic",
+            tier: "restricted",
+            persists_home: Some(true),
+            context: ContextExpectation::GenericMcp {
+                url: "https://93.184.216.34",
+                transport: "http+sse",
+            },
+        },
+        ReferenceBlueprint {
+            path: "blueprints/hermes+filesystem+openshell.yaml",
+            agent_driver: "hermes",
+            context_driver: "filesystem",
+            tier: "balanced",
+            persists_home: None,
+            context: ContextExpectation::Filesystem {
+                mount: "~/projects",
+            },
+        },
+        ReferenceBlueprint {
+            path: "blueprints/claude+nexus+openshell.yaml",
+            agent_driver: "claude",
+            context_driver: "nexus",
+            tier: "balanced",
+            persists_home: Some(true),
+            context: ContextExpectation::Nexus {
+                hub_url: "https://93.184.216.35",
+            },
+        },
+        ReferenceBlueprint {
+            path: "blueprints/codex+mcp-generic+openshell.yaml",
+            agent_driver: "codex",
+            context_driver: "mcp-generic",
+            tier: "restricted",
+            persists_home: None,
+            context: ContextExpectation::GenericMcp {
+                url: "https://93.184.216.34",
+                transport: "http+sse",
+            },
+        },
+        ReferenceBlueprint {
+            path: "blueprints/hermes+nexus+openshell.yaml",
+            agent_driver: "hermes",
+            context_driver: "nexus",
+            tier: "balanced",
+            persists_home: None,
+            context: ContextExpectation::Nexus {
+                hub_url: "https://93.184.216.35",
+            },
+        },
+        ReferenceBlueprint {
+            path: "blueprints/openclaw+nexus+openshell.yaml",
+            agent_driver: "openclaw",
+            context_driver: "nexus",
+            tier: "balanced",
+            persists_home: Some(true),
+            context: ContextExpectation::Nexus {
+                hub_url: "https://93.184.216.35",
+            },
+        },
+    ]
+}
+```
+
+Replace `all_reference_blueprints_parse` with:
+
+```rust
+#[test]
+fn all_reference_blueprints_parse() {
+    let _guard = env_lock().lock().unwrap();
+
+    std::env::set_var("MCP_URL", "https://93.184.216.34");
+    std::env::set_var("NEXUS_HUB_URL", "https://93.184.216.35");
+
+    for case in reference_blueprints() {
+        let doc = std::fs::read_to_string(workspace_path(case.path)).unwrap();
+        let blueprint = Blueprint::from_yaml(&doc).unwrap();
+
+        assert_eq!(blueprint.version, "0.1.0", "{}", case.path);
+        assert_eq!(
+            blueprint.min_agentenv_version,
+            env!("CARGO_PKG_VERSION"),
+            "{}",
+            case.path
+        );
+        assert_eq!(blueprint.sandbox.driver, "openshell", "{}", case.path);
+        assert_eq!(blueprint.agent.driver, case.agent_driver, "{}", case.path);
+        assert_eq!(
+            blueprint.context.driver, case.context_driver,
+            "{}",
+            case.path
+        );
+        assert_eq!(blueprint.policy.tier, case.tier, "{}", case.path);
+        assert_eq!(
+            blueprint
+                .inference
+                .as_ref()
+                .map(|section| section.driver.as_str()),
+            Some("passthrough"),
+            "{}",
+            case.path
+        );
+        assert_eq!(
+            blueprint
+                .state
+                .as_ref()
+                .and_then(|state| state.persist_home),
+            case.persists_home,
+            "{}",
+            case.path
+        );
+
+        match case.context {
+            ContextExpectation::Filesystem { mount } => {
+                assert_eq!(
+                    blueprint
+                        .context
+                        .extra
+                        .get("mount")
+                        .unwrap()
+                        .as_str()
+                        .unwrap(),
+                    mount,
+                    "{}",
+                    case.path
+                );
+            }
+            ContextExpectation::GenericMcp { url, transport } => {
+                let endpoint = blueprint.context.extra.get("endpoint").unwrap();
+                assert_eq!(yaml_string_field(endpoint, "url"), url, "{}", case.path);
+                assert_eq!(
+                    yaml_string_field(endpoint, "transport"),
+                    transport,
+                    "{}",
+                    case.path
+                );
+            }
+            ContextExpectation::Nexus { hub_url } => {
+                assert_eq!(
+                    blueprint
+                        .context
+                        .extra
+                        .get("mode")
+                        .unwrap()
+                        .as_str()
+                        .unwrap(),
+                    "hub",
+                    "{}",
+                    case.path
+                );
+                assert_eq!(
+                    blueprint
+                        .context
+                        .extra
+                        .get("hub_url")
+                        .unwrap()
+                        .as_str()
+                        .unwrap(),
+                    hub_url,
+                    "{}",
+                    case.path
+                );
+            }
+        }
+    }
+}
+```
+
+- [ ] **Step 2: Run the test to verify RED**
+
+Run:
+
+```sh
+cargo test -p agentenv-core --test reference_blueprints all_reference_blueprints_parse
+```
+
+Expected: FAIL because at least `blueprints/codex+filesystem+openshell.yaml` does not exist.
+
+- [ ] **Step 3: Commit the failing test**
+
+```bash
+git add crates/agentenv-core/tests/reference_blueprints.rs
+git commit -m "test: cover full reference blueprint set"
+```
+
+---
+
+### Task 2: Add Missing Reference Blueprints
+
+**Files:**
+- Create: `blueprints/codex+filesystem+openshell.yaml`
+- Create: `blueprints/openclaw+filesystem+openshell.yaml`
+- Create: `blueprints/claude+mcp-generic+openshell.yaml`
+- Create: `blueprints/hermes+filesystem+openshell.yaml`
+- Create: `blueprints/claude+nexus+openshell.yaml`
+
+- [ ] **Step 1: Add `codex+filesystem+openshell.yaml`**
+
+Create `blueprints/codex+filesystem+openshell.yaml`:
+
+```yaml
+# Reference blueprint - OpenAI Codex in OpenShell with a local filesystem context.
+# Good for: getting started with Codex against a local project tree.
+#
+# Prerequisites:
+#   export OPENAI_API_KEY=sk-openai-example
+#
+# Usage:
+#   agentenv create myapp --blueprint blueprints/codex+filesystem+openshell.yaml
+#   agentenv enter myapp
+
+version: 0.1.0
+min_agentenv_version: 0.0.1-alpha0
+
+sandbox:
+  driver: openshell
+  version: ">=0.0.1-alpha0,<0.1"
+
+agent:
+  driver: codex
+  credentials:
+    OPENAI_API_KEY:
+      source: env
+      required: true
+
+context:
+  driver: filesystem
+  mount: ~/projects
+
+inference:
+  driver: passthrough
+
+policy:
+  tier: balanced
+  presets:
+    - github_read
+    - npm_read
+
+state:
+  persist_home: true
+```
+
+- [ ] **Step 2: Add `openclaw+filesystem+openshell.yaml`**
+
+Create `blueprints/openclaw+filesystem+openshell.yaml`:
+
+```yaml
+# Reference blueprint - OpenClaw in OpenShell with a local filesystem context.
+# Good for: getting started with an always-on OpenClaw assistant over local code.
+#
+# Prerequisites:
+#   export OPENAI_API_KEY=sk-openai-example
+#
+# Usage:
+#   agentenv create assistant --blueprint blueprints/openclaw+filesystem+openshell.yaml
+#   agentenv enter assistant
+
+version: 0.1.0
+min_agentenv_version: 0.0.1-alpha0
+
+sandbox:
+  driver: openshell
+  version: ">=0.0.1-alpha0,<0.1"
+
+agent:
+  driver: openclaw
+  config:
+    provider: openai
+  credentials:
+    OPENAI_API_KEY:
+      source: env
+      required: true
+
+context:
+  driver: filesystem
+  mount: ~/projects
+
+inference:
+  driver: passthrough
+
+policy:
+  tier: balanced
+  presets:
+    - github_read
+    - npm_read
+
+state:
+  persist_home: true
+```
+
+- [ ] **Step 3: Add `claude+mcp-generic+openshell.yaml`**
+
+Create `blueprints/claude+mcp-generic+openshell.yaml`:
+
+```yaml
+# Reference blueprint - Claude Code in OpenShell with a generic MCP context server.
+# Good for: connecting Claude to any MCP-compatible knowledge service.
+#
+# Prerequisites:
+#   export ANTHROPIC_API_KEY=sk-ant-example
+#   export MCP_URL=https://mcp.internal.company.com
+#   export MCP_TOKEN=mcp-token-example
+#
+# Usage:
+#   agentenv create docs --blueprint blueprints/claude+mcp-generic+openshell.yaml
+#   agentenv enter docs
+
+version: 0.1.0
+min_agentenv_version: 0.0.1-alpha0
+
+sandbox:
+  driver: openshell
+  version: ">=0.0.1-alpha0,<0.1"
+
+agent:
+  driver: claude
+  credentials:
+    ANTHROPIC_API_KEY:
+      source: env
+      required: true
+
+context:
+  driver: mcp-generic
+  endpoint:
+    url: ${MCP_URL}
+    transport: http+sse
+  credentials:
+    MCP_TOKEN:
+      source: env
+      required: true
+
+inference:
+  driver: passthrough
+
+policy:
+  tier: restricted
+  presets: []
+  overrides:
+    - allow: "${MCP_URL}"
+
+state:
+  persist_home: true
+```
+
+- [ ] **Step 4: Add `hermes+filesystem+openshell.yaml`**
+
+Create `blueprints/hermes+filesystem+openshell.yaml`:
+
+```yaml
+# Reference blueprint - Hermes subprocess agent in OpenShell with a local filesystem context.
+# Good for: demonstrating an external polyglot agent driver against local code.
+#
+# Prerequisites:
+#   export OPENAI_API_KEY=sk-openai-example
+#   agentenv drivers list   # confirm the hermes agent driver is installed
+#
+# Usage:
+#   agentenv create research --blueprint blueprints/hermes+filesystem+openshell.yaml
+#   agentenv enter research
+
+version: 0.1.0
+min_agentenv_version: 0.0.1-alpha0
+
+sandbox:
+  driver: openshell
+  version: ">=0.0.1-alpha0,<0.1"
+
+agent:
+  driver: hermes
+  credentials:
+    OPENAI_API_KEY:
+      source: env
+      required: true
+
+context:
+  driver: filesystem
+  mount: ~/projects
+
+inference:
+  driver: passthrough
+
+policy:
+  tier: balanced
+  presets:
+    - github_read
+```
+
+- [ ] **Step 5: Add `claude+nexus+openshell.yaml`**
+
+Create `blueprints/claude+nexus+openshell.yaml`:
+
+```yaml
+# Reference blueprint - Claude Code in OpenShell with a shared Nexus hub.
+# Good for: enterprise teams using Claude with shared company context.
+#
+# Prerequisites:
+#   export ANTHROPIC_API_KEY=sk-ant-example
+#   export NEXUS_HUB_URL=https://nexus.company.com
+#   export NEXUS_TOKEN=nexus-token-example
+#   agentenv drivers list   # confirm the nexus context driver is installed
+#
+# Usage:
+#   agentenv create enterprise --blueprint blueprints/claude+nexus+openshell.yaml
+#   agentenv enter enterprise
+
+version: 0.1.0
+min_agentenv_version: 0.0.1-alpha0
+
+sandbox:
+  driver: openshell
+  version: ">=0.0.1-alpha0,<0.1"
+
+agent:
+  driver: claude
+  credentials:
+    ANTHROPIC_API_KEY:
+      source: env
+      required: true
+
+context:
+  driver: nexus
+  mode: hub
+  hub_url: ${NEXUS_HUB_URL}
+  credentials:
+    NEXUS_TOKEN:
+      source: env
+      required: true
+
+inference:
+  driver: passthrough
+
+policy:
+  tier: balanced
+  presets:
+    - github_read
+    - npm_read
+  overrides:
+    - allow: "${NEXUS_HUB_URL}"
+
+state:
+  persist_home: true
+```
+
+- [ ] **Step 6: Normalize existing reference blueprint headers**
+
+Replace only the leading comment block in `blueprints/claude+filesystem+openshell.yaml` with:
+
+```yaml
+# Reference blueprint - Claude Code in OpenShell with a local filesystem context.
+# Good for: getting started with Claude against a local project tree.
+#
+# Prerequisites:
+#   export ANTHROPIC_API_KEY=sk-ant-example
+#
+# Usage:
+#   agentenv create myapp --blueprint blueprints/claude+filesystem+openshell.yaml
+#   agentenv enter myapp
+```
+
+Replace only the leading comment block in `blueprints/codex+mcp-generic+openshell.yaml` with:
+
+```yaml
+# Reference blueprint - OpenAI Codex in OpenShell with a generic MCP context server.
+# Good for: connecting Codex to any MCP-compatible knowledge service.
+#
+# Prerequisites:
+#   export OPENAI_API_KEY=sk-openai-example
+#   export MCP_URL=https://mcp.internal.company.com
+#   export MCP_TOKEN=mcp-token-example
+#
+# Usage:
+#   agentenv create legal --blueprint blueprints/codex+mcp-generic+openshell.yaml
+#   agentenv enter legal
+```
+
+Replace only the leading comment block in `blueprints/hermes+nexus+openshell.yaml` with:
+
+```yaml
+# Reference blueprint - Hermes subprocess agent in OpenShell with a shared Nexus hub.
+# Good for: demonstrating external Hermes and Nexus subprocess drivers together.
+#
+# Prerequisites:
+#   export OPENAI_API_KEY=sk-openai-example
+#   export NEXUS_HUB_URL=https://nexus.company.com
+#   export NEXUS_TOKEN=nexus-token-example
+#   agentenv drivers list   # confirm hermes and nexus drivers are installed
+#
+# Usage:
+#   agentenv create research --blueprint blueprints/hermes+nexus+openshell.yaml
+#   agentenv enter research
+#   agentenv destroy research --yes
+```
+
+Replace only the leading comment block in `blueprints/openclaw+nexus+openshell.yaml` with:
+
+```yaml
+# Reference blueprint - OpenClaw in OpenShell with a shared Nexus hub.
+# Good for: enterprise teams using OpenClaw with shared company context.
+#
+# Prerequisites:
+#   export OPENAI_API_KEY=sk-openai-example
+#   export NEXUS_HUB_URL=https://nexus.company.com
+#   export NEXUS_TOKEN=nexus-token-example
+#   agentenv drivers list   # confirm the nexus context driver is installed
+#
+# Usage:
+#   agentenv create assistant --blueprint blueprints/openclaw+nexus+openshell.yaml
+#   agentenv enter assistant
+```
+
+- [ ] **Step 7: Run the all-blueprints test to verify GREEN**
+
+Run:
+
+```sh
+cargo test -p agentenv-core --test reference_blueprints all_reference_blueprints_parse
+```
+
+Expected: PASS.
+
+- [ ] **Step 8: Commit the new blueprints**
+
+```bash
+git add blueprints crates/agentenv-core/tests/reference_blueprints.rs
+git commit -m "feat: add reference blueprint set"
+```
+
+---
+
+### Task 3: Fast Coverage For Blueprint Docs And Sample Projects
+
+**Files:**
+- Modify: `crates/agentenv-core/tests/reference_blueprints.rs`
+
+- [ ] **Step 1: Write failing docs and examples tests**
+
+Add these tests above `interpolation_resolves_env_variable`:
+
+```rust
+#[test]
+fn docs_catalog_mentions_every_reference_blueprint() {
+    let docs = std::fs::read_to_string(workspace_path("docs/BLUEPRINTS.md")).unwrap();
+
+    for case in reference_blueprints() {
+        let file_name = case.path.strip_prefix("blueprints/").unwrap();
+        assert!(
+            docs.contains(file_name),
+            "docs/BLUEPRINTS.md must mention {file_name}"
+        );
+    }
+}
+
+#[test]
+fn sample_project_blueprints_parse() {
+    let _guard = env_lock().lock().unwrap();
+
+    std::env::set_var("NEXUS_HUB_URL", "https://93.184.216.35");
+
+    for path in [
+        "examples/quickstart/agentenv.yaml",
+        "examples/enterprise-hub/agentenv.yaml",
+        "examples/headless-ci/agentenv.yaml",
+    ] {
+        let doc = std::fs::read_to_string(workspace_path(path)).unwrap();
+        let blueprint = Blueprint::from_yaml(&doc).unwrap();
+
+        assert_eq!(blueprint.version, "0.1.0", "{path}");
+        assert_eq!(blueprint.sandbox.driver, "openshell", "{path}");
+        assert_eq!(
+            blueprint
+                .inference
+                .as_ref()
+                .map(|section| section.driver.as_str()),
+            Some("passthrough"),
+            "{path}"
+        );
+    }
+}
+```
+
+- [ ] **Step 2: Run the focused tests to verify RED**
+
+Run:
+
+```sh
+cargo test -p agentenv-core --test reference_blueprints
+```
+
+Expected: FAIL because `docs/BLUEPRINTS.md` and `examples/` do not exist. The earlier blueprint tests should still pass.
+
+- [ ] **Step 3: Commit the failing docs/examples tests**
+
+```bash
+git add crates/agentenv-core/tests/reference_blueprints.rs
+git commit -m "test: require blueprint docs and examples"
+```
+
+---
+
+### Task 4: Add Blueprint Catalog And Sample Projects
+
+**Files:**
+- Create: `docs/BLUEPRINTS.md`
+- Create: `examples/quickstart/agentenv.yaml`
+- Create: `examples/quickstart/README.md`
+- Create: `examples/enterprise-hub/agentenv.yaml`
+- Create: `examples/enterprise-hub/Dockerfile`
+- Create: `examples/enterprise-hub/certs/company-ca.pem`
+- Create: `examples/enterprise-hub/README.md`
+- Create: `examples/headless-ci/agentenv.yaml`
+- Create: `examples/headless-ci/README.md`
+
+- [ ] **Step 1: Add the catalog document**
+
+Create `docs/BLUEPRINTS.md`:
+
+```markdown
+# Reference Blueprints
+
+Reference blueprints are checked-in `agentenv.yaml` compositions that double as starter templates. Each file is runnable as-is after its listed credentials, URLs, and external drivers are available.
+
+| Blueprint | Audience | Context | Policy | Pick it when |
+|---|---|---|---|---|
+| `claude+filesystem+openshell.yaml` | Getting started | Local filesystem | `balanced` | You want Claude Code over local projects. |
+| `codex+filesystem+openshell.yaml` | Getting started | Local filesystem | `balanced` | You want Codex over local projects. |
+| `openclaw+filesystem+openshell.yaml` | Getting started | Local filesystem | `balanced` | You want an OpenClaw assistant with persistent home state. |
+| `claude+mcp-generic+openshell.yaml` | Integrators | Generic MCP endpoint | `restricted` | You have an MCP service and want Claude as the agent. |
+| `hermes+filesystem+openshell.yaml` | Polyglot demos | Local filesystem | `balanced` | You want to exercise an external Hermes agent driver. |
+| `claude+nexus+openshell.yaml` | Enterprise reference | Nexus hub | `balanced` | You use Claude with shared company context. |
+| `codex+mcp-generic+openshell.yaml` | Integrators | Generic MCP endpoint | `restricted` | You have an MCP service and want Codex as the agent. |
+| `hermes+nexus+openshell.yaml` | Polyglot enterprise demos | Nexus hub | `balanced` | You want Hermes through subprocess drivers with Nexus context. |
+| `openclaw+nexus+openshell.yaml` | Enterprise reference | Nexus hub | `balanced` | You want OpenClaw with shared company context. |
+
+## Getting-Started Filesystem Blueprints
+
+`claude+filesystem+openshell.yaml`, `codex+filesystem+openshell.yaml`, and `openclaw+filesystem+openshell.yaml` mount `~/projects` through the filesystem context driver and expose it over MCP inside OpenShell. They are the lowest-friction templates because they do not require remote context infrastructure.
+
+Required credentials:
+
+- Claude: `ANTHROPIC_API_KEY`
+- Codex and OpenClaw: `OPENAI_API_KEY`
+
+Usage:
+
+```sh
+agentenv create myapp --blueprint blueprints/claude+filesystem+openshell.yaml
+agentenv enter myapp
+```
+
+Trade-off: `balanced` policy includes common package and GitHub read presets, so these are better for local development than for tightly regulated data.
+
+## Generic MCP Blueprints
+
+`claude+mcp-generic+openshell.yaml` and `codex+mcp-generic+openshell.yaml` connect agents to any MCP-compatible HTTP+SSE endpoint.
+
+Required environment:
+
+- `MCP_URL`
+- `MCP_TOKEN`
+- agent API key for the selected agent
+
+Usage:
+
+```sh
+export MCP_URL=https://mcp.internal.company.com
+export MCP_TOKEN=mcp-token-example
+agentenv create docs --blueprint blueprints/codex+mcp-generic+openshell.yaml
+```
+
+Trade-off: the `restricted` policy keeps egress narrow and allows only the configured MCP endpoint by default.
+
+## Hermes Blueprints
+
+`hermes+filesystem+openshell.yaml` and `hermes+nexus+openshell.yaml` use the external Hermes subprocess agent driver. Confirm it is installed before creating the env:
+
+```sh
+agentenv drivers list
+```
+
+Required environment:
+
+- `OPENAI_API_KEY`
+- `NEXUS_HUB_URL` and `NEXUS_TOKEN` for the Nexus variant
+
+Trade-off: these blueprints demonstrate third-party driver composition, so they depend on driver installation in addition to normal credentials.
+
+## Nexus Blueprints
+
+`claude+nexus+openshell.yaml`, `hermes+nexus+openshell.yaml`, and `openclaw+nexus+openshell.yaml` connect to a shared Nexus hub.
+
+Required environment:
+
+- `NEXUS_HUB_URL`
+- `NEXUS_TOKEN`
+- agent API key for the selected agent
+
+Usage:
+
+```sh
+export NEXUS_HUB_URL=https://nexus.company.com
+export NEXUS_TOKEN=nexus-token-example
+agentenv create enterprise --blueprint blueprints/claude+nexus+openshell.yaml
+```
+
+Trade-off: Nexus blueprints are the best fit for shared enterprise context, but they require a reachable hub and installed Nexus context driver.
+
+## Sample Projects
+
+- `examples/quickstart/` shows the smallest local project flow.
+- `examples/enterprise-hub/` shows a Nexus hub template with company CA and internal base-image conventions.
+- `examples/headless-ci/` shows a non-interactive CI template for automated code maintenance.
+```
+
+- [ ] **Step 2: Add the quickstart sample project**
+
+Create `examples/quickstart/agentenv.yaml`:
+
+```yaml
+version: 0.1.0
+min_agentenv_version: 0.0.1-alpha0
+
+sandbox:
+  driver: openshell
+  version: ">=0.0.1-alpha0,<0.1"
+
+agent:
+  driver: claude
+  credentials:
+    ANTHROPIC_API_KEY:
+      source: env
+      required: true
+
+context:
+  driver: filesystem
+  mount: .
+
+inference:
+  driver: passthrough
+
+policy:
+  tier: balanced
+  presets:
+    - github_read
+    - npm_read
+
+state:
+  persist_home: true
+```
+
+Create `examples/quickstart/README.md`:
+
+```markdown
+# Quickstart Example
+
+This project is the smallest local agentenv template. It mounts the current directory as the filesystem context and starts Claude Code in OpenShell.
+
+## Prerequisites
+
+```sh
+export ANTHROPIC_API_KEY=sk-ant-example
+```
+
+## Lifecycle
+
+```sh
+agentenv create quickstart
+agentenv enter quickstart
+agentenv exec quickstart -- echo ok
+agentenv freeze quickstart --output agentenv.lock
+agentenv destroy quickstart --yes
+```
+
+Run the commands from this directory so `agentenv create` discovers `agentenv.yaml`.
+```
+
+- [ ] **Step 3: Add the enterprise hub sample project**
+
+Create `examples/enterprise-hub/agentenv.yaml`:
+
+```yaml
+version: 0.1.0
+min_agentenv_version: 0.0.1-alpha0
+
+sandbox:
+  driver: openshell
+  version: ">=0.0.1-alpha0,<0.1"
+  image: registry.internal.example.com/agentenv/company-base:latest
+
+agent:
+  driver: claude
+  credentials:
+    ANTHROPIC_API_KEY:
+      source: env
+      required: true
+
+context:
+  driver: nexus
+  mode: hub
+  hub_url: ${NEXUS_HUB_URL}
+  credentials:
+    NEXUS_TOKEN:
+      source: env
+      required: true
+
+inference:
+  driver: passthrough
+
+policy:
+  tier: balanced
+  presets:
+    - github_read
+    - npm_read
+  overrides:
+    - allow: "${NEXUS_HUB_URL}"
+
+state:
+  persist_home: true
+```
+
+Create `examples/enterprise-hub/Dockerfile`:
+
+```dockerfile
+FROM ubuntu:24.04
+
+COPY certs/company-ca.pem /usr/local/share/ca-certificates/company-ca.crt
+RUN update-ca-certificates
+```
+
+Create `examples/enterprise-hub/certs/company-ca.pem`:
+
+```text
+-----BEGIN CERTIFICATE-----
+MIIBlTCCATugAwIBAgIUWmFnZW50ZW52ZXhhbXBsZWNhMDAwMDAwCgYIKoZIzj0E
+AwIwGDEWMBQGA1UEAwwNYWdlbnRlbnYtZGVtbzAeFw0yNjAxMDEwMDAwMDBaFw0y
+NzAxMDEwMDAwMDBaMBgxFjAUBgNVBAMMDWFnZW50ZW52LWRlbW8wWTATBgcqhkjO
+PQIBBggqhkjOPQMBBwNCAASw7hRkMzX9nF2f7nK1KoCx5qBR0Y0x7pMVn8A8Y2xC
+6jV+W0b+ZQz8vDq1dR6m1xJxq7Hf4d7Qf0GmVYqQ8o1MwUTAdBgNVHQ4EFgQUeXhh
+bXBsZS1jYS1ub3QtZm9yLXByb2QwHwYDVR0jBBgwFoAUeXhhbXBsZS1jYS1ub3Qt
+Zm9yLXByb2QwDwYDVR0TAQH/BAUwAwEB/zAKBggqhkjOPQQDAgNIADBFAiA7h2V4
+examplecertificatebodyforagentenvdemoonlyAAAAAIhAIhAL2h2V4examplecert
+ificatebodyforagentenvdemoonlyBBBBB
+-----END CERTIFICATE-----
+```
+
+Create `examples/enterprise-hub/README.md`:
+
+```markdown
+# Enterprise Hub Example
+
+This template assumes a shared Nexus hub, a company CA, and an internal OpenShell base image.
+
+## Prerequisites
+
+```sh
+export ANTHROPIC_API_KEY=sk-ant-example
+export NEXUS_HUB_URL=https://nexus.company.com
+export NEXUS_TOKEN=nexus-token-example
+agentenv drivers list
+```
+
+Build and publish the internal base image referenced by `agentenv.yaml`:
+
+```sh
+docker build -t registry.internal.example.com/agentenv/company-base:latest .
+docker push registry.internal.example.com/agentenv/company-base:latest
+```
+
+## Lifecycle
+
+```sh
+agentenv create enterprise-hub
+agentenv enter enterprise-hub
+agentenv freeze enterprise-hub --output agentenv.lock
+agentenv destroy enterprise-hub --yes
+```
+
+Run the lifecycle commands from this directory so `agentenv create` discovers `agentenv.yaml`.
+```
+
+- [ ] **Step 4: Add the headless CI sample project**
+
+Create `examples/headless-ci/agentenv.yaml`:
+
+```yaml
+version: 0.1.0
+min_agentenv_version: 0.0.1-alpha0
+
+sandbox:
+  driver: openshell
+  version: ">=0.0.1-alpha0,<0.1"
+
+agent:
+  driver: codex
+  credentials:
+    OPENAI_API_KEY:
+      source: env
+      required: true
+
+context:
+  driver: filesystem
+  mount: .
+
+inference:
+  driver: passthrough
+
+policy:
+  tier: balanced
+  presets:
+    - github_read
+    - npm_read
+
+state:
+  persist_home: false
+```
+
+Create `examples/headless-ci/README.md`:
+
+```markdown
+# Headless CI Example
+
+This template runs Codex in non-interactive mode for repository maintenance jobs such as lint fixes.
+
+## Prerequisites
+
+```sh
+export OPENAI_API_KEY=sk-openai-example
+```
+
+## CI Flow
+
+```sh
+agentenv create ci-fix --non-interactive
+agentenv exec ci-fix -- sh -lc 'echo ok'
+agentenv freeze ci-fix --output agentenv.lock
+agentenv destroy ci-fix --yes --non-interactive
+```
+
+Use your CI system to run project-specific commands inside `agentenv exec`, then inspect the working tree before committing changes.
+```
+
+- [ ] **Step 5: Run docs/examples tests to verify GREEN**
+
+Run:
+
+```sh
+cargo test -p agentenv-core --test reference_blueprints
+```
+
+Expected: PASS.
+
+- [ ] **Step 6: Commit docs and examples**
+
+```bash
+git add docs/BLUEPRINTS.md examples crates/agentenv-core/tests/reference_blueprints.rs
+git commit -m "docs: catalog blueprints and examples"
+```
+
+---
+
+### Task 5: Dedicated Blueprint Integration Crate
+
+**Files:**
+- Modify: `Cargo.toml`
+- Create: `tests/blueprint-integration/Cargo.toml`
+- Create: `tests/blueprint-integration/tests/reference_blueprints.rs`
+
+- [ ] **Step 1: Add the workspace member and test package**
+
+Add `"tests/blueprint-integration",` to the root `Cargo.toml` `members` list after `"tests/driver-conformance",`.
+
+Create `tests/blueprint-integration/Cargo.toml`:
+
+```toml
+[package]
+name = "blueprint-integration"
+version.workspace = true
+edition.workspace = true
+rust-version.workspace = true
+license.workspace = true
+repository.workspace = true
+homepage.workspace = true
+authors.workspace = true
+
+[features]
+integration = []
+
+[dev-dependencies]
+serde_json.workspace = true
+uuid.workspace = true
+```
+
+- [ ] **Step 2: Write the integration harness**
+
+Create `tests/blueprint-integration/tests/reference_blueprints.rs`:
+
+```rust
+#![cfg(feature = "integration")]
+
+use std::{
+    env, fs,
+    path::{Path, PathBuf},
+    process::{Command, Output},
+};
+
+use uuid::Uuid;
+
+struct BlueprintCase {
+    path: &'static str,
+    required_env: &'static [&'static str],
+    required_drivers: &'static [DriverRequirement],
+}
+
+#[derive(Clone, Copy)]
+struct DriverRequirement {
+    kind: &'static str,
+    name: &'static str,
+}
+
+const HERMES: DriverRequirement = DriverRequirement {
+    kind: "agent",
+    name: "hermes",
+};
+
+const NEXUS: DriverRequirement = DriverRequirement {
+    kind: "context",
+    name: "nexus",
+};
+
+fn cases() -> Vec<BlueprintCase> {
+    vec![
+        BlueprintCase {
+            path: "blueprints/claude+filesystem+openshell.yaml",
+            required_env: &["ANTHROPIC_API_KEY"],
+            required_drivers: &[],
+        },
+        BlueprintCase {
+            path: "blueprints/codex+filesystem+openshell.yaml",
+            required_env: &["OPENAI_API_KEY"],
+            required_drivers: &[],
+        },
+        BlueprintCase {
+            path: "blueprints/openclaw+filesystem+openshell.yaml",
+            required_env: &["OPENAI_API_KEY"],
+            required_drivers: &[],
+        },
+        BlueprintCase {
+            path: "blueprints/claude+mcp-generic+openshell.yaml",
+            required_env: &["ANTHROPIC_API_KEY", "MCP_URL", "MCP_TOKEN"],
+            required_drivers: &[],
+        },
+        BlueprintCase {
+            path: "blueprints/hermes+filesystem+openshell.yaml",
+            required_env: &["OPENAI_API_KEY"],
+            required_drivers: &[HERMES],
+        },
+        BlueprintCase {
+            path: "blueprints/claude+nexus+openshell.yaml",
+            required_env: &["ANTHROPIC_API_KEY", "NEXUS_HUB_URL", "NEXUS_TOKEN"],
+            required_drivers: &[NEXUS],
+        },
+        BlueprintCase {
+            path: "blueprints/codex+mcp-generic+openshell.yaml",
+            required_env: &["OPENAI_API_KEY", "MCP_URL", "MCP_TOKEN"],
+            required_drivers: &[],
+        },
+        BlueprintCase {
+            path: "blueprints/hermes+nexus+openshell.yaml",
+            required_env: &["OPENAI_API_KEY", "NEXUS_HUB_URL", "NEXUS_TOKEN"],
+            required_drivers: &[HERMES, NEXUS],
+        },
+        BlueprintCase {
+            path: "blueprints/openclaw+nexus+openshell.yaml",
+            required_env: &["OPENAI_API_KEY", "NEXUS_HUB_URL", "NEXUS_TOKEN"],
+            required_drivers: &[NEXUS],
+        },
+    ]
+}
+
+#[test]
+#[ignore = "requires OpenShell and blueprint-specific credentials or subprocess drivers"]
+fn reference_blueprints_create_exec_destroy() {
+    if let Some(reason) = missing_openshell() {
+        eprintln!("skipping blueprint integration: {reason}");
+        return;
+    }
+
+    for case in cases() {
+        if let Some(reason) = missing_case_prerequisite(&case) {
+            eprintln!("skipping {}: {reason}", case.path);
+            continue;
+        }
+
+        run_case(&case);
+    }
+}
+
+fn run_case(case: &BlueprintCase) {
+    let root = workspace_root();
+    let home = env::temp_dir().join(format!(
+        "agentenv-blueprint-it-{}",
+        Uuid::new_v4()
+    ));
+    let projects = home.join("projects");
+    fs::create_dir_all(&projects).unwrap();
+    fs::write(projects.join("README.md"), "blueprint integration\n").unwrap();
+
+    let name = case
+        .path
+        .strip_prefix("blueprints/")
+        .unwrap()
+        .strip_suffix(".yaml")
+        .unwrap()
+        .replace('+', "-");
+    let blueprint = root.join(case.path);
+    let mut created = false;
+    let result = (|| -> Result<(), String> {
+        let create = agentenv_command()
+            .arg("create")
+            .arg(&name)
+            .arg("--blueprint")
+            .arg(&blueprint)
+            .arg("--non-interactive")
+            .env("HOME", &home)
+            .env("AGENTENV_DISABLE_KEYRING", "1")
+            .output()
+            .unwrap();
+        require_success(&format!("create {}", case.path), &create)?;
+        created = true;
+
+        let exec = agentenv_command()
+            .arg("exec")
+            .arg(&name)
+            .arg("--")
+            .arg("echo")
+            .arg("ok")
+            .env("HOME", &home)
+            .env("AGENTENV_DISABLE_KEYRING", "1")
+            .output()
+            .unwrap();
+        require_success(&format!("exec {}", case.path), &exec)?;
+        let stdout = String::from_utf8_lossy(&exec.stdout);
+        if !stdout.contains("ok") {
+            return Err(format!("exec output for {} did not contain ok:\n{}", case.path, output_summary(&exec)));
+        }
+
+        Ok(())
+    })();
+
+    if created {
+        let destroy = agentenv_command()
+            .arg("destroy")
+            .arg(&name)
+            .arg("--yes")
+            .arg("--non-interactive")
+            .env("HOME", &home)
+            .env("AGENTENV_DISABLE_KEYRING", "1")
+            .output()
+            .unwrap();
+        if !destroy.status.success() {
+            panic!(
+                "destroy failed after {}:\n{}",
+                case.path,
+                output_summary(&destroy)
+            );
+        }
+    }
+
+    if let Err(message) = result {
+        panic!("{message}");
+    }
+}
+
+fn missing_case_prerequisite(case: &BlueprintCase) -> Option<String> {
+    for name in case.required_env {
+        match env::var(name) {
+            Ok(value) if !value.trim().is_empty() => {}
+            _ => return Some(format!("missing environment variable {name}")),
+        }
+    }
+
+    for requirement in case.required_drivers {
+        if !driver_list_contains(requirement.kind, requirement.name) {
+            return Some(format!(
+                "missing {} driver {}",
+                requirement.kind, requirement.name
+            ));
+        }
+    }
+
+    None
+}
+
+fn missing_openshell() -> Option<String> {
+    match Command::new("openshell").arg("--version").output() {
+        Ok(output) if output.status.success() => None,
+        Ok(output) => Some(format!(
+            "openshell --version exited unsuccessfully:\n{}",
+            output_summary(&output)
+        )),
+        Err(error) => Some(format!("openshell binary unavailable: {error}")),
+    }
+}
+
+fn driver_list_contains(kind: &str, name: &str) -> bool {
+    let output = agentenv_command()
+        .arg("drivers")
+        .arg("list")
+        .arg("--json")
+        .output()
+        .unwrap();
+    if !output.status.success() {
+        return false;
+    }
+    let Ok(json) = serde_json::from_slice::<serde_json::Value>(&output.stdout) else {
+        return false;
+    };
+    json["drivers"].as_array().is_some_and(|drivers| {
+        drivers
+            .iter()
+            .any(|driver| driver["kind"] == kind && driver["name"] == name)
+    })
+}
+
+fn agentenv_command() -> Command {
+    if let Some(path) = env::var_os("AGENTENV_BIN") {
+        Command::new(path)
+    } else {
+        let mut command = Command::new(env!("CARGO"));
+        command
+            .arg("run")
+            .arg("--quiet")
+            .arg("-p")
+            .arg("agentenv")
+            .arg("--");
+        command
+    }
+}
+
+fn require_success(label: &str, output: &Output) -> Result<(), String> {
+    if output.status.success() {
+        Ok(())
+    } else {
+        Err(format!("{label} failed:\n{}", output_summary(output)))
+    }
+}
+
+fn output_summary(output: &Output) -> String {
+    format!(
+        "status: {}\nstdout:\n{}\nstderr:\n{}",
+        output
+            .status
+            .code()
+            .map(|code| code.to_string())
+            .unwrap_or_else(|| "signal".to_owned()),
+        String::from_utf8_lossy(&output.stdout),
+        String::from_utf8_lossy(&output.stderr)
+    )
+}
+
+fn workspace_root() -> PathBuf {
+    Path::new(env!("CARGO_MANIFEST_DIR"))
+        .join("../..")
+        .canonicalize()
+        .unwrap()
+}
+```
+
+- [ ] **Step 3: Run the integration package without the feature**
+
+Run:
+
+```sh
+cargo test -p blueprint-integration
+```
+
+Expected: PASS with no live OpenShell operations.
+
+- [ ] **Step 4: Run the ignored integration harness and verify skip behavior**
+
+Run:
+
+```sh
+cargo test -p blueprint-integration --features integration -- --ignored --nocapture
+```
+
+Expected on a machine without OpenShell or credentials: PASS with `skipping` messages naming missing prerequisites. Expected on a fully provisioned machine: each eligible blueprint creates an env, runs `echo ok`, and destroys the env.
+
+- [ ] **Step 5: Commit the integration crate**
+
+```bash
+git add Cargo.toml tests/blueprint-integration
+git commit -m "test: add blueprint integration harness"
+```
+
+---
+
+### Task 6: Final Verification And Cleanup
+
+**Files:**
+- Review: all changed files from Tasks 1-5
+
+- [ ] **Step 1: Run formatting**
+
+Run:
+
+```sh
+cargo fmt
+```
+
+Expected: exit 0.
+
+- [ ] **Step 2: Run clippy**
+
+Run:
+
+```sh
+cargo clippy --workspace --all-targets -- -D warnings
+```
+
+Expected: exit 0 with no warnings.
+
+- [ ] **Step 3: Run the full workspace test suite**
+
+Run:
+
+```sh
+cargo test --workspace
+```
+
+Expected: exit 0. Ignored live tests remain ignored in the default run.
+
+- [ ] **Step 4: Run the live harness command for skip evidence**
+
+Run:
+
+```sh
+cargo test -p blueprint-integration --features integration -- --ignored --nocapture
+```
+
+Expected: exit 0. On this machine, unavailable live prerequisites may produce visible `skipping` messages instead of creating envs.
+
+- [ ] **Step 5: Inspect the final diff**
+
+Run:
+
+```sh
+git status --short
+git diff --stat HEAD
+```
+
+Expected: only issue #20 files are changed.
+
+- [ ] **Step 6: Commit final verification fixes if formatting changed files**
+
+If `cargo fmt` changed files after Task 5, commit those formatting-only changes:
+
+```bash
+git add Cargo.toml crates/agentenv-core/tests/reference_blueprints.rs tests/blueprint-integration
+git commit -m "chore: format blueprint integration changes"
+```
+
+If `cargo fmt` did not change files, do not create an empty commit.

--- a/docs/superpowers/specs/2026-05-02-m5-4-reference-blueprints-design.md
+++ b/docs/superpowers/specs/2026-05-02-m5-4-reference-blueprints-design.md
@@ -1,0 +1,165 @@
+# M5-4 Design: Reference Blueprints And Sample Projects
+
+- Date: 2026-05-02
+- Issue: https://github.com/windoliver/agentenv/issues/20
+- Milestone: M5 packaging, DX, and security
+- Affected crates: `agentenv-core`, `agentenv`, new `tests/blueprint-integration`
+- Affected docs and templates: `blueprints/`, `docs/BLUEPRINTS.md`, `examples/`, `Cargo.toml`
+
+## 1. Context And Goals
+
+Issue #20 turns the reference blueprints into both documentation and starter templates. The repository already has four blueprints, fast parser coverage in `agentenv-core/tests/reference_blueprints.rs`, built-in drivers for Claude, Codex, OpenClaw, filesystem, MCP generic, and passthrough inference, and subprocess discovery support for Hermes and Nexus.
+
+This work should expand the blueprint set to nine files, add sample projects, document the trade-offs, and add an optional integration harness that can run real create, exec, and destroy flows when the required drivers and credentials are present.
+
+The implementation must preserve agentenv's narrow-waist architecture: blueprints describe sandbox, agent, context, inference, policy, and state; they should not bypass MCP or driver capability handshakes.
+
+## 2. Recommended Architecture
+
+Use three validation layers:
+
+1. `agentenv-core/tests/reference_blueprints.rs` remains the fast default suite for all reference blueprints. It parses, validates, resolves, and checks expected driver composition for all nine files.
+2. `docs/BLUEPRINTS.md` and top-of-file comments provide human-facing guidance. They explain what each blueprint is for, which environment variables or subprocess drivers it needs, and what policy posture it uses.
+3. A new workspace crate at `tests/blueprint-integration/` owns optional end-to-end tests behind an `integration` feature. These tests run `create -> exec "echo ok" -> destroy` for each blueprint only when the relevant prerequisites are available.
+
+This keeps normal test runs fast and deterministic while giving release or driver-equipped environments a single place to exercise live blueprints.
+
+## 3. Blueprint Set
+
+Ship these files under `blueprints/`:
+
+| File | Composition | Audience |
+|---|---|---|
+| `claude+filesystem+openshell.yaml` | Claude + filesystem + OpenShell | Getting started |
+| `codex+filesystem+openshell.yaml` | Codex + filesystem + OpenShell | Getting started |
+| `openclaw+filesystem+openshell.yaml` | OpenClaw + filesystem + OpenShell | Getting started |
+| `claude+mcp-generic+openshell.yaml` | Claude + generic MCP + OpenShell | Integrators |
+| `hermes+filesystem+openshell.yaml` | Hermes subprocess agent + filesystem + OpenShell | Polyglot demo |
+| `claude+nexus+openshell.yaml` | Claude + Nexus hub + OpenShell | Enterprise reference |
+| `codex+mcp-generic+openshell.yaml` | Codex + generic MCP + OpenShell | Integrators |
+| `hermes+nexus+openshell.yaml` | Hermes subprocess agent + Nexus hub + OpenShell | Polyglot enterprise demo |
+| `openclaw+nexus+openshell.yaml` | OpenClaw + Nexus hub + OpenShell | Enterprise reference |
+
+Each blueprint should use the current `version: 0.1.0`, `min_agentenv_version: 0.0.1-alpha0`, OpenShell sandbox, and passthrough inference unless the existing format changes before implementation. URL placeholders should remain environment-variable based so checked-in files never hard-code internal endpoints.
+
+Top comments should be consistent:
+
+1. one-line purpose.
+2. prerequisite environment variables or installed subprocess drivers.
+3. a minimal usage block with `agentenv create`.
+4. a note when the blueprint depends on remote MCP or Nexus.
+
+## 4. Documentation And Examples
+
+Add `docs/BLUEPRINTS.md` with a catalog table and short sections for each blueprint. Each section should cover:
+
+1. audience and intended use.
+2. required credentials and environment variables.
+3. driver prerequisites.
+4. policy tier and presets.
+5. trade-offs and when to pick a different blueprint.
+
+Add three sample projects:
+
+1. `examples/quickstart/`
+   - `agentenv.yaml` based on `claude+filesystem+openshell.yaml`.
+   - `README.md` walks through `create -> enter -> work -> freeze -> destroy`.
+2. `examples/enterprise-hub/`
+   - `agentenv.yaml` based on a Nexus blueprint.
+   - include company CA and internal Dockerfile assumptions as placeholders, not secrets.
+   - `README.md` explains required `NEXUS_HUB_URL`, `NEXUS_TOKEN`, and local CA/Dockerfile paths.
+3. `examples/headless-ci/`
+   - `agentenv.yaml` optimized for non-interactive CI.
+   - `README.md` shows a lint-fix style flow using non-interactive create, exec, freeze, and destroy commands.
+
+Examples should be runnable templates, not prose-only docs. Placeholder values are acceptable when they are explicitly environment-driven and documented.
+
+## 5. Integration Harness
+
+Add a new workspace member:
+
+```text
+tests/blueprint-integration/
+```
+
+The crate should expose an `integration` feature and tests that are ignored or skipped unless explicitly enabled. Its responsibility is live end-to-end validation, not YAML parsing. The harness should:
+
+1. enumerate the nine blueprint paths from one table.
+2. check prerequisites per blueprint before attempting create:
+   - OpenShell availability.
+   - required agent credentials such as `ANTHROPIC_API_KEY` or `OPENAI_API_KEY`.
+   - `MCP_URL` and `MCP_TOKEN` for generic MCP.
+   - `NEXUS_HUB_URL`, `NEXUS_TOKEN`, and installed Nexus subprocess driver for Nexus.
+   - installed Hermes subprocess driver for Hermes.
+3. skip unavailable cases with a clear message naming the missing prerequisite.
+4. create a unique env name per test.
+5. run `agentenv create <name> --blueprint <path> --non-interactive`.
+6. run `agentenv exec <name> "echo ok"` and assert stdout contains `ok`.
+7. always attempt `agentenv destroy <name> --yes --non-interactive` after successful create, even if exec fails.
+
+The harness can shell out to the built `agentenv` binary using Rust test helpers. It should avoid requiring live remote MCP or Nexus in default CI.
+
+## 6. Fast Test Coverage
+
+Update `agentenv-core/tests/reference_blueprints.rs` to cover all nine files. The test should keep deterministic placeholder values for URL environment variables so SSRF validation accepts them and interpolation can resolve.
+
+Assertions should verify:
+
+1. blueprint version and minimum agentenv version.
+2. selected sandbox, agent, context, and inference drivers.
+3. expected policy tier.
+4. expected state persistence where relevant.
+5. context-specific fields, including filesystem mount, generic MCP endpoint, and Nexus hub URL.
+
+This test should not depend on installed subprocess drivers or live credentials.
+
+## 7. Error Handling And Cleanup
+
+Reference files should prefer explicit environment placeholders over literal internal URLs or secrets. Credential values must remain references only; no checked-in sample should contain a real token.
+
+Integration cleanup should be best effort. Once create succeeds, destroy should run in a cleanup path regardless of the exec result. Cleanup failures should be reported in the test output because they may leave a local sandbox behind.
+
+Skips should be intentional and visible. A missing prerequisite is a skip; a failed create, exec, or destroy after prerequisites are present is a test failure.
+
+## 8. Scope And Non-Goals
+
+In scope:
+
+1. Add the missing five reference blueprints and polish the existing four.
+2. Add `docs/BLUEPRINTS.md`.
+3. Add three sample project directories.
+4. Extend fast parse, validate, and resolve coverage.
+5. Add the optional end-to-end integration crate.
+
+Out of scope:
+
+1. Changing the blueprint schema version.
+2. Changing the driver protocol.
+3. Implementing or modifying Hermes or Nexus subprocess drivers.
+4. Adding a new context transport.
+5. Making live remote MCP or Nexus mandatory in default CI.
+
+## 9. Implementation Notes
+
+The implementation should start test-first:
+
+1. extend the reference blueprint test table to include all nine expected files and watch it fail for missing files.
+2. add missing blueprint files and adjust existing files until the fast suite passes.
+3. add docs and examples with lightweight file-presence or parse coverage where useful.
+4. add the integration crate and verify skipped behavior locally without live prerequisites.
+
+Full verification before completion should include:
+
+```sh
+cargo fmt
+cargo clippy --workspace --all-targets -- -D warnings
+cargo test --workspace
+```
+
+The live harness should be documented as:
+
+```sh
+cargo test -p blueprint-integration --features integration -- --ignored
+```
+
+The exact package name may be adjusted to fit Cargo naming conventions, but the path should remain `tests/blueprint-integration/`.

--- a/examples/enterprise-hub/Dockerfile
+++ b/examples/enterprise-hub/Dockerfile
@@ -1,0 +1,4 @@
+FROM ubuntu:24.04
+
+COPY certs/company-ca.pem /usr/local/share/ca-certificates/company-ca.crt
+RUN update-ca-certificates

--- a/examples/enterprise-hub/README.md
+++ b/examples/enterprise-hub/README.md
@@ -1,0 +1,30 @@
+# Enterprise Hub Example
+
+This template assumes a shared Nexus hub, a company CA, and an internal OpenShell base image.
+
+## Prerequisites
+
+```sh
+export ANTHROPIC_API_KEY=sk-ant-example
+export NEXUS_HUB_URL=https://nexus.company.com
+export NEXUS_TOKEN=nexus-token-example
+agentenv drivers list
+```
+
+Build and publish the internal base image referenced by `agentenv.yaml`:
+
+```sh
+docker build -t registry.internal.example.com/agentenv/company-base:latest .
+docker push registry.internal.example.com/agentenv/company-base:latest
+```
+
+## Lifecycle
+
+```sh
+agentenv create enterprise-hub
+agentenv enter enterprise-hub
+agentenv freeze enterprise-hub --output agentenv.lock
+agentenv destroy enterprise-hub --yes
+```
+
+Run the lifecycle commands from this directory so `agentenv create` discovers `agentenv.yaml`.

--- a/examples/enterprise-hub/README.md
+++ b/examples/enterprise-hub/README.md
@@ -6,17 +6,21 @@ This template assumes a shared Nexus hub, a company CA, and an internal OpenShel
 
 ```sh
 export ANTHROPIC_API_KEY=sk-ant-example
-export NEXUS_HUB_URL=https://nexus.company.com
+export NEXUS_HUB_URL=https://example.com/nexus
 export NEXUS_TOKEN=nexus-token-example
 agentenv drivers list
 ```
 
+Replace `NEXUS_HUB_URL` with your Nexus hub URL before use.
+
 Build and publish the internal base image referenced by `agentenv.yaml`:
 
 ```sh
-docker build -t registry.internal.example.com/agentenv/company-base:latest .
-docker push registry.internal.example.com/agentenv/company-base:latest
+docker build -t registry.internal.example.com/agentenv/company-base:2026.05 .
+docker push registry.internal.example.com/agentenv/company-base:2026.05
 ```
+
+Before creating the environment, replace both the `sandbox.image` reference and `sandbox.digest` in `agentenv.yaml` with the values for your published internal image.
 
 ## Lifecycle
 

--- a/examples/enterprise-hub/README.md
+++ b/examples/enterprise-hub/README.md
@@ -15,6 +15,8 @@ Replace `NEXUS_HUB_URL` with your Nexus hub URL before use.
 
 Build and publish the internal base image referenced by `agentenv.yaml`:
 
+Replace `certs/company-ca.pem` with your organization's PEM-encoded root CA certificate before building the sample image.
+
 ```sh
 docker build -t registry.internal.example.com/agentenv/company-base:2026.05 .
 docker push registry.internal.example.com/agentenv/company-base:2026.05

--- a/examples/enterprise-hub/agentenv.yaml
+++ b/examples/enterprise-hub/agentenv.yaml
@@ -1,0 +1,37 @@
+version: 0.1.0
+min_agentenv_version: 0.0.1-alpha0
+
+sandbox:
+  driver: openshell
+  version: ">=0.0.1-alpha0,<0.1"
+  image: registry.internal.example.com/agentenv/company-base:latest
+
+agent:
+  driver: claude
+  credentials:
+    ANTHROPIC_API_KEY:
+      source: env
+      required: true
+
+context:
+  driver: nexus
+  mode: hub
+  hub_url: ${NEXUS_HUB_URL}
+  credentials:
+    NEXUS_TOKEN:
+      source: env
+      required: true
+
+inference:
+  driver: passthrough
+
+policy:
+  tier: balanced
+  presets:
+    - github_read
+    - npm_read
+  overrides:
+    - allow: "${NEXUS_HUB_URL}"
+
+state:
+  persist_home: true

--- a/examples/enterprise-hub/agentenv.yaml
+++ b/examples/enterprise-hub/agentenv.yaml
@@ -4,7 +4,8 @@ min_agentenv_version: 0.0.1-alpha0
 sandbox:
   driver: openshell
   version: ">=0.0.1-alpha0,<0.1"
-  image: registry.internal.example.com/agentenv/company-base:latest
+  image: registry.internal.example.com/agentenv/company-base:2026.05
+  digest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
 
 agent:
   driver: claude

--- a/examples/enterprise-hub/certs/company-ca.pem
+++ b/examples/enterprise-hub/certs/company-ca.pem
@@ -1,0 +1,2 @@
+# Example company CA placeholder.
+# Replace this file with your organization's PEM-encoded root CA certificate before building the sample image.

--- a/examples/headless-ci/README.md
+++ b/examples/headless-ci/README.md
@@ -1,0 +1,20 @@
+# Headless CI Example
+
+This template runs Codex in non-interactive mode for repository maintenance jobs such as lint fixes.
+
+## Prerequisites
+
+```sh
+export OPENAI_API_KEY=sk-openai-example
+```
+
+## CI Flow
+
+```sh
+agentenv create ci-fix --non-interactive
+agentenv exec ci-fix -- sh -lc 'echo ok'
+agentenv freeze ci-fix --output agentenv.lock
+agentenv destroy ci-fix --yes --non-interactive
+```
+
+Use your CI system to run project-specific commands inside `agentenv exec`, then inspect the working tree before committing changes.

--- a/examples/headless-ci/agentenv.yaml
+++ b/examples/headless-ci/agentenv.yaml
@@ -1,0 +1,29 @@
+version: 0.1.0
+min_agentenv_version: 0.0.1-alpha0
+
+sandbox:
+  driver: openshell
+  version: ">=0.0.1-alpha0,<0.1"
+
+agent:
+  driver: codex
+  credentials:
+    OPENAI_API_KEY:
+      source: env
+      required: true
+
+context:
+  driver: filesystem
+  mount: .
+
+inference:
+  driver: passthrough
+
+policy:
+  tier: balanced
+  presets:
+    - github_read
+    - npm_read
+
+state:
+  persist_home: false

--- a/examples/quickstart/README.md
+++ b/examples/quickstart/README.md
@@ -1,0 +1,21 @@
+# Quickstart Example
+
+This project is the smallest local agentenv template. It mounts the current directory as the filesystem context and starts Claude Code in OpenShell.
+
+## Prerequisites
+
+```sh
+export ANTHROPIC_API_KEY=sk-ant-example
+```
+
+## Lifecycle
+
+```sh
+agentenv create quickstart
+agentenv enter quickstart
+agentenv exec quickstart -- echo ok
+agentenv freeze quickstart --output agentenv.lock
+agentenv destroy quickstart --yes
+```
+
+Run the commands from this directory so `agentenv create` discovers `agentenv.yaml`.

--- a/examples/quickstart/agentenv.yaml
+++ b/examples/quickstart/agentenv.yaml
@@ -1,0 +1,29 @@
+version: 0.1.0
+min_agentenv_version: 0.0.1-alpha0
+
+sandbox:
+  driver: openshell
+  version: ">=0.0.1-alpha0,<0.1"
+
+agent:
+  driver: claude
+  credentials:
+    ANTHROPIC_API_KEY:
+      source: env
+      required: true
+
+context:
+  driver: filesystem
+  mount: .
+
+inference:
+  driver: passthrough
+
+policy:
+  tier: balanced
+  presets:
+    - github_read
+    - npm_read
+
+state:
+  persist_home: true

--- a/tests/blueprint-integration/Cargo.toml
+++ b/tests/blueprint-integration/Cargo.toml
@@ -1,0 +1,15 @@
+[package]
+name = "blueprint-integration"
+version.workspace = true
+edition.workspace = true
+rust-version.workspace = true
+license.workspace = true
+repository.workspace = true
+homepage.workspace = true
+authors.workspace = true
+
+[features]
+integration = []
+
+[dev-dependencies]
+uuid.workspace = true

--- a/tests/blueprint-integration/tests/reference_blueprints.rs
+++ b/tests/blueprint-integration/tests/reference_blueprints.rs
@@ -1,0 +1,311 @@
+#![cfg(feature = "integration")]
+
+use std::env;
+use std::ffi::OsString;
+use std::fs;
+use std::path::PathBuf;
+use std::process::{Command, Output};
+
+use uuid::Uuid;
+
+#[derive(Clone, Copy)]
+struct DriverRequirement {
+    kind: &'static str,
+    name: &'static str,
+}
+
+struct BlueprintCase {
+    path: &'static str,
+    env_vars: &'static [&'static str],
+    drivers: &'static [DriverRequirement],
+}
+
+const AGENT_HERMES: DriverRequirement = DriverRequirement {
+    kind: "agent",
+    name: "hermes",
+};
+const CONTEXT_NEXUS: DriverRequirement = DriverRequirement {
+    kind: "context",
+    name: "nexus",
+};
+
+const CASES: &[BlueprintCase] = &[
+    BlueprintCase {
+        path: "blueprints/claude+filesystem+openshell.yaml",
+        env_vars: &["ANTHROPIC_API_KEY"],
+        drivers: &[],
+    },
+    BlueprintCase {
+        path: "blueprints/codex+filesystem+openshell.yaml",
+        env_vars: &["OPENAI_API_KEY"],
+        drivers: &[],
+    },
+    BlueprintCase {
+        path: "blueprints/openclaw+filesystem+openshell.yaml",
+        env_vars: &["OPENAI_API_KEY"],
+        drivers: &[],
+    },
+    BlueprintCase {
+        path: "blueprints/claude+mcp-generic+openshell.yaml",
+        env_vars: &["ANTHROPIC_API_KEY", "MCP_URL", "MCP_TOKEN"],
+        drivers: &[],
+    },
+    BlueprintCase {
+        path: "blueprints/hermes+filesystem+openshell.yaml",
+        env_vars: &["OPENAI_API_KEY"],
+        drivers: &[AGENT_HERMES],
+    },
+    BlueprintCase {
+        path: "blueprints/claude+nexus+openshell.yaml",
+        env_vars: &["ANTHROPIC_API_KEY", "NEXUS_HUB_URL", "NEXUS_TOKEN"],
+        drivers: &[CONTEXT_NEXUS],
+    },
+    BlueprintCase {
+        path: "blueprints/codex+mcp-generic+openshell.yaml",
+        env_vars: &["OPENAI_API_KEY", "MCP_URL", "MCP_TOKEN"],
+        drivers: &[],
+    },
+    BlueprintCase {
+        path: "blueprints/hermes+nexus+openshell.yaml",
+        env_vars: &["OPENAI_API_KEY", "NEXUS_HUB_URL", "NEXUS_TOKEN"],
+        drivers: &[AGENT_HERMES, CONTEXT_NEXUS],
+    },
+    BlueprintCase {
+        path: "blueprints/openclaw+nexus+openshell.yaml",
+        env_vars: &["OPENAI_API_KEY", "NEXUS_HUB_URL", "NEXUS_TOKEN"],
+        drivers: &[CONTEXT_NEXUS],
+    },
+];
+
+#[test]
+#[ignore = "requires OpenShell and blueprint-specific credentials or subprocess drivers"]
+fn reference_blueprints_create_exec_destroy() -> Result<(), Box<dyn std::error::Error>> {
+    if !command_status_ok("openshell", ["--version"])? {
+        println!(
+            "skipping blueprint integration tests: `openshell --version` failed or is missing"
+        );
+        return Ok(());
+    }
+
+    let workspace = workspace_root();
+    let driver_output = agentenv_output(&workspace, ["drivers", "list"])?;
+    if !driver_output.status.success() {
+        println!(
+            "skipping blueprint integration tests: `agentenv drivers list` failed\n{}",
+            String::from_utf8_lossy(&driver_output.stderr)
+        );
+        return Ok(());
+    }
+    let drivers = String::from_utf8_lossy(&driver_output.stdout);
+
+    for case in CASES {
+        run_case_if_eligible(&workspace, case, &drivers)?;
+    }
+
+    Ok(())
+}
+
+fn run_case_if_eligible(
+    workspace: &PathBuf,
+    case: &BlueprintCase,
+    drivers: &str,
+) -> Result<(), Box<dyn std::error::Error>> {
+    let missing_env: Vec<&str> = case
+        .env_vars
+        .iter()
+        .copied()
+        .filter(|name| env::var(name).map_or(true, |value| value.trim().is_empty()))
+        .collect();
+    if !missing_env.is_empty() {
+        println!(
+            "skipping {}: missing required env var(s): {}",
+            case.path,
+            missing_env.join(", ")
+        );
+        return Ok(());
+    }
+
+    for driver in case.drivers {
+        if !driver_list_contains(drivers, driver) {
+            println!(
+                "skipping {}: missing required driver: {} {}",
+                case.path, driver.kind, driver.name
+            );
+            return Ok(());
+        }
+    }
+
+    run_case(workspace, case)
+}
+
+fn run_case(workspace: &PathBuf, case: &BlueprintCase) -> Result<(), Box<dyn std::error::Error>> {
+    let id = Uuid::new_v4().simple().to_string();
+    let env_name = format!("{}-{id}", env_name_stem(case.path));
+    let home = env::temp_dir().join(format!("agentenv-blueprint-{id}"));
+    let projects = home.join("projects");
+    fs::create_dir_all(&projects)?;
+    fs::write(projects.join("README.md"), "# Blueprint integration\n")?;
+
+    let blueprint = workspace.join(case.path);
+    let create = agentenv_output_with_home(
+        workspace,
+        &home,
+        [
+            OsString::from("create"),
+            OsString::from(&env_name),
+            OsString::from("--blueprint"),
+            blueprint.into_os_string(),
+            OsString::from("--non-interactive"),
+        ],
+    )?;
+    if !create.status.success() {
+        remove_temp_home(&home);
+        panic!(
+            "`agentenv create` failed for {}\nstdout:\n{}\nstderr:\n{}",
+            case.path,
+            String::from_utf8_lossy(&create.stdout),
+            String::from_utf8_lossy(&create.stderr)
+        );
+    }
+
+    let exec = agentenv_output_with_home(
+        workspace,
+        &home,
+        [
+            OsString::from("exec"),
+            OsString::from(&env_name),
+            OsString::from("--"),
+            OsString::from("echo"),
+            OsString::from("ok"),
+        ],
+    );
+    let destroy = agentenv_output_with_home(
+        workspace,
+        &home,
+        [
+            OsString::from("destroy"),
+            OsString::from(&env_name),
+            OsString::from("--yes"),
+            OsString::from("--non-interactive"),
+        ],
+    );
+    remove_temp_home(&home);
+
+    let exec = exec?;
+    let destroy = destroy?;
+    assert!(
+        destroy.status.success(),
+        "`agentenv destroy` failed for {}\nstdout:\n{}\nstderr:\n{}",
+        case.path,
+        String::from_utf8_lossy(&destroy.stdout),
+        String::from_utf8_lossy(&destroy.stderr)
+    );
+    assert!(
+        exec.status.success(),
+        "`agentenv exec` failed for {}\nstdout:\n{}\nstderr:\n{}",
+        case.path,
+        String::from_utf8_lossy(&exec.stdout),
+        String::from_utf8_lossy(&exec.stderr)
+    );
+    assert!(
+        String::from_utf8_lossy(&exec.stdout).contains("ok"),
+        "`agentenv exec` stdout for {} did not contain `ok`\nstdout:\n{}\nstderr:\n{}",
+        case.path,
+        String::from_utf8_lossy(&exec.stdout),
+        String::from_utf8_lossy(&exec.stderr)
+    );
+
+    Ok(())
+}
+
+fn workspace_root() -> PathBuf {
+    PathBuf::from(env!("CARGO_MANIFEST_DIR"))
+        .ancestors()
+        .nth(2)
+        .expect("blueprint-integration is under tests/")
+        .to_path_buf()
+}
+
+fn driver_list_contains(output: &str, required: &DriverRequirement) -> bool {
+    output.lines().any(|line| {
+        let mut fields = line.split_whitespace();
+        fields.next() == Some(required.kind) && fields.next() == Some(required.name)
+    })
+}
+
+fn agentenv_output<const N: usize>(
+    workspace: &PathBuf,
+    args: [&str; N],
+) -> Result<Output, Box<dyn std::error::Error>> {
+    let args = args.map(OsString::from);
+    agentenv_output_with_home(workspace, &workspace.join(".target-test-home"), args)
+}
+
+fn agentenv_output_with_home<const N: usize>(
+    workspace: &PathBuf,
+    home: &PathBuf,
+    args: [OsString; N],
+) -> Result<Output, Box<dyn std::error::Error>> {
+    let mut command = agentenv_command(workspace);
+    command.args(args).env("HOME", home).current_dir(workspace);
+    if let Some(driver_path) = driver_path_with_original_home() {
+        command.env("AGENTENV_DRIVER_PATH", driver_path);
+    }
+    Ok(command.output()?)
+}
+
+fn agentenv_command(workspace: &PathBuf) -> Command {
+    if let Ok(binary) = env::var("AGENTENV_BIN") {
+        Command::new(binary)
+    } else {
+        let mut command = Command::new("cargo");
+        command.args(["run", "--quiet", "-p", "agentenv", "--"]);
+        command.current_dir(workspace);
+        command
+    }
+}
+
+fn command_status_ok<const N: usize>(
+    program: &str,
+    args: [&str; N],
+) -> Result<bool, Box<dyn std::error::Error>> {
+    match Command::new(program).args(args).status() {
+        Ok(status) => Ok(status.success()),
+        Err(error) if error.kind() == std::io::ErrorKind::NotFound => Ok(false),
+        Err(error) => Err(Box::new(error)),
+    }
+}
+
+fn env_name_stem(path: &str) -> String {
+    path.rsplit('/')
+        .next()
+        .unwrap_or(path)
+        .trim_end_matches(".yaml")
+        .chars()
+        .map(|ch| if ch.is_ascii_alphanumeric() { ch } else { '-' })
+        .collect()
+}
+
+fn driver_path_with_original_home() -> Option<OsString> {
+    let original_home_drivers = env::var_os("HOME")
+        .map(PathBuf::from)
+        .map(|home| home.join(".agentenv/drivers"));
+    let paths: Vec<PathBuf> = env::var_os("AGENTENV_DRIVER_PATH")
+        .map(|value| env::split_paths(&value).collect::<Vec<_>>())
+        .unwrap_or_default()
+        .into_iter()
+        .chain(original_home_drivers)
+        .collect();
+
+    if paths.is_empty() {
+        None
+    } else {
+        env::join_paths(paths).ok()
+    }
+}
+
+fn remove_temp_home(home: &PathBuf) {
+    if let Err(error) = fs::remove_dir_all(home) {
+        eprintln!("failed to remove temp HOME `{}`: {error}", home.display());
+    }
+}

--- a/tests/blueprint-integration/tests/reference_blueprints.rs
+++ b/tests/blueprint-integration/tests/reference_blueprints.rs
@@ -90,11 +90,11 @@ fn reference_blueprints_create_exec_destroy() -> Result<(), Box<dyn std::error::
     let workspace = workspace_root();
     let driver_output = agentenv_output(&workspace, ["drivers", "list"])?;
     if !driver_output.status.success() {
-        println!(
-            "skipping blueprint integration tests: `agentenv drivers list` failed\n{}",
+        panic!(
+            "`agentenv drivers list` failed\nstdout:\n{}\nstderr:\n{}",
+            String::from_utf8_lossy(&driver_output.stdout),
             String::from_utf8_lossy(&driver_output.stderr)
         );
-        return Ok(());
     }
     let drivers = String::from_utf8_lossy(&driver_output.stdout);
 

--- a/tests/blueprint-integration/tests/reference_blueprints.rs
+++ b/tests/blueprint-integration/tests/reference_blueprints.rs
@@ -159,10 +159,11 @@ fn run_case(workspace: &PathBuf, case: &BlueprintCase) -> Result<(), Box<dyn std
         ],
     )?;
     if !create.status.success() {
-        remove_temp_home(&home);
         panic!(
-            "`agentenv create` failed for {}\nstdout:\n{}\nstderr:\n{}",
+            "`agentenv create` failed for {}\nenv: {}\ntemp HOME preserved at: {}\nstdout:\n{}\nstderr:\n{}",
             case.path,
+            env_name,
+            home.display(),
             String::from_utf8_lossy(&create.stdout),
             String::from_utf8_lossy(&create.stderr)
         );
@@ -189,17 +190,32 @@ fn run_case(workspace: &PathBuf, case: &BlueprintCase) -> Result<(), Box<dyn std
             OsString::from("--non-interactive"),
         ],
     );
+
+    let destroy = match destroy {
+        Ok(output) => output,
+        Err(error) => {
+            panic!(
+                "failed to run `agentenv destroy` for {}\nenv: {}\ntemp HOME preserved at: {}\nerror: {}",
+                case.path,
+                env_name,
+                home.display(),
+                error
+            );
+        }
+    };
+    if !destroy.status.success() {
+        panic!(
+            "`agentenv destroy` failed for {}\nenv: {}\ntemp HOME preserved at: {}\nstdout:\n{}\nstderr:\n{}",
+            case.path,
+            env_name,
+            home.display(),
+            String::from_utf8_lossy(&destroy.stdout),
+            String::from_utf8_lossy(&destroy.stderr)
+        );
+    }
     remove_temp_home(&home);
 
     let exec = exec?;
-    let destroy = destroy?;
-    assert!(
-        destroy.status.success(),
-        "`agentenv destroy` failed for {}\nstdout:\n{}\nstderr:\n{}",
-        case.path,
-        String::from_utf8_lossy(&destroy.stdout),
-        String::from_utf8_lossy(&destroy.stderr)
-    );
     assert!(
         exec.status.success(),
         "`agentenv exec` failed for {}\nstdout:\n{}\nstderr:\n{}",
@@ -254,7 +270,11 @@ fn agentenv_output_with_home<const N: usize>(
     args: [OsString; N],
 ) -> Result<Output, Box<dyn std::error::Error>> {
     let mut command = agentenv_command(workspace);
-    command.args(args).env("HOME", home).current_dir(workspace);
+    command
+        .args(args)
+        .env("HOME", home)
+        .env("AGENTENV_DISABLE_KEYRING", "1")
+        .current_dir(workspace);
     if let Some(driver_path) = driver_path_with_original_home() {
         command.env("AGENTENV_DRIVER_PATH", driver_path);
     }

--- a/tests/blueprint-integration/tests/reference_blueprints.rs
+++ b/tests/blueprint-integration/tests/reference_blueprints.rs
@@ -229,7 +229,14 @@ fn workspace_root() -> PathBuf {
 fn driver_list_contains(output: &str, required: &DriverRequirement) -> bool {
     output.lines().any(|line| {
         let mut fields = line.split_whitespace();
-        fields.next() == Some(required.kind) && fields.next() == Some(required.name)
+        let kind = fields.next();
+        let name = fields.next();
+        let _version = fields.next();
+        let source = fields.next();
+
+        kind == Some(required.kind)
+            && name == Some(required.name)
+            && matches!(source, Some("installed" | "override"))
     })
 }
 
@@ -308,4 +315,27 @@ fn remove_temp_home(home: &PathBuf) {
     if let Err(error) = fs::remove_dir_all(home) {
         eprintln!("failed to remove temp HOME `{}`: {error}", home.display());
     }
+}
+
+#[test]
+fn driver_list_contains_requires_subprocess_source() {
+    let output = "\
+KIND       NAME                     VERSION        SOURCE     BINARY
+agent      hermes                   0.0.1-alpha0   built-in   -
+context    nexus                    0.0.1-alpha0   built-in   -
+agent      hermes                   0.0.1-alpha0   installed  /tmp/hermes
+context    nexus                    0.0.1-alpha0   override   /tmp/nexus
+";
+
+    assert!(driver_list_contains(output, &AGENT_HERMES));
+    assert!(driver_list_contains(output, &CONTEXT_NEXUS));
+
+    let built_in_only = "\
+KIND       NAME                     VERSION        SOURCE     BINARY
+agent      hermes                   0.0.1-alpha0   built-in   -
+context    nexus                    0.0.1-alpha0   built-in   -
+";
+
+    assert!(!driver_list_contains(built_in_only, &AGENT_HERMES));
+    assert!(!driver_list_contains(built_in_only, &CONTEXT_NEXUS));
 }


### PR DESCRIPTION
## Summary
- Expands the reference blueprint set to nine agent/context/OpenShell combinations with normalized usage headers.
- Adds `docs/BLUEPRINTS.md` plus runnable quickstart, enterprise hub, and headless CI sample project templates.
- Adds fast parse/resolve/verify coverage for all reference blueprints and an optional live `create -> exec -> destroy` integration harness.
- Stabilizes Python-backed JSON-RPC fixture tests that were timing out under parallel workspace test load.

Closes #20.

## Test Plan
- [x] `cargo fmt`
- [x] `cargo clippy --workspace --all-targets -- -D warnings`
- [x] `cargo test --workspace`
- [x] `cargo test -p blueprint-integration --features integration -- --ignored --nocapture`

## E2E Note
The CLI-backed live harness was run, but full live `create -> exec -> destroy` E2E did not execute locally because `openshell --version` is unavailable in this environment. The harness exited successfully after printing the skip reason. On a machine with OpenShell and the blueprint-specific credentials/drivers, the same command exercises eligible blueprints end to end.
