### PR TITLE
[codex] Add image hardening profiles

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -223,6 +223,7 @@ dependencies = [
  "agentenv-proto",
  "once_cell",
  "serde",
+ "serde_json",
  "serde_yaml",
  "thiserror 1.0.69",
 ]

--- a/crates/agentenv-core/src/hardening.rs
+++ b/crates/agentenv-core/src/hardening.rs
@@ -290,12 +290,11 @@ fn analyze_dockerfile(contents: &str, profile: &HardeningProfile) -> DockerfileA
         .map(|package| normalize_package_token(package))
         .collect::<BTreeSet<_>>();
     let mut analysis = DockerfileAnalysis::default();
+    let mut current_stage_root_user = None;
 
-    for (index, line) in contents.lines().enumerate() {
-        let line_number = index + 1;
-        let Some(active) = active_dockerfile_line(line) else {
-            continue;
-        };
+    for instruction in dockerfile_instructions(contents) {
+        let line_number = instruction.line;
+        let active = instruction.text.as_str();
         let lower = active.to_ascii_lowercase();
 
         if active.contains(&profile.dockerfile.marker) {
@@ -309,8 +308,11 @@ fn analyze_dockerfile(contents: &str, profile: &HardeningProfile) -> DockerfileA
         {
             analysis.first_cap_add_line = Some(line_number);
         }
+        if is_from_instruction(active) {
+            current_stage_root_user = None;
+        }
         if let Some(user) = final_user_from_line(active) {
-            analysis.final_root_user = if matches!(user.as_str(), "root" | "0") {
+            current_stage_root_user = if matches!(user.as_str(), "root" | "0") {
                 Some((line_number, user))
             } else {
                 None
@@ -328,7 +330,58 @@ fn analyze_dockerfile(contents: &str, profile: &HardeningProfile) -> DockerfileA
         }
     }
 
+    analysis.final_root_user = current_stage_root_user;
     analysis
+}
+
+#[derive(Debug)]
+struct DockerfileInstruction {
+    line: usize,
+    text: String,
+}
+
+fn dockerfile_instructions(contents: &str) -> Vec<DockerfileInstruction> {
+    let mut instructions = Vec::new();
+    let mut current = String::new();
+    let mut current_line = None;
+
+    for (index, line) in contents.lines().enumerate() {
+        let line_number = index + 1;
+        let Some(active) = active_dockerfile_line(line) else {
+            continue;
+        };
+        if current_line.is_none() {
+            current_line = Some(line_number);
+        }
+
+        let (segment, continued) = continuation_segment(active);
+        if !segment.is_empty() {
+            if !current.is_empty() {
+                current.push(' ');
+            }
+            current.push_str(segment);
+        }
+
+        if !continued {
+            if !current.is_empty() {
+                instructions.push(DockerfileInstruction {
+                    line: current_line.unwrap_or(line_number),
+                    text: current,
+                });
+            }
+            current = String::new();
+            current_line = None;
+        }
+    }
+
+    if !current.is_empty() {
+        instructions.push(DockerfileInstruction {
+            line: current_line.unwrap_or(1),
+            text: current,
+        });
+    }
+
+    instructions
 }
 
 fn active_dockerfile_line(line: &str) -> Option<&str> {
@@ -338,6 +391,20 @@ fn active_dockerfile_line(line: &str) -> Option<&str> {
     } else {
         Some(trimmed)
     }
+}
+
+fn continuation_segment(line: &str) -> (&str, bool) {
+    let trimmed = line.trim_end();
+    let Some(segment) = trimmed.strip_suffix('\\') else {
+        return (trimmed, false);
+    };
+    (segment.trim_end(), true)
+}
+
+fn is_from_instruction(line: &str) -> bool {
+    line.split_whitespace()
+        .next()
+        .is_some_and(|instruction| instruction.eq_ignore_ascii_case("FROM"))
 }
 
 fn final_user_from_line(line: &str) -> Option<String> {

--- a/crates/agentenv-core/src/hardening.rs
+++ b/crates/agentenv-core/src/hardening.rs
@@ -1,0 +1,83 @@
+use std::collections::BTreeMap;
+
+use agentenv_policy::{
+    apply_hardening_to_policy, hardening_metadata, resolve_hardening_profile, HardeningProfile,
+    PolicyError,
+};
+use thiserror::Error;
+
+use crate::blueprint::ComponentSection;
+
+const DEFAULT_HARDENING_PROFILE: &str = "baseline";
+
+#[derive(Debug, Clone)]
+pub struct ResolvedHardening {
+    pub profile: HardeningProfile,
+    pub metadata: BTreeMap<String, serde_json::Value>,
+}
+
+#[derive(Debug, Error)]
+pub enum HardeningError {
+    #[error("invalid sandbox.hardening: expected non-empty string profile name or null")]
+    InvalidType,
+    #[error("invalid sandbox.hardening: expected non-empty string profile name")]
+    EmptyName,
+    #[error("invalid sandbox.hardening `{name}`: {source}")]
+    Resolve {
+        name: String,
+        #[source]
+        source: PolicyError,
+    },
+    #[error("invalid sandbox.hardening `{name}` metadata: {source}")]
+    Metadata {
+        name: String,
+        #[source]
+        source: PolicyError,
+    },
+    #[error("failed to apply sandbox.hardening `{name}`: {source}")]
+    Apply {
+        name: String,
+        #[source]
+        source: PolicyError,
+    },
+}
+
+pub type HardeningResult<T> = Result<T, HardeningError>;
+
+pub fn resolve_sandbox_hardening(sandbox: &ComponentSection) -> HardeningResult<ResolvedHardening> {
+    let name = sandbox_hardening_profile_name(sandbox)?;
+    let profile = resolve_hardening_profile(&name).map_err(|source| HardeningError::Resolve {
+        name: name.clone(),
+        source,
+    })?;
+    let metadata = hardening_metadata(&profile).map_err(|source| HardeningError::Metadata {
+        name: name.clone(),
+        source,
+    })?;
+
+    Ok(ResolvedHardening { profile, metadata })
+}
+
+pub fn apply_resolved_hardening_to_policy(
+    policy: &mut agentenv_proto::NetworkPolicy,
+    resolved: &ResolvedHardening,
+    persist_home: bool,
+) -> HardeningResult<()> {
+    apply_hardening_to_policy(policy, &resolved.profile, persist_home).map_err(|source| {
+        HardeningError::Apply {
+            name: resolved.profile.name.clone(),
+            source,
+        }
+    })
+}
+
+fn sandbox_hardening_profile_name(sandbox: &ComponentSection) -> HardeningResult<String> {
+    match sandbox.extra.get("hardening") {
+        None | Some(serde_yaml::Value::Null) => Ok(DEFAULT_HARDENING_PROFILE.to_owned()),
+        Some(serde_yaml::Value::String(name)) if name.trim().is_empty() => {
+            Err(HardeningError::EmptyName)
+        }
+        Some(serde_yaml::Value::String(name)) => Ok(name.clone()),
+        Some(_) => Err(HardeningError::InvalidType),
+    }
+}

--- a/crates/agentenv-core/src/hardening.rs
+++ b/crates/agentenv-core/src/hardening.rs
@@ -1,19 +1,61 @@
-use std::collections::BTreeMap;
+use std::{
+    collections::{BTreeMap, BTreeSet},
+    fs,
+    path::{Path, PathBuf},
+};
 
 use agentenv_policy::{
     apply_hardening_to_policy, hardening_metadata, resolve_hardening_profile, HardeningProfile,
     PolicyError,
 };
+use serde::{Deserialize, Serialize};
 use thiserror::Error;
 
-use crate::blueprint::ComponentSection;
+use crate::{
+    blueprint::{Blueprint, ComponentSection},
+    runtime::RuntimeError,
+};
 
 const DEFAULT_HARDENING_PROFILE: &str = "baseline";
+const DOCKERFILE_UNREADABLE: &str = "dockerfile_unreadable";
+const DOCKERFILE_USER_ROOT: &str = "dockerfile_user_root";
+const DOCKERFILE_PRIVILEGED: &str = "dockerfile_privileged";
+const DOCKERFILE_CAP_ADD: &str = "dockerfile_cap_add";
+const DOCKERFILE_MISSING_HARDENING_MARKER: &str = "dockerfile_missing_hardening_marker";
+const DOCKERFILE_REINTRODUCES_STRIPPED_PACKAGE: &str = "dockerfile_reintroduces_stripped_package";
 
 #[derive(Debug, Clone)]
 pub struct ResolvedHardening {
     pub profile: HardeningProfile,
     pub metadata: BTreeMap<String, serde_json::Value>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct HardeningLintReport {
+    pub profile: String,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub dockerfile: Option<PathBuf>,
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub diagnostics: Vec<HardeningLintDiagnostic>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct HardeningLintDiagnostic {
+    pub severity: HardeningLintSeverity,
+    pub code: String,
+    pub message: String,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub line: Option<usize>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub remediation: Option<String>,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "lowercase")]
+pub enum HardeningLintSeverity {
+    Info,
+    Warning,
+    Error,
 }
 
 #[derive(Debug, Error)]
@@ -71,6 +113,32 @@ pub fn apply_resolved_hardening_to_policy(
     })
 }
 
+pub fn lint_blueprint_hardening(
+    blueprint_yaml: &str,
+    cwd: &Path,
+) -> Result<HardeningLintReport, RuntimeError> {
+    let blueprint = Blueprint::from_yaml(blueprint_yaml)?;
+    lint_sandbox_hardening(&blueprint.sandbox, cwd)
+}
+
+pub(crate) fn lint_sandbox_hardening(
+    sandbox: &ComponentSection,
+    cwd: &Path,
+) -> Result<HardeningLintReport, RuntimeError> {
+    let resolved = resolve_sandbox_hardening(sandbox)?;
+    let dockerfile = byo_dockerfile_path(&sandbox.extra).map(|path| resolve_path(cwd, &path));
+    let diagnostics = dockerfile
+        .as_deref()
+        .map(|path| lint_dockerfile(path, &resolved.profile))
+        .unwrap_or_default();
+
+    Ok(HardeningLintReport {
+        profile: resolved.profile.name,
+        dockerfile,
+        diagnostics,
+    })
+}
+
 fn sandbox_hardening_profile_name(sandbox: &ComponentSection) -> HardeningResult<String> {
     match sandbox.extra.get("hardening") {
         None | Some(serde_yaml::Value::Null) => Ok(DEFAULT_HARDENING_PROFILE.to_owned()),
@@ -79,5 +147,308 @@ fn sandbox_hardening_profile_name(sandbox: &ComponentSection) -> HardeningResult
         }
         Some(serde_yaml::Value::String(name)) => Ok(name.clone()),
         Some(_) => Err(HardeningError::InvalidType),
+    }
+}
+
+fn byo_dockerfile_path(sandbox_extra: &BTreeMap<String, serde_yaml::Value>) -> Option<PathBuf> {
+    let image = sandbox_extra.get("image")?.as_mapping()?;
+    if yaml_mapping_string(image, "source") != Some("byo") {
+        return None;
+    }
+    yaml_mapping_string(image, "dockerfile").map(PathBuf::from)
+}
+
+fn yaml_mapping_string<'a>(mapping: &'a serde_yaml::Mapping, key: &str) -> Option<&'a str> {
+    mapping
+        .get(serde_yaml::Value::String(key.to_owned()))
+        .and_then(serde_yaml::Value::as_str)
+}
+
+fn resolve_path(cwd: &Path, path: &Path) -> PathBuf {
+    if path.is_absolute() {
+        path.to_path_buf()
+    } else {
+        cwd.join(path)
+    }
+}
+
+fn lint_dockerfile(path: &Path, profile: &HardeningProfile) -> Vec<HardeningLintDiagnostic> {
+    let contents = match fs::read_to_string(path) {
+        Ok(contents) => contents,
+        Err(source) => {
+            return vec![diagnostic(
+                HardeningLintSeverity::Error,
+                DOCKERFILE_UNREADABLE,
+                format!(
+                    "could not read BYO Dockerfile `{}`: {source}",
+                    path.display()
+                ),
+                None,
+                Some("Check the Dockerfile path and permissions before creating the environment"),
+            )];
+        }
+    };
+
+    let analysis = analyze_dockerfile(&contents, profile);
+    let mut diagnostics = Vec::new();
+
+    if let Some((line, user)) = analysis.final_root_user {
+        diagnostics.push(diagnostic(
+            root_user_severity(profile),
+            DOCKERFILE_USER_ROOT,
+            format!(
+                "BYO Dockerfile `{}` leaves the final image user as `{user}` for hardening profile `{}`",
+                path.display(),
+                profile.name
+            ),
+            Some(line),
+            Some("Set a non-root final USER that matches the sandbox policy"),
+        ));
+    }
+
+    if let Some(line) = analysis.first_privileged_line {
+        diagnostics.push(diagnostic(
+            HardeningLintSeverity::Warning,
+            DOCKERFILE_PRIVILEGED,
+            format!(
+                "BYO Dockerfile `{}` references `--privileged`, which conflicts with sandbox isolation expectations",
+                path.display()
+            ),
+            Some(line),
+            Some("Remove privileged container nesting from the sandbox image build"),
+        ));
+    }
+
+    if let Some(line) = analysis.first_cap_add_line {
+        diagnostics.push(diagnostic(
+            HardeningLintSeverity::Warning,
+            DOCKERFILE_CAP_ADD,
+            format!(
+                "BYO Dockerfile `{}` references capability additions, which may conflict with hardening profile `{}`",
+                path.display(),
+                profile.name
+            ),
+            Some(line),
+            Some("Move Linux capability requirements into agentenv policy instead of the image"),
+        ));
+    }
+
+    if !analysis.marker_present {
+        diagnostics.push(diagnostic(
+            HardeningLintSeverity::Warning,
+            DOCKERFILE_MISSING_HARDENING_MARKER,
+            format!(
+                "BYO Dockerfile `{}` does not declare hardening marker `{}`",
+                path.display(),
+                profile.dockerfile.marker
+            ),
+            None,
+            Some(
+                "Apply the selected hardening profile fragment or declare its marker in the image",
+            ),
+        ));
+    }
+
+    if !analysis.reintroduced_packages.is_empty() {
+        let packages = analysis
+            .reintroduced_packages
+            .keys()
+            .cloned()
+            .collect::<Vec<_>>()
+            .join(", ");
+        let line = analysis.reintroduced_packages.values().copied().min();
+        diagnostics.push(diagnostic(
+            package_reintroduction_severity(profile),
+            DOCKERFILE_REINTRODUCES_STRIPPED_PACKAGE,
+            format!(
+                "BYO Dockerfile `{}` installs package(s) stripped by hardening profile `{}`: {packages}",
+                path.display(),
+                profile.name
+            ),
+            line,
+            Some("Remove package installation or choose a hardening profile that permits these tools"),
+        ));
+    }
+
+    diagnostics
+}
+
+#[derive(Debug, Default)]
+struct DockerfileAnalysis {
+    final_root_user: Option<(usize, String)>,
+    first_privileged_line: Option<usize>,
+    first_cap_add_line: Option<usize>,
+    marker_present: bool,
+    reintroduced_packages: BTreeMap<String, usize>,
+}
+
+fn analyze_dockerfile(contents: &str, profile: &HardeningProfile) -> DockerfileAnalysis {
+    let stripped_packages = profile
+        .packages
+        .strip
+        .iter()
+        .map(|package| normalize_package_token(package))
+        .collect::<BTreeSet<_>>();
+    let mut analysis = DockerfileAnalysis::default();
+
+    for (index, line) in contents.lines().enumerate() {
+        let line_number = index + 1;
+        let Some(active) = active_dockerfile_line(line) else {
+            continue;
+        };
+        let lower = active.to_ascii_lowercase();
+
+        if active.contains(&profile.dockerfile.marker) {
+            analysis.marker_present = true;
+        }
+        if lower.contains("--privileged") && analysis.first_privileged_line.is_none() {
+            analysis.first_privileged_line = Some(line_number);
+        }
+        if (lower.contains("cap_add") || lower.contains("cap-add"))
+            && analysis.first_cap_add_line.is_none()
+        {
+            analysis.first_cap_add_line = Some(line_number);
+        }
+        if let Some(user) = final_user_from_line(active) {
+            analysis.final_root_user = if matches!(user.as_str(), "root" | "0") {
+                Some((line_number, user))
+            } else {
+                None
+            };
+        }
+
+        for package in installed_packages_from_line(active) {
+            let normalized = normalize_package_token(&package);
+            if stripped_packages.contains(&normalized) {
+                analysis
+                    .reintroduced_packages
+                    .entry(normalized)
+                    .or_insert(line_number);
+            }
+        }
+    }
+
+    analysis
+}
+
+fn active_dockerfile_line(line: &str) -> Option<&str> {
+    let trimmed = line.trim();
+    if trimmed.is_empty() || trimmed.starts_with('#') {
+        None
+    } else {
+        Some(trimmed)
+    }
+}
+
+fn final_user_from_line(line: &str) -> Option<String> {
+    let mut parts = line.split_whitespace();
+    let instruction = parts.next()?;
+    if !instruction.eq_ignore_ascii_case("USER") {
+        return None;
+    }
+    parts.next().map(|user| {
+        user.trim_matches(|ch| ch == '"' || ch == '\'')
+            .split(':')
+            .next()
+            .unwrap_or(user)
+            .to_ascii_lowercase()
+    })
+}
+
+fn installed_packages_from_line(line: &str) -> Vec<String> {
+    let mut parts = line.splitn(2, char::is_whitespace);
+    let instruction = parts.next().unwrap_or_default();
+    if !instruction.eq_ignore_ascii_case("RUN") {
+        return Vec::new();
+    }
+    let command = parts.next().unwrap_or_default();
+    let tokens = dockerfile_command_tokens(command);
+    let mut packages = Vec::new();
+
+    for index in 0..tokens.len().saturating_sub(1) {
+        let token = tokens[index].as_str();
+        let next = tokens[index + 1].as_str();
+        let package_start = match (token, next) {
+            ("apk", "add") | ("apt-get", "install") | ("apt", "install") => index + 2,
+            _ => continue,
+        };
+        packages.extend(package_tokens_after_install(&tokens[package_start..]));
+    }
+
+    packages
+}
+
+fn dockerfile_command_tokens(command: &str) -> Vec<String> {
+    command
+        .split_whitespace()
+        .map(|token| {
+            token
+                .trim_matches(|ch: char| matches!(ch, '"' | '\'' | '(' | ')'))
+                .to_ascii_lowercase()
+        })
+        .filter(|token| !token.is_empty())
+        .collect()
+}
+
+fn package_tokens_after_install(tokens: &[String]) -> Vec<String> {
+    let mut packages = Vec::new();
+    for token in tokens {
+        if matches!(token.as_str(), "&&" | "||" | "|" | ";" | "\\") {
+            break;
+        }
+        let cleaned = token.trim_end_matches([',', ';', '\\']);
+        let ends_command = token.len() != cleaned.len();
+        if !cleaned.is_empty() && !cleaned.starts_with('-') {
+            packages.push(cleaned.to_owned());
+        }
+        if ends_command {
+            break;
+        }
+    }
+    packages
+}
+
+fn normalize_package_token(package: &str) -> String {
+    package
+        .trim()
+        .trim_matches(|ch: char| matches!(ch, '"' | '\'' | ',' | ';' | '\\'))
+        .split(['=', '<', '>'])
+        .next()
+        .unwrap_or_default()
+        .split(':')
+        .next()
+        .unwrap_or_default()
+        .to_ascii_lowercase()
+}
+
+fn root_user_severity(profile: &HardeningProfile) -> HardeningLintSeverity {
+    if profile.name == "open" {
+        HardeningLintSeverity::Warning
+    } else {
+        HardeningLintSeverity::Error
+    }
+}
+
+fn package_reintroduction_severity(profile: &HardeningProfile) -> HardeningLintSeverity {
+    if profile.name == "strict" {
+        HardeningLintSeverity::Error
+    } else {
+        HardeningLintSeverity::Warning
+    }
+}
+
+fn diagnostic(
+    severity: HardeningLintSeverity,
+    code: &str,
+    message: String,
+    line: Option<usize>,
+    remediation: Option<&str>,
+) -> HardeningLintDiagnostic {
+    HardeningLintDiagnostic {
+        severity,
+        code: code.to_owned(),
+        message,
+        line,
+        remediation: remediation.map(ToOwned::to_owned),
     }
 }

--- a/crates/agentenv-core/src/hardening.rs
+++ b/crates/agentenv-core/src/hardening.rs
@@ -16,7 +16,7 @@ use crate::{
     runtime::RuntimeError,
 };
 
-const DEFAULT_HARDENING_PROFILE: &str = "baseline";
+pub(crate) const DEFAULT_HARDENING_PROFILE: &str = "baseline";
 const DOCKERFILE_UNREADABLE: &str = "dockerfile_unreadable";
 const DOCKERFILE_USER_ROOT: &str = "dockerfile_user_root";
 const DOCKERFILE_PRIVILEGED: &str = "dockerfile_privileged";
@@ -111,6 +111,10 @@ pub fn apply_resolved_hardening_to_policy(
             source,
         }
     })
+}
+
+pub(crate) fn sandbox_hardening_declared(sandbox: &ComponentSection) -> bool {
+    sandbox.extra.contains_key("hardening")
 }
 
 pub fn lint_blueprint_hardening(

--- a/crates/agentenv-core/src/lib.rs
+++ b/crates/agentenv-core/src/lib.rs
@@ -10,6 +10,7 @@ pub mod driver_artifact;
 pub mod driver_catalog;
 pub mod env;
 pub mod error;
+pub mod hardening;
 pub mod inference;
 pub mod lifecycle;
 pub mod lockfile;

--- a/crates/agentenv-core/src/lifecycle.rs
+++ b/crates/agentenv-core/src/lifecycle.rs
@@ -165,6 +165,8 @@ pub enum LifecycleError {
         #[source]
         source: Box<SsrfBlocked>,
     },
+    #[error(transparent)]
+    Hardening(#[from] crate::hardening::HardeningError),
     #[error("failed to serialize canonical resolved blueprint: {0}")]
     CanonicalBlueprintSerialize(serde_yaml::Error),
 }
@@ -215,6 +217,7 @@ fn verify_resolved_blueprint(
     resolved: ResolvedBlueprint,
 ) -> Result<ResolvedBlueprint, LifecycleError> {
     validate_blueprint_urls(&resolved.blueprint)?;
+    crate::hardening::resolve_sandbox_hardening(&resolved.blueprint.sandbox)?;
     let canonical = canonical_blueprint(&resolved)?;
     collect_credentials(&canonical)?;
     Ok(resolved)
@@ -251,6 +254,7 @@ pub fn reproduce_from_lockfile(
 fn build_lockfile_from_blueprint_yaml(yaml: &str) -> Result<Lockfile, LifecycleError> {
     let resolved = resolve_blueprint(yaml)?;
     validate_blueprint_urls(&resolved.blueprint)?;
+    crate::hardening::resolve_sandbox_hardening(&resolved.blueprint.sandbox)?;
     let canonical = canonical_blueprint(&resolved)?;
     let credentials = collect_credentials(&canonical)?;
 

--- a/crates/agentenv-core/src/portable_lockfile.rs
+++ b/crates/agentenv-core/src/portable_lockfile.rs
@@ -75,6 +75,8 @@ pub enum PortableLockfileError {
     #[error(transparent)]
     Lockfile(#[from] crate::lockfile::LockfileError),
     #[error(transparent)]
+    Hardening(#[from] crate::hardening::HardeningError),
+    #[error(transparent)]
     Policy(#[from] agentenv_policy::PolicyError),
     #[error("missing artifact for {kind} driver `{name}` version `{version}`")]
     MissingDriverArtifact {
@@ -95,16 +97,12 @@ pub fn build_portable_lockfile(
 ) -> Result<PortableLockfile, PortableLockfileError> {
     let registry = registry_from_artifacts(&input.driver_artifacts);
     let resolved = verify_blueprint_yaml_with_registry(&input.blueprint_yaml, &registry)?;
-    let composition = portable_canonical_blueprint(&resolved)?;
+    let mut composition = portable_canonical_blueprint(&resolved)?;
+    lock_default_sandbox_hardening(&mut composition);
     let blueprint_hash = portable_blueprint_hash(&composition)?;
     let policy = PortablePolicy {
         declared: composition.policy.clone(),
-        resolved: compose_policy(
-            parse_tier(&composition.policy.tier)?,
-            &parse_presets(&composition.policy.presets)?,
-            policy_overrides(&composition.policy.overrides),
-            &PresetRegistry::load_builtin()?,
-        )?,
+        resolved: resolved_policy_for_composition(&composition)?,
     };
     let credentials = collect_portable_credentials(&composition);
     let artifacts = portable_collect_artifacts(&composition)?;
@@ -388,16 +386,7 @@ fn verify_policy(lockfile: &PortableLockfile, report: &mut PortableVerifyReport)
         return;
     }
 
-    let recomputed = parse_tier(&lockfile.policy.declared.tier).and_then(|tier| {
-        let presets = parse_presets(&lockfile.policy.declared.presets)?;
-        let registry = PresetRegistry::load_builtin()?;
-        compose_policy(
-            tier,
-            &presets,
-            policy_overrides(&lockfile.policy.declared.overrides),
-            &registry,
-        )
-    });
+    let recomputed = resolved_policy_for_composition(&lockfile.composition);
 
     match recomputed {
         Ok(policy) if policy == lockfile.policy.resolved => {}
@@ -538,6 +527,50 @@ fn collect_portable_credentials(
         credentials.extend(inference.credentials.clone());
     }
     credentials
+}
+
+fn lock_default_sandbox_hardening(composition: &mut crate::lockfile::PortableComposition) {
+    if matches!(
+        composition.sandbox.extra.get("hardening"),
+        None | Some(serde_yaml::Value::Null)
+    ) {
+        composition.sandbox.extra.insert(
+            "hardening".to_owned(),
+            serde_yaml::Value::String(crate::hardening::DEFAULT_HARDENING_PROFILE.to_owned()),
+        );
+    }
+}
+
+fn resolved_policy_for_composition(
+    composition: &crate::lockfile::PortableComposition,
+) -> Result<NetworkPolicy, PortableLockfileError> {
+    let mut policy = compose_policy(
+        parse_tier(&composition.policy.tier)?,
+        &parse_presets(&composition.policy.presets)?,
+        policy_overrides(&composition.policy.overrides),
+        &PresetRegistry::load_builtin()?,
+    )?;
+    apply_portable_hardening_to_policy(&mut policy, composition)?;
+    Ok(policy)
+}
+
+fn apply_portable_hardening_to_policy(
+    policy: &mut NetworkPolicy,
+    composition: &crate::lockfile::PortableComposition,
+) -> Result<(), PortableLockfileError> {
+    let sandbox = blueprint_component_from_portable(&composition.sandbox);
+    if !crate::hardening::sandbox_hardening_declared(&sandbox) {
+        return Ok(());
+    }
+
+    let resolved = crate::hardening::resolve_sandbox_hardening(&sandbox)?;
+    let persist_home = composition
+        .state
+        .as_ref()
+        .and_then(|state| state.persist_home)
+        .unwrap_or(false);
+    crate::hardening::apply_resolved_hardening_to_policy(policy, &resolved, persist_home)?;
+    Ok(())
 }
 
 fn blueprint_yaml_from_portable_composition(

--- a/crates/agentenv-core/src/runtime.rs
+++ b/crates/agentenv-core/src/runtime.rs
@@ -1062,8 +1062,15 @@ async fn create_env_with_input(
                 handle: context_handle.handle.clone(),
             })
             .await?;
-        let resolved_hardening =
-            crate::hardening::resolve_sandbox_hardening(&resolved.blueprint.sandbox)?;
+        let send_hardening_metadata = input.resolved_policy.is_none()
+            || crate::hardening::sandbox_hardening_declared(&resolved.blueprint.sandbox);
+        let resolved_hardening = if send_hardening_metadata {
+            Some(crate::hardening::resolve_sandbox_hardening(
+                &resolved.blueprint.sandbox,
+            )?)
+        } else {
+            None
+        };
         let persist_home = resolved
             .blueprint
             .state
@@ -1108,10 +1115,12 @@ async fn create_env_with_input(
                 })
             })?,
         };
-        if input.resolved_policy.is_none() {
+        if let (None, Some(resolved_hardening)) =
+            (input.resolved_policy.as_ref(), resolved_hardening.as_ref())
+        {
             crate::hardening::apply_resolved_hardening_to_policy(
                 &mut policy,
-                &resolved_hardening,
+                resolved_hardening,
                 persist_home,
             )?;
             policy.network.allow.extend(context_network_rules.rules);
@@ -1128,7 +1137,7 @@ async fn create_env_with_input(
             &context_endpoint,
             env,
             Some(create_policy.clone()),
-            &resolved_hardening,
+            resolved_hardening.as_ref(),
         )?;
         let sandbox_handle = match set.sandbox.create(sandbox_spec).await {
             Ok(handle) => {
@@ -1468,6 +1477,9 @@ pub fn freeze_env_lockfile(options: &RuntimeOptions, name: &str) -> RuntimeResul
     if let crate::lockfile::LockfileDocument::Portable(mut lockfile) =
         crate::lockfile::LockfileDocument::from_yaml(&description.lock_yaml)?
     {
+        let env_blueprint = crate::blueprint::Blueprint::from_yaml(&description.blueprint_yaml)?;
+        let env_hardening_declared =
+            crate::hardening::sandbox_hardening_declared(&env_blueprint.sandbox);
         let expected_lockfile = crate::portable_lockfile::build_portable_lockfile(
             crate::portable_lockfile::PortableLockfileInput {
                 name: description.state.name.clone(),
@@ -1475,10 +1487,11 @@ pub fn freeze_env_lockfile(options: &RuntimeOptions, name: &str) -> RuntimeResul
                 driver_artifacts: driver_artifacts.clone(),
             },
         )?;
-        if lockfile.composition != expected_lockfile.composition
-            || lockfile.blueprint_hash != expected_lockfile.blueprint_hash
-            || lockfile.policy.declared != expected_lockfile.composition.policy
-        {
+        if !portable_lockfile_matches_env_blueprint(
+            &lockfile,
+            &expected_lockfile,
+            env_hardening_declared,
+        )? {
             return Err(RuntimeError::PortableLockfileVerification {
                 details:
                     "portable lockfile composition does not match env blueprint or declared policy"
@@ -1521,6 +1534,29 @@ pub fn freeze_env_lockfile(options: &RuntimeOptions, name: &str) -> RuntimeResul
     }
 
     Ok(lockfile.to_yaml_deterministic()?)
+}
+
+fn portable_lockfile_matches_env_blueprint(
+    lockfile: &crate::lockfile::PortableLockfile,
+    expected: &crate::lockfile::PortableLockfile,
+    env_hardening_declared: bool,
+) -> RuntimeResult<bool> {
+    if lockfile.policy.declared != expected.composition.policy {
+        return Ok(false);
+    }
+    if lockfile.composition == expected.composition
+        && lockfile.blueprint_hash == expected.blueprint_hash
+    {
+        return Ok(true);
+    }
+    if env_hardening_declared || lockfile.composition.sandbox.extra.contains_key("hardening") {
+        return Ok(false);
+    }
+
+    let mut legacy_expected = expected.composition.clone();
+    legacy_expected.sandbox.extra.remove("hardening");
+    let legacy_hash = crate::lifecycle::portable_blueprint_hash(&legacy_expected)?;
+    Ok(lockfile.composition == legacy_expected && lockfile.blueprint_hash == legacy_hash)
 }
 
 pub async fn reproduce_env(
@@ -1831,7 +1867,7 @@ fn sandbox_spec_for_create(
     context_endpoint: &agentenv_proto::McpEndpoint,
     env: BTreeMap<String, String>,
     policy: Option<agentenv_proto::NetworkPolicy>,
-    resolved_hardening: &crate::hardening::ResolvedHardening,
+    resolved_hardening: Option<&crate::hardening::ResolvedHardening>,
 ) -> RuntimeResult<agentenv_proto::SandboxSpec> {
     let mut metadata = BTreeMap::from([
         ("name".to_owned(), serde_json::json!(name)),
@@ -1852,7 +1888,9 @@ fn sandbox_spec_for_create(
             serde_json::json!("/sandbox"),
         ),
     ]);
-    metadata.extend(resolved_hardening.metadata.clone());
+    if let Some(resolved_hardening) = resolved_hardening {
+        metadata.extend(resolved_hardening.metadata.clone());
+    }
     let image = match sandbox_extra.get("image") {
         Some(serde_yaml::Value::String(image)) => Some(image.clone()),
         Some(serde_yaml::Value::Mapping(image)) => {
@@ -5929,6 +5967,50 @@ policy:
         );
     }
 
+    #[test]
+    fn portable_lockfile_records_default_hardening_profile() {
+        let root = unique_root("agentenv-portable-default-hardening");
+        let yaml = r#"
+version: 0.1.0
+min_agentenv_version: 0.0.1-alpha0
+sandbox:
+  driver: openshell
+agent:
+  driver: codex
+context:
+  driver: filesystem
+  mount: .
+policy:
+  tier: restricted
+  presets: []
+"#;
+        let mut discovery_config = crate::driver_catalog::DriverDiscoveryConfig::from_env();
+        discovery_config.installed_root = root.join("drivers");
+        let driver_artifacts =
+            crate::driver_artifact::discover_driver_artifacts(discovery_config, None)
+                .expect("discover driver artifacts");
+        let lockfile = crate::portable_lockfile::build_portable_lockfile(
+            crate::portable_lockfile::PortableLockfileInput {
+                name: "demo".to_owned(),
+                blueprint_yaml: yaml.to_owned(),
+                driver_artifacts,
+            },
+        )
+        .expect("build portable lockfile");
+
+        assert_eq!(
+            lockfile.composition.sandbox.extra["hardening"],
+            serde_yaml::Value::String("baseline".to_owned())
+        );
+        assert!(lockfile
+            .policy
+            .resolved
+            .filesystem
+            .read_only
+            .contains(&"/etc".to_owned()));
+        let _ = fs::remove_dir_all(root);
+    }
+
     #[tokio::test]
     async fn create_env_records_computed_byo_digest_in_lockfile() {
         let root = unique_root("agentenv-create-byo-digest-lock");
@@ -6584,6 +6666,10 @@ version: 0.1.0
 min_agentenv_version: 0.0.1-alpha0
 sandbox:
   driver: openshell
+  image:
+    source: byo
+    dockerfile: /tmp/legacy-sandbox/Dockerfile
+    expected_digest: sha256:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
 agent:
   driver: codex
 context:
@@ -6606,6 +6692,17 @@ policy:
             },
         )
         .expect("build portable lockfile");
+        lockfile.composition.sandbox.extra.remove("hardening");
+        lockfile.blueprint_hash = crate::lifecycle::portable_blueprint_hash(&lockfile.composition)
+            .expect("recompute legacy blueprint hash");
+        let registry = agentenv_policy::PresetRegistry::load_builtin().expect("load presets");
+        lockfile.policy.resolved = agentenv_policy::compose_policy(
+            agentenv_policy::Tier::Restricted,
+            &[],
+            None,
+            &registry,
+        )
+        .expect("compose legacy policy");
         let pinned_rule = agentenv_proto::NetworkRule {
             target: NetworkTarget::Host {
                 host: "pinned.example".to_owned(),
@@ -6655,6 +6752,26 @@ policy:
         assert!(
             !create_policies[0].network.allow.contains(&context_rule),
             "sandbox create policy should not add context-required rules during reproduce"
+        );
+        let create_specs = tracker
+            .create_specs
+            .lock()
+            .expect("create spec tracker")
+            .clone();
+        assert_eq!(create_specs.len(), 1);
+        assert_eq!(
+            create_specs[0].metadata["byo_dockerfile"],
+            serde_json::json!("/tmp/legacy-sandbox/Dockerfile")
+        );
+        assert!(
+            !create_specs[0]
+                .metadata
+                .contains_key("hardening_dockerfile_fragment"),
+            "legacy lockfiles without sandbox.hardening must not inject image hardening"
+        );
+        assert!(
+            !create_specs[0].metadata.contains_key("hardening_profile"),
+            "legacy lockfiles without sandbox.hardening must not default hardening metadata"
         );
         let applied_policies = tracker
             .applied_policies
@@ -6945,6 +7062,89 @@ policy:
         assert!(frozen.contains("name: renamed-demo"));
         assert!(frozen.contains("resolved:"));
         assert!(frozen.contains("frozen-pinned.example"));
+    }
+
+    #[tokio::test]
+    async fn freeze_after_reproduce_accepts_legacy_lockfile_without_hardening() {
+        let root = unique_root("agentenv-freeze-legacy-no-hardening");
+        let options = RuntimeOptions {
+            root: root.clone(),
+            log_level: LogLevel::Info,
+            non_interactive: true,
+        };
+        let yaml = r#"
+version: 0.1.0
+min_agentenv_version: 0.0.1-alpha0
+sandbox:
+  driver: openshell
+agent:
+  driver: codex
+context:
+  driver: filesystem
+  mount: .
+policy:
+  tier: restricted
+  presets: []
+"#;
+        let mut discovery_config = crate::driver_catalog::DriverDiscoveryConfig::from_env();
+        discovery_config.installed_root = root.join("drivers");
+        let driver_artifacts =
+            crate::driver_artifact::discover_driver_artifacts(discovery_config, None)
+                .expect("discover driver artifacts");
+        let mut lockfile = crate::portable_lockfile::build_portable_lockfile(
+            crate::portable_lockfile::PortableLockfileInput {
+                name: "source-demo".to_owned(),
+                blueprint_yaml: yaml.to_owned(),
+                driver_artifacts,
+            },
+        )
+        .expect("build portable lockfile");
+        lockfile.composition.sandbox.extra.remove("hardening");
+        lockfile.blueprint_hash = crate::lifecycle::portable_blueprint_hash(&lockfile.composition)
+            .expect("recompute legacy blueprint hash");
+        let registry = agentenv_policy::PresetRegistry::load_builtin().expect("load presets");
+        lockfile.policy.resolved = agentenv_policy::compose_policy(
+            agentenv_policy::Tier::Restricted,
+            &[],
+            None,
+            &registry,
+        )
+        .expect("compose legacy policy");
+        lockfile
+            .policy
+            .resolved
+            .network
+            .allow
+            .push(agentenv_proto::NetworkRule {
+                target: NetworkTarget::Host {
+                    host: "legacy-pinned.example".to_owned(),
+                    port: Some(443),
+                    scheme: Some("https".to_owned()),
+                    http_access: None,
+                },
+            });
+        let lockfile_yaml = lockfile
+            .to_yaml_deterministic()
+            .expect("render portable lockfile");
+        let mut credentials = super::tests_support::EmptyCredentialProvider;
+
+        super::reproduce_env(
+            &options,
+            &TinyFactory,
+            &mut credentials,
+            "legacy-demo",
+            &lockfile_yaml,
+        )
+        .await
+        .expect("reproduce env");
+
+        let frozen = super::freeze_env_lockfile(&options, "legacy-demo").expect("freeze env");
+
+        assert!(frozen.contains("legacy-pinned.example"));
+        assert!(
+            !frozen.contains("hardening: baseline"),
+            "freezing a reproduced legacy lockfile should preserve absent hardening"
+        );
     }
 
     #[tokio::test]

--- a/crates/agentenv-core/src/runtime.rs
+++ b/crates/agentenv-core/src/runtime.rs
@@ -282,6 +282,8 @@ pub enum RuntimeError {
     #[error(transparent)]
     PortableLockfile(#[from] crate::portable_lockfile::PortableLockfileError),
     #[error(transparent)]
+    Blueprint(#[from] crate::error::BlueprintError),
+    #[error(transparent)]
     Hardening(#[from] crate::hardening::HardeningError),
     #[error(transparent)]
     ApprovalConfig(#[from] agentenv_approvals::ApprovalConfigError),
@@ -623,10 +625,21 @@ pub fn add_byo_dockerfile_preflight_warnings(
     report: &mut crate::admission::AdmissionReport,
     sandbox_extra: &BTreeMap<String, serde_yaml::Value>,
 ) {
-    let Some(dockerfile) = byo_dockerfile_path(sandbox_extra) else {
-        return;
+    let sandbox = crate::blueprint::ComponentSection {
+        driver: "openshell".to_owned(),
+        version: None,
+        credentials: None,
+        extra: sandbox_extra.clone(),
     };
-    let issues = dockerfile_preflight_warnings(&dockerfile);
+    let issues = match crate::hardening::lint_sandbox_hardening(&sandbox, Path::new(".")) {
+        Ok(report) => hardening_lint_preflight_issues(&report.diagnostics),
+        Err(error) => vec![agentenv_proto::PreflightIssue {
+            severity: agentenv_proto::IssueSeverity::Error,
+            code: "dockerfile_lint_failed".to_owned(),
+            message: format!("failed to lint BYO Dockerfile hardening: {error}"),
+            remediation: Some("Check sandbox.image and sandbox.hardening configuration".to_owned()),
+        }],
+    };
     if issues.is_empty() {
         return;
     }
@@ -637,6 +650,7 @@ pub fn add_byo_dockerfile_preflight_warnings(
         .find(|check| check.kind == DriverKind::Sandbox)
     {
         check.issues.extend(issues);
+        refresh_preflight_status(report);
         return;
     }
 
@@ -646,6 +660,51 @@ pub fn add_byo_dockerfile_preflight_warnings(
         ok: true,
         issues,
     });
+    refresh_preflight_status(report);
+}
+
+fn hardening_lint_preflight_issues(
+    diagnostics: &[crate::hardening::HardeningLintDiagnostic],
+) -> Vec<agentenv_proto::PreflightIssue> {
+    diagnostics
+        .iter()
+        .map(|diagnostic| agentenv_proto::PreflightIssue {
+            severity: match diagnostic.severity {
+                crate::hardening::HardeningLintSeverity::Info => {
+                    agentenv_proto::IssueSeverity::Info
+                }
+                crate::hardening::HardeningLintSeverity::Warning => {
+                    agentenv_proto::IssueSeverity::Warning
+                }
+                crate::hardening::HardeningLintSeverity::Error => {
+                    agentenv_proto::IssueSeverity::Error
+                }
+            },
+            code: diagnostic.code.clone(),
+            message: diagnostic.message.clone(),
+            remediation: diagnostic.remediation.clone(),
+        })
+        .collect()
+}
+
+fn refresh_preflight_status(report: &mut crate::admission::AdmissionReport) {
+    let has_error = report.checks.iter().any(|check| {
+        !check.ok
+            || check
+                .issues
+                .iter()
+                .any(|issue| issue.severity == agentenv_proto::IssueSeverity::Error)
+    });
+    report.status = if has_error {
+        crate::admission::AdmissionStatus::Rejected
+    } else {
+        crate::admission::AdmissionStatus::Accepted
+    };
+    report.reason_code = if has_error {
+        crate::admission::ReasonCode::PreflightFailed
+    } else {
+        crate::admission::ReasonCode::Created
+    };
 }
 
 async fn run_preflight_with_pins(
@@ -1897,99 +1956,6 @@ fn byo_image_needs_computed_digest(sandbox_extra: &BTreeMap<String, serde_yaml::
             yaml_mapping_string(image, "source") == Some("byo")
                 && yaml_mapping_string(image, "expected_digest").is_none()
         })
-}
-
-fn byo_dockerfile_path(sandbox_extra: &BTreeMap<String, serde_yaml::Value>) -> Option<PathBuf> {
-    let image = sandbox_extra.get("image")?.as_mapping()?;
-    if yaml_mapping_string(image, "source") != Some("byo") {
-        return None;
-    }
-    yaml_mapping_string(image, "dockerfile").map(PathBuf::from)
-}
-
-fn dockerfile_preflight_warnings(path: &Path) -> Vec<agentenv_proto::PreflightIssue> {
-    let contents = match fs::read_to_string(path) {
-        Ok(contents) => contents,
-        Err(source) => {
-            return vec![preflight_warning(
-                "byo_dockerfile_unreadable",
-                format!(
-                    "could not read BYO Dockerfile `{}`: {source}",
-                    path.display()
-                ),
-                Some("Check the Dockerfile path and permissions before creating the environment"),
-            )];
-        }
-    };
-
-    let mut saw_privileged = false;
-    let mut saw_cap_add = false;
-    let mut final_user = None;
-    for line in contents.lines() {
-        let trimmed = line.trim();
-        if trimmed.is_empty() || trimmed.starts_with('#') {
-            continue;
-        }
-        let lower = trimmed.to_ascii_lowercase();
-        if lower.contains("--privileged") {
-            saw_privileged = true;
-        }
-        if lower.contains("cap_add") || lower.contains("cap-add") {
-            saw_cap_add = true;
-        }
-        if let Some(rest) = lower.strip_prefix("user ") {
-            final_user = rest
-                .split_whitespace()
-                .next()
-                .map(|user| user.split(':').next().unwrap_or(user).to_owned());
-        }
-    }
-
-    let mut issues = Vec::new();
-    if saw_privileged {
-        issues.push(preflight_warning(
-            "byo_dockerfile_privileged",
-            format!(
-                "BYO Dockerfile `{}` references `--privileged`, which conflicts with sandbox isolation expectations",
-                path.display()
-            ),
-            Some("Remove privileged container nesting from the sandbox image build"),
-        ));
-    }
-    if saw_cap_add {
-        issues.push(preflight_warning(
-            "byo_dockerfile_cap_add",
-            format!(
-                "BYO Dockerfile `{}` references `cap_add`, which may conflict with sandbox capability policy",
-                path.display()
-            ),
-            Some("Move Linux capability requirements into agentenv policy instead of the image"),
-        ));
-    }
-    if matches!(final_user.as_deref(), Some("root" | "0")) {
-        issues.push(preflight_warning(
-            "byo_dockerfile_user_root",
-            format!(
-                "BYO Dockerfile `{}` leaves the final image user as root",
-                path.display()
-            ),
-            Some("Set a non-root final USER that matches the sandbox policy"),
-        ));
-    }
-    issues
-}
-
-fn preflight_warning(
-    code: &str,
-    message: String,
-    remediation: Option<&str>,
-) -> agentenv_proto::PreflightIssue {
-    agentenv_proto::PreflightIssue {
-        severity: agentenv_proto::IssueSeverity::Warning,
-        code: code.to_owned(),
-        message,
-        remediation: remediation.map(ToOwned::to_owned),
-    }
 }
 
 fn sanitize_byo_build_name(name: &str) -> String {
@@ -3341,6 +3307,7 @@ fn runtime_error_reason_code(error: &RuntimeError) -> &'static str {
         | RuntimeError::Lifecycle(_)
         | RuntimeError::Lockfile(_)
         | RuntimeError::PortableLockfile(_)
+        | RuntimeError::Blueprint(_)
         | RuntimeError::Hardening(_)
         | RuntimeError::ApprovalConfig(_)
         | RuntimeError::LegacyLockfileReproduce
@@ -6053,19 +6020,25 @@ USER root
 
         super::add_byo_dockerfile_preflight_warnings(&mut report, &sandbox_extra);
 
-        assert_eq!(report.status, crate::admission::AdmissionStatus::Accepted);
+        assert_eq!(report.status, crate::admission::AdmissionStatus::Rejected);
+        assert_eq!(
+            report.reason_code,
+            crate::admission::ReasonCode::PreflightFailed
+        );
         let codes = report.checks[0]
             .issues
             .iter()
             .map(|issue| issue.code.as_str())
             .collect::<Vec<_>>();
-        assert!(codes.contains(&"byo_dockerfile_privileged"));
-        assert!(codes.contains(&"byo_dockerfile_cap_add"));
-        assert!(codes.contains(&"byo_dockerfile_user_root"));
+        assert!(codes.contains(&"dockerfile_privileged"));
+        assert!(codes.contains(&"dockerfile_cap_add"));
+        assert!(codes.contains(&"dockerfile_user_root"));
+        assert!(codes.contains(&"dockerfile_missing_hardening_marker"));
         assert!(report.checks[0]
             .issues
             .iter()
-            .all(|issue| issue.severity == agentenv_proto::IssueSeverity::Warning));
+            .any(|issue| issue.code == "dockerfile_user_root"
+                && issue.severity == agentenv_proto::IssueSeverity::Error));
         fs::remove_dir_all(root).unwrap();
     }
 

--- a/crates/agentenv-core/src/runtime.rs
+++ b/crates/agentenv-core/src/runtime.rs
@@ -282,6 +282,8 @@ pub enum RuntimeError {
     #[error(transparent)]
     PortableLockfile(#[from] crate::portable_lockfile::PortableLockfileError),
     #[error(transparent)]
+    Hardening(#[from] crate::hardening::HardeningError),
+    #[error(transparent)]
     ApprovalConfig(#[from] agentenv_approvals::ApprovalConfigError),
     #[error(transparent)]
     ApprovalNotification(#[from] agentenv_approvals::ApprovalNotificationError),
@@ -1001,6 +1003,14 @@ async fn create_env_with_input(
                 handle: context_handle.handle.clone(),
             })
             .await?;
+        let resolved_hardening =
+            crate::hardening::resolve_sandbox_hardening(&resolved.blueprint.sandbox)?;
+        let persist_home = resolved
+            .blueprint
+            .state
+            .as_ref()
+            .and_then(|state| state.persist_home)
+            .unwrap_or(false);
 
         let (inference_handle, inference_endpoint) = match (
             set.inference.as_ref(),
@@ -1040,6 +1050,11 @@ async fn create_env_with_input(
             })?,
         };
         if input.resolved_policy.is_none() {
+            crate::hardening::apply_resolved_hardening_to_policy(
+                &mut policy,
+                &resolved_hardening,
+                persist_home,
+            )?;
             policy.network.allow.extend(context_network_rules.rules);
         }
 
@@ -1054,6 +1069,7 @@ async fn create_env_with_input(
             &context_endpoint,
             env,
             Some(create_policy.clone()),
+            &resolved_hardening,
         )?;
         let sandbox_handle = match set.sandbox.create(sandbox_spec).await {
             Ok(handle) => {
@@ -1756,6 +1772,7 @@ fn sandbox_spec_for_create(
     context_endpoint: &agentenv_proto::McpEndpoint,
     env: BTreeMap<String, String>,
     policy: Option<agentenv_proto::NetworkPolicy>,
+    resolved_hardening: &crate::hardening::ResolvedHardening,
 ) -> RuntimeResult<agentenv_proto::SandboxSpec> {
     let mut metadata = BTreeMap::from([
         ("name".to_owned(), serde_json::json!(name)),
@@ -1776,6 +1793,7 @@ fn sandbox_spec_for_create(
             serde_json::json!("/sandbox"),
         ),
     ]);
+    metadata.extend(resolved_hardening.metadata.clone());
     let image = match sandbox_extra.get("image") {
         Some(serde_yaml::Value::String(image)) => Some(image.clone()),
         Some(serde_yaml::Value::Mapping(image)) => {
@@ -3323,6 +3341,7 @@ fn runtime_error_reason_code(error: &RuntimeError) -> &'static str {
         | RuntimeError::Lifecycle(_)
         | RuntimeError::Lockfile(_)
         | RuntimeError::PortableLockfile(_)
+        | RuntimeError::Hardening(_)
         | RuntimeError::ApprovalConfig(_)
         | RuntimeError::LegacyLockfileReproduce
         | RuntimeError::PortableLockfileVerification { .. }
@@ -5843,6 +5862,104 @@ policy:
             )
         );
         assert_eq!(metadata["agentenv_agent"], serde_json::json!("codex"));
+    }
+
+    #[tokio::test]
+    async fn sandbox_spec_defaults_to_baseline_hardening_metadata() {
+        let root = unique_root("agentenv-create-baseline-hardening");
+        let options = RuntimeOptions {
+            root,
+            log_level: LogLevel::Info,
+            non_interactive: true,
+        };
+        let yaml = r#"
+version: 0.1.0
+min_agentenv_version: 0.0.1-alpha0
+sandbox:
+  driver: openshell
+agent:
+  driver: codex
+context:
+  driver: filesystem
+  mount: .
+policy:
+  tier: restricted
+  presets: []
+"#;
+        let tracker = Arc::new(AgentSetupTracker::default());
+        let mut credentials = super::tests_support::EmptyCredentialProvider;
+
+        super::create_env(
+            &options,
+            &AgentSetupFactory {
+                tracker: Arc::clone(&tracker),
+            },
+            &mut credentials,
+            "demo",
+            yaml,
+        )
+        .await
+        .unwrap();
+
+        let specs = tracker.create_specs.lock().expect("create spec tracker");
+        assert_eq!(specs.len(), 1);
+        assert_eq!(
+            specs[0].metadata["hardening_profile"],
+            serde_json::json!("baseline")
+        );
+        assert!(specs[0]
+            .metadata
+            .contains_key("hardening_dockerfile_fragment"));
+    }
+
+    #[tokio::test]
+    async fn sandbox_spec_propagates_strict_hardening_metadata() {
+        let root = unique_root("agentenv-create-strict-hardening");
+        let options = RuntimeOptions {
+            root,
+            log_level: LogLevel::Info,
+            non_interactive: true,
+        };
+        let yaml = r#"
+version: 0.1.0
+min_agentenv_version: 0.0.1-alpha0
+sandbox:
+  driver: openshell
+  hardening: strict
+agent:
+  driver: codex
+context:
+  driver: filesystem
+  mount: .
+policy:
+  tier: restricted
+  presets: []
+"#;
+        let tracker = Arc::new(AgentSetupTracker::default());
+        let mut credentials = super::tests_support::EmptyCredentialProvider;
+
+        super::create_env(
+            &options,
+            &AgentSetupFactory {
+                tracker: Arc::clone(&tracker),
+            },
+            &mut credentials,
+            "demo",
+            yaml,
+        )
+        .await
+        .unwrap();
+
+        let specs = tracker.create_specs.lock().expect("create spec tracker");
+        assert_eq!(specs.len(), 1);
+        assert_eq!(
+            specs[0].metadata["hardening_profile"],
+            serde_json::json!("strict")
+        );
+        assert_eq!(
+            specs[0].metadata["hardening_ulimit_nproc"],
+            serde_json::json!(512)
+        );
     }
 
     #[tokio::test]

--- a/crates/agentenv-core/tests/hardening_lint.rs
+++ b/crates/agentenv-core/tests/hardening_lint.rs
@@ -1,0 +1,132 @@
+use std::{
+    collections::BTreeMap,
+    fs,
+    path::{Path, PathBuf},
+    time::{SystemTime, UNIX_EPOCH},
+};
+
+use agentenv_core::hardening::{lint_blueprint_hardening, HardeningLintSeverity};
+
+fn unique_root(prefix: &str) -> PathBuf {
+    let nanos = SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .expect("system clock should be after epoch")
+        .as_nanos();
+    std::env::temp_dir().join(format!("{prefix}-{}-{nanos}", std::process::id()))
+}
+
+fn blueprint(dockerfile: &str, hardening: Option<&str>) -> String {
+    let hardening = hardening
+        .map(|profile| format!("  hardening: {profile}\n"))
+        .unwrap_or_default();
+    format!(
+        r#"
+version: 0.1.0
+min_agentenv_version: 0.0.1-alpha0
+sandbox:
+  driver: openshell
+{hardening}  image:
+    source: byo
+    dockerfile: {dockerfile}
+agent:
+  driver: codex
+context:
+  driver: filesystem
+policy:
+  tier: restricted
+  presets: []
+"#
+    )
+}
+
+fn diagnostic_severities(
+    report: &agentenv_core::hardening::HardeningLintReport,
+) -> BTreeMap<&str, HardeningLintSeverity> {
+    report
+        .diagnostics
+        .iter()
+        .map(|diagnostic| (diagnostic.code.as_str(), diagnostic.severity))
+        .collect()
+}
+
+#[test]
+fn strict_dockerfile_reports_hardening_conflicts() {
+    let root = unique_root("agentenv-hardening-lint-strict");
+    let sandbox_dir = root.join("sandbox");
+    fs::create_dir_all(&sandbox_dir).unwrap();
+    let dockerfile = sandbox_dir.join("Dockerfile");
+    fs::write(
+        &dockerfile,
+        r#"
+FROM alpine:3.20
+RUN apk add --no-cache gcc git
+RUN docker run --privileged alpine true
+RUN echo cap_add: NET_ADMIN
+USER root
+"#,
+    )
+    .unwrap();
+
+    let yaml = blueprint("sandbox/Dockerfile", Some("strict"));
+    let report = lint_blueprint_hardening(&yaml, Path::new(&root)).unwrap();
+
+    assert_eq!(report.profile, "strict");
+    assert_eq!(report.dockerfile.as_deref(), Some(dockerfile.as_path()));
+
+    let severities = diagnostic_severities(&report);
+    assert_eq!(
+        severities.get("dockerfile_user_root"),
+        Some(&HardeningLintSeverity::Error)
+    );
+    assert_eq!(
+        severities.get("dockerfile_reintroduces_stripped_package"),
+        Some(&HardeningLintSeverity::Error)
+    );
+    assert!(severities.contains_key("dockerfile_privileged"));
+    assert!(severities.contains_key("dockerfile_cap_add"));
+    assert!(severities.contains_key("dockerfile_missing_hardening_marker"));
+    assert!(report
+        .diagnostics
+        .iter()
+        .any(|diagnostic| diagnostic.severity == HardeningLintSeverity::Error));
+
+    fs::remove_dir_all(root).unwrap();
+}
+
+#[test]
+fn baseline_is_default_and_package_reintroduction_is_warning() {
+    let root = unique_root("agentenv-hardening-lint-baseline");
+    let sandbox_dir = root.join("sandbox");
+    fs::create_dir_all(&sandbox_dir).unwrap();
+    fs::write(
+        sandbox_dir.join("Dockerfile"),
+        r#"
+FROM ubuntu:24.04
+ENV AGENTENV_HARDENING_PROFILE=baseline
+RUN apt-get update && apt-get install -y gcc
+USER agent
+"#,
+    )
+    .unwrap();
+
+    let yaml = blueprint("sandbox/Dockerfile", None);
+    let report = lint_blueprint_hardening(&yaml, Path::new(&root)).unwrap();
+
+    assert_eq!(report.profile, "baseline");
+    let severities = diagnostic_severities(&report);
+    assert_eq!(
+        severities.get("dockerfile_reintroduces_stripped_package"),
+        Some(&HardeningLintSeverity::Warning)
+    );
+    assert!(!severities.contains_key("dockerfile_missing_hardening_marker"));
+
+    fs::remove_dir_all(root).unwrap();
+}
+
+#[test]
+fn lint_severity_serializes_lowercase() {
+    assert_eq!(
+        serde_json::to_value(HardeningLintSeverity::Warning).unwrap(),
+        serde_json::json!("warning")
+    );
+}

--- a/crates/agentenv-core/tests/hardening_lint.rs
+++ b/crates/agentenv-core/tests/hardening_lint.rs
@@ -124,6 +124,76 @@ USER agent
 }
 
 #[test]
+fn strict_detects_package_reintroduction_from_multiline_apt_install() {
+    let root = unique_root("agentenv-hardening-lint-multiline-apt");
+    let sandbox_dir = root.join("sandbox");
+    fs::create_dir_all(&sandbox_dir).unwrap();
+    fs::write(
+        sandbox_dir.join("Dockerfile"),
+        r#"
+FROM ubuntu:24.04
+ENV AGENTENV_HARDENING_PROFILE=strict
+RUN apt-get update && apt-get install -y \
+    gcc \
+    git
+USER agent
+"#,
+    )
+    .unwrap();
+
+    let yaml = blueprint("sandbox/Dockerfile", Some("strict"));
+    let report = lint_blueprint_hardening(&yaml, Path::new(&root)).unwrap();
+
+    let package_diagnostic = report
+        .diagnostics
+        .iter()
+        .find(|diagnostic| diagnostic.code == "dockerfile_reintroduces_stripped_package")
+        .expect("expected package reintroduction diagnostic");
+    assert_eq!(package_diagnostic.severity, HardeningLintSeverity::Error);
+    assert!(
+        package_diagnostic.message.contains("gcc") && package_diagnostic.message.contains("git"),
+        "unexpected diagnostic message: {}",
+        package_diagnostic.message
+    );
+
+    fs::remove_dir_all(root).unwrap();
+}
+
+#[test]
+fn builder_stage_user_root_does_not_apply_to_final_stage() {
+    let root = unique_root("agentenv-hardening-lint-multistage-user");
+    let sandbox_dir = root.join("sandbox");
+    fs::create_dir_all(&sandbox_dir).unwrap();
+    fs::write(
+        sandbox_dir.join("Dockerfile"),
+        r#"
+FROM alpine:3.20 AS builder
+USER root
+RUN echo building
+
+FROM alpine:3.20
+ENV AGENTENV_HARDENING_PROFILE=strict
+RUN echo final
+"#,
+    )
+    .unwrap();
+
+    let yaml = blueprint("sandbox/Dockerfile", Some("strict"));
+    let report = lint_blueprint_hardening(&yaml, Path::new(&root)).unwrap();
+
+    assert!(
+        !report
+            .diagnostics
+            .iter()
+            .any(|diagnostic| diagnostic.code == "dockerfile_user_root"),
+        "builder-stage USER root should not be reported for final stage: {:?}",
+        report.diagnostics
+    );
+
+    fs::remove_dir_all(root).unwrap();
+}
+
+#[test]
 fn lint_severity_serializes_lowercase() {
     assert_eq!(
         serde_json::to_value(HardeningLintSeverity::Warning).unwrap(),

--- a/crates/agentenv-core/tests/roundtrip.rs
+++ b/crates/agentenv-core/tests/roundtrip.rs
@@ -298,3 +298,35 @@ policy:
         "sha256:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
     );
 }
+
+#[test]
+fn roundtrip_rejects_unknown_hardening_profile() {
+    let yaml = r#"
+version: 0.1.0
+min_agentenv_version: 0.0.1-alpha0
+sandbox:
+  driver: openshell
+  hardening: hardened-like-fort-knox
+agent:
+  driver: codex
+context:
+  driver: filesystem
+  mount: ~/projects
+policy:
+  tier: balanced
+  presets: []
+"#;
+
+    let err = agentenv_core::lifecycle::verify_blueprint_yaml(yaml).unwrap_err();
+    let message = err.to_string();
+
+    assert!(
+        message.contains("sandbox.hardening"),
+        "unexpected error: {message}"
+    );
+    assert!(
+        message.contains("hardened-like-fort-knox"),
+        "unexpected error: {message}"
+    );
+    assert!(message.contains("hardening"), "unexpected error: {message}");
+}

--- a/crates/agentenv-policy/Cargo.toml
+++ b/crates/agentenv-policy/Cargo.toml
@@ -14,5 +14,6 @@ description = "Policy scaffolding for agentenv"
 agentenv-proto = { path = "../agentenv-proto" }
 once_cell.workspace = true
 serde.workspace = true
+serde_json.workspace = true
 serde_yaml.workspace = true
 thiserror.workspace = true

--- a/crates/agentenv-policy/README.md
+++ b/crates/agentenv-policy/README.md
@@ -1,3 +1,20 @@
 # agentenv-policy
 
 M1 scaffold crate for the `agentenv` workspace.
+
+## Image Hardening Profiles
+
+Image hardening profiles live under `hardening/` and are loaded by the policy
+crate alongside network policy presets.
+
+- `baseline.yaml` is the default production profile for sandbox images.
+- `strict.yaml` is the sensitive-work profile with tighter package, capability,
+  tmpfs, and runtime recommendations.
+- `open.yaml` is the minimal profile for exploratory environments.
+
+The crate owns typed parsing, normalization, and validation for built-in and
+custom profiles. It also merges supported filesystem settings into
+`NetworkPolicy` and serializes image/runtime recommendations into stable
+`hardening_*` metadata for sandbox drivers. Validation rejects malformed profile
+YAML, empty names or descriptions, invalid filesystem paths, invalid package or
+capability entries, missing Dockerfile fragments, and non-positive ulimits.

--- a/crates/agentenv-policy/hardening/baseline.yaml
+++ b/crates/agentenv-policy/hardening/baseline.yaml
@@ -1,0 +1,45 @@
+name: baseline
+description: Default production hardening for agentenv sandbox images.
+packages:
+  strip:
+    - gcc
+    - g++
+    - make
+    - nc
+    - tcpdump
+    - nmap
+    - strace
+    - gdb
+mounts:
+  read_only:
+    - /etc
+    - /usr
+    - /opt
+  read_write:
+    - /workspace
+    - /tmp
+    - /var/tmp
+  tmpfs: []
+ulimits:
+  nproc: 512
+  nofile: 4096
+capabilities:
+  drop:
+    - NET_RAW
+dockerfile:
+  marker: AGENTENV_HARDENING_PROFILE=baseline
+  fragment: |
+    RUN set -eu; \
+        if command -v apt-get >/dev/null 2>&1; then \
+          apt-get purge -y gcc g++ make netcat-openbsd netcat-traditional tcpdump nmap strace gdb || true; \
+          apt-get autoremove -y || true; \
+          rm -rf /var/lib/apt/lists/*; \
+        elif command -v apk >/dev/null 2>&1; then \
+          apk del gcc g++ make netcat-openbsd tcpdump nmap strace gdb || true; \
+        else \
+          echo "agentenv hardening: unsupported package manager" >&2; \
+          exit 78; \
+        fi; \
+        find / -xdev -perm /6000 -type f -exec chmod a-s {} + 2>/dev/null || true
+disable_core_dumps: false
+disable_user_namespaces: false

--- a/crates/agentenv-policy/hardening/open.yaml
+++ b/crates/agentenv-policy/hardening/open.yaml
@@ -1,0 +1,21 @@
+name: open
+description: Minimal hardening for research and exploratory sandboxes.
+packages:
+  strip: []
+mounts:
+  read_only: []
+  read_write:
+    - /workspace
+    - /tmp
+    - /var/tmp
+  tmpfs: []
+ulimits: {}
+capabilities:
+  drop: []
+dockerfile:
+  marker: AGENTENV_HARDENING_PROFILE=open
+  fragment: |
+    RUN set -eu; \
+        find / -xdev -perm /6000 -type f -exec chmod a-s {} + 2>/dev/null || true
+disable_core_dumps: false
+disable_user_namespaces: false

--- a/crates/agentenv-policy/hardening/strict.yaml
+++ b/crates/agentenv-policy/hardening/strict.yaml
@@ -1,0 +1,52 @@
+name: strict
+description: Sensitive-work hardening for legal, financial, PHI, and other high-risk sandboxes.
+packages:
+  strip:
+    - gcc
+    - g++
+    - make
+    - nc
+    - tcpdump
+    - nmap
+    - strace
+    - gdb
+    - curl
+    - wget
+    - git
+mounts:
+  read_only:
+    - /etc
+    - /usr
+    - /opt
+  read_write:
+    - /workspace
+    - /var/tmp
+  tmpfs:
+    - path: /tmp
+      size: 256m
+ulimits:
+  nproc: 512
+  nofile: 4096
+capabilities:
+  drop:
+    - NET_RAW
+    - SYS_ADMIN
+    - SYS_PTRACE
+dockerfile:
+  marker: AGENTENV_HARDENING_PROFILE=strict
+  fragment: |
+    RUN set -eu; \
+        if command -v apt-get >/dev/null 2>&1; then \
+          apt-get purge -y gcc g++ make netcat-openbsd netcat-traditional tcpdump nmap strace gdb curl wget git || true; \
+          apt-get autoremove -y || true; \
+          rm -rf /var/lib/apt/lists/*; \
+        elif command -v apk >/dev/null 2>&1; then \
+          apk del gcc g++ make netcat-openbsd tcpdump nmap strace gdb curl wget git || true; \
+        else \
+          echo "agentenv hardening: unsupported package manager" >&2; \
+          exit 78; \
+        fi; \
+        find / -xdev -perm /6000 -type f -exec chmod a-s {} + 2>/dev/null || true; \
+        printf '* hard core 0\n* soft core 0\n' >/etc/security/limits.d/agentenv-core.conf
+disable_core_dumps: true
+disable_user_namespaces: true

--- a/crates/agentenv-policy/src/error.rs
+++ b/crates/agentenv-policy/src/error.rs
@@ -12,6 +12,10 @@ pub enum PolicyError {
     RequiresRecreate { domains: String },
     #[error("failed to load preset registry: {message}")]
     PresetRegistry { message: String },
+    #[error("unknown hardening profile `{name}`. available profiles: {available}")]
+    UnknownHardeningProfile { name: String, available: String },
+    #[error("invalid hardening profile `{name}`: {message}")]
+    HardeningProfile { name: String, message: String },
     #[error("translator `{translator}` does not support this policy: {message}")]
     TranslationUnsupported {
         translator: &'static str,

--- a/crates/agentenv-policy/src/hardening.rs
+++ b/crates/agentenv-policy/src/hardening.rs
@@ -1,0 +1,311 @@
+use std::{collections::BTreeMap, env, fs, path::Path};
+
+use serde::{Deserialize, Serialize};
+use serde_json::Value;
+
+use crate::{model::NetworkPolicy, PolicyError, PolicyResult};
+
+const BUILTIN_PROFILE_NAMES: [&str; 3] = ["baseline", "strict", "open"];
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct HardeningProfile {
+    pub name: String,
+    pub description: String,
+    pub packages: HardeningPackages,
+    pub mounts: HardeningMounts,
+    pub ulimits: HardeningUlimits,
+    pub capabilities: HardeningCapabilities,
+    pub dockerfile: HardeningDockerfile,
+    pub disable_core_dumps: bool,
+    pub disable_user_namespaces: bool,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct HardeningPackages {
+    pub strip: Vec<String>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct HardeningMounts {
+    pub read_only: Vec<String>,
+    pub read_write: Vec<String>,
+    pub tmpfs: Vec<HardeningTmpfsMount>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct HardeningTmpfsMount {
+    pub path: String,
+    pub size: Option<String>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, Default)]
+pub struct HardeningUlimits {
+    pub nproc: Option<u64>,
+    pub nofile: Option<u64>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct HardeningCapabilities {
+    pub drop: Vec<String>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct HardeningDockerfile {
+    pub marker: String,
+    pub fragment: String,
+}
+
+impl HardeningProfile {
+    pub fn from_yaml(name: &str, yaml: &str) -> PolicyResult<Self> {
+        let mut profile: Self =
+            serde_yaml::from_str(yaml).map_err(|err| hardening_error(name, err.to_string()))?;
+        profile.normalize();
+        profile.validate(name)?;
+        Ok(profile)
+    }
+
+    fn normalize(&mut self) {
+        sort_and_dedup(&mut self.packages.strip);
+        sort_and_dedup(&mut self.mounts.read_only);
+        sort_and_dedup(&mut self.mounts.read_write);
+        sort_and_dedup(&mut self.capabilities.drop);
+        self.mounts.tmpfs.sort_by_key(tmpfs_sort_key);
+        self.mounts.tmpfs.dedup();
+    }
+
+    fn validate(&self, source_name: &str) -> PolicyResult<()> {
+        if self.name.trim().is_empty() {
+            return Err(hardening_error(source_name, "name must be non-empty"));
+        }
+        if self.description.trim().is_empty() {
+            return Err(hardening_error(&self.name, "description must be non-empty"));
+        }
+        if self.dockerfile.marker.trim().is_empty() {
+            return Err(hardening_error(
+                &self.name,
+                "dockerfile marker must be non-empty",
+            ));
+        }
+        if !self.dockerfile.fragment.contains("RUN ") {
+            return Err(hardening_error(
+                &self.name,
+                "dockerfile fragment must contain `RUN `",
+            ));
+        }
+        if self.ulimits.nproc == Some(0) {
+            return Err(hardening_error(&self.name, "nproc ulimit must be positive"));
+        }
+        if self.ulimits.nofile == Some(0) {
+            return Err(hardening_error(
+                &self.name,
+                "nofile ulimit must be positive",
+            ));
+        }
+        for package in &self.packages.strip {
+            if package.trim().is_empty() || package.chars().any(char::is_whitespace) {
+                return Err(hardening_error(
+                    &self.name,
+                    "package strip entries must be non-empty and contain no whitespace",
+                ));
+            }
+        }
+        for mount in &self.mounts.tmpfs {
+            if !mount.path.starts_with('/') {
+                return Err(hardening_error(
+                    &self.name,
+                    format!("tmpfs path `{}` must be absolute", mount.path),
+                ));
+            }
+            if mount
+                .size
+                .as_deref()
+                .is_some_and(|size| size.trim().is_empty())
+            {
+                return Err(hardening_error(
+                    &self.name,
+                    format!("tmpfs path `{}` size must be non-empty", mount.path),
+                ));
+            }
+        }
+        Ok(())
+    }
+}
+
+pub fn builtin_hardening_profile(name: &str) -> PolicyResult<HardeningProfile> {
+    let yaml = match name {
+        "baseline" => include_str!("../hardening/baseline.yaml"),
+        "strict" => include_str!("../hardening/strict.yaml"),
+        "open" => include_str!("../hardening/open.yaml"),
+        _ => return Err(unknown_hardening_profile(name)),
+    };
+
+    HardeningProfile::from_yaml(name, yaml)
+}
+
+pub fn resolve_hardening_profile(value: &str) -> PolicyResult<HardeningProfile> {
+    if BUILTIN_PROFILE_NAMES.contains(&value) {
+        return builtin_hardening_profile(value);
+    }
+
+    let local_path = Path::new(value);
+    if local_path.is_file() {
+        return load_profile_from_path(value, local_path);
+    }
+
+    if let Ok(profile_dir) = env::var("AGENTENV_HARDENING_PROFILE_DIR") {
+        let path = Path::new(&profile_dir).join(format!("{value}.yaml"));
+        if path.is_file() {
+            return load_profile_from_path(value, &path);
+        }
+    }
+
+    if let Some(home_dir) = home_dir() {
+        let path = home_dir
+            .join(".agentenv")
+            .join("hardening")
+            .join(format!("{value}.yaml"));
+        if path.is_file() {
+            return load_profile_from_path(value, &path);
+        }
+    }
+
+    Err(unknown_hardening_profile(value))
+}
+
+pub fn apply_hardening_to_policy(
+    policy: &mut NetworkPolicy,
+    profile: &HardeningProfile,
+    persist_home: bool,
+) -> PolicyResult<()> {
+    for path in &profile.mounts.read_only {
+        merge_path(
+            &mut policy.filesystem.read_only,
+            &mut policy.filesystem.read_write,
+            path,
+        );
+    }
+
+    for path in &profile.mounts.read_write {
+        merge_path(
+            &mut policy.filesystem.read_write,
+            &mut policy.filesystem.read_only,
+            path,
+        );
+    }
+
+    if persist_home {
+        merge_path(
+            &mut policy.filesystem.read_write,
+            &mut policy.filesystem.read_only,
+            "$HOME",
+        );
+    }
+
+    sort_and_dedup(&mut policy.filesystem.read_only);
+    sort_and_dedup(&mut policy.filesystem.read_write);
+    Ok(())
+}
+
+pub fn hardening_metadata(
+    profile: &HardeningProfile,
+) -> PolicyResult<BTreeMap<String, serde_json::Value>> {
+    profile.validate(&profile.name)?;
+
+    let mut metadata = BTreeMap::new();
+    metadata.insert(
+        "hardening_profile".to_owned(),
+        Value::String(profile.name.clone()),
+    );
+    metadata.insert(
+        "hardening_packages_strip".to_owned(),
+        serde_json::to_value(&profile.packages.strip).map_err(json_error)?,
+    );
+    metadata.insert(
+        "hardening_tmpfs".to_owned(),
+        serde_json::to_value(&profile.mounts.tmpfs).map_err(json_error)?,
+    );
+    metadata.insert(
+        "hardening_capabilities_drop".to_owned(),
+        serde_json::to_value(&profile.capabilities.drop).map_err(json_error)?,
+    );
+    metadata.insert(
+        "hardening_dockerfile_marker".to_owned(),
+        Value::String(profile.dockerfile.marker.clone()),
+    );
+    metadata.insert(
+        "hardening_dockerfile_fragment".to_owned(),
+        Value::String(profile.dockerfile.fragment.clone()),
+    );
+    metadata.insert(
+        "hardening_disable_core_dumps".to_owned(),
+        Value::Bool(profile.disable_core_dumps),
+    );
+    metadata.insert(
+        "hardening_disable_user_namespaces".to_owned(),
+        Value::Bool(profile.disable_user_namespaces),
+    );
+    if let Some(nproc) = profile.ulimits.nproc {
+        metadata.insert(
+            "hardening_ulimit_nproc".to_owned(),
+            Value::Number(nproc.into()),
+        );
+    }
+    if let Some(nofile) = profile.ulimits.nofile {
+        metadata.insert(
+            "hardening_ulimit_nofile".to_owned(),
+            Value::Number(nofile.into()),
+        );
+    }
+
+    Ok(metadata)
+}
+
+fn load_profile_from_path(name: &str, path: &Path) -> PolicyResult<HardeningProfile> {
+    let yaml = fs::read_to_string(path).map_err(|err| {
+        hardening_error(name, format!("failed to read `{}`: {err}", path.display()))
+    })?;
+    HardeningProfile::from_yaml(name, &yaml)
+}
+
+fn home_dir() -> Option<std::path::PathBuf> {
+    env::var_os("HOME")
+        .or_else(|| env::var_os("USERPROFILE"))
+        .map(std::path::PathBuf::from)
+}
+
+fn merge_path(target: &mut Vec<String>, other: &mut Vec<String>, path: &str) {
+    target.retain(|existing| existing != path);
+    other.retain(|existing| existing != path);
+    target.push(path.to_owned());
+}
+
+fn sort_and_dedup(values: &mut Vec<String>) {
+    values.sort();
+    values.dedup();
+}
+
+fn tmpfs_sort_key(mount: &HardeningTmpfsMount) -> String {
+    format!(
+        "{}|{}",
+        mount.path,
+        mount.size.as_deref().unwrap_or_default()
+    )
+}
+
+fn hardening_error(name: &str, message: impl Into<String>) -> PolicyError {
+    PolicyError::HardeningProfile {
+        name: name.to_owned(),
+        message: message.into(),
+    }
+}
+
+fn json_error(err: serde_json::Error) -> PolicyError {
+    hardening_error("metadata", err.to_string())
+}
+
+fn unknown_hardening_profile(name: &str) -> PolicyError {
+    PolicyError::UnknownHardeningProfile {
+        name: name.to_owned(),
+        available: BUILTIN_PROFILE_NAMES.join(", "),
+    }
+}

--- a/crates/agentenv-policy/src/hardening.rs
+++ b/crates/agentenv-policy/src/hardening.rs
@@ -8,6 +8,7 @@ use crate::{model::NetworkPolicy, PolicyError, PolicyResult};
 const BUILTIN_PROFILE_NAMES: [&str; 3] = ["baseline", "strict", "open"];
 
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
 pub struct HardeningProfile {
     pub name: String,
     pub description: String,
@@ -27,12 +28,14 @@ pub struct HardeningProfile {
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, Default)]
+#[serde(deny_unknown_fields)]
 pub struct HardeningPackages {
     #[serde(default)]
     pub strip: Vec<String>,
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, Default)]
+#[serde(deny_unknown_fields)]
 pub struct HardeningMounts {
     #[serde(default)]
     pub read_only: Vec<String>,
@@ -43,24 +46,28 @@ pub struct HardeningMounts {
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
 pub struct HardeningTmpfsMount {
     pub path: String,
     pub size: Option<String>,
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, Default)]
+#[serde(deny_unknown_fields)]
 pub struct HardeningUlimits {
     pub nproc: Option<u64>,
     pub nofile: Option<u64>,
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, Default)]
+#[serde(deny_unknown_fields)]
 pub struct HardeningCapabilities {
     #[serde(default)]
     pub drop: Vec<String>,
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
 pub struct HardeningDockerfile {
     pub marker: String,
     pub fragment: String,
@@ -117,6 +124,14 @@ impl HardeningProfile {
                 return Err(hardening_error(
                     &self.name,
                     "package strip entries must be non-empty and contain no whitespace",
+                ));
+            }
+        }
+        for capability in &self.capabilities.drop {
+            if capability.trim().is_empty() || capability.chars().any(char::is_whitespace) {
+                return Err(hardening_error(
+                    &self.name,
+                    "capabilities.drop entries must be non-empty and contain no whitespace",
                 ));
             }
         }

--- a/crates/agentenv-policy/src/hardening.rs
+++ b/crates/agentenv-policy/src/hardening.rs
@@ -244,18 +244,14 @@ pub fn hardening_metadata(
         "hardening_disable_user_namespaces".to_owned(),
         Value::Bool(profile.disable_user_namespaces),
     );
-    if let Some(nproc) = profile.ulimits.nproc {
-        metadata.insert(
-            "hardening_ulimit_nproc".to_owned(),
-            Value::Number(nproc.into()),
-        );
-    }
-    if let Some(nofile) = profile.ulimits.nofile {
-        metadata.insert(
-            "hardening_ulimit_nofile".to_owned(),
-            Value::Number(nofile.into()),
-        );
-    }
+    metadata.insert(
+        "hardening_ulimit_nproc".to_owned(),
+        serde_json::to_value(profile.ulimits.nproc).map_err(json_error)?,
+    );
+    metadata.insert(
+        "hardening_ulimit_nofile".to_owned(),
+        serde_json::to_value(profile.ulimits.nofile).map_err(json_error)?,
+    );
 
     Ok(metadata)
 }

--- a/crates/agentenv-policy/src/hardening.rs
+++ b/crates/agentenv-policy/src/hardening.rs
@@ -209,6 +209,8 @@ pub fn apply_hardening_to_policy(
     profile: &HardeningProfile,
     persist_home: bool,
 ) -> PolicyResult<()> {
+    profile.validate(&profile.name)?;
+
     for path in &profile.mounts.read_only {
         merge_path(
             &mut policy.filesystem.read_only,

--- a/crates/agentenv-policy/src/hardening.rs
+++ b/crates/agentenv-policy/src/hardening.rs
@@ -11,24 +11,34 @@ const BUILTIN_PROFILE_NAMES: [&str; 3] = ["baseline", "strict", "open"];
 pub struct HardeningProfile {
     pub name: String,
     pub description: String,
+    #[serde(default)]
     pub packages: HardeningPackages,
+    #[serde(default)]
     pub mounts: HardeningMounts,
+    #[serde(default)]
     pub ulimits: HardeningUlimits,
+    #[serde(default)]
     pub capabilities: HardeningCapabilities,
     pub dockerfile: HardeningDockerfile,
+    #[serde(default)]
     pub disable_core_dumps: bool,
+    #[serde(default)]
     pub disable_user_namespaces: bool,
 }
 
-#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, Default)]
 pub struct HardeningPackages {
+    #[serde(default)]
     pub strip: Vec<String>,
 }
 
-#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, Default)]
 pub struct HardeningMounts {
+    #[serde(default)]
     pub read_only: Vec<String>,
+    #[serde(default)]
     pub read_write: Vec<String>,
+    #[serde(default)]
     pub tmpfs: Vec<HardeningTmpfsMount>,
 }
 
@@ -44,8 +54,9 @@ pub struct HardeningUlimits {
     pub nofile: Option<u64>,
 }
 
-#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, Default)]
 pub struct HardeningCapabilities {
+    #[serde(default)]
     pub drop: Vec<String>,
 }
 
@@ -109,6 +120,8 @@ impl HardeningProfile {
                 ));
             }
         }
+        validate_filesystem_paths(&self.name, "read_only", &self.mounts.read_only)?;
+        validate_filesystem_paths(&self.name, "read_write", &self.mounts.read_write)?;
         for mount in &self.mounts.tmpfs {
             if !mount.path.starts_with('/') {
                 return Err(hardening_error(
@@ -129,6 +142,25 @@ impl HardeningProfile {
         }
         Ok(())
     }
+}
+
+fn validate_filesystem_paths(name: &str, field: &str, paths: &[String]) -> PolicyResult<()> {
+    for path in paths {
+        if path.trim().is_empty() {
+            return Err(hardening_error(
+                name,
+                format!("mounts.{field} path must be non-empty and absolute"),
+            ));
+        }
+        if !path.starts_with('/') {
+            return Err(hardening_error(
+                name,
+                format!("mounts.{field} path `{path}` must be absolute"),
+            ));
+        }
+    }
+
+    Ok(())
 }
 
 pub fn builtin_hardening_profile(name: &str) -> PolicyResult<HardeningProfile> {

--- a/crates/agentenv-policy/src/lib.rs
+++ b/crates/agentenv-policy/src/lib.rs
@@ -2,12 +2,18 @@
 
 pub mod engine;
 pub mod error;
+pub mod hardening;
 pub mod model;
 pub mod presets;
 pub mod translate;
 
 pub use crate::engine::{compose_policy, Tier};
 pub use crate::error::{PolicyError, PolicyResult};
+pub use crate::hardening::{
+    apply_hardening_to_policy, builtin_hardening_profile, hardening_metadata,
+    resolve_hardening_profile, HardeningCapabilities, HardeningDockerfile, HardeningMounts,
+    HardeningPackages, HardeningProfile, HardeningTmpfsMount, HardeningUlimits,
+};
 pub use crate::model::{PresetAccess, PresetSelection};
 pub use crate::presets::PresetRegistry;
 pub use crate::translate::{

--- a/crates/agentenv-policy/src/translate/openshell.rs
+++ b/crates/agentenv-policy/src/translate/openshell.rs
@@ -29,8 +29,14 @@ impl super::PolicyTranslator for OpenShellTranslator {
             version: 1,
             filesystem_policy: FilesystemPolicyDocument {
                 include_workdir: true,
-                read_only: policy.filesystem.read_only.clone(),
-                read_write: policy.filesystem.read_write.clone(),
+                read_only: openshell_filesystem_paths(
+                    &policy.filesystem.read_only,
+                    &policy.process.run_as_user,
+                )?,
+                read_write: openshell_filesystem_paths(
+                    &policy.filesystem.read_write,
+                    &policy.process.run_as_user,
+                )?,
             },
             landlock: LandlockDocument {
                 compatibility: "best_effort",
@@ -67,6 +73,44 @@ impl super::PolicyTranslator for OpenShellTranslator {
                 }),
         })
     }
+}
+
+fn openshell_filesystem_paths(
+    paths: &[String],
+    run_as_user: &str,
+) -> crate::PolicyResult<Vec<String>> {
+    paths
+        .iter()
+        .map(|path| openshell_filesystem_path(path, run_as_user))
+        .collect()
+}
+
+fn openshell_filesystem_path(path: &str, run_as_user: &str) -> crate::PolicyResult<String> {
+    if path == "$HOME" {
+        return openshell_home_path(run_as_user);
+    }
+    if let Some(rest) = path.strip_prefix("$HOME/") {
+        return Ok(format!("{}/{}", openshell_home_path(run_as_user)?, rest));
+    }
+    Ok(path.to_owned())
+}
+
+fn openshell_home_path(run_as_user: &str) -> crate::PolicyResult<String> {
+    let user = run_as_user.trim();
+    if user.is_empty() || matches!(user, "root" | "0") {
+        return Ok("/root".to_owned());
+    }
+    if user
+        .chars()
+        .all(|ch| ch.is_ascii_alphanumeric() || matches!(ch, '_' | '-'))
+    {
+        return Ok(format!("/home/{user}"));
+    }
+
+    Err(crate::PolicyError::TranslationUnsupported {
+        translator: "openshell",
+        message: format!("unsupported run_as_user for $HOME filesystem path: {run_as_user}"),
+    })
 }
 
 fn reject_unsupported_process(policy: &NetworkPolicy) -> crate::PolicyResult<()> {

--- a/crates/agentenv-policy/tests/hardening_profiles.rs
+++ b/crates/agentenv-policy/tests/hardening_profiles.rs
@@ -164,6 +164,56 @@ dockerfile:
 }
 
 #[test]
+fn invalid_profile_rejects_unknown_nested_fields() {
+    let err = HardeningProfile::from_yaml(
+        "bad-field",
+        r#"
+name: bad-field
+description: Misspelled field profile for tests.
+mounts:
+  readwrite:
+    - /tmp
+dockerfile:
+  marker: AGENTENV_HARDENING_PROFILE=bad-field
+  fragment: |
+    RUN true
+"#,
+    )
+    .expect_err("unknown field should fail");
+
+    let message = err.to_string();
+    assert!(message.contains("unknown field"));
+    assert!(message.contains("readwrite"));
+}
+
+#[test]
+fn invalid_profile_rejects_empty_or_whitespace_capability_drops() {
+    for capability in ["", "SYS ADMIN"] {
+        let yaml = format!(
+            r#"
+name: bad-capability
+description: Bad capability profile for tests.
+capabilities:
+  drop:
+    - "{capability}"
+dockerfile:
+  marker: AGENTENV_HARDENING_PROFILE=bad-capability
+  fragment: |
+    RUN true
+"#
+        );
+
+        let err = HardeningProfile::from_yaml("bad-capability", &yaml)
+            .expect_err("invalid capability should fail");
+        let message = err.to_string();
+
+        assert!(message.contains("capabilities.drop"));
+        assert!(message.contains("non-empty"));
+        assert!(message.contains("whitespace"));
+    }
+}
+
+#[test]
 fn hardening_merge_rejects_directly_constructed_invalid_filesystem_paths() {
     let registry = PresetRegistry::load_builtin().expect("load presets");
     let mut policy = compose_policy(Tier::Balanced, &[], None, &registry).expect("compose");

--- a/crates/agentenv-policy/tests/hardening_profiles.rs
+++ b/crates/agentenv-policy/tests/hardening_profiles.rs
@@ -106,11 +106,24 @@ fn hardening_metadata_is_stable_json() {
 
     assert_eq!(metadata["hardening_profile"], "strict");
     assert_eq!(metadata["hardening_ulimit_nproc"], 512);
+    assert_eq!(metadata["hardening_ulimit_nofile"], 4096);
     assert_eq!(metadata["hardening_disable_core_dumps"], true);
     assert!(metadata["hardening_packages_strip"]
         .as_array()
         .expect("strip array")
         .contains(&serde_json::Value::String("curl".to_owned())));
+
+    let open = builtin_hardening_profile("open").expect("load open");
+    let open_metadata = hardening_metadata(&open).expect("metadata");
+
+    assert_eq!(
+        open_metadata["hardening_ulimit_nproc"],
+        serde_json::Value::Null
+    );
+    assert_eq!(
+        open_metadata["hardening_ulimit_nofile"],
+        serde_json::Value::Null
+    );
 }
 
 #[test]

--- a/crates/agentenv-policy/tests/hardening_profiles.rs
+++ b/crates/agentenv-policy/tests/hardening_profiles.rs
@@ -6,7 +6,7 @@ use std::{
 
 use agentenv_policy::{
     apply_hardening_to_policy, builtin_hardening_profile, compose_policy, hardening_metadata,
-    resolve_hardening_profile, HardeningProfile, PresetRegistry, Tier,
+    resolve_hardening_profile, HardeningProfile, HardeningUlimits, PresetRegistry, Tier,
 };
 
 #[test]
@@ -107,7 +107,6 @@ dockerfile:
 #[test]
 fn resolve_hardening_profile_loads_env_dir_yaml_name() {
     let _guard = env_mutex().lock().expect("env mutex");
-    let previous_dir = std::env::var_os("AGENTENV_HARDENING_PROFILE_DIR");
     let dir = temp_profile_path("env-dir");
     fs::create_dir_all(&dir).expect("create temp profile dir");
     fs::write(
@@ -123,22 +122,9 @@ dockerfile:
     )
     .expect("write env profile");
 
-    // SAFETY: this test serializes all AGENTENV_HARDENING_PROFILE_DIR access
-    // through env_mutex, and restores the previous value before releasing it.
-    unsafe {
-        std::env::set_var("AGENTENV_HARDENING_PROFILE_DIR", &dir);
-    }
+    let _env_guard = EnvVarGuard::set("AGENTENV_HARDENING_PROFILE_DIR", &dir);
 
     let resolved = resolve_hardening_profile("env-custom");
-
-    // SAFETY: guarded by env_mutex; see set_var safety note above.
-    unsafe {
-        if let Some(previous_dir) = previous_dir {
-            std::env::set_var("AGENTENV_HARDENING_PROFILE_DIR", previous_dir);
-        } else {
-            std::env::remove_var("AGENTENV_HARDENING_PROFILE_DIR");
-        }
-    }
     fs::remove_dir_all(dir).expect("remove temp profile dir");
 
     let profile = resolved.expect("resolve env profile");
@@ -175,6 +161,27 @@ dockerfile:
         assert!(message.contains("path"));
         assert!(message.contains("absolute") || message.contains("non-empty"));
     }
+}
+
+#[test]
+fn hardening_merge_rejects_directly_constructed_invalid_filesystem_paths() {
+    let registry = PresetRegistry::load_builtin().expect("load presets");
+    let mut policy = compose_policy(Tier::Balanced, &[], None, &registry).expect("compose");
+    let mut profile = builtin_hardening_profile("open").expect("load open");
+    profile.mounts.read_write = vec!["relative".to_owned()];
+    profile.ulimits = HardeningUlimits::default();
+
+    let err = apply_hardening_to_policy(&mut policy, &profile, false)
+        .expect_err("apply should validate directly constructed profile");
+    let message = err.to_string();
+
+    assert!(message.contains("read_write"));
+    assert!(message.contains("path"));
+    assert!(message.contains("absolute"));
+    assert!(!policy
+        .filesystem
+        .read_write
+        .contains(&"relative".to_owned()));
 }
 
 #[test]
@@ -269,4 +276,35 @@ fn temp_profile_path(name: &str) -> std::path::PathBuf {
 fn env_mutex() -> &'static Mutex<()> {
     static ENV_MUTEX: OnceLock<Mutex<()>> = OnceLock::new();
     ENV_MUTEX.get_or_init(|| Mutex::new(()))
+}
+
+struct EnvVarGuard {
+    name: &'static str,
+    previous: Option<std::ffi::OsString>,
+}
+
+impl EnvVarGuard {
+    fn set(name: &'static str, value: impl AsRef<std::ffi::OsStr>) -> Self {
+        let previous = std::env::var_os(name);
+        // SAFETY: callers hold env_mutex while this guard is live, serializing
+        // mutation of the process environment for this test.
+        unsafe {
+            std::env::set_var(name, value);
+        }
+        Self { name, previous }
+    }
+}
+
+impl Drop for EnvVarGuard {
+    fn drop(&mut self) {
+        // SAFETY: callers hold env_mutex while this guard is live, serializing
+        // mutation of the process environment for this test.
+        unsafe {
+            if let Some(previous) = &self.previous {
+                std::env::set_var(self.name, previous);
+            } else {
+                std::env::remove_var(self.name);
+            }
+        }
+    }
 }

--- a/crates/agentenv-policy/tests/hardening_profiles.rs
+++ b/crates/agentenv-policy/tests/hardening_profiles.rs
@@ -1,5 +1,6 @@
 use std::{
     fs,
+    sync::{Mutex, OnceLock},
     time::{SystemTime, UNIX_EPOCH},
 };
 
@@ -75,6 +76,105 @@ disable_user_namespaces: false
     assert_eq!(profile.mounts.tmpfs[0].size.as_deref(), Some("64m"));
 
     fs::remove_file(path).expect("remove temp profile");
+}
+
+#[test]
+fn minimal_custom_profile_uses_empty_defaults() {
+    let profile = HardeningProfile::from_yaml(
+        "minimal",
+        r#"
+name: minimal
+description: Minimal custom profile for tests.
+dockerfile:
+  marker: AGENTENV_HARDENING_PROFILE=minimal
+  fragment: |
+    RUN true
+"#,
+    )
+    .expect("minimal profile should parse");
+
+    assert!(profile.packages.strip.is_empty());
+    assert!(profile.mounts.read_only.is_empty());
+    assert!(profile.mounts.read_write.is_empty());
+    assert!(profile.mounts.tmpfs.is_empty());
+    assert_eq!(profile.ulimits.nproc, None);
+    assert_eq!(profile.ulimits.nofile, None);
+    assert!(profile.capabilities.drop.is_empty());
+    assert!(!profile.disable_core_dumps);
+    assert!(!profile.disable_user_namespaces);
+}
+
+#[test]
+fn resolve_hardening_profile_loads_env_dir_yaml_name() {
+    let _guard = env_mutex().lock().expect("env mutex");
+    let previous_dir = std::env::var_os("AGENTENV_HARDENING_PROFILE_DIR");
+    let dir = temp_profile_path("env-dir");
+    fs::create_dir_all(&dir).expect("create temp profile dir");
+    fs::write(
+        dir.join("env-custom.yaml"),
+        r#"
+name: env-custom
+description: Env dir custom profile for tests.
+dockerfile:
+  marker: AGENTENV_HARDENING_PROFILE=env-custom
+  fragment: |
+    RUN true
+"#,
+    )
+    .expect("write env profile");
+
+    // SAFETY: this test serializes all AGENTENV_HARDENING_PROFILE_DIR access
+    // through env_mutex, and restores the previous value before releasing it.
+    unsafe {
+        std::env::set_var("AGENTENV_HARDENING_PROFILE_DIR", &dir);
+    }
+
+    let resolved = resolve_hardening_profile("env-custom");
+
+    // SAFETY: guarded by env_mutex; see set_var safety note above.
+    unsafe {
+        if let Some(previous_dir) = previous_dir {
+            std::env::set_var("AGENTENV_HARDENING_PROFILE_DIR", previous_dir);
+        } else {
+            std::env::remove_var("AGENTENV_HARDENING_PROFILE_DIR");
+        }
+    }
+    fs::remove_dir_all(dir).expect("remove temp profile dir");
+
+    let profile = resolved.expect("resolve env profile");
+    assert_eq!(profile.name, "env-custom");
+}
+
+#[test]
+fn invalid_profile_rejects_non_absolute_filesystem_paths() {
+    for (field, path) in [
+        ("read_only", "relative"),
+        ("read_only", ""),
+        ("read_write", "relative"),
+        ("read_write", ""),
+    ] {
+        let yaml = format!(
+            r#"
+name: bad-path
+description: Bad filesystem path profile for tests.
+mounts:
+  {field}:
+    - "{path}"
+dockerfile:
+  marker: AGENTENV_HARDENING_PROFILE=bad-path
+  fragment: |
+    RUN true
+"#
+        );
+
+        let err = HardeningProfile::from_yaml("bad-path", &yaml)
+            .expect_err("relative or empty path should fail");
+        let message = err.to_string();
+
+        assert!(message.contains(field));
+        assert!(message.contains("path"));
+        assert!(message.contains("absolute") || message.contains("non-empty"));
+    }
 }
 
 #[test]
@@ -164,4 +264,9 @@ fn temp_profile_path(name: &str) -> std::path::PathBuf {
         .expect("time")
         .as_nanos();
     std::env::temp_dir().join(format!("agentenv-policy-{unique}-{name}"))
+}
+
+fn env_mutex() -> &'static Mutex<()> {
+    static ENV_MUTEX: OnceLock<Mutex<()>> = OnceLock::new();
+    ENV_MUTEX.get_or_init(|| Mutex::new(()))
 }

--- a/crates/agentenv-policy/tests/hardening_profiles.rs
+++ b/crates/agentenv-policy/tests/hardening_profiles.rs
@@ -1,0 +1,154 @@
+use std::{
+    fs,
+    time::{SystemTime, UNIX_EPOCH},
+};
+
+use agentenv_policy::{
+    apply_hardening_to_policy, builtin_hardening_profile, compose_policy, hardening_metadata,
+    resolve_hardening_profile, HardeningProfile, PresetRegistry, Tier,
+};
+
+#[test]
+fn built_in_hardening_profiles_parse_and_differ() {
+    let baseline = builtin_hardening_profile("baseline").expect("load baseline");
+    let strict = builtin_hardening_profile("strict").expect("load strict");
+    let open = builtin_hardening_profile("open").expect("load open");
+
+    assert!(baseline.packages.strip.contains(&"gcc".to_owned()));
+    assert!(strict.packages.strip.contains(&"curl".to_owned()));
+    assert!(!open.packages.strip.contains(&"gcc".to_owned()));
+
+    assert_eq!(baseline.ulimits.nproc, Some(512));
+    assert_eq!(baseline.ulimits.nofile, Some(4096));
+    assert!(strict.disable_core_dumps);
+    assert!(strict.disable_user_namespaces);
+
+    assert!(baseline.dockerfile.marker.contains("baseline"));
+    assert!(strict.dockerfile.marker.contains("strict"));
+    assert!(open.dockerfile.marker.contains("open"));
+}
+
+#[test]
+fn unknown_hardening_profile_reports_available_names() {
+    let err = builtin_hardening_profile("unknown").expect_err("unknown profile should fail");
+    let message = err.to_string();
+
+    assert!(message.contains("unknown"));
+    assert!(message.contains("baseline"));
+    assert!(message.contains("strict"));
+    assert!(message.contains("open"));
+}
+
+#[test]
+fn resolve_hardening_profile_loads_custom_yaml_path() {
+    let path = temp_profile_path("custom-profile.yaml");
+    fs::write(
+        &path,
+        r#"
+name: custom
+description: Custom profile for tests.
+packages:
+  strip: []
+mounts:
+  read_only: []
+  read_write: []
+  tmpfs:
+    - path: /cache
+      size: 64m
+ulimits: {}
+capabilities:
+  drop: []
+dockerfile:
+  marker: AGENTENV_HARDENING_PROFILE=custom
+  fragment: |
+    RUN true
+disable_core_dumps: false
+disable_user_namespaces: false
+"#,
+    )
+    .expect("write temp profile");
+
+    let profile = resolve_hardening_profile(path.to_str().expect("utf-8 path")).expect("resolve");
+
+    assert_eq!(profile.name, "custom");
+    assert_eq!(profile.mounts.tmpfs[0].path, "/cache");
+    assert_eq!(profile.mounts.tmpfs[0].size.as_deref(), Some("64m"));
+
+    fs::remove_file(path).expect("remove temp profile");
+}
+
+#[test]
+fn hardening_merge_updates_filesystem_policy_and_persisted_home() {
+    let registry = PresetRegistry::load_builtin().expect("load presets");
+    let mut policy = compose_policy(Tier::Balanced, &[], None, &registry).expect("compose");
+    let baseline = builtin_hardening_profile("baseline").expect("load baseline");
+
+    apply_hardening_to_policy(&mut policy, &baseline, true).expect("apply hardening");
+
+    assert!(policy.filesystem.read_only.contains(&"/etc".to_owned()));
+    assert!(policy.filesystem.read_only.contains(&"/opt".to_owned()));
+    assert!(policy
+        .filesystem
+        .read_write
+        .contains(&"/workspace".to_owned()));
+    assert!(policy.filesystem.read_write.contains(&"/tmp".to_owned()));
+    assert!(policy
+        .filesystem
+        .read_write
+        .contains(&"/var/tmp".to_owned()));
+    assert!(policy.filesystem.read_write.contains(&"$HOME".to_owned()));
+}
+
+#[test]
+fn hardening_metadata_is_stable_json() {
+    let strict = builtin_hardening_profile("strict").expect("load strict");
+    let metadata = hardening_metadata(&strict).expect("metadata");
+
+    assert_eq!(metadata["hardening_profile"], "strict");
+    assert_eq!(metadata["hardening_ulimit_nproc"], 512);
+    assert_eq!(metadata["hardening_disable_core_dumps"], true);
+    assert!(metadata["hardening_packages_strip"]
+        .as_array()
+        .expect("strip array")
+        .contains(&serde_json::Value::String("curl".to_owned())));
+}
+
+#[test]
+fn invalid_profile_rejects_non_positive_ulimits() {
+    let err = HardeningProfile::from_yaml(
+        "bad",
+        r#"
+name: bad
+description: Bad profile for tests.
+packages:
+  strip: []
+mounts:
+  read_only: []
+  read_write: []
+  tmpfs: []
+ulimits:
+  nproc: 0
+capabilities:
+  drop: []
+dockerfile:
+  marker: AGENTENV_HARDENING_PROFILE=bad
+  fragment: |
+    RUN true
+disable_core_dumps: false
+disable_user_namespaces: false
+"#,
+    )
+    .expect_err("non-positive ulimit should fail");
+
+    let message = err.to_string();
+    assert!(message.contains("nproc"));
+    assert!(message.contains("positive"));
+}
+
+fn temp_profile_path(name: &str) -> std::path::PathBuf {
+    let unique = SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .expect("time")
+        .as_nanos();
+    std::env::temp_dir().join(format!("agentenv-policy-{unique}-{name}"))
+}

--- a/crates/agentenv-policy/tests/translate_openshell.rs
+++ b/crates/agentenv-policy/tests/translate_openshell.rs
@@ -283,6 +283,25 @@ fn readwrite_presets_translate_to_read_write_access() {
 }
 
 #[test]
+fn persisted_home_marker_translates_to_absolute_sandbox_home() {
+    let mut policy = supported_policy();
+    policy.filesystem.read_write.push("$HOME".to_owned());
+
+    let translated = translator().translate(&policy).expect("translate policy");
+    let document: serde_yaml::Value =
+        serde_yaml::from_str(&translated.policy_yaml).expect("parse policy yaml");
+    let read_write = document["filesystem_policy"]["read_write"]
+        .as_sequence()
+        .expect("read_write sequence")
+        .iter()
+        .filter_map(serde_yaml::Value::as_str)
+        .collect::<Vec<_>>();
+
+    assert!(read_write.contains(&"/home/sandbox"));
+    assert!(!read_write.contains(&"$HOME"));
+}
+
+#[test]
 fn full_npm_registry_access_translates_to_l4_passthrough() {
     let mut policy = supported_policy();
     policy.network.allow = vec![NetworkRule {

--- a/crates/agentenv/src/main.rs
+++ b/crates/agentenv/src/main.rs
@@ -18,6 +18,7 @@ use agentenv_approvals::{
 };
 use agentenv_core::admission::{AdmissionReport, AdmissionStatus, ReasonCode};
 use agentenv_core::driver_catalog::{DiscoveredDriver, DriverCatalog};
+use agentenv_core::hardening::HardeningLintSeverity;
 use agentenv_credstore::{CredentialStore, CredentialStoreError, SecretString};
 use agentenv_events::{
     audit::{AuditPolicy, AuditSigningKey, AuditStore},
@@ -72,6 +73,7 @@ enum Commands {
     Approvals(ApprovalsArgs),
     Term(TermArgs),
     Exec(ExecArgs),
+    Blueprint(BlueprintArgs),
     Credentials(CredentialsArgs),
     Drivers(DriversArgs),
     VerifyBlueprint {
@@ -435,6 +437,24 @@ struct TermArgs {
 }
 
 #[derive(Debug, Args)]
+struct BlueprintArgs {
+    #[command(subcommand)]
+    command: BlueprintCommand,
+}
+
+#[derive(Debug, Subcommand)]
+enum BlueprintCommand {
+    Lint(BlueprintLintArgs),
+}
+
+#[derive(Debug, Args)]
+struct BlueprintLintArgs {
+    file: PathBuf,
+    #[arg(long)]
+    json: bool,
+}
+
+#[derive(Debug, Args)]
 struct CredentialsArgs {
     #[command(subcommand)]
     command: CredentialCommand,
@@ -521,6 +541,7 @@ async fn run() -> Result<()> {
         Some(Commands::Approvals(args)) => run_approvals(args, &cli.events_sink).await,
         Some(Commands::Exec(args)) => run_exec(args, &cli.events_sink).await,
         Some(Commands::Term(args)) => run_term(args).await,
+        Some(Commands::Blueprint(command)) => run_blueprint(command),
         Some(Commands::Credentials(command)) => run_credentials(command, &cli.events_sink).await,
         Some(Commands::Drivers(command)) => run_drivers(command),
         Some(Commands::VerifyBlueprint { file }) => verify_blueprint(&file),
@@ -3308,6 +3329,75 @@ async fn run_credentials(args: CredentialsArgs, event_sink_args: &[String]) -> R
     }
 }
 
+fn run_blueprint(args: BlueprintArgs) -> Result<()> {
+    match args.command {
+        BlueprintCommand::Lint(args) => run_blueprint_lint(args),
+    }
+}
+
+fn run_blueprint_lint(args: BlueprintLintArgs) -> Result<()> {
+    let blueprint_yaml = read_text_file(&args.file, "blueprint")?;
+    let cwd = args
+        .file
+        .parent()
+        .filter(|parent| !parent.as_os_str().is_empty())
+        .unwrap_or_else(|| Path::new("."));
+    let report = agentenv_core::hardening::lint_blueprint_hardening(&blueprint_yaml, cwd)
+        .with_context(|| format!("failed to lint blueprint `{}`", args.file.display()))?;
+    let has_error = report
+        .diagnostics
+        .iter()
+        .any(|diagnostic| diagnostic.severity == HardeningLintSeverity::Error);
+
+    if args.json {
+        render::print_json(&report)?;
+    } else {
+        print_hardening_lint_text(&report);
+    }
+
+    if has_error {
+        exit_process(1);
+    }
+    Ok(())
+}
+
+fn print_hardening_lint_text(report: &agentenv_core::hardening::HardeningLintReport) {
+    println!("profile: {}", report.profile);
+    if let Some(path) = report.dockerfile.as_ref() {
+        println!("dockerfile: {}", path.display());
+    }
+
+    if report.diagnostics.is_empty() {
+        println!("diagnostics: none");
+        return;
+    }
+
+    for diagnostic in &report.diagnostics {
+        let line = diagnostic
+            .line
+            .map(|line| format!(" line {line}"))
+            .unwrap_or_default();
+        println!(
+            "{} {}{}: {}",
+            hardening_lint_severity_label(diagnostic.severity),
+            diagnostic.code,
+            line,
+            diagnostic.message
+        );
+        if let Some(remediation) = diagnostic.remediation.as_ref() {
+            println!("  remediation: {remediation}");
+        }
+    }
+}
+
+fn hardening_lint_severity_label(severity: HardeningLintSeverity) -> &'static str {
+    match severity {
+        HardeningLintSeverity::Info => "info",
+        HardeningLintSeverity::Warning => "warning",
+        HardeningLintSeverity::Error => "error",
+    }
+}
+
 fn run_drivers(args: DriversArgs) -> Result<()> {
     match args.command {
         DriverCommand::List => {
@@ -3641,6 +3731,7 @@ mod tests {
                 "approvals".to_string(),
                 "term".to_string(),
                 "exec".to_string(),
+                "blueprint".to_string(),
                 "credentials".to_string(),
                 "drivers".to_string(),
                 "verify-blueprint".to_string(),

--- a/crates/agentenv/src/render.rs
+++ b/crates/agentenv/src/render.rs
@@ -45,9 +45,10 @@ pub fn reason_for_error(error: &RuntimeError) -> ReasonCode {
         RuntimeError::UnsupportedDriver { .. } | RuntimeError::MissingSelectedDriver { .. } => {
             ReasonCode::CapabilityMissing
         }
-        RuntimeError::Lifecycle(_) | RuntimeError::InvalidPolicyTier { .. } => {
-            ReasonCode::InvalidBlueprint
-        }
+        RuntimeError::Lifecycle(_)
+        | RuntimeError::Blueprint(_)
+        | RuntimeError::Hardening(_)
+        | RuntimeError::InvalidPolicyTier { .. } => ReasonCode::InvalidBlueprint,
         RuntimeError::Lockfile(_)
         | RuntimeError::PortableLockfile(_)
         | RuntimeError::ApprovalConfig(_)

--- a/crates/agentenv/tests/cli_behavior.rs
+++ b/crates/agentenv/tests/cli_behavior.rs
@@ -245,6 +245,89 @@ fn verify_blueprint_succeeds_on_reference_blueprint() {
 }
 
 #[test]
+fn cli_includes_commands() {
+    let output = Command::new(agentenv_bin()).arg("--help").output().unwrap();
+
+    assert!(output.status.success(), "{}", output_summary(&output));
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    let blueprint = stdout
+        .find("blueprint")
+        .unwrap_or_else(|| panic!("stdout was: {stdout}"));
+    let credentials = stdout
+        .find("credentials")
+        .unwrap_or_else(|| panic!("stdout was: {stdout}"));
+    assert!(
+        blueprint < credentials,
+        "`blueprint` should be listed before `credentials`; stdout was: {stdout}"
+    );
+}
+
+#[test]
+fn blueprint_lint_reports_json_diagnostics() {
+    let temp_dir = make_temp_dir("blueprint-lint-json-diagnostics");
+    let dockerfile = temp_dir.join("Dockerfile");
+    fs::write(
+        &dockerfile,
+        r#"
+FROM alpine:3.20
+RUN apk add --no-cache curl
+USER root
+"#,
+    )
+    .unwrap();
+    let blueprint = temp_dir.join("agentenv.yaml");
+    fs::write(
+        &blueprint,
+        r#"
+version: 0.1.0
+min_agentenv_version: 0.0.1-alpha0
+sandbox:
+  driver: openshell
+  hardening: strict
+  image:
+    source: byo
+    dockerfile: Dockerfile
+agent:
+  driver: codex
+context:
+  driver: filesystem
+  mount: .
+inference:
+  driver: passthrough
+policy:
+  tier: restricted
+  presets: []
+"#,
+    )
+    .unwrap();
+
+    let output = Command::new(agentenv_bin())
+        .arg("blueprint")
+        .arg("lint")
+        .arg(&blueprint)
+        .arg("--json")
+        .current_dir(&temp_dir)
+        .output()
+        .unwrap();
+
+    assert!(!output.status.success(), "{}", output_summary(&output));
+    let json: serde_json::Value = serde_json::from_slice(&output.stdout)
+        .unwrap_or_else(|err| panic!("JSON parse failed: {err}\n{}", output_summary(&output)));
+    assert_eq!(json["profile"], "strict");
+    let codes = json["diagnostics"]
+        .as_array()
+        .expect("diagnostics should be an array")
+        .iter()
+        .filter_map(|diagnostic| diagnostic["code"].as_str())
+        .collect::<BTreeSet<_>>();
+    assert!(codes.contains("dockerfile_user_root"), "codes: {codes:?}");
+    assert!(
+        codes.contains("dockerfile_reintroduces_stripped_package"),
+        "codes: {codes:?}"
+    );
+}
+
+#[test]
 fn drivers_list_includes_built_in_drivers() {
     let temp_dir = make_temp_dir("drivers-list-builtins");
 

--- a/crates/drivers/sandbox-openshell/README.md
+++ b/crates/drivers/sandbox-openshell/README.md
@@ -28,6 +28,21 @@ image ID and fails before sandbox creation on mismatch. If omitted, the computed
 digest is written to `~/.agentenv/build/<env>/image-digest` for the core to
 record in `lock.yaml`.
 
+## Hardening
+
+OpenShell consumes `SandboxSpec.metadata` during `create`. When BYO Dockerfile
+metadata includes a selected hardening profile, the driver appends the
+corresponding hardening marker and Dockerfile fragment to the staged Dockerfile
+before `docker build`. Digest verification and digest recording use the built
+image after that fragment is injected, so `sandbox.image.expected_digest` must
+match the hardened image.
+
+The driver parses and validates runtime hardening metadata such as ulimits,
+core-dump disabling, and user-namespace disabling, but the current OpenShell
+implementation does not add unsupported runtime CLI arguments to
+`openshell sandbox create`. Unsupported runtime hardening fields are surfaced by
+blueprint lint and preflight diagnostics instead of being silently ignored.
+
 Integration test command:
 
 ```bash

--- a/crates/drivers/sandbox-openshell/README.md
+++ b/crates/drivers/sandbox-openshell/README.md
@@ -40,8 +40,11 @@ match the hardened image.
 The driver parses and validates runtime hardening metadata such as ulimits,
 core-dump disabling, and user-namespace disabling, but the current OpenShell
 implementation does not add unsupported runtime CLI arguments to
-`openshell sandbox create`. Unsupported runtime hardening fields are surfaced by
-blueprint lint and preflight diagnostics instead of being silently ignored.
+`openshell sandbox create`; valid runtime metadata is not currently enforced by
+the OpenShell CLI integration. Blueprint lint and preflight currently catch BYO
+Dockerfile conflicts such as a root final user, privileged or `cap-add`
+references, missing hardening marker, and reintroduction of packages stripped by
+the selected profile.
 
 Integration test command:
 

--- a/crates/drivers/sandbox-openshell/src/lib.rs
+++ b/crates/drivers/sandbox-openshell/src/lib.rs
@@ -1816,8 +1816,18 @@ fn append_hardening_fragment(
         contents.push_str(marker);
         contents.push('\n');
     }
+    let final_user = final_stage_user(&contents);
+    let restore_user = final_user.filter(|user| !dockerfile_user_is_root(user));
+    if restore_user.is_some() {
+        contents.push_str("USER root\n");
+    }
     contents.push_str(fragment);
     if !fragment.ends_with('\n') {
+        contents.push('\n');
+    }
+    if let Some(user) = restore_user {
+        contents.push_str("USER ");
+        contents.push_str(&user);
         contents.push('\n');
     }
 
@@ -1827,6 +1837,38 @@ fn append_hardening_fragment(
             staged_dockerfile.display()
         ),
     })
+}
+
+fn final_stage_user(contents: &str) -> Option<String> {
+    let mut user = None;
+    for raw_line in contents.lines() {
+        let line = raw_line.trim_start();
+        if line.is_empty() || line.starts_with('#') {
+            continue;
+        }
+        let (instruction, rest) = split_dockerfile_instruction(line);
+        if instruction.eq_ignore_ascii_case("FROM") {
+            user = None;
+        } else if instruction.eq_ignore_ascii_case("USER") {
+            let rest = rest.trim();
+            if !rest.is_empty() {
+                user = Some(rest.to_owned());
+            }
+        }
+    }
+    user
+}
+
+fn split_dockerfile_instruction(line: &str) -> (&str, &str) {
+    match line.find(char::is_whitespace) {
+        Some(index) => (&line[..index], &line[index..]),
+        None => (line, ""),
+    }
+}
+
+fn dockerfile_user_is_root(user: &str) -> bool {
+    let user = user.split(':').next().unwrap_or(user).trim();
+    matches!(user, "root" | "0")
 }
 
 fn copy_dir_contents(src: &Path, dst: &Path) -> io::Result<()> {
@@ -4877,6 +4919,40 @@ mod driver_tests {
             std::fs::read_to_string(stage_dir.join("image-digest")).expect("digest file"),
             format!("{digest}\n")
         );
+        std::fs::remove_dir_all(tempdir).expect("remove tempdir");
+    }
+
+    #[test]
+    fn append_hardening_fragment_runs_as_root_and_restores_final_user() {
+        let tempdir = unique_tempdir("sandbox-openshell-byo-hardening-user");
+        let staged_dockerfile = tempdir.join("Dockerfile");
+        std::fs::write(
+            &staged_dockerfile,
+            "FROM alpine:3.20\nRUN adduser -D sandbox\nUSER sandbox\n",
+        )
+        .expect("write staged Dockerfile");
+        let hardening = super::OpenShellHardeningConfig {
+            profile: Some("strict".to_owned()),
+            dockerfile_marker: Some("AGENTENV_HARDENING_PROFILE=strict".to_owned()),
+            dockerfile_fragment: Some("RUN echo hardening\n".to_owned()),
+            ulimit_nproc: None,
+            ulimit_nofile: None,
+            disable_core_dumps: None,
+            disable_user_namespaces: None,
+        };
+
+        super::append_hardening_fragment(&staged_dockerfile, &hardening)
+            .expect("append hardening fragment");
+
+        let contents = std::fs::read_to_string(&staged_dockerfile).expect("staged Dockerfile");
+        let user_root = contents.find("USER root\n").expect("root user switch");
+        let run_fragment = contents
+            .find("RUN echo hardening\n")
+            .expect("hardening fragment");
+        let restore_user = contents.rfind("USER sandbox\n").expect("restored user");
+        assert!(user_root < run_fragment);
+        assert!(run_fragment < restore_user);
+        assert!(contents.trim_end().ends_with("USER sandbox"));
         std::fs::remove_dir_all(tempdir).expect("remove tempdir");
     }
 

--- a/crates/drivers/sandbox-openshell/src/lib.rs
+++ b/crates/drivers/sandbox-openshell/src/lib.rs
@@ -65,6 +65,7 @@ const TMUX_AGENTENV_COMMAND_OPTION: &str = "@agentenv_command";
 const TMUX_AGENTENV_SESSION_NAME_OPTION: &str = "@agentenv_session_name";
 const TMUX_SESSION_FORMAT: &str =
     "#{session_name}\t#{session_attached}\t#{session_created}\t#{@agentenv_handle}\t#{@agentenv_session_name}\t#{@agentenv_command}";
+const DEFAULT_HARDENING_DOCKERFILE_MARKER: &str = "AGENTENV_HARDENING_PROFILE=custom";
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum UpdateDisposition {
@@ -1647,10 +1648,19 @@ fn byo_dockerfile_config(
 fn openshell_hardening_config(
     metadata: &BTreeMap<String, Value>,
 ) -> DriverResult<OpenShellHardeningConfig> {
+    let dockerfile_fragment = optional_metadata_string(metadata, "hardening_dockerfile_fragment")?;
+    let dockerfile_marker =
+        optional_metadata_comment_string(metadata, "hardening_dockerfile_marker")?;
+    let dockerfile_marker = if dockerfile_fragment.is_some() && dockerfile_marker.is_none() {
+        Some(DEFAULT_HARDENING_DOCKERFILE_MARKER.to_owned())
+    } else {
+        dockerfile_marker
+    };
+
     Ok(OpenShellHardeningConfig {
-        profile: optional_metadata_string(metadata, "hardening_profile")?,
-        dockerfile_marker: optional_metadata_string(metadata, "hardening_dockerfile_marker")?,
-        dockerfile_fragment: optional_metadata_string(metadata, "hardening_dockerfile_fragment")?,
+        profile: optional_metadata_comment_string(metadata, "hardening_profile")?,
+        dockerfile_marker,
+        dockerfile_fragment,
         ulimit_nproc: optional_metadata_unsigned_integer(metadata, "hardening_ulimit_nproc")?,
         ulimit_nofile: optional_metadata_unsigned_integer(metadata, "hardening_ulimit_nofile")?,
         disable_core_dumps: optional_metadata_bool(metadata, "hardening_disable_core_dumps")?,
@@ -1672,6 +1682,21 @@ fn optional_metadata_string(
             message: format!("metadata.{key} must be a string when set"),
         }),
     }
+}
+
+fn optional_metadata_comment_string(
+    metadata: &BTreeMap<String, Value>,
+    key: &str,
+) -> DriverResult<Option<String>> {
+    let Some(value) = optional_metadata_string(metadata, key)? else {
+        return Ok(None);
+    };
+    if value.contains(['\r', '\n']) {
+        return Err(DriverError::InvalidInput {
+            message: format!("metadata.{key} must not contain CR or LF characters"),
+        });
+    }
+    Ok(Some(value))
 }
 
 fn optional_metadata_unsigned_integer(
@@ -4895,6 +4920,245 @@ mod driver_tests {
         assert!(message.contains("positive"));
         assert!(runner.calls().is_empty());
         assert!(!workdir.join("build").join("devbox").exists());
+        std::fs::remove_dir_all(tempdir).expect("remove tempdir");
+    }
+
+    #[test]
+    fn create_rejects_newline_hardening_comment_metadata_before_build() {
+        for (key, value) in [
+            ("hardening_profile", "strict\nRUN apk add curl"),
+            (
+                "hardening_dockerfile_marker",
+                "AGENTENV_HARDENING_PROFILE=strict\rRUN apk add curl",
+            ),
+        ] {
+            let tempdir = unique_tempdir("sandbox-openshell-newline-hardening");
+            let context_dir = tempdir.join("enterprise-sandbox");
+            std::fs::create_dir_all(&context_dir).expect("create context");
+            let dockerfile = context_dir.join("Dockerfile");
+            std::fs::write(&dockerfile, "FROM alpine:3.20\n").expect("write Dockerfile");
+            let workdir = tempdir.join(".agentenv");
+            let runner = Arc::new(RecordingCommandRunner::new(vec![]));
+            let driver = OpenShellDriver::with_command_runner_and_workdir(runner.clone(), &workdir);
+
+            let runtime = tokio::runtime::Builder::new_current_thread()
+                .enable_all()
+                .build()
+                .expect("runtime");
+            let err = runtime
+                .block_on(async {
+                    driver
+                        .create(SandboxSpec {
+                            image: None,
+                            env: BTreeMap::new(),
+                            policy: None,
+                            metadata: BTreeMap::from([
+                                ("name".to_owned(), json!("devbox")),
+                                (
+                                    "byo_dockerfile".to_owned(),
+                                    json!(dockerfile.display().to_string()),
+                                ),
+                                (key.to_owned(), json!(value)),
+                                (
+                                    "hardening_dockerfile_fragment".to_owned(),
+                                    json!("RUN apk del build-base\n"),
+                                ),
+                            ]),
+                        })
+                        .await
+                })
+                .expect_err("newline hardening metadata should reject create");
+
+            let message = err.to_string();
+            assert!(message.contains(key));
+            assert!(runner.calls().is_empty());
+            assert!(!workdir.join("build").join("devbox").exists());
+            std::fs::remove_dir_all(tempdir).expect("remove tempdir");
+        }
+    }
+
+    #[test]
+    fn create_keeps_byo_dockerfile_unchanged_when_hardening_fragment_absent() {
+        let tempdir = unique_tempdir("sandbox-openshell-byo-no-hardening-fragment");
+        let context_dir = tempdir.join("enterprise-sandbox");
+        std::fs::create_dir_all(&context_dir).expect("create context");
+        let dockerfile = context_dir.join("Containerfile.agentenv");
+        let dockerfile_contents =
+            "FROM alpine:3.20\nARG AGENTENV_VERSION\nRUN test -n \"$AGENTENV_VERSION\"\n";
+        std::fs::write(&dockerfile, dockerfile_contents).expect("write Dockerfile");
+        let workdir = tempdir.join(".agentenv");
+        let stage_dir = workdir.join("build").join("devbox");
+        let stage_dockerfile = stage_dir.join("Dockerfile");
+        let stage_dir_arg = stage_dir.display().to_string();
+        let tag = "agentenv-byo-devbox:latest";
+        let digest = "sha256:dddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddd";
+        let runner = Arc::new(FlexibleCommandRunner::new(vec![
+            FlexibleCommandExpectation::success("docker", |_| {}, "", ""),
+            FlexibleCommandExpectation::success(
+                "docker",
+                move |call| {
+                    assert_eq!(
+                        call.request.args,
+                        vec![
+                            "image".to_owned(),
+                            "inspect".to_owned(),
+                            "--format".to_owned(),
+                            "{{.Id}}".to_owned(),
+                            tag.to_owned(),
+                        ]
+                    );
+                },
+                &format!("{digest}\n"),
+                "",
+            ),
+            FlexibleCommandExpectation::success(
+                "openshell",
+                move |call| {
+                    assert_eq!(
+                        call.request,
+                        command_request(&[
+                            "sandbox",
+                            "create",
+                            "--name",
+                            "devbox",
+                            "--no-auto-providers",
+                            "--from",
+                            &stage_dir_arg,
+                            "--",
+                            "true",
+                        ])
+                    );
+                },
+                "",
+                "",
+            ),
+        ]));
+        let driver = OpenShellDriver::with_command_runner_and_workdir(runner.clone(), &workdir);
+
+        let runtime = tokio::runtime::Builder::new_current_thread()
+            .enable_all()
+            .build()
+            .expect("runtime");
+        let result = runtime
+            .block_on(async {
+                driver
+                    .create(SandboxSpec {
+                        image: None,
+                        env: BTreeMap::new(),
+                        policy: None,
+                        metadata: BTreeMap::from([
+                            ("name".to_owned(), json!("devbox")),
+                            (
+                                "byo_dockerfile".to_owned(),
+                                json!(dockerfile.display().to_string()),
+                            ),
+                            ("hardening_profile".to_owned(), json!("strict")),
+                            (
+                                "hardening_dockerfile_marker".to_owned(),
+                                json!("AGENTENV_HARDENING_PROFILE=strict"),
+                            ),
+                        ]),
+                    })
+                    .await
+            })
+            .expect("create");
+
+        assert_eq!(result.handle, "devbox");
+        assert_eq!(runner.calls().len(), 3);
+        assert_eq!(
+            std::fs::read_to_string(&stage_dockerfile).expect("staged Dockerfile"),
+            dockerfile_contents
+        );
+        std::fs::remove_dir_all(tempdir).expect("remove tempdir");
+    }
+
+    #[test]
+    fn create_uses_default_hardening_marker_when_fragment_marker_absent() {
+        let tempdir = unique_tempdir("sandbox-openshell-byo-default-hardening-marker");
+        let context_dir = tempdir.join("enterprise-sandbox");
+        std::fs::create_dir_all(&context_dir).expect("create context");
+        let dockerfile = context_dir.join("Dockerfile");
+        std::fs::write(&dockerfile, "FROM alpine:3.20\n").expect("write Dockerfile");
+        let workdir = tempdir.join(".agentenv");
+        let stage_dir = workdir.join("build").join("devbox");
+        let stage_dockerfile = stage_dir.join("Dockerfile");
+        let stage_dir_arg = stage_dir.display().to_string();
+        let tag = "agentenv-byo-devbox:latest";
+        let digest = "sha256:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa";
+        let runner = Arc::new(FlexibleCommandRunner::new(vec![
+            FlexibleCommandExpectation::success("docker", |_| {}, "", ""),
+            FlexibleCommandExpectation::success(
+                "docker",
+                move |call| {
+                    assert_eq!(
+                        call.request.args,
+                        vec![
+                            "image".to_owned(),
+                            "inspect".to_owned(),
+                            "--format".to_owned(),
+                            "{{.Id}}".to_owned(),
+                            tag.to_owned(),
+                        ]
+                    );
+                },
+                &format!("{digest}\n"),
+                "",
+            ),
+            FlexibleCommandExpectation::success(
+                "openshell",
+                move |call| {
+                    assert_eq!(
+                        call.request,
+                        command_request(&[
+                            "sandbox",
+                            "create",
+                            "--name",
+                            "devbox",
+                            "--no-auto-providers",
+                            "--from",
+                            &stage_dir_arg,
+                            "--",
+                            "true",
+                        ])
+                    );
+                },
+                "",
+                "",
+            ),
+        ]));
+        let driver = OpenShellDriver::with_command_runner_and_workdir(runner.clone(), &workdir);
+
+        let runtime = tokio::runtime::Builder::new_current_thread()
+            .enable_all()
+            .build()
+            .expect("runtime");
+        runtime
+            .block_on(async {
+                driver
+                    .create(SandboxSpec {
+                        image: None,
+                        env: BTreeMap::new(),
+                        policy: None,
+                        metadata: BTreeMap::from([
+                            ("name".to_owned(), json!("devbox")),
+                            (
+                                "byo_dockerfile".to_owned(),
+                                json!(dockerfile.display().to_string()),
+                            ),
+                            (
+                                "hardening_dockerfile_fragment".to_owned(),
+                                json!("RUN apk del build-base\n"),
+                            ),
+                        ]),
+                    })
+                    .await
+            })
+            .expect("create");
+
+        let staged_dockerfile =
+            std::fs::read_to_string(&stage_dockerfile).expect("staged Dockerfile");
+        assert!(staged_dockerfile.contains("AGENTENV_HARDENING_PROFILE=custom"));
+        assert!(staged_dockerfile.contains("RUN apk del build-base"));
         std::fs::remove_dir_all(tempdir).expect("remove tempdir");
     }
 

--- a/crates/drivers/sandbox-openshell/src/lib.rs
+++ b/crates/drivers/sandbox-openshell/src/lib.rs
@@ -381,6 +381,18 @@ struct ByoDockerfileConfig {
     workspace_mount: String,
 }
 
+#[allow(dead_code)]
+#[derive(Debug, Clone, PartialEq, Eq)]
+struct OpenShellHardeningConfig {
+    profile: Option<String>,
+    dockerfile_marker: Option<String>,
+    dockerfile_fragment: Option<String>,
+    ulimit_nproc: Option<u64>,
+    ulimit_nofile: Option<u64>,
+    disable_core_dumps: Option<bool>,
+    disable_user_namespaces: Option<bool>,
+}
+
 struct LogStream {
     handle: String,
     command: Box<dyn SpawnedCommand>,
@@ -628,8 +640,9 @@ impl SandboxDriver for OpenShellDriver {
                 });
             }
         };
+        let hardening = openshell_hardening_config(&spec.metadata)?;
         let image = match byo_dockerfile_config(&spec.metadata)? {
-            Some(config) => self.prepare_byo_dockerfile_context(&name, &config)?,
+            Some(config) => self.prepare_byo_dockerfile_context(&name, &config, &hardening)?,
             None => spec.image.unwrap_or_else(|| "openclaw".to_owned()),
         };
         let remote = match spec.metadata.get("remote") {
@@ -962,6 +975,7 @@ impl OpenShellDriver {
         &self,
         name: &str,
         config: &ByoDockerfileConfig,
+        hardening: &OpenShellHardeningConfig,
     ) -> DriverResult<String> {
         let dockerfile =
             fs::canonicalize(&config.dockerfile).map_err(|source| DriverError::InvalidInput {
@@ -986,6 +1000,7 @@ impl OpenShellDriver {
         let build_name = sanitize_build_name(name);
         let stage_dir = self.workdir().join("build").join(&build_name);
         stage_build_context(context_dir, &dockerfile, &stage_dir)?;
+        append_hardening_fragment(&stage_dir.join("Dockerfile"), hardening)?;
 
         let tag = format!("agentenv-byo-{build_name}:latest");
         let dockerfile_arg = stage_dir.join("Dockerfile").display().to_string();
@@ -1629,6 +1644,23 @@ fn byo_dockerfile_config(
     }))
 }
 
+fn openshell_hardening_config(
+    metadata: &BTreeMap<String, Value>,
+) -> DriverResult<OpenShellHardeningConfig> {
+    Ok(OpenShellHardeningConfig {
+        profile: optional_metadata_string(metadata, "hardening_profile")?,
+        dockerfile_marker: optional_metadata_string(metadata, "hardening_dockerfile_marker")?,
+        dockerfile_fragment: optional_metadata_string(metadata, "hardening_dockerfile_fragment")?,
+        ulimit_nproc: optional_metadata_unsigned_integer(metadata, "hardening_ulimit_nproc")?,
+        ulimit_nofile: optional_metadata_unsigned_integer(metadata, "hardening_ulimit_nofile")?,
+        disable_core_dumps: optional_metadata_bool(metadata, "hardening_disable_core_dumps")?,
+        disable_user_namespaces: optional_metadata_bool(
+            metadata,
+            "hardening_disable_user_namespaces",
+        )?,
+    })
+}
+
 fn optional_metadata_string(
     metadata: &BTreeMap<String, Value>,
     key: &str,
@@ -1638,6 +1670,37 @@ fn optional_metadata_string(
         Some(Value::Null) | None => Ok(None),
         Some(_) => Err(DriverError::InvalidInput {
             message: format!("metadata.{key} must be a string when set"),
+        }),
+    }
+}
+
+fn optional_metadata_unsigned_integer(
+    metadata: &BTreeMap<String, Value>,
+    key: &str,
+) -> DriverResult<Option<u64>> {
+    match metadata.get(key) {
+        Some(Value::Number(value)) => match value.as_u64() {
+            Some(value) if value > 0 => Ok(Some(value)),
+            _ => Err(DriverError::InvalidInput {
+                message: format!("metadata.{key} must be a positive unsigned integer when set"),
+            }),
+        },
+        Some(Value::Null) | None => Ok(None),
+        Some(_) => Err(DriverError::InvalidInput {
+            message: format!("metadata.{key} must be a positive unsigned integer when set"),
+        }),
+    }
+}
+
+fn optional_metadata_bool(
+    metadata: &BTreeMap<String, Value>,
+    key: &str,
+) -> DriverResult<Option<bool>> {
+    match metadata.get(key) {
+        Some(Value::Bool(value)) => Ok(Some(*value)),
+        Some(Value::Null) | None => Ok(None),
+        Some(_) => Err(DriverError::InvalidInput {
+            message: format!("metadata.{key} must be a boolean when set"),
         }),
     }
 }
@@ -1696,6 +1759,49 @@ fn stage_build_context(
         }
     })?;
     Ok(())
+}
+
+fn append_hardening_fragment(
+    staged_dockerfile: &Path,
+    hardening: &OpenShellHardeningConfig,
+) -> DriverResult<()> {
+    let Some(fragment) = hardening.dockerfile_fragment.as_deref() else {
+        return Ok(());
+    };
+
+    let mut contents =
+        fs::read_to_string(staged_dockerfile).map_err(|source| DriverError::InvalidInput {
+            message: format!(
+                "failed to read staged BYO Dockerfile `{}` before hardening: {source}",
+                staged_dockerfile.display()
+            ),
+        })?;
+    if !contents.ends_with('\n') {
+        contents.push('\n');
+    }
+    contents.push('\n');
+    contents.push_str("# agentenv hardening");
+    if let Some(profile) = hardening.profile.as_deref() {
+        contents.push_str(" profile=");
+        contents.push_str(profile);
+    }
+    contents.push('\n');
+    if let Some(marker) = hardening.dockerfile_marker.as_deref() {
+        contents.push_str("# ");
+        contents.push_str(marker);
+        contents.push('\n');
+    }
+    contents.push_str(fragment);
+    if !fragment.ends_with('\n') {
+        contents.push('\n');
+    }
+
+    fs::write(staged_dockerfile, contents).map_err(|source| DriverError::InvalidInput {
+        message: format!(
+            "failed to append hardening fragment to staged BYO Dockerfile `{}`: {source}",
+            staged_dockerfile.display()
+        ),
+    })
 }
 
 fn copy_dir_contents(src: &Path, dst: &Path) -> io::Result<()> {
@@ -4713,6 +4819,19 @@ mod driver_tests {
                                 "agentenv_version".to_owned(),
                                 json!(env!("CARGO_PKG_VERSION")),
                             ),
+                            ("hardening_profile".to_owned(), json!("strict")),
+                            (
+                                "hardening_dockerfile_marker".to_owned(),
+                                json!("AGENTENV_HARDENING_PROFILE=strict"),
+                            ),
+                            (
+                                "hardening_dockerfile_fragment".to_owned(),
+                                json!("RUN apk del build-base\n"),
+                            ),
+                            ("hardening_ulimit_nproc".to_owned(), json!(256)),
+                            ("hardening_ulimit_nofile".to_owned(), json!(1024)),
+                            ("hardening_disable_core_dumps".to_owned(), json!(true)),
+                            ("hardening_disable_user_namespaces".to_owned(), json!(true)),
                         ]),
                     })
                     .await
@@ -4721,15 +4840,61 @@ mod driver_tests {
 
         assert_eq!(result.handle, "devbox");
         assert_eq!(runner.calls().len(), 3);
-        assert_eq!(
-            std::fs::read_to_string(&stage_dockerfile).expect("staged Dockerfile"),
-            std::fs::read_to_string(&dockerfile).expect("source Dockerfile")
-        );
+        let staged_dockerfile =
+            std::fs::read_to_string(&stage_dockerfile).expect("staged Dockerfile");
+        assert!(staged_dockerfile
+            .starts_with(&std::fs::read_to_string(&dockerfile).expect("source Dockerfile")));
+        assert!(staged_dockerfile.contains("agentenv hardening"));
+        assert!(staged_dockerfile.contains("AGENTENV_HARDENING_PROFILE=strict"));
+        assert!(staged_dockerfile.contains("RUN apk del build-base"));
         assert!(stage_dir.join("internal-cli").is_file());
         assert_eq!(
             std::fs::read_to_string(stage_dir.join("image-digest")).expect("digest file"),
             format!("{digest}\n")
         );
+        std::fs::remove_dir_all(tempdir).expect("remove tempdir");
+    }
+
+    #[test]
+    fn create_rejects_invalid_hardening_metadata_before_build() {
+        let tempdir = unique_tempdir("sandbox-openshell-invalid-hardening");
+        let context_dir = tempdir.join("enterprise-sandbox");
+        std::fs::create_dir_all(&context_dir).expect("create context");
+        let dockerfile = context_dir.join("Dockerfile");
+        std::fs::write(&dockerfile, "FROM alpine:3.20\n").expect("write Dockerfile");
+        let workdir = tempdir.join(".agentenv");
+        let runner = Arc::new(RecordingCommandRunner::new(vec![]));
+        let driver = OpenShellDriver::with_command_runner_and_workdir(runner.clone(), &workdir);
+
+        let runtime = tokio::runtime::Builder::new_current_thread()
+            .enable_all()
+            .build()
+            .expect("runtime");
+        let err = runtime
+            .block_on(async {
+                driver
+                    .create(SandboxSpec {
+                        image: None,
+                        env: BTreeMap::new(),
+                        policy: None,
+                        metadata: BTreeMap::from([
+                            ("name".to_owned(), json!("devbox")),
+                            (
+                                "byo_dockerfile".to_owned(),
+                                json!(dockerfile.display().to_string()),
+                            ),
+                            ("hardening_ulimit_nproc".to_owned(), json!(0)),
+                        ]),
+                    })
+                    .await
+            })
+            .expect_err("invalid hardening metadata should reject create");
+
+        let message = err.to_string();
+        assert!(message.contains("hardening_ulimit_nproc"));
+        assert!(message.contains("positive"));
+        assert!(runner.calls().is_empty());
+        assert!(!workdir.join("build").join("devbox").exists());
         std::fs::remove_dir_all(tempdir).expect("remove tempdir");
     }
 

--- a/docs/BLUEPRINTS.md
+++ b/docs/BLUEPRINTS.md
@@ -14,6 +14,28 @@ Reference blueprints are checked-in `agentenv.yaml` compositions that double as 
 | `hermes+nexus+openshell.yaml` | Polyglot enterprise demos | Nexus hub | `balanced` | You want Hermes through subprocess drivers with Nexus context. |
 | `openclaw+nexus+openshell.yaml` | Enterprise reference | Nexus hub | `balanced` | You want OpenClaw with shared company context. |
 
+## Hardening Profiles
+
+Blueprints may set `sandbox.hardening` to choose an image hardening profile.
+When omitted, the core uses `baseline`.
+
+- `baseline` is the default production posture. It removes common compilers and
+  network/debug tools, drops `NET_RAW`, and keeps normal developer writable
+  paths.
+- `strict` is for sensitive work. It strips more tools, drops additional
+  capabilities, tightens `/tmp`, and disables core dumps and user namespaces.
+- `open` keeps only minimal image hardening for exploratory environments where
+  tool availability matters more than locked-down images.
+
+For BYO Dockerfiles, run:
+
+```sh
+agentenv blueprint lint <agentenv.yaml>
+```
+
+The linter resolves the selected profile and reports Dockerfile patterns that
+conflict with hardening before creating the environment.
+
 ## Getting-Started Filesystem Blueprints
 
 `claude+filesystem+openshell.yaml`, `codex+filesystem+openshell.yaml`, and `openclaw+filesystem+openshell.yaml` mount `~/projects` through the filesystem context driver and expose it over MCP inside OpenShell. They are the lowest-friction templates because they do not require remote context infrastructure.

--- a/docs/BLUEPRINTS.md
+++ b/docs/BLUEPRINTS.md
@@ -20,10 +20,11 @@ Blueprints may set `sandbox.hardening` to choose an image hardening profile.
 When omitted, the core uses `baseline`.
 
 - `baseline` is the default production posture. It removes common compilers and
-  network/debug tools, drops `NET_RAW`, and keeps normal developer writable
-  paths.
+  network/debug tools at the image layer, requests `NET_RAW` capability
+  dropping, and keeps normal developer writable paths.
 - `strict` is for sensitive work. It strips more tools, drops additional
-  capabilities, tightens `/tmp`, and disables core dumps and user namespaces.
+  packages, and includes runtime recommendations for capability drops, `/tmp`
+  tmpfs, core dumps, and user namespaces.
 - `open` keeps only minimal image hardening for exploratory environments where
   tool availability matters more than locked-down images.
 
@@ -35,6 +36,11 @@ agentenv blueprint lint <agentenv.yaml>
 
 The linter resolves the selected profile and reports Dockerfile patterns that
 conflict with hardening before creating the environment.
+
+Current OpenShell BYO enforcement injects the selected Dockerfile fragment and
+uses the supported filesystem policy merge. Runtime hardening metadata is parsed
+and validated for future driver mappings; it is not currently translated into
+extra OpenShell CLI arguments.
 
 ## Getting-Started Filesystem Blueprints
 

--- a/docs/DRIVER_PROTOCOL.md
+++ b/docs/DRIVER_PROTOCOL.md
@@ -137,8 +137,8 @@ Each driver kind (`sandbox` / `agent` / `context` / `inference`) has its own set
 | `destroy` | `{handle}` | `{}` |
 
 Image hardening profiles are create-time sandbox configuration in schema 1.1.
-Core resolves `sandbox.hardening`, merges supported filesystem and process
-settings into `SandboxSpec.policy`, and sends image/runtime settings through
+Core resolves `sandbox.hardening`, merges supported filesystem settings into
+`SandboxSpec.policy`, and sends process, runtime, and image settings through
 `SandboxSpec.metadata` keys prefixed with `hardening_`. Sandbox drivers may
 consume that metadata during `create`; schema 1.1 does not define a separate
 `apply_hardening` method.

--- a/docs/DRIVER_PROTOCOL.md
+++ b/docs/DRIVER_PROTOCOL.md
@@ -136,6 +136,13 @@ Each driver kind (`sandbox` / `agent` / `context` / `inference`) has its own set
 | `stop` | `{handle}` | `{}` |
 | `destroy` | `{handle}` | `{}` |
 
+Image hardening profiles are create-time sandbox configuration in schema 1.1.
+Core resolves `sandbox.hardening`, merges supported filesystem and process
+settings into `SandboxSpec.policy`, and sends image/runtime settings through
+`SandboxSpec.metadata` keys prefixed with `hardening_`. Sandbox drivers may
+consume that metadata during `create`; schema 1.1 does not define a separate
+`apply_hardening` method.
+
 Persistent sessions are optional. Core checks `supports_persistent_sessions`
 before calling session methods. Drivers that cannot provide durable attach,
 detach, resume, and single-session kill semantics return `CapabilityMissing`

--- a/docs/superpowers/plans/2026-05-03-m5-6-image-hardening.md
+++ b/docs/superpowers/plans/2026-05-03-m5-6-image-hardening.md
@@ -1,0 +1,2049 @@
+# M5-6 Image Hardening Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Ship baseline, strict, and open image-hardening profiles that default through create flows, propagate into sandbox policy/metadata, harden BYO Dockerfile builds, and provide `agentenv blueprint lint`.
+
+**Architecture:** Keep the driver protocol stable. `agentenv-policy` owns profile parsing and profile-to-policy merge logic; `agentenv-core` resolves blueprint hardening and produces metadata/lint reports; `sandbox-openshell` consumes create-time metadata to inject image hardening and parse runtime requests.
+
+**Tech Stack:** Rust 2021, `serde`, `serde_yaml`, `serde_json`, `clap`, existing `agentenv_proto::NetworkPolicy`, existing OpenShell command-runner test harness.
+
+---
+
+## File Structure
+
+- Create `crates/agentenv-policy/hardening/baseline.yaml`: default profile data.
+- Create `crates/agentenv-policy/hardening/strict.yaml`: strict profile data.
+- Create `crates/agentenv-policy/hardening/open.yaml`: open profile data.
+- Create `crates/agentenv-policy/src/hardening.rs`: typed profile structs, built-in/custom loading, validation, metadata serialization, and policy merge helpers.
+- Modify `crates/agentenv-policy/src/error.rs`: add hardening-specific `PolicyError` variants.
+- Modify `crates/agentenv-policy/src/lib.rs`: export hardening types and helpers.
+- Create `crates/agentenv-policy/tests/hardening_profiles.rs`: profile parsing, validation, and merge coverage.
+- Create `crates/agentenv-core/src/hardening.rs`: blueprint hardening resolution, Dockerfile linting, and lint report structs.
+- Modify `crates/agentenv-core/src/lib.rs`: expose the new module.
+- Modify `crates/agentenv-core/src/lifecycle.rs`: validate `sandbox.hardening` in blueprint verification.
+- Modify `crates/agentenv-core/src/runtime.rs`: default/merge hardening during create, add hardening metadata to `SandboxSpec`, and replace BYO preflight warnings with hardening-aware lint diagnostics.
+- Create `crates/agentenv-core/tests/hardening_lint.rs`: public lint and blueprint validation tests.
+- Modify `crates/agentenv/src/main.rs`: add `agentenv blueprint lint <file> [--json]`.
+- Modify `crates/agentenv/src/render.rs`: JSON/text rendering structs or helpers if keeping rendering out of `main.rs` is cleaner.
+- Modify `crates/agentenv/tests/cli_behavior.rs`: integration tests for `blueprint lint`.
+- Modify `crates/drivers/sandbox-openshell/src/lib.rs`: parse hardening metadata and inject generated hardening fragments into staged BYO Dockerfiles.
+- Modify `crates/drivers/sandbox-openshell/README.md`: document hardening behavior for BYO builds.
+- Modify `docs/DRIVER_PROTOCOL.md`: document create-time metadata approach and reserved future method.
+- Modify `docs/BLUEPRINTS.md`: document `sandbox.hardening` defaults and profile choices.
+
+## Task 0: Post The Issue Approach
+
+**Files:**
+- No repo file changes.
+
+- [ ] **Step 1: Post the selected approach on issue #22**
+
+Use the GitHub connector or this CLI command:
+
+```bash
+gh issue comment 22 --repo windoliver/agentenv --body 'Implementation approach:
+
+- Keep the driver protocol stable for M5-6. Hardening is create-time sandbox configuration derived by core, not a new post-create driver RPC method.
+- Add built-in hardening profile YAML and typed loaders in agentenv-policy for baseline, strict, and open.
+- Resolve sandbox.hardening in core, default to baseline, merge supported filesystem/process posture into the existing policy, and pass image/runtime settings through SandboxSpec metadata.
+- Extend OpenShell BYO Dockerfile staging to inject the selected hardening fragment before build while preserving digest verification and recording.
+- Add agentenv blueprint lint to evaluate the selected hardening profile against the BYO Dockerfile with deterministic text and JSON diagnostics.
+- Cover the change test-first across agentenv-policy, agentenv-core, sandbox-openshell, and agentenv CLI, then run cargo fmt, clippy -D warnings, and cargo test --workspace.'
+```
+
+Expected: the issue receives one top-level comment describing the protocol-stable approach.
+
+## Task 1: Add Policy Hardening Profiles
+
+**Files:**
+- Create: `crates/agentenv-policy/hardening/baseline.yaml`
+- Create: `crates/agentenv-policy/hardening/strict.yaml`
+- Create: `crates/agentenv-policy/hardening/open.yaml`
+- Create: `crates/agentenv-policy/src/hardening.rs`
+- Modify: `crates/agentenv-policy/src/error.rs`
+- Modify: `crates/agentenv-policy/src/lib.rs`
+- Test: `crates/agentenv-policy/tests/hardening_profiles.rs`
+
+- [ ] **Step 1: Write failing policy profile tests**
+
+Create `crates/agentenv-policy/tests/hardening_profiles.rs`:
+
+```rust
+use agentenv_policy::{
+    apply_hardening_to_policy, builtin_hardening_profile, hardening_metadata,
+    resolve_hardening_profile, HardeningProfile, PresetRegistry, Tier,
+};
+
+#[test]
+fn built_in_hardening_profiles_parse_and_differ() {
+    let baseline = builtin_hardening_profile("baseline").expect("baseline profile");
+    let strict = builtin_hardening_profile("strict").expect("strict profile");
+    let open = builtin_hardening_profile("open").expect("open profile");
+
+    assert_eq!(baseline.name, "baseline");
+    assert_eq!(strict.name, "strict");
+    assert_eq!(open.name, "open");
+    assert!(baseline.packages.strip.iter().any(|pkg| pkg == "gcc"));
+    assert!(strict.packages.strip.iter().any(|pkg| pkg == "curl"));
+    assert!(!open.packages.strip.iter().any(|pkg| pkg == "gcc"));
+    assert_eq!(baseline.ulimits.nproc, Some(512));
+    assert_eq!(baseline.ulimits.nofile, Some(4096));
+    assert!(strict.disable_core_dumps);
+    assert!(strict.disable_user_namespaces);
+    assert!(baseline.dockerfile.marker.contains("baseline"));
+    assert!(strict.dockerfile.marker.contains("strict"));
+}
+
+#[test]
+fn unknown_hardening_profile_reports_available_names() {
+    let err = builtin_hardening_profile("sealed").expect_err("unknown profile");
+
+    assert!(err.to_string().contains("sealed"));
+    assert!(err.to_string().contains("baseline"));
+    assert!(err.to_string().contains("strict"));
+    assert!(err.to_string().contains("open"));
+}
+
+#[test]
+fn resolve_hardening_profile_loads_custom_yaml_path() {
+    let root = std::env::temp_dir().join(format!(
+        "agentenv-hardening-profile-{}",
+        std::process::id()
+    ));
+    std::fs::create_dir_all(&root).expect("create temp profile dir");
+    let profile_path = root.join("custom.yaml");
+    std::fs::write(
+        &profile_path,
+        r#"
+name: custom
+description: Custom test profile.
+packages:
+  strip: [gdb]
+mounts:
+  read_only: [/etc]
+  read_write: [/sandbox]
+  tmpfs:
+    - path: /tmp
+      size: 64m
+ulimits:
+  nproc: 128
+  nofile: 1024
+capabilities:
+  drop: [NET_RAW]
+disable_core_dumps: true
+disable_user_namespaces: false
+dockerfile:
+  marker: AGENTENV_HARDENING_PROFILE=custom
+  fragment: |
+    RUN echo custom-hardening >/etc/agentenv-hardening
+"#,
+    )
+    .expect("write custom profile");
+
+    let profile = resolve_hardening_profile(profile_path.to_str().unwrap()).expect("load custom");
+
+    assert_eq!(profile.name, "custom");
+    assert_eq!(profile.mounts.tmpfs[0].path, "/tmp");
+    assert_eq!(profile.mounts.tmpfs[0].size.as_deref(), Some("64m"));
+    std::fs::remove_dir_all(root).expect("remove temp profile dir");
+}
+
+#[test]
+fn hardening_merge_updates_filesystem_policy_and_persisted_home() {
+    let registry = PresetRegistry::load_builtin().expect("registry");
+    let mut policy =
+        agentenv_policy::compose_policy(Tier::Balanced, &[], None, &registry).expect("compose");
+    let profile = builtin_hardening_profile("baseline").expect("baseline");
+
+    apply_hardening_to_policy(&mut policy, &profile, true).expect("merge hardening");
+
+    assert!(policy.filesystem.read_only.contains(&"/etc".to_owned()));
+    assert!(policy.filesystem.read_only.contains(&"/opt".to_owned()));
+    assert!(policy.filesystem.read_write.contains(&"/workspace".to_owned()));
+    assert!(policy.filesystem.read_write.contains(&"/tmp".to_owned()));
+    assert!(policy.filesystem.read_write.contains(&"/var/tmp".to_owned()));
+    assert!(policy.filesystem.read_write.contains(&"$HOME".to_owned()));
+}
+
+#[test]
+fn hardening_metadata_is_stable_json() {
+    let profile = builtin_hardening_profile("strict").expect("strict");
+    let metadata = hardening_metadata(&profile).expect("metadata");
+
+    assert_eq!(metadata["hardening_profile"], serde_json::json!("strict"));
+    assert_eq!(metadata["hardening_ulimit_nproc"], serde_json::json!(512));
+    assert_eq!(metadata["hardening_disable_core_dumps"], serde_json::json!(true));
+    assert!(metadata["hardening_packages_strip"]
+        .as_array()
+        .unwrap()
+        .iter()
+        .any(|value| value == "curl"));
+}
+
+#[test]
+fn invalid_profile_rejects_non_positive_ulimits() {
+    let yaml = r#"
+name: broken
+description: Broken profile.
+packages:
+  strip: []
+mounts:
+  read_only: []
+  read_write: []
+  tmpfs: []
+ulimits:
+  nproc: 0
+  nofile: 4096
+capabilities:
+  drop: []
+disable_core_dumps: false
+disable_user_namespaces: false
+dockerfile:
+  marker: AGENTENV_HARDENING_PROFILE=broken
+  fragment: |
+    RUN true
+"#;
+
+    let err = HardeningProfile::from_yaml("broken.yaml", yaml).expect_err("invalid profile");
+
+    assert!(err.to_string().contains("nproc"));
+    assert!(err.to_string().contains("positive"));
+}
+```
+
+- [ ] **Step 2: Run the failing policy test**
+
+Run:
+
+```bash
+cargo test -p agentenv-policy --test hardening_profiles
+```
+
+Expected: FAIL because `hardening_profiles.rs` imports unresolved hardening APIs.
+
+- [ ] **Step 3: Add built-in profile YAML files**
+
+Create `crates/agentenv-policy/hardening/baseline.yaml`:
+
+```yaml
+name: baseline
+description: Default production hardening for agentenv sandbox images.
+packages:
+  strip:
+    - gcc
+    - g++
+    - make
+    - nc
+    - tcpdump
+    - nmap
+    - strace
+    - gdb
+mounts:
+  read_only:
+    - /etc
+    - /usr
+    - /opt
+  read_write:
+    - /workspace
+    - /tmp
+    - /var/tmp
+  tmpfs: []
+ulimits:
+  nproc: 512
+  nofile: 4096
+capabilities:
+  drop:
+    - NET_RAW
+dockerfile:
+  marker: AGENTENV_HARDENING_PROFILE=baseline
+  fragment: |
+    RUN set -eu; \
+        if command -v apt-get >/dev/null 2>&1; then \
+          apt-get purge -y gcc g++ make netcat-openbsd netcat-traditional tcpdump nmap strace gdb || true; \
+          apt-get autoremove -y || true; \
+          rm -rf /var/lib/apt/lists/*; \
+        elif command -v apk >/dev/null 2>&1; then \
+          apk del gcc g++ make netcat-openbsd tcpdump nmap strace gdb || true; \
+        else \
+          echo "agentenv hardening: unsupported package manager" >&2; \
+          exit 78; \
+        fi; \
+        find / -xdev -perm /6000 -type f -exec chmod a-s {} + 2>/dev/null || true
+disable_core_dumps: false
+disable_user_namespaces: false
+```
+
+Create `crates/agentenv-policy/hardening/strict.yaml`:
+
+```yaml
+name: strict
+description: Sensitive-work hardening for legal, financial, PHI, and other high-risk sandboxes.
+packages:
+  strip:
+    - gcc
+    - g++
+    - make
+    - nc
+    - tcpdump
+    - nmap
+    - strace
+    - gdb
+    - curl
+    - wget
+    - git
+mounts:
+  read_only:
+    - /etc
+    - /usr
+    - /opt
+  read_write:
+    - /workspace
+    - /var/tmp
+  tmpfs:
+    - path: /tmp
+      size: 256m
+ulimits:
+  nproc: 512
+  nofile: 4096
+capabilities:
+  drop:
+    - NET_RAW
+    - SYS_ADMIN
+    - SYS_PTRACE
+dockerfile:
+  marker: AGENTENV_HARDENING_PROFILE=strict
+  fragment: |
+    RUN set -eu; \
+        if command -v apt-get >/dev/null 2>&1; then \
+          apt-get purge -y gcc g++ make netcat-openbsd netcat-traditional tcpdump nmap strace gdb curl wget git || true; \
+          apt-get autoremove -y || true; \
+          rm -rf /var/lib/apt/lists/*; \
+        elif command -v apk >/dev/null 2>&1; then \
+          apk del gcc g++ make netcat-openbsd tcpdump nmap strace gdb curl wget git || true; \
+        else \
+          echo "agentenv hardening: unsupported package manager" >&2; \
+          exit 78; \
+        fi; \
+        find / -xdev -perm /6000 -type f -exec chmod a-s {} + 2>/dev/null || true; \
+        printf '* hard core 0\n* soft core 0\n' >/etc/security/limits.d/agentenv-core.conf
+disable_core_dumps: true
+disable_user_namespaces: true
+```
+
+Create `crates/agentenv-policy/hardening/open.yaml`:
+
+```yaml
+name: open
+description: Minimal hardening for research and exploratory sandboxes.
+packages:
+  strip: []
+mounts:
+  read_only: []
+  read_write:
+    - /workspace
+    - /tmp
+    - /var/tmp
+  tmpfs: []
+ulimits: {}
+capabilities:
+  drop: []
+dockerfile:
+  marker: AGENTENV_HARDENING_PROFILE=open
+  fragment: |
+    RUN set -eu; \
+        find / -xdev -perm /6000 -type f -exec chmod a-s {} + 2>/dev/null || true
+disable_core_dumps: false
+disable_user_namespaces: false
+```
+
+- [ ] **Step 4: Add hardening error variants**
+
+Modify `crates/agentenv-policy/src/error.rs`:
+
+```rust
+#[derive(Debug, Error, PartialEq, Eq)]
+pub enum PolicyError {
+    #[error("unknown preset `{name}`. available presets: {available}")]
+    UnknownPreset { name: String, available: String },
+    #[error("unsupported access mode `{access}` for preset `{name}`")]
+    UnsupportedPresetAccess { name: String, access: String },
+    #[error("policy update requires recreate for domains: {domains}")]
+    RequiresRecreate { domains: String },
+    #[error("failed to load preset registry: {message}")]
+    PresetRegistry { message: String },
+    #[error("unknown hardening profile `{name}`. available profiles: {available}")]
+    UnknownHardeningProfile { name: String, available: String },
+    #[error("invalid hardening profile `{name}`: {message}")]
+    HardeningProfile { name: String, message: String },
+    #[error("translator `{translator}` does not support this policy: {message}")]
+    TranslationUnsupported {
+        translator: &'static str,
+        message: String,
+    },
+}
+```
+
+- [ ] **Step 5: Implement profile parsing and merge helpers**
+
+Create `crates/agentenv-policy/src/hardening.rs`:
+
+```rust
+use std::{collections::BTreeMap, env, path::Path};
+
+use agentenv_proto::NetworkPolicy;
+use serde::{Deserialize, Serialize};
+use serde_json::Value;
+
+use crate::{PolicyError, PolicyResult};
+
+const BASELINE_PROFILE: &str = include_str!("../hardening/baseline.yaml");
+const STRICT_PROFILE: &str = include_str!("../hardening/strict.yaml");
+const OPEN_PROFILE: &str = include_str!("../hardening/open.yaml");
+const BUILTIN_NAMES: [&str; 3] = ["baseline", "strict", "open"];
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct HardeningProfile {
+    pub name: String,
+    pub description: String,
+    #[serde(default)]
+    pub packages: HardeningPackages,
+    #[serde(default)]
+    pub mounts: HardeningMounts,
+    #[serde(default)]
+    pub ulimits: HardeningUlimits,
+    #[serde(default)]
+    pub capabilities: HardeningCapabilities,
+    pub dockerfile: HardeningDockerfile,
+    #[serde(default)]
+    pub disable_core_dumps: bool,
+    #[serde(default)]
+    pub disable_user_namespaces: bool,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, Default)]
+pub struct HardeningPackages {
+    #[serde(default)]
+    pub strip: Vec<String>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, Default)]
+pub struct HardeningMounts {
+    #[serde(default)]
+    pub read_only: Vec<String>,
+    #[serde(default)]
+    pub read_write: Vec<String>,
+    #[serde(default)]
+    pub tmpfs: Vec<HardeningTmpfsMount>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct HardeningTmpfsMount {
+    pub path: String,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub size: Option<String>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, Default)]
+pub struct HardeningUlimits {
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub nproc: Option<u64>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub nofile: Option<u64>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, Default)]
+pub struct HardeningCapabilities {
+    #[serde(default)]
+    pub drop: Vec<String>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct HardeningDockerfile {
+    pub marker: String,
+    pub fragment: String,
+}
+
+impl HardeningProfile {
+    pub fn from_yaml(name: &str, yaml: &str) -> PolicyResult<Self> {
+        let mut profile: HardeningProfile =
+            serde_yaml::from_str(yaml).map_err(|err| PolicyError::HardeningProfile {
+                name: name.to_owned(),
+                message: err.to_string(),
+            })?;
+        profile.normalize();
+        profile.validate()?;
+        Ok(profile)
+    }
+
+    fn normalize(&mut self) {
+        self.packages.strip.sort();
+        self.packages.strip.dedup();
+        self.mounts.read_only.sort();
+        self.mounts.read_only.dedup();
+        self.mounts.read_write.sort();
+        self.mounts.read_write.dedup();
+        self.capabilities.drop.sort();
+        self.capabilities.drop.dedup();
+    }
+
+    fn validate(&self) -> PolicyResult<()> {
+        if self.name.trim().is_empty() {
+            return Err(invalid_profile(&self.name, "name must not be empty"));
+        }
+        if self.description.trim().is_empty() {
+            return Err(invalid_profile(&self.name, "description must not be empty"));
+        }
+        if self.dockerfile.marker.trim().is_empty() {
+            return Err(invalid_profile(&self.name, "dockerfile.marker must not be empty"));
+        }
+        if !self.dockerfile.fragment.contains("RUN ") {
+            return Err(invalid_profile(
+                &self.name,
+                "dockerfile.fragment must contain a RUN instruction",
+            ));
+        }
+        validate_positive(self.ulimits.nproc, &self.name, "ulimits.nproc")?;
+        validate_positive(self.ulimits.nofile, &self.name, "ulimits.nofile")?;
+        for mount in &self.mounts.tmpfs {
+            if !mount.path.starts_with('/') {
+                return Err(invalid_profile(
+                    &self.name,
+                    "mounts.tmpfs.path must be an absolute path",
+                ));
+            }
+            if mount.size.as_deref().is_some_and(str::is_empty) {
+                return Err(invalid_profile(
+                    &self.name,
+                    "mounts.tmpfs.size must not be empty when set",
+                ));
+            }
+        }
+        for package in &self.packages.strip {
+            if package.trim().is_empty() || package.bytes().any(|byte| byte.is_ascii_whitespace()) {
+                return Err(invalid_profile(
+                    &self.name,
+                    "packages.strip entries must be non-empty package names",
+                ));
+            }
+        }
+        Ok(())
+    }
+}
+
+pub fn builtin_hardening_profile(name: &str) -> PolicyResult<HardeningProfile> {
+    match name {
+        "baseline" => HardeningProfile::from_yaml("baseline", BASELINE_PROFILE),
+        "strict" => HardeningProfile::from_yaml("strict", STRICT_PROFILE),
+        "open" => HardeningProfile::from_yaml("open", OPEN_PROFILE),
+        other => Err(PolicyError::UnknownHardeningProfile {
+            name: other.to_owned(),
+            available: BUILTIN_NAMES.join(", "),
+        }),
+    }
+}
+
+pub fn resolve_hardening_profile(value: &str) -> PolicyResult<HardeningProfile> {
+    if BUILTIN_NAMES.contains(&value) {
+        return builtin_hardening_profile(value);
+    }
+    let direct = Path::new(value);
+    if direct.is_file() {
+        return load_profile_path(direct);
+    }
+    if let Ok(dir) = env::var("AGENTENV_HARDENING_PROFILE_DIR") {
+        let candidate = Path::new(&dir).join(format!("{value}.yaml"));
+        if candidate.is_file() {
+            return load_profile_path(&candidate);
+        }
+    }
+    if let Some(home) = dirs::home_dir() {
+        let candidate = home.join(".agentenv").join("hardening").join(format!("{value}.yaml"));
+        if candidate.is_file() {
+            return load_profile_path(&candidate);
+        }
+    }
+    Err(PolicyError::UnknownHardeningProfile {
+        name: value.to_owned(),
+        available: BUILTIN_NAMES.join(", "),
+    })
+}
+
+fn load_profile_path(path: &Path) -> PolicyResult<HardeningProfile> {
+    let yaml = std::fs::read_to_string(path).map_err(|err| PolicyError::HardeningProfile {
+        name: path.display().to_string(),
+        message: err.to_string(),
+    })?;
+    HardeningProfile::from_yaml(&path.display().to_string(), &yaml)
+}
+
+pub fn apply_hardening_to_policy(
+    policy: &mut NetworkPolicy,
+    profile: &HardeningProfile,
+    persist_home: bool,
+) -> PolicyResult<()> {
+    merge_paths(&mut policy.filesystem.read_only, &mut policy.filesystem.read_write, &profile.mounts.read_only);
+    merge_paths(&mut policy.filesystem.read_write, &mut policy.filesystem.read_only, &profile.mounts.read_write);
+    if persist_home {
+        merge_paths(
+            &mut policy.filesystem.read_write,
+            &mut policy.filesystem.read_only,
+            &["$HOME".to_owned()],
+        );
+    }
+    Ok(())
+}
+
+pub fn hardening_metadata(profile: &HardeningProfile) -> PolicyResult<BTreeMap<String, Value>> {
+    let mut metadata = BTreeMap::new();
+    metadata.insert("hardening_profile".to_owned(), Value::String(profile.name.clone()));
+    metadata.insert(
+        "hardening_packages_strip".to_owned(),
+        serde_json::to_value(&profile.packages.strip).map_err(json_error(&profile.name))?,
+    );
+    metadata.insert(
+        "hardening_tmpfs".to_owned(),
+        serde_json::to_value(&profile.mounts.tmpfs).map_err(json_error(&profile.name))?,
+    );
+    metadata.insert(
+        "hardening_capabilities_drop".to_owned(),
+        serde_json::to_value(&profile.capabilities.drop).map_err(json_error(&profile.name))?,
+    );
+    metadata.insert(
+        "hardening_dockerfile_marker".to_owned(),
+        Value::String(profile.dockerfile.marker.clone()),
+    );
+    metadata.insert(
+        "hardening_dockerfile_fragment".to_owned(),
+        Value::String(profile.dockerfile.fragment.clone()),
+    );
+    if let Some(nproc) = profile.ulimits.nproc {
+        metadata.insert("hardening_ulimit_nproc".to_owned(), Value::from(nproc));
+    }
+    if let Some(nofile) = profile.ulimits.nofile {
+        metadata.insert("hardening_ulimit_nofile".to_owned(), Value::from(nofile));
+    }
+    metadata.insert(
+        "hardening_disable_core_dumps".to_owned(),
+        Value::Bool(profile.disable_core_dumps),
+    );
+    metadata.insert(
+        "hardening_disable_user_namespaces".to_owned(),
+        Value::Bool(profile.disable_user_namespaces),
+    );
+    Ok(metadata)
+}
+
+fn validate_positive(value: Option<u64>, profile: &str, field: &str) -> PolicyResult<()> {
+    if value == Some(0) {
+        return Err(invalid_profile(profile, &format!("{field} must be positive")));
+    }
+    Ok(())
+}
+
+fn invalid_profile(name: &str, message: &str) -> PolicyError {
+    PolicyError::HardeningProfile {
+        name: name.to_owned(),
+        message: message.to_owned(),
+    }
+}
+
+fn merge_paths(target: &mut Vec<String>, other: &mut Vec<String>, incoming: &[String]) {
+    for path in incoming {
+        target.retain(|existing| existing != path);
+        other.retain(|existing| existing != path);
+        target.push(path.clone());
+    }
+    target.sort();
+    target.dedup();
+}
+
+fn json_error(profile: &str) -> impl FnOnce(serde_json::Error) -> PolicyError + '_ {
+    move |err| PolicyError::HardeningProfile {
+        name: profile.to_owned(),
+        message: err.to_string(),
+    }
+}
+```
+
+Add `dirs.workspace = true` to `crates/agentenv-policy/Cargo.toml`.
+
+- [ ] **Step 6: Export the new policy API**
+
+Modify `crates/agentenv-policy/src/lib.rs`:
+
+```rust
+pub mod hardening;
+```
+
+Add these exports below the existing exports:
+
+```rust
+pub use crate::hardening::{
+    apply_hardening_to_policy, builtin_hardening_profile, hardening_metadata,
+    resolve_hardening_profile, HardeningCapabilities, HardeningDockerfile, HardeningMounts,
+    HardeningPackages, HardeningProfile, HardeningTmpfsMount, HardeningUlimits,
+};
+```
+
+- [ ] **Step 7: Run policy tests**
+
+Run:
+
+```bash
+cargo test -p agentenv-policy --test hardening_profiles
+cargo test -p agentenv-policy
+```
+
+Expected: PASS.
+
+- [ ] **Step 8: Commit policy profiles**
+
+```bash
+git add Cargo.toml crates/agentenv-policy
+git commit -m "feat: add hardening profile registry"
+```
+
+## Task 2: Resolve And Propagate Hardening In Core
+
+**Files:**
+- Create: `crates/agentenv-core/src/hardening.rs`
+- Modify: `crates/agentenv-core/src/lib.rs`
+- Modify: `crates/agentenv-core/src/lifecycle.rs`
+- Modify: `crates/agentenv-core/src/runtime.rs`
+- Test: `crates/agentenv-core/src/runtime.rs`
+- Test: `crates/agentenv-core/tests/roundtrip.rs`
+
+- [ ] **Step 1: Write failing core tests**
+
+Add this test to `crates/agentenv-core/tests/roundtrip.rs`:
+
+```rust
+#[test]
+fn roundtrip_rejects_unknown_hardening_profile() {
+    let yaml = r#"
+version: 0.1.0
+min_agentenv_version: 0.0.1-alpha0
+sandbox:
+  driver: openshell
+  hardening: sealed
+agent:
+  driver: codex
+context:
+  driver: filesystem
+  mount: ~/projects
+policy:
+  tier: balanced
+  presets: []
+"#;
+
+    let err = agentenv_core::lifecycle::verify_blueprint_yaml(yaml)
+        .expect_err("unknown profile should fail verification");
+
+    assert!(err.to_string().contains("sealed"));
+    assert!(err.to_string().contains("hardening"));
+}
+```
+
+Add these tests inside the existing `#[cfg(test)] mod tests` in `crates/agentenv-core/src/runtime.rs`:
+
+```rust
+#[test]
+fn sandbox_spec_defaults_to_baseline_hardening_metadata() {
+    let selection = DriverSelection {
+        sandbox: "openshell".to_owned(),
+        agent: "codex".to_owned(),
+        context: "filesystem".to_owned(),
+        inference: None,
+    };
+    let endpoint = agentenv_proto::McpEndpoint {
+        url: String::new(),
+        transport: agentenv_proto::McpTransport::Stdio,
+        headers: BTreeMap::new(),
+    };
+    let profile = crate::hardening::resolve_sandbox_hardening(&BTreeMap::new())
+        .expect("baseline hardening");
+    let spec = sandbox_spec_for_create(
+        "demo",
+        &selection,
+        &BTreeMap::new(),
+        &endpoint,
+        BTreeMap::new(),
+        None,
+        &profile,
+    )
+    .expect("sandbox spec");
+
+    assert_eq!(spec.metadata["hardening_profile"], serde_json::json!("baseline"));
+    assert!(spec.metadata["hardening_packages_strip"]
+        .as_array()
+        .unwrap()
+        .contains(&serde_json::json!("gcc")));
+}
+
+#[test]
+fn sandbox_spec_propagates_strict_hardening_metadata() {
+    let selection = DriverSelection {
+        sandbox: "openshell".to_owned(),
+        agent: "codex".to_owned(),
+        context: "filesystem".to_owned(),
+        inference: None,
+    };
+    let endpoint = agentenv_proto::McpEndpoint {
+        url: String::new(),
+        transport: agentenv_proto::McpTransport::Stdio,
+        headers: BTreeMap::new(),
+    };
+    let sandbox_extra = BTreeMap::from([(
+        "hardening".to_owned(),
+        serde_yaml::Value::String("strict".to_owned()),
+    )]);
+    let profile = crate::hardening::resolve_sandbox_hardening(&sandbox_extra)
+        .expect("strict hardening");
+    let spec = sandbox_spec_for_create(
+        "demo",
+        &selection,
+        &sandbox_extra,
+        &endpoint,
+        BTreeMap::new(),
+        None,
+        &profile,
+    )
+    .expect("sandbox spec");
+
+    assert_eq!(spec.metadata["hardening_profile"], serde_json::json!("strict"));
+    assert_eq!(
+        spec.metadata["hardening_disable_core_dumps"],
+        serde_json::json!(true)
+    );
+    assert!(spec.metadata["hardening_packages_strip"]
+        .as_array()
+        .unwrap()
+        .contains(&serde_json::json!("curl")));
+}
+```
+
+- [ ] **Step 2: Run failing core tests**
+
+Run:
+
+```bash
+cargo test -p agentenv-core roundtrip_rejects_unknown_hardening_profile
+cargo test -p agentenv-core sandbox_spec_defaults_to_baseline_hardening_metadata sandbox_spec_propagates_strict_hardening_metadata
+```
+
+Expected: FAIL because `crate::hardening` and the new `sandbox_spec_for_create` argument do not exist.
+
+- [ ] **Step 3: Add core hardening resolution helpers**
+
+Create `crates/agentenv-core/src/hardening.rs`:
+
+```rust
+use std::collections::BTreeMap;
+
+use agentenv_policy::{hardening_metadata, resolve_hardening_profile, HardeningProfile};
+use serde_yaml::Value;
+
+use crate::{driver::DriverError, lifecycle::LifecycleError, runtime::RuntimeError};
+
+#[derive(Debug, Clone)]
+pub struct ResolvedHardening {
+    pub profile: HardeningProfile,
+    pub metadata: BTreeMap<String, serde_json::Value>,
+}
+
+pub fn resolve_sandbox_hardening(
+    sandbox_extra: &BTreeMap<String, Value>,
+) -> Result<ResolvedHardening, RuntimeError> {
+    let name = sandbox_hardening_value(sandbox_extra)
+        .map_err(runtime_invalid_hardening)?
+        .unwrap_or("baseline");
+    let profile = resolve_hardening_profile(name).map_err(|err| {
+        RuntimeError::Driver(DriverError::InvalidInput {
+            message: err.to_string(),
+        })
+    })?;
+    let metadata = hardening_metadata(&profile).map_err(|err| {
+        RuntimeError::Driver(DriverError::InvalidInput {
+            message: err.to_string(),
+        })
+    })?;
+    Ok(ResolvedHardening { profile, metadata })
+}
+
+pub fn validate_sandbox_hardening(
+    sandbox_extra: &BTreeMap<String, Value>,
+) -> Result<(), LifecycleError> {
+    let name = sandbox_hardening_value(sandbox_extra).map_err(|message| {
+        LifecycleError::InvalidHardeningProfile {
+            message,
+        }
+    })?;
+    let Some(name) = name else {
+        resolve_hardening_profile("baseline").map_err(|err| LifecycleError::InvalidHardeningProfile {
+            message: err.to_string(),
+        })?;
+        return Ok(());
+    };
+    resolve_hardening_profile(name).map_err(|err| LifecycleError::InvalidHardeningProfile {
+        message: err.to_string(),
+    })?;
+    Ok(())
+}
+
+fn sandbox_hardening_value(
+    sandbox_extra: &BTreeMap<String, Value>,
+) -> Result<Option<&str>, String> {
+    match sandbox_extra.get("hardening") {
+        Some(Value::String(value)) if !value.trim().is_empty() => Ok(Some(value.as_str())),
+        Some(Value::String(_)) => Err("sandbox.hardening must not be empty".to_owned()),
+        Some(Value::Null) | None => Ok(None),
+        Some(_) => Err("sandbox.hardening must be a string when set".to_owned()),
+    }
+}
+
+fn runtime_invalid_hardening(message: String) -> RuntimeError {
+    RuntimeError::Driver(DriverError::InvalidInput { message })
+}
+```
+
+Modify `crates/agentenv-core/src/lib.rs`:
+
+```rust
+pub mod hardening;
+```
+
+Add a `LifecycleError` variant in `crates/agentenv-core/src/lifecycle.rs`:
+
+```rust
+#[error("invalid hardening profile: {message}")]
+InvalidHardeningProfile { message: String },
+```
+
+Call validation in `verify_resolved_blueprint` after URL validation:
+
+```rust
+crate::hardening::validate_sandbox_hardening(&resolved.blueprint.sandbox.extra)?;
+```
+
+- [ ] **Step 4: Apply hardening during create and sandbox spec construction**
+
+In `crates/agentenv-core/src/runtime.rs`, resolve hardening before composing policy in `create_env_inner`:
+
+```rust
+let hardening = crate::hardening::resolve_sandbox_hardening(&resolved.blueprint.sandbox.extra)?;
+```
+
+After composing policy and adding context network rules, merge hardening only when the policy came from the blueprint rather than a lockfile:
+
+```rust
+if input.resolved_policy.is_none() {
+    let persist_home = resolved
+        .blueprint
+        .state
+        .as_ref()
+        .and_then(|state| state.persist_home)
+        .unwrap_or(false);
+    agentenv_policy::apply_hardening_to_policy(&mut policy, &hardening.profile, persist_home)
+        .map_err(|err| RuntimeError::Driver(crate::driver::DriverError::InvalidInput {
+            message: err.to_string(),
+        }))?;
+}
+```
+
+Change `sandbox_spec_for_create` signature:
+
+```rust
+fn sandbox_spec_for_create(
+    name: &str,
+    selection: &DriverSelection,
+    sandbox_extra: &BTreeMap<String, serde_yaml::Value>,
+    context_endpoint: &agentenv_proto::McpEndpoint,
+    env: BTreeMap<String, String>,
+    policy: Option<agentenv_proto::NetworkPolicy>,
+    hardening: &crate::hardening::ResolvedHardening,
+) -> RuntimeResult<agentenv_proto::SandboxSpec> {
+```
+
+Before returning `SandboxSpec`, merge metadata:
+
+```rust
+metadata.extend(hardening.metadata.clone());
+```
+
+Update the production call:
+
+```rust
+let sandbox_spec = sandbox_spec_for_create(
+    name,
+    &selection,
+    &resolved.blueprint.sandbox.extra,
+    &context_endpoint,
+    env,
+    Some(create_policy.clone()),
+    &hardening,
+)?;
+```
+
+Update every test call to pass `&profile` as shown in Step 1.
+
+- [ ] **Step 5: Run core tests**
+
+Run:
+
+```bash
+cargo test -p agentenv-core roundtrip_rejects_unknown_hardening_profile
+cargo test -p agentenv-core sandbox_spec_defaults_to_baseline_hardening_metadata sandbox_spec_propagates_strict_hardening_metadata
+cargo test -p agentenv-core
+```
+
+Expected: PASS.
+
+- [ ] **Step 6: Commit core propagation**
+
+```bash
+git add crates/agentenv-core
+git commit -m "feat: propagate sandbox hardening metadata"
+```
+
+## Task 3: Add Hardening-Aware Dockerfile Linting
+
+**Files:**
+- Modify: `crates/agentenv-core/src/hardening.rs`
+- Modify: `crates/agentenv-core/src/runtime.rs`
+- Test: `crates/agentenv-core/tests/hardening_lint.rs`
+
+- [ ] **Step 1: Write failing public lint tests**
+
+Create `crates/agentenv-core/tests/hardening_lint.rs`:
+
+```rust
+use agentenv_core::hardening::{lint_blueprint_hardening, HardeningLintSeverity};
+
+fn temp_root(name: &str) -> std::path::PathBuf {
+    let root = std::env::temp_dir().join(format!(
+        "agentenv-{name}-{}",
+        std::time::SystemTime::now()
+            .duration_since(std::time::UNIX_EPOCH)
+            .unwrap()
+            .as_nanos()
+    ));
+    std::fs::create_dir_all(&root).unwrap();
+    root
+}
+
+#[test]
+fn lint_reports_strict_dockerfile_errors() {
+    let root = temp_root("hardening-lint-strict");
+    let dockerfile = root.join("Dockerfile");
+    std::fs::write(
+        &dockerfile,
+        r#"
+FROM alpine:3.20
+RUN apk add --no-cache curl git
+RUN docker run --privileged alpine true
+RUN echo cap_add: NET_ADMIN
+USER root
+"#,
+    )
+    .unwrap();
+    let yaml = format!(
+        r#"
+version: 0.1.0
+min_agentenv_version: 0.0.1-alpha0
+sandbox:
+  driver: openshell
+  hardening: strict
+  image:
+    source: byo
+    dockerfile: {}
+agent:
+  driver: codex
+context:
+  driver: filesystem
+  mount: ~/projects
+policy:
+  tier: balanced
+  presets: []
+"#,
+        dockerfile.display()
+    );
+
+    let report = lint_blueprint_hardening(&yaml, &root).expect("lint report");
+    let codes = report
+        .diagnostics
+        .iter()
+        .map(|diagnostic| diagnostic.code.as_str())
+        .collect::<Vec<_>>();
+
+    assert!(codes.contains(&"dockerfile_user_root"));
+    assert!(codes.contains(&"dockerfile_privileged"));
+    assert!(codes.contains(&"dockerfile_cap_add"));
+    assert!(codes.contains(&"dockerfile_missing_hardening_marker"));
+    assert!(codes.contains(&"dockerfile_reintroduces_stripped_package"));
+    assert!(report
+        .diagnostics
+        .iter()
+        .any(|diagnostic| diagnostic.severity == HardeningLintSeverity::Error));
+    std::fs::remove_dir_all(root).unwrap();
+}
+
+#[test]
+fn lint_baseline_package_reintroduction_is_warning() {
+    let root = temp_root("hardening-lint-baseline");
+    let dockerfile = root.join("Dockerfile");
+    std::fs::write(
+        &dockerfile,
+        r#"
+FROM alpine:3.20
+RUN apk add --no-cache gcc
+USER sandbox
+"#,
+    )
+    .unwrap();
+    let yaml = format!(
+        r#"
+version: 0.1.0
+min_agentenv_version: 0.0.1-alpha0
+sandbox:
+  driver: openshell
+  image:
+    source: byo
+    dockerfile: {}
+agent:
+  driver: codex
+context:
+  driver: filesystem
+  mount: ~/projects
+policy:
+  tier: balanced
+  presets: []
+"#,
+        dockerfile.display()
+    );
+
+    let report = lint_blueprint_hardening(&yaml, &root).expect("lint report");
+    let diagnostic = report
+        .diagnostics
+        .iter()
+        .find(|diagnostic| diagnostic.code == "dockerfile_reintroduces_stripped_package")
+        .expect("package diagnostic");
+
+    assert_eq!(report.profile, "baseline");
+    assert_eq!(diagnostic.severity, HardeningLintSeverity::Warning);
+    std::fs::remove_dir_all(root).unwrap();
+}
+```
+
+- [ ] **Step 2: Run failing lint tests**
+
+Run:
+
+```bash
+cargo test -p agentenv-core --test hardening_lint
+```
+
+Expected: FAIL because `lint_blueprint_hardening` and lint types do not exist.
+
+- [ ] **Step 3: Implement lint report types and Dockerfile analysis**
+
+Append to `crates/agentenv-core/src/hardening.rs`:
+
+```rust
+use std::path::{Path, PathBuf};
+
+use serde::Serialize;
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize)]
+pub struct HardeningLintReport {
+    pub profile: String,
+    pub dockerfile: Option<PathBuf>,
+    pub diagnostics: Vec<HardeningLintDiagnostic>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize)]
+pub struct HardeningLintDiagnostic {
+    pub severity: HardeningLintSeverity,
+    pub code: String,
+    pub message: String,
+    pub remediation: Option<String>,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize)]
+#[serde(rename_all = "lowercase")]
+pub enum HardeningLintSeverity {
+    Warning,
+    Error,
+}
+
+pub fn lint_blueprint_hardening(
+    blueprint_yaml: &str,
+    cwd: &Path,
+) -> Result<HardeningLintReport, RuntimeError> {
+    let blueprint = crate::blueprint::Blueprint::from_yaml(blueprint_yaml)
+        .map_err(crate::lifecycle::LifecycleError::from)?;
+    let hardening = resolve_sandbox_hardening(&blueprint.sandbox.extra)?;
+    let dockerfile = byo_dockerfile_path(&blueprint.sandbox.extra, cwd)?;
+    let mut diagnostics = Vec::new();
+    if let Some(path) = dockerfile.as_ref() {
+        diagnostics.extend(lint_dockerfile(path, &hardening.profile));
+    }
+    diagnostics.extend(runtime_support_diagnostics(&hardening.profile, &blueprint.sandbox.driver));
+    Ok(HardeningLintReport {
+        profile: hardening.profile.name,
+        dockerfile,
+        diagnostics,
+    })
+}
+
+pub fn dockerfile_preflight_issues(
+    sandbox_extra: &BTreeMap<String, Value>,
+) -> Vec<agentenv_proto::PreflightIssue> {
+    let Ok(hardening) = resolve_sandbox_hardening(sandbox_extra) else {
+        return Vec::new();
+    };
+    let Ok(Some(path)) = byo_dockerfile_path(sandbox_extra, Path::new(".")) else {
+        return Vec::new();
+    };
+    lint_dockerfile(&path, &hardening.profile)
+        .into_iter()
+        .map(|diagnostic| agentenv_proto::PreflightIssue {
+            severity: match diagnostic.severity {
+                HardeningLintSeverity::Warning => agentenv_proto::IssueSeverity::Warning,
+                HardeningLintSeverity::Error => agentenv_proto::IssueSeverity::Error,
+            },
+            code: diagnostic.code,
+            message: diagnostic.message,
+            remediation: diagnostic.remediation,
+        })
+        .collect()
+}
+
+fn byo_dockerfile_path(
+    sandbox_extra: &BTreeMap<String, Value>,
+    cwd: &Path,
+) -> Result<Option<PathBuf>, RuntimeError> {
+    let image = match sandbox_extra.get("image").and_then(Value::as_mapping) {
+        Some(image) => image,
+        None => return Ok(None),
+    };
+    if yaml_mapping_string(image, "source") != Some("byo") {
+        return Ok(None);
+    }
+    let Some(raw) = yaml_mapping_string(image, "dockerfile") else {
+        return Ok(None);
+    };
+    let path = Path::new(raw);
+    Ok(Some(if path.is_absolute() {
+        path.to_path_buf()
+    } else {
+        cwd.join(path)
+    }))
+}
+
+fn lint_dockerfile(
+    path: &Path,
+    profile: &agentenv_policy::HardeningProfile,
+) -> Vec<HardeningLintDiagnostic> {
+    let contents = match std::fs::read_to_string(path) {
+        Ok(contents) => contents,
+        Err(err) => {
+            return vec![diagnostic(
+                HardeningLintSeverity::Error,
+                "dockerfile_unreadable",
+                format!("could not read BYO Dockerfile `{}`: {err}", path.display()),
+                "Check the Dockerfile path and permissions before creating the environment",
+            )];
+        }
+    };
+    let mut final_user = None::<String>;
+    let mut saw_privileged = false;
+    let mut saw_cap_add = false;
+    let mut installed = Vec::<String>::new();
+    for line in contents.lines() {
+        let trimmed = line.trim();
+        if trimmed.is_empty() || trimmed.starts_with('#') {
+            continue;
+        }
+        let lower = trimmed.to_ascii_lowercase();
+        if lower.contains("--privileged") {
+            saw_privileged = true;
+        }
+        if lower.contains("cap_add") || lower.contains("cap-add") {
+            saw_cap_add = true;
+        }
+        if let Some(rest) = lower.strip_prefix("user ") {
+            final_user = rest
+                .split_whitespace()
+                .next()
+                .map(|user| user.split(':').next().unwrap_or(user).to_owned());
+        }
+        if lower.starts_with("run ") {
+            installed.extend(installed_packages_from_run_line(&lower));
+        }
+    }
+
+    let mut diagnostics = Vec::new();
+    if matches!(final_user.as_deref(), Some("root" | "0")) {
+        diagnostics.push(diagnostic(
+            root_user_severity(profile),
+            "dockerfile_user_root",
+            format!("BYO Dockerfile `{}` leaves the final image user as root", path.display()),
+            "Set a non-root final USER that matches the sandbox policy",
+        ));
+    }
+    if saw_privileged {
+        diagnostics.push(diagnostic(
+            HardeningLintSeverity::Warning,
+            "dockerfile_privileged",
+            format!("BYO Dockerfile `{}` references `--privileged`", path.display()),
+            "Remove privileged container nesting from the sandbox image build",
+        ));
+    }
+    if saw_cap_add {
+        diagnostics.push(diagnostic(
+            HardeningLintSeverity::Warning,
+            "dockerfile_cap_add",
+            format!("BYO Dockerfile `{}` references cap_add or cap-add", path.display()),
+            "Move Linux capability requirements into agentenv policy instead of the image",
+        ));
+    }
+    if !contents.contains(&profile.dockerfile.marker) {
+        diagnostics.push(diagnostic(
+            HardeningLintSeverity::Warning,
+            "dockerfile_missing_hardening_marker",
+            format!("BYO Dockerfile `{}` does not contain `{}`", path.display(), profile.dockerfile.marker),
+            "Run through agentenv create or include the selected hardening fragment in the image build",
+        ));
+    }
+    for package in profile.packages.strip.iter().filter(|package| installed.contains(package)) {
+        diagnostics.push(diagnostic(
+            package_reintroduction_severity(profile),
+            "dockerfile_reintroduces_stripped_package",
+            format!("BYO Dockerfile `{}` installs `{package}`, which `{}` strips", path.display(), profile.name),
+            "Remove the package install or choose a less restrictive hardening profile",
+        ));
+    }
+    diagnostics
+}
+
+fn installed_packages_from_run_line(line: &str) -> Vec<String> {
+    let mut packages = Vec::new();
+    let tokens = line
+        .split(|ch: char| ch.is_ascii_whitespace() || matches!(ch, '\\' | ';' | '&'))
+        .filter(|token| !token.is_empty())
+        .collect::<Vec<_>>();
+    for window in tokens.windows(2) {
+        if matches!(window, ["add", pkg] | ["install", pkg]) && !pkg.starts_with('-') {
+            packages.push((*pkg).to_owned());
+        }
+    }
+    packages
+}
+
+fn runtime_support_diagnostics(
+    profile: &agentenv_policy::HardeningProfile,
+    driver: &str,
+) -> Vec<HardeningLintDiagnostic> {
+    if driver == "openshell" && (!profile.mounts.tmpfs.is_empty() || profile.disable_user_namespaces) {
+        return vec![diagnostic(
+            HardeningLintSeverity::Warning,
+            "hardening_runtime_unsupported",
+            format!("sandbox driver `{driver}` may not enforce every runtime setting in `{}`", profile.name),
+            "Review driver preflight output and OpenShell support before relying on this setting",
+        )];
+    }
+    Vec::new()
+}
+
+fn root_user_severity(profile: &agentenv_policy::HardeningProfile) -> HardeningLintSeverity {
+    match profile.name.as_str() {
+        "baseline" | "strict" => HardeningLintSeverity::Error,
+        _ => HardeningLintSeverity::Warning,
+    }
+}
+
+fn package_reintroduction_severity(profile: &agentenv_policy::HardeningProfile) -> HardeningLintSeverity {
+    if profile.name == "strict" {
+        HardeningLintSeverity::Error
+    } else {
+        HardeningLintSeverity::Warning
+    }
+}
+
+fn diagnostic(
+    severity: HardeningLintSeverity,
+    code: &str,
+    message: String,
+    remediation: &str,
+) -> HardeningLintDiagnostic {
+    HardeningLintDiagnostic {
+        severity,
+        code: code.to_owned(),
+        message,
+        remediation: Some(remediation.to_owned()),
+    }
+}
+
+fn yaml_mapping_string<'a>(mapping: &'a serde_yaml::Mapping, key: &str) -> Option<&'a str> {
+    mapping
+        .get(serde_yaml::Value::String(key.to_owned()))
+        .and_then(Value::as_str)
+}
+```
+
+If duplicate `Path`, `Serialize`, or `Value` imports conflict with the top of the file, merge them into the existing `use` declarations.
+
+- [ ] **Step 4: Replace old BYO preflight warnings with hardening-aware warnings**
+
+Modify `add_byo_dockerfile_preflight_warnings` in `crates/agentenv-core/src/runtime.rs`:
+
+```rust
+pub fn add_byo_dockerfile_preflight_warnings(
+    report: &mut crate::admission::AdmissionReport,
+    sandbox_extra: &BTreeMap<String, serde_yaml::Value>,
+) {
+    let issues = crate::hardening::dockerfile_preflight_issues(sandbox_extra);
+    if issues.is_empty() {
+        return;
+    }
+
+    if let Some(check) = report
+        .checks
+        .iter_mut()
+        .find(|check| check.kind == DriverKind::Sandbox)
+    {
+        check.issues.extend(issues);
+        return;
+    }
+
+    report.checks.push(crate::admission::PreflightCheck {
+        kind: DriverKind::Sandbox,
+        driver: "openshell".to_owned(),
+        ok: true,
+        issues,
+    });
+}
+```
+
+Remove the old private `byo_dockerfile_path`, `dockerfile_preflight_warnings`, and `preflight_warning` helpers from `runtime.rs` after tests pass.
+
+- [ ] **Step 5: Run lint and core tests**
+
+Run:
+
+```bash
+cargo test -p agentenv-core --test hardening_lint
+cargo test -p agentenv-core byo_dockerfile_preflight_warnings_detect_conflicting_patterns
+cargo test -p agentenv-core
+```
+
+Expected: PASS. If `byo_dockerfile_preflight_warnings_detect_conflicting_patterns` now sees `dockerfile_*` codes instead of `byo_dockerfile_*`, update that test to assert the new codes.
+
+- [ ] **Step 6: Commit core linting**
+
+```bash
+git add crates/agentenv-core
+git commit -m "feat: lint hardening profiles against Dockerfiles"
+```
+
+## Task 4: Add `agentenv blueprint lint`
+
+**Files:**
+- Modify: `crates/agentenv/src/main.rs`
+- Modify: `crates/agentenv/src/render.rs`
+- Test: `crates/agentenv/src/main.rs`
+- Test: `crates/agentenv/tests/cli_behavior.rs`
+
+- [ ] **Step 1: Write failing CLI tests**
+
+In `crates/agentenv/src/main.rs`, update `cli_includes_commands` expected list by inserting `"blueprint".to_string()` before `"credentials".to_string()`.
+
+Add this integration test to `crates/agentenv/tests/cli_behavior.rs`:
+
+```rust
+#[test]
+fn blueprint_lint_reports_json_diagnostics() {
+    let temp_dir = make_temp_dir("blueprint-lint-json");
+    let dockerfile = temp_dir.join("Dockerfile");
+    fs::write(
+        &dockerfile,
+        r#"
+FROM alpine:3.20
+RUN apk add --no-cache curl git
+USER root
+"#,
+    )
+    .unwrap();
+    let blueprint = temp_dir.join("agentenv.yaml");
+    fs::write(
+        &blueprint,
+        format!(
+            r#"
+version: 0.1.0
+min_agentenv_version: 0.0.1-alpha0
+sandbox:
+  driver: openshell
+  hardening: strict
+  image:
+    source: byo
+    dockerfile: {}
+agent:
+  driver: codex
+context:
+  driver: filesystem
+  mount: ~/projects
+policy:
+  tier: balanced
+  presets: []
+"#,
+            dockerfile.display()
+        ),
+    )
+    .unwrap();
+
+    let output = Command::new(agentenv_bin())
+        .arg("blueprint")
+        .arg("lint")
+        .arg(&blueprint)
+        .arg("--json")
+        .env("HOME", &temp_dir)
+        .current_dir(&temp_dir)
+        .output()
+        .unwrap();
+
+    assert!(!output.status.success(), "lint should fail on strict errors");
+    let json: serde_json::Value = serde_json::from_slice(&output.stdout).unwrap();
+    assert_eq!(json["profile"], "strict");
+    let codes = json["diagnostics"]
+        .as_array()
+        .unwrap()
+        .iter()
+        .map(|diagnostic| diagnostic["code"].as_str().unwrap())
+        .collect::<Vec<_>>();
+    assert!(codes.contains(&"dockerfile_user_root"));
+    assert!(codes.contains(&"dockerfile_reintroduces_stripped_package"));
+}
+```
+
+- [ ] **Step 2: Run failing CLI tests**
+
+Run:
+
+```bash
+cargo test -p agentenv cli_includes_commands
+cargo test -p agentenv --test cli_behavior blueprint_lint_reports_json_diagnostics
+```
+
+Expected: FAIL because the `blueprint` subcommand does not exist.
+
+- [ ] **Step 3: Add the subcommand types and dispatcher**
+
+In `crates/agentenv/src/main.rs`, add `Blueprint(BlueprintArgs)` to `Commands` before `Credentials`.
+
+Add these arg structs near the other command args:
+
+```rust
+#[derive(Debug, Args)]
+struct BlueprintArgs {
+    #[command(subcommand)]
+    command: BlueprintCommand,
+}
+
+#[derive(Debug, Subcommand)]
+enum BlueprintCommand {
+    Lint(BlueprintLintArgs),
+}
+
+#[derive(Debug, Args)]
+struct BlueprintLintArgs {
+    file: PathBuf,
+    #[arg(long)]
+    json: bool,
+}
+```
+
+Add to the `match cli.command` dispatcher:
+
+```rust
+Some(Commands::Blueprint(args)) => run_blueprint(args),
+```
+
+Add the runner:
+
+```rust
+fn run_blueprint(args: BlueprintArgs) -> Result<()> {
+    match args.command {
+        BlueprintCommand::Lint(args) => run_blueprint_lint(args),
+    }
+}
+
+fn run_blueprint_lint(args: BlueprintLintArgs) -> Result<()> {
+    let yaml = read_text_file(&args.file, "blueprint")?;
+    let cwd = args
+        .file
+        .parent()
+        .filter(|path| !path.as_os_str().is_empty())
+        .unwrap_or_else(|| Path::new("."));
+    let report = agentenv_core::hardening::lint_blueprint_hardening(&yaml, cwd)
+        .with_context(|| format!("failed to lint blueprint `{}`", args.file.display()))?;
+    let has_errors = report.diagnostics.iter().any(|diagnostic| {
+        diagnostic.severity == agentenv_core::hardening::HardeningLintSeverity::Error
+    });
+    if args.json {
+        render::print_json(&report)?;
+    } else {
+        print_hardening_lint_text(&report);
+    }
+    if has_errors {
+        exit_process(1);
+    }
+    Ok(())
+}
+
+fn print_hardening_lint_text(report: &agentenv_core::hardening::HardeningLintReport) {
+    println!("hardening profile: {}", report.profile);
+    if let Some(path) = report.dockerfile.as_ref() {
+        println!("dockerfile: {}", path.display());
+    }
+    if report.diagnostics.is_empty() {
+        println!("ok: no hardening diagnostics");
+        return;
+    }
+    for diagnostic in &report.diagnostics {
+        println!(
+            "{} {}: {}",
+            match diagnostic.severity {
+                agentenv_core::hardening::HardeningLintSeverity::Warning => "warning",
+                agentenv_core::hardening::HardeningLintSeverity::Error => "error",
+            },
+            diagnostic.code,
+            diagnostic.message
+        );
+        if let Some(remediation) = diagnostic.remediation.as_deref() {
+            println!("  remediation: {remediation}");
+        }
+    }
+}
+```
+
+- [ ] **Step 4: Run CLI tests**
+
+Run:
+
+```bash
+cargo test -p agentenv cli_includes_commands
+cargo test -p agentenv --test cli_behavior blueprint_lint_reports_json_diagnostics
+```
+
+Expected: PASS.
+
+- [ ] **Step 5: Commit CLI lint command**
+
+```bash
+git add crates/agentenv/src/main.rs crates/agentenv/src/render.rs crates/agentenv/tests/cli_behavior.rs
+git commit -m "feat: add blueprint hardening lint command"
+```
+
+## Task 5: Inject Hardening Into OpenShell BYO Builds
+
+**Files:**
+- Modify: `crates/drivers/sandbox-openshell/src/lib.rs`
+- Test: `crates/drivers/sandbox-openshell/src/lib.rs`
+
+- [ ] **Step 1: Write failing OpenShell tests**
+
+Modify `create_builds_byo_dockerfile_and_uses_staged_context` in `crates/drivers/sandbox-openshell/src/lib.rs`. Replace the staged Dockerfile equality assertion with:
+
+```rust
+let staged = std::fs::read_to_string(&stage_dockerfile).expect("staged Dockerfile");
+assert!(staged.contains("FROM alpine:3.20"));
+assert!(staged.contains("AGENTENV_HARDENING_PROFILE=strict"));
+assert!(staged.contains("apk del"));
+```
+
+Add strict metadata to that test's `SandboxSpec.metadata`:
+
+```rust
+("hardening_profile".to_owned(), json!("strict")),
+(
+    "hardening_dockerfile_marker".to_owned(),
+    json!("AGENTENV_HARDENING_PROFILE=strict"),
+),
+(
+    "hardening_dockerfile_fragment".to_owned(),
+    json!("RUN echo AGENTENV_HARDENING_PROFILE=strict && apk del curl git || true"),
+),
+("hardening_ulimit_nproc".to_owned(), json!(512)),
+("hardening_ulimit_nofile".to_owned(), json!(4096)),
+("hardening_disable_core_dumps".to_owned(), json!(true)),
+("hardening_disable_user_namespaces".to_owned(), json!(true)),
+```
+
+Add this test near the BYO tests:
+
+```rust
+#[test]
+fn create_rejects_invalid_hardening_metadata_before_build() {
+    let tempdir = unique_tempdir("sandbox-openshell-invalid-hardening");
+    let context_dir = tempdir.join("enterprise-sandbox");
+    std::fs::create_dir_all(&context_dir).expect("create context");
+    let dockerfile = context_dir.join("Dockerfile");
+    std::fs::write(&dockerfile, "FROM alpine:3.20\n").expect("write Dockerfile");
+    let runner = Arc::new(FlexibleCommandRunner::new(Vec::new()));
+    let driver = OpenShellDriver::with_command_runner_and_workdir(runner, tempdir.join(".agentenv"));
+    let runtime = tokio::runtime::Builder::new_current_thread()
+        .enable_all()
+        .build()
+        .expect("runtime");
+
+    let err = runtime
+        .block_on(async {
+            driver
+                .create(SandboxSpec {
+                    image: None,
+                    env: BTreeMap::new(),
+                    policy: None,
+                    metadata: BTreeMap::from([
+                        ("name".to_owned(), json!("devbox")),
+                        ("byo_dockerfile".to_owned(), json!(dockerfile.display().to_string())),
+                        ("hardening_profile".to_owned(), json!("strict")),
+                        ("hardening_ulimit_nproc".to_owned(), json!(0)),
+                    ]),
+                })
+                .await
+        })
+        .expect_err("invalid hardening should fail");
+
+    assert!(err.to_string().contains("hardening_ulimit_nproc"));
+    assert!(err.to_string().contains("positive"));
+    std::fs::remove_dir_all(tempdir).expect("remove tempdir");
+}
+```
+
+- [ ] **Step 2: Run failing OpenShell tests**
+
+Run:
+
+```bash
+cargo test -p sandbox-openshell create_builds_byo_dockerfile_and_uses_staged_context create_rejects_invalid_hardening_metadata_before_build
+```
+
+Expected: FAIL because hardening fragment injection and metadata validation do not exist.
+
+- [ ] **Step 3: Add OpenShell hardening config parsing**
+
+In `crates/drivers/sandbox-openshell/src/lib.rs`, add structs near `ByoDockerfileConfig`:
+
+```rust
+#[derive(Debug, Clone, PartialEq, Eq, Default)]
+struct OpenShellHardeningConfig {
+    profile: Option<String>,
+    dockerfile_marker: Option<String>,
+    dockerfile_fragment: Option<String>,
+    ulimit_nproc: Option<u64>,
+    ulimit_nofile: Option<u64>,
+    disable_core_dumps: bool,
+    disable_user_namespaces: bool,
+}
+```
+
+Add parsing helpers near `byo_dockerfile_config`:
+
+```rust
+fn hardening_config(metadata: &BTreeMap<String, Value>) -> DriverResult<OpenShellHardeningConfig> {
+    let ulimit_nproc = optional_metadata_u64(metadata, "hardening_ulimit_nproc")?;
+    let ulimit_nofile = optional_metadata_u64(metadata, "hardening_ulimit_nofile")?;
+    validate_positive_metadata("hardening_ulimit_nproc", ulimit_nproc)?;
+    validate_positive_metadata("hardening_ulimit_nofile", ulimit_nofile)?;
+    Ok(OpenShellHardeningConfig {
+        profile: optional_metadata_string(metadata, "hardening_profile")?,
+        dockerfile_marker: optional_metadata_string(metadata, "hardening_dockerfile_marker")?,
+        dockerfile_fragment: optional_metadata_string(metadata, "hardening_dockerfile_fragment")?,
+        ulimit_nproc,
+        ulimit_nofile,
+        disable_core_dumps: optional_metadata_bool(metadata, "hardening_disable_core_dumps")?
+            .unwrap_or(false),
+        disable_user_namespaces: optional_metadata_bool(
+            metadata,
+            "hardening_disable_user_namespaces",
+        )?
+        .unwrap_or(false),
+    })
+}
+
+fn optional_metadata_u64(
+    metadata: &BTreeMap<String, Value>,
+    key: &str,
+) -> DriverResult<Option<u64>> {
+    match metadata.get(key) {
+        Some(Value::Number(value)) => value.as_u64().map(Some).ok_or_else(|| {
+            DriverError::InvalidInput {
+                message: format!("metadata.{key} must be an unsigned integer when set"),
+            }
+        }),
+        Some(Value::Null) | None => Ok(None),
+        Some(_) => Err(DriverError::InvalidInput {
+            message: format!("metadata.{key} must be an unsigned integer when set"),
+        }),
+    }
+}
+
+fn optional_metadata_bool(
+    metadata: &BTreeMap<String, Value>,
+    key: &str,
+) -> DriverResult<Option<bool>> {
+    match metadata.get(key) {
+        Some(Value::Bool(value)) => Ok(Some(*value)),
+        Some(Value::Null) | None => Ok(None),
+        Some(_) => Err(DriverError::InvalidInput {
+            message: format!("metadata.{key} must be a boolean when set"),
+        }),
+    }
+}
+
+fn validate_positive_metadata(key: &str, value: Option<u64>) -> DriverResult<()> {
+    if value == Some(0) {
+        return Err(DriverError::InvalidInput {
+            message: format!("metadata.{key} must be positive when set"),
+        });
+    }
+    Ok(())
+}
+```
+
+- [ ] **Step 4: Inject the fragment during staging**
+
+Change `prepare_byo_dockerfile_context` signature:
+
+```rust
+fn prepare_byo_dockerfile_context(
+    &self,
+    name: &str,
+    config: &ByoDockerfileConfig,
+    hardening: &OpenShellHardeningConfig,
+) -> DriverResult<String> {
+```
+
+After `stage_build_context(context_dir, &dockerfile, &stage_dir)?;`, add:
+
+```rust
+inject_hardening_fragment(&stage_dir.join("Dockerfile"), hardening)?;
+```
+
+Add helper:
+
+```rust
+fn inject_hardening_fragment(
+    dockerfile: &Path,
+    hardening: &OpenShellHardeningConfig,
+) -> DriverResult<()> {
+    let Some(fragment) = hardening.dockerfile_fragment.as_deref() else {
+        return Ok(());
+    };
+    let marker = hardening
+        .dockerfile_marker
+        .as_deref()
+        .unwrap_or("AGENTENV_HARDENING_PROFILE=custom");
+    let mut contents = fs::read_to_string(dockerfile).map_err(|source| DriverError::InvalidInput {
+        message: format!(
+            "failed to read staged Dockerfile `{}` before hardening injection: {source}",
+            dockerfile.display()
+        ),
+    })?;
+    if !contents.ends_with('\n') {
+        contents.push('\n');
+    }
+    contents.push_str("\n# agentenv hardening\n");
+    contents.push_str("# ");
+    contents.push_str(marker);
+    contents.push('\n');
+    contents.push_str(fragment.trim_end());
+    contents.push('\n');
+    fs::write(dockerfile, contents).map_err(|source| DriverError::InvalidInput {
+        message: format!(
+            "failed to write staged Dockerfile `{}` after hardening injection: {source}",
+            dockerfile.display()
+        ),
+    })
+}
+```
+
+In `create`, parse hardening before image preparation:
+
+```rust
+let hardening = hardening_config(&spec.metadata)?;
+let image = match byo_dockerfile_config(&spec.metadata)? {
+    Some(config) => self.prepare_byo_dockerfile_context(&name, &config, &hardening)?,
+    None => spec.image.unwrap_or_else(|| "openclaw".to_owned()),
+};
+```
+
+Keep `hardening` available for future OpenShell CLI mappings, but do not add CLI args that OpenShell does not support.
+
+- [ ] **Step 5: Run OpenShell tests**
+
+Run:
+
+```bash
+cargo test -p sandbox-openshell create_builds_byo_dockerfile_and_uses_staged_context create_rejects_invalid_hardening_metadata_before_build
+cargo test -p sandbox-openshell
+```
+
+Expected: PASS.
+
+- [ ] **Step 6: Commit OpenShell hardening build injection**
+
+```bash
+git add crates/drivers/sandbox-openshell/src/lib.rs
+git commit -m "feat: inject hardening into openshell BYO builds"
+```
+
+## Task 6: Update Documentation
+
+**Files:**
+- Modify: `docs/DRIVER_PROTOCOL.md`
+- Modify: `docs/BLUEPRINTS.md`
+- Modify: `crates/agentenv-policy/README.md`
+- Modify: `crates/drivers/sandbox-openshell/README.md`
+
+- [ ] **Step 1: Update driver protocol docs**
+
+In `docs/DRIVER_PROTOCOL.md`, add this paragraph after the `SandboxDriver` method table:
+
+```markdown
+Image hardening profiles are create-time sandbox configuration in schema 1.1. Core resolves `sandbox.hardening`, merges supported filesystem/process settings into `SandboxSpec.policy`, and sends image/runtime settings through `SandboxSpec.metadata` keys prefixed with `hardening_`. Drivers that build or launch container images may consume those metadata keys during `create`. No separate `apply_hardening` method exists in schema 1.1; a future additive method is reserved for sandbox drivers that need post-create or independently reloadable hardening.
+```
+
+- [ ] **Step 2: Update blueprint docs**
+
+In `docs/BLUEPRINTS.md`, add this section near the policy discussion:
+
+````markdown
+## Hardening Profiles
+
+`sandbox.hardening` selects image and runtime hardening for container-image-backed sandboxes:
+
+```yaml
+sandbox:
+  driver: openshell
+  hardening: strict
+```
+
+When omitted, agentenv uses `baseline`. `baseline` removes build and network-debug tools, requests read-only system paths, tightens process limits, and strips SUID bits in the generated image fragment. `strict` also removes `curl`, `wget`, and `git`, requests tmpfs for `/tmp`, disables core dumps, and requests user namespaces disabled. `open` keeps minimal hardening for research environments where tooling availability matters more than production posture.
+
+Use `agentenv blueprint lint <agentenv.yaml>` to check a BYO Dockerfile against the selected profile before create.
+````
+
+- [ ] **Step 3: Update policy crate README**
+
+Append to `crates/agentenv-policy/README.md`:
+
+```markdown
+## Image Hardening Profiles
+
+Built-in hardening profiles live under `hardening/` and are loaded through typed Rust structs:
+
+- `baseline`: default production profile.
+- `strict`: sensitive-work profile with stronger image stripping and runtime requests.
+- `open`: minimal profile for exploratory environments.
+
+The profile loader validates package names, tmpfs mounts, ulimit values, and generated Dockerfile fragments before core passes profile data to sandbox drivers.
+```
+
+- [ ] **Step 4: Update OpenShell README**
+
+Append to `crates/drivers/sandbox-openshell/README.md`:
+
+```markdown
+## Hardening
+
+OpenShell consumes hardening metadata from `SandboxSpec.metadata` during `create`. For BYO Dockerfile builds, the staged Dockerfile receives the selected agentenv hardening fragment before `docker build`, so digest verification reflects the hardened image. Runtime hardening fields that OpenShell cannot map directly are surfaced by blueprint lint/preflight diagnostics instead of being silently ignored.
+```
+
+- [ ] **Step 5: Commit docs**
+
+```bash
+git add docs/DRIVER_PROTOCOL.md docs/BLUEPRINTS.md crates/agentenv-policy/README.md crates/drivers/sandbox-openshell/README.md
+git commit -m "docs: document image hardening profiles"
+```
+
+## Task 7: Full Verification And Fixups
+
+**Files:**
+- Modify only files needed to fix compiler, formatting, lint, or regression issues found by this task.
+
+- [ ] **Step 1: Format**
+
+Run:
+
+```bash
+cargo fmt
+```
+
+Expected: exits 0 with no required manual changes after formatting.
+
+- [ ] **Step 2: Run clippy**
+
+Run:
+
+```bash
+cargo clippy --workspace --all-targets -- -D warnings
+```
+
+Expected: PASS. Fix every warning in the smallest relevant file. Do not suppress warnings unless the lint is demonstrably wrong.
+
+- [ ] **Step 3: Run workspace tests**
+
+Run:
+
+```bash
+cargo test --workspace
+```
+
+Expected: PASS.
+
+- [ ] **Step 4: Inspect final diff**
+
+Run:
+
+```bash
+git status --short
+git diff --stat origin/main..HEAD
+```
+
+Expected: only issue #22 hardening files and docs are changed.
+
+- [ ] **Step 5: Commit verification fixes if needed**
+
+If `cargo fmt`, clippy, or tests changed files after the last task commit:
+
+```bash
+git add -u
+git commit -m "fix: stabilize hardening profile implementation"
+```
+
+Expected: branch contains focused commits and a clean worktree.
+
+## Self-Review
+
+Spec coverage:
+
+- Three built-in profiles: Task 1.
+- Baseline default and strict/open propagation: Tasks 1 and 2.
+- BYO Dockerfile hardening fragment and digest preservation: Task 5.
+- Runtime metadata and graceful unsupported diagnostics: Tasks 2, 3, and 5.
+- `agentenv blueprint lint`: Tasks 3 and 4.
+- Docs and protocol-stable explanation: Task 6.
+
+Placeholder scan:
+
+- The plan contains no placeholder markers, ellipsis implementation markers, or unnamed follow-up work.
+- Code snippets use concrete file paths, function names, metadata keys, and command lines.
+
+Type consistency:
+
+- Policy APIs exported by Task 1 are the same APIs used by Tasks 2 and 3.
+- `ResolvedHardening` is defined in Task 2 before runtime calls use it.
+- Lint report structs are defined in Task 3 before CLI rendering uses them in Task 4.
+- OpenShell metadata keys match `hardening_metadata` from Task 1.

--- a/docs/superpowers/specs/2026-05-03-m5-6-image-hardening-design.md
+++ b/docs/superpowers/specs/2026-05-03-m5-6-image-hardening-design.md
@@ -1,0 +1,237 @@
+# M5-6 Design: Image Hardening Profiles
+
+- Date: 2026-05-03
+- Issue: https://github.com/windoliver/agentenv/issues/22
+- Milestone: M5 packaging, DX, and security
+- Affected crates: `agentenv-policy`, `agentenv-core`, `agentenv`, `agentenv-proto`, `sandbox-openshell`
+- Affected docs and profiles: `docs/DRIVER_PROTOCOL.md`, `docs/BLUEPRINTS.md`, `crates/agentenv-policy/hardening/`
+
+## 1. Context And Goals
+
+Issue #22 adds image-hardening profiles for container-image-backed sandboxes. It depends on the BYO Dockerfile work from #19, which now provides `sandbox.image.source: byo`, `agentenv create --from`, OpenShell Dockerfile staging, image digest verification, and basic Dockerfile preflight warnings.
+
+The goal is to make hardening a reusable profile system that applies to agentenv-owned images and BYO Dockerfiles. The first implementation should ship `baseline`, `strict`, and `open`; default to `baseline`; propagate selected hardening into image build inputs and runtime sandbox creation; and add a Dockerfile linter that checks a blueprint against the selected profile.
+
+This design keeps agentenv's driver protocol stable. It follows the #19 pattern: core resolves user-facing blueprint configuration, then passes create-time sandbox details through existing `SandboxSpec` policy and metadata fields. A separate `SandboxDriver::apply_hardening` method can be added later if multiple sandbox drivers need a post-create or independently reloadable hardening operation.
+
+## 2. Recommended Architecture
+
+Hardening belongs in `agentenv-policy`, because it is another policy preset family rather than a fifth pluggable axis. Add first-class hardening types, validation, and built-in profile loading there, with YAML profile files under:
+
+```text
+crates/agentenv-policy/hardening/
+```
+
+Core resolves `sandbox.hardening` from the existing flattened sandbox component. If omitted, it uses `baseline`. The resolved profile is merged into the existing create-time `NetworkPolicy` for fields that already fit the four-domain model:
+
+- filesystem read-only paths.
+- filesystem read-write paths.
+- process profile markers.
+
+Settings that do not fit the current policy model stay as hardening metadata in `SandboxSpec.metadata`:
+
+- packages to strip.
+- tmpfs mount recommendations.
+- `ulimit` values.
+- capability drops.
+- disable core dumps.
+- disable user namespaces.
+- generated Dockerfile hardening fragment content and marker.
+
+OpenShell enforces hardening during sandbox creation. It injects image-layer hardening into BYO Dockerfile staging before building, and maps runtime hardening metadata into OpenShell create or policy behavior where the underlying CLI supports it. Unsupported profile recommendations produce deterministic preflight or lint diagnostics rather than disappearing silently.
+
+## 3. Hardening Profiles
+
+Each built-in profile is a YAML bundle with a stable typed schema:
+
+```yaml
+name: baseline
+description: Default production hardening for agentenv sandbox images.
+packages:
+  strip: []
+mounts:
+  read_only: []
+  read_write: []
+  tmpfs: []
+ulimits:
+  nproc: 512
+  nofile: 4096
+capabilities:
+  drop: []
+disable_core_dumps: false
+disable_user_namespaces: false
+dockerfile:
+  marker: AGENTENV_HARDENING_PROFILE=baseline
+  fragment: |
+    RUN set -eu; \
+        find / -xdev -perm /6000 -type f -exec chmod a-s {} + 2>/dev/null || true
+```
+
+`baseline` is the default. It strips build and network-debug tools (`gcc`, `g++`, `make`, `nc`, `tcpdump`, `nmap`, `strace`, `gdb`), makes `/etc`, `/usr`, and `/opt` read-only, leaves `/workspace`, `/tmp`, and `/var/tmp` writable, adds `$HOME` as writable when `state.persist_home: true`, tightens `nproc` and `nofile`, and removes SUID binaries in the image layer.
+
+`strict` includes baseline and adds removal of `curl`, `wget`, and `git` unless explicitly allowed by future profile extensions. It puts `/tmp` on size-capped tmpfs, disables core dumps, and requests user namespaces disabled inside the sandbox.
+
+`open` keeps only minimal hardening. It should still run as the sandbox user and avoid SUID binaries, but it does not strip developer tools or network-debug tools. This profile is for research and exploratory environments where tool availability is more important than production hardening.
+
+Custom profile support is allowed through the same resolver, but the first implementation should keep it narrow: a non-built-in `sandbox.hardening` value resolves to a local YAML file path, then to a named profile under `AGENTENV_HARDENING_PROFILE_DIR`, then to `~/.agentenv/hardening/`. Invalid or missing profiles are create and lint errors.
+
+## 4. Blueprint And Runtime Flow
+
+Blueprint shape:
+
+```yaml
+sandbox:
+  driver: openshell
+  hardening: strict
+```
+
+The existing `ComponentSection.extra` representation can carry this field without changing the blueprint schema version. Runtime should add typed helpers so the rest of the code does not inspect raw YAML maps repeatedly.
+
+On `agentenv create`:
+
+1. CLI optionally overlays `--from` into `sandbox.image.source: byo`, as it does now.
+2. Core verifies the blueprint and resolves the effective hardening profile, defaulting to `baseline`.
+3. Core composes the existing policy and merges hardening filesystem/process defaults into the create-time policy.
+4. Core builds `SandboxSpec` with the effective policy plus `hardening_*` metadata.
+5. OpenShell stages and builds BYO Dockerfile contexts with an injected hardening fragment.
+6. OpenShell creates the sandbox with available runtime hardening settings.
+7. If agent installation temporarily broadens network policy, core restores the final policy exactly as it does now.
+
+For agentenv-owned images, this repository does not currently contain base-image Dockerfiles. The implementation should still expose the generated built-in hardening fragment and test it directly, so future base-image build code can reuse the same fragment rather than duplicating hardening shell.
+
+## 5. OpenShell Driver Enforcement
+
+The OpenShell driver already has a clear BYO build boundary:
+
+```text
+resolve Dockerfile -> stage context -> docker build -> inspect digest -> openshell sandbox create --from
+```
+
+Hardening should extend that boundary. The staged Dockerfile should receive an agentenv-generated hardening fragment after user content, with a profile marker comment or environment marker that the linter can recognize. The fragment should be deterministic and shell-portable enough for common Debian and Alpine images. Unsupported package managers should fail the build with a readable message rather than reporting success without hardening.
+
+Runtime metadata should be parsed into a driver-local config struct rather than scattered string lookups. The driver should map known settings to available OpenShell behavior. If OpenShell cannot express a recommendation yet, preflight and lint should report the gap with a stable diagnostic code. Create should fail only for malformed metadata or settings that the selected profile marks as required.
+
+The implementation must preserve existing BYO digest behavior: expected digest mismatches still fail, and omitted digest values are still recorded in the lockfile after build.
+
+## 6. Dockerfile Linter
+
+Add:
+
+```text
+agentenv blueprint lint <agentenv.yaml>
+agentenv blueprint lint <agentenv.yaml> --json
+```
+
+The linter resolves the blueprint, effective hardening profile, and BYO Dockerfile path if present. It does not create a sandbox or build an image. It should reuse the same profile loader and Dockerfile analysis logic used by preflight.
+
+Initial diagnostics:
+
+- `hardening_unknown_profile`: selected profile cannot be resolved.
+- `hardening_invalid_profile`: profile YAML fails validation.
+- `dockerfile_unreadable`: BYO Dockerfile cannot be read.
+- `dockerfile_user_root`: final stage leaves `USER root` or `USER 0`.
+- `dockerfile_privileged`: file references `--privileged`.
+- `dockerfile_cap_add`: file references `cap_add` or `cap-add`.
+- `dockerfile_missing_hardening_marker`: file does not include the expected agentenv hardening marker.
+- `dockerfile_reintroduces_stripped_package`: file installs a package stripped by the selected profile.
+- `hardening_runtime_unsupported`: selected profile asks for a runtime setting the selected sandbox driver does not advertise or cannot map.
+
+`USER root` should be an error for `baseline` and `strict`. Package reintroduction should be a warning for `baseline` and an error for `strict`. `open` should keep anti-patterns as warnings unless the Dockerfile is unreadable.
+
+The linter should be conservative. It should parse common Dockerfile instructions and report what it can prove. It should not claim to fully evaluate build args, multi-platform conditionals, or shell scripts.
+
+## 7. Error Handling
+
+Fail early during create, verify, and lint for:
+
+- malformed `sandbox.hardening` values.
+- missing custom profile files.
+- invalid hardening YAML types.
+- non-positive ulimit values.
+- invalid tmpfs size strings.
+- invalid package names.
+- invalid generated Dockerfile fragments.
+
+Warnings are appropriate for:
+
+- unsupported runtime recommendations on a driver that can still safely create a sandbox.
+- Dockerfile patterns that may be legitimate but weaken hardening.
+- linter limitations when a Dockerfile uses dynamic shell or build-arg behavior.
+
+Driver errors should stay in existing `DriverError` variants. This avoids broadening public error shape while still giving users actionable messages.
+
+## 8. Documentation
+
+Update `docs/DRIVER_PROTOCOL.md` to state that this implementation carries hardening through create-time `SandboxSpec.policy` and `SandboxSpec.metadata`, without adding a new method. The document should explicitly reserve a future additive method if post-create hardening becomes necessary.
+
+Update `docs/BLUEPRINTS.md` and relevant reference examples with a short explanation of `sandbox.hardening`, defaults, and when to choose `strict` or `open`.
+
+Add crate-level policy docs or README text describing the three built-in profiles and the YAML schema. The profile descriptions should match the shipped YAML exactly.
+
+## 9. Test Coverage
+
+`agentenv-policy`:
+
+- built-in profiles parse and validate.
+- `baseline`, `strict`, and `open` differ as documented.
+- invalid profiles report field-specific errors.
+- hardening-to-policy merge handles `persist_home`.
+
+`agentenv-core`:
+
+- omitted `sandbox.hardening` defaults to `baseline`.
+- `hardening: strict` propagates expected policy and metadata.
+- unknown and malformed profiles fail before sandbox creation.
+- `--from` overlay still preserves hardening behavior.
+
+`sandbox-openshell`:
+
+- BYO staging injects the selected hardening fragment.
+- build args and digest behavior remain intact.
+- runtime hardening metadata is parsed into a typed config.
+- unsupported settings produce deterministic diagnostics.
+
+`agentenv` CLI:
+
+- `agentenv blueprint lint` text and JSON output.
+- `USER root`, privileged/cap_add, missing marker, and strict package bans.
+- existing `verify-blueprint`, create preflight, and `--from` tests keep passing.
+
+Full verification before implementation completion:
+
+```sh
+cargo fmt
+cargo clippy --workspace --all-targets -- -D warnings
+cargo test --workspace
+```
+
+## 10. Scope And Non-Goals
+
+In scope:
+
+1. Ship built-in hardening profiles.
+2. Default create flows to `baseline`.
+3. Propagate `strict` and `open` through policy, image build, runtime metadata, and linting.
+4. Preserve the driver protocol for this issue.
+5. Add deterministic Dockerfile lint diagnostics.
+
+Out of scope:
+
+1. Adding a fifth pluggable axis.
+2. Adding a new serialization format.
+3. Implementing a Docker, E2B, or Firecracker sandbox driver.
+4. Fully interpreting Dockerfile shell semantics.
+5. Rebuilding or publishing agentenv-owned base images from this repository.
+6. Adding post-create hardening reload behavior.
+
+## 11. Implementation Notes
+
+Start test-first:
+
+1. Add profile parsing and validation tests in `agentenv-policy`.
+2. Add core tests that assert the default baseline and strict metadata propagation.
+3. Add CLI lint tests before implementing the subcommand.
+4. Add OpenShell staging tests that fail until the hardening fragment is injected.
+5. Implement the smallest runtime metadata mapping needed for the built-in profiles.
+
+Before writing implementation code, post the selected approach on issue #22. The comment should state that this implementation keeps the driver protocol stable and uses create-time `SandboxSpec` policy and metadata, matching the #19 BYO Dockerfile pattern.


### PR DESCRIPTION
## Summary

Closes #22.

This adds baseline, strict, and open image hardening profiles and wires them through the create flow without changing the driver protocol. Core now resolves `sandbox.hardening`, applies supported filesystem hardening to the composed policy, exposes hardening metadata to sandbox drivers, and provides hardening-aware Dockerfile linting through `agentenv blueprint lint`.

OpenShell consumes the metadata during BYO Dockerfile create flows, injects the selected hardening fragment before `docker build`, validates hardening metadata, and keeps existing digest verification/recording behavior on the hardened image.

Docs were updated for blueprint usage, policy profiles, protocol behavior, and OpenShell runtime support caveats.

## Validation

- `cargo fmt`
- `cargo clippy --workspace --all-targets -- -D warnings`
- `cargo test --workspace`
- `git diff --check origin/main..HEAD`
