### PR TITLE
[codex] add microvm sandbox driver

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -85,6 +85,7 @@ dependencies = [
  "predicates",
  "reqwest",
  "rpassword",
+ "sandbox-microvm",
  "sandbox-openshell",
  "sandbox-remote-ssh",
  "serde",
@@ -2853,6 +2854,21 @@ name = "ryu"
 version = "1.0.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9774ba4a74de5f7b1c1451ed6cd5285a32eddb5cccb8cc655a4e50009e06477f"
+
+[[package]]
+name = "sandbox-microvm"
+version = "0.0.1-alpha0"
+dependencies = [
+ "agentenv-core",
+ "agentenv-proto",
+ "async-trait",
+ "driver-conformance",
+ "serde",
+ "serde_json",
+ "tempfile",
+ "tokio",
+ "url",
+]
 
 [[package]]
 name = "sandbox-openshell"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,6 +13,7 @@ members = [
     "crates/tui",
     "crates/drivers/sandbox-openshell",
     "crates/drivers/sandbox-remote-ssh",
+    "crates/drivers/sandbox-microvm",
     "crates/drivers/agent-claude",
     "crates/drivers/agent-codex",
     "crates/drivers/agent-openclaw",

--- a/README.md
+++ b/README.md
@@ -47,15 +47,15 @@ The key insight: **every axis is pluggable**.
      │ drivers │   │ drivers │  │ drivers │ │ drivers │  │   adapters   │
      ├─────────┤   ├─────────┤  ├─────────┤ ├─────────┤  ├──────────────┤
      │OpenShell│   │ Claude  │  │  Nexus  │ │NVIDIA   │  │ stdio        │
-     │Docker*  │   │ Codex   │  │ mcp-gen │ │OpenAI   │  │ http         │
-     │E2B*     │   │ Hermes* │  │ fs      │ │Anthropic│  │ http+sse     │
-     │         │   │OpenClaw │  │ none    │ │Ollama   │  │ ssh+http     │
+     │MicroVM  │   │ Codex   │  │ mcp-gen │ │OpenAI   │  │ http         │
+     │Docker*  │   │ Hermes* │  │ fs      │ │Anthropic│  │ http+sse     │
+     │E2B*     │   │OpenClaw │  │ none    │ │Ollama   │  │ ssh+http     │
      └─────────┘   └─────────┘  └─────────┘ └─────────┘  └──────────────┘
 
                                                              * post-MVP
 ```
 
-- **Sandbox** — the isolated runtime (OpenShell, Docker, E2B, Firecracker, ...)
+- **Sandbox** — the isolated runtime (OpenShell, Firecracker microVMs, Docker, E2B, ...)
 - **Agent** — the AI program that runs inside (Claude Code, Codex, Hermes, OpenClaw, ...)
 - **Context** — the knowledge backend the agent calls via MCP (Nexus, any MCP server, filesystem-only, none)
 - **Inference** — how model calls are routed (provider + credentials stay on the host)

--- a/README.md
+++ b/README.md
@@ -55,7 +55,7 @@ The key insight: **every axis is pluggable**.
                                                              * post-MVP
 ```
 
-- **Sandbox** — the isolated runtime (OpenShell, Firecracker microVMs, Docker, E2B, ...)
+- **Sandbox** — the isolated runtime (OpenShell, Firecracker microVMs on Linux/KVM, Apple Container microVMs on macOS, Docker, E2B, ...)
 - **Agent** — the AI program that runs inside (Claude Code, Codex, Hermes, OpenClaw, ...)
 - **Context** — the knowledge backend the agent calls via MCP (Nexus, any MCP server, filesystem-only, none)
 - **Inference** — how model calls are routed (provider + credentials stay on the host)

--- a/crates/agentenv-core/src/driver_catalog.rs
+++ b/crates/agentenv-core/src/driver_catalog.rs
@@ -27,6 +27,10 @@ const BUILT_IN_DRIVER_SPECS: &[BuiltInDriverSpec] = &[
         names: &["remote-ssh", "sandbox-remote-ssh"],
     },
     BuiltInDriverSpec {
+        kind: DriverKind::Sandbox,
+        names: &["microvm", "sandbox-microvm"],
+    },
+    BuiltInDriverSpec {
         kind: DriverKind::Agent,
         names: &["claude", "agent-claude"],
     },
@@ -590,6 +594,9 @@ mod tests {
 
         assert!(specs.iter().any(|spec| {
             spec.kind == DriverKind::Sandbox && spec.names == ["openshell", "sandbox-openshell"]
+        }));
+        assert!(specs.iter().any(|spec| {
+            spec.kind == DriverKind::Sandbox && spec.names == ["microvm", "sandbox-microvm"]
         }));
         assert!(specs.iter().any(|spec| {
             spec.kind == DriverKind::Agent && spec.names == ["codex", "agent-codex"]

--- a/crates/agentenv-events/src/store.rs
+++ b/crates/agentenv-events/src/store.rs
@@ -1,6 +1,7 @@
 use std::fs::File;
 use std::io::{BufRead, BufReader};
 use std::path::{Path, PathBuf};
+use std::time::Duration;
 
 use rusqlite::types::Value as SqlValue;
 use rusqlite::{params, params_from_iter, Connection, OpenFlags};
@@ -525,7 +526,9 @@ impl SqliteEventStore {
     fn connection(&self) -> StoreResult<Connection> {
         create_private_database_file(&self.path)?;
         let path = database_open_path(&self.path)?;
-        Ok(Connection::open_with_flags(path, database_open_flags())?)
+        let conn = Connection::open_with_flags(path, database_open_flags())?;
+        conn.busy_timeout(Duration::from_secs(5))?;
+        Ok(conn)
     }
 }
 

--- a/crates/agentenv/Cargo.toml
+++ b/crates/agentenv/Cargo.toml
@@ -40,6 +40,7 @@ inference-openai = { path = "../drivers/inference-openai" }
 inference-passthrough = { path = "../drivers/inference-passthrough" }
 rpassword = "7"
 sandbox-openshell = { path = "../drivers/sandbox-openshell" }
+sandbox-microvm = { path = "../drivers/sandbox-microvm" }
 sandbox-remote-ssh = { path = "../drivers/sandbox-remote-ssh" }
 serde.workspace = true
 serde_json.workspace = true

--- a/crates/agentenv/src/builtin_factory.rs
+++ b/crates/agentenv/src/builtin_factory.rs
@@ -105,6 +105,7 @@ fn build_driver_set_with_context(
             "remote-ssh" | "sandbox-remote-ssh" => {
                 Box::new(sandbox_remote_ssh::RemoteSshDriver::default())
             }
+            "microvm" | "sandbox-microvm" => Box::new(sandbox_microvm::MicroVmDriver::default()),
             other => {
                 return Err(RuntimeError::UnsupportedDriver {
                     kind: "sandbox",
@@ -230,6 +231,15 @@ fn build_pinned_sandbox(
                 pin,
             )?;
             Ok(Box::new(sandbox_remote_ssh::RemoteSshDriver::default()))
+        }
+        "microvm" | "sandbox-microvm" => {
+            validate_builtin_pin(
+                "sandbox",
+                agentenv_proto::DriverKind::Sandbox,
+                &["microvm", "sandbox-microvm"],
+                pin,
+            )?;
+            Ok(Box::new(sandbox_microvm::MicroVmDriver::default()))
         }
         other => Err(RuntimeError::UnsupportedDriver {
             kind: "sandbox",
@@ -607,6 +617,21 @@ mod tests {
     #[test]
     fn builds_remote_ssh_sandbox_aliases() {
         for sandbox in ["remote-ssh", "sandbox-remote-ssh"] {
+            let selection = DriverSelection {
+                sandbox: sandbox.to_owned(),
+                agent: "codex".to_owned(),
+                context: "filesystem".to_owned(),
+                inference: Some("passthrough".to_owned()),
+            };
+
+            let set = BuiltInDriverFactory.build(&selection).unwrap();
+            drop(set);
+        }
+    }
+
+    #[test]
+    fn builds_microvm_sandbox_aliases() {
+        for sandbox in ["microvm", "sandbox-microvm"] {
             let selection = DriverSelection {
                 sandbox: sandbox.to_owned(),
                 agent: "codex".to_owned(),

--- a/crates/drivers/sandbox-microvm/Cargo.toml
+++ b/crates/drivers/sandbox-microvm/Cargo.toml
@@ -1,0 +1,27 @@
+[package]
+name = "sandbox-microvm"
+version.workspace = true
+edition.workspace = true
+rust-version.workspace = true
+license.workspace = true
+repository.workspace = true
+homepage.workspace = true
+authors.workspace = true
+readme = "README.md"
+description = "MicroVM sandbox driver for agentenv"
+
+[features]
+integration = []
+
+[dependencies]
+agentenv-core = { path = "../../agentenv-core" }
+agentenv-proto = { path = "../../agentenv-proto" }
+async-trait.workspace = true
+serde.workspace = true
+serde_json.workspace = true
+url.workspace = true
+
+[dev-dependencies]
+driver-conformance = { path = "../../../tests/driver-conformance" }
+tokio = { version = "1", features = ["macros", "rt"] }
+tempfile = "=3.16.0"

--- a/crates/drivers/sandbox-microvm/README.md
+++ b/crates/drivers/sandbox-microvm/README.md
@@ -1,0 +1,45 @@
+# sandbox-microvm
+
+Built-in `SandboxDriver` for microVM-backed agent environments.
+
+The driver currently implements the Firecracker runtime on Linux/KVM hosts and
+reserves the same driver surface for future Apple Container and Kata support.
+Those runtime names are parsed but return explicit capability errors until their
+host integrations are implemented.
+
+Example sandbox section:
+
+```yaml
+sandbox:
+  driver: microvm
+  runtime: firecracker
+  kernel: /var/lib/agentenv/kernel/vmlinux-6.8
+  rootfs: /var/lib/agentenv/rootfs.ext4
+  memory_mb: 2048
+  cpus: 2
+  tap: tap-agentenv0
+```
+
+Optional SSH metadata enables `connect`, `exec`, `copy_in`, and `copy_out` when
+the guest image already exposes SSH:
+
+```yaml
+sandbox:
+  driver: microvm
+  runtime: firecracker
+  kernel: /var/lib/agentenv/kernel/vmlinux-6.8
+  rootfs: /var/lib/agentenv/rootfs.ext4
+  ssh_host: 127.0.0.1
+  ssh_port: 10022
+  ssh_user: root
+```
+
+Run live integration tests with:
+
+```bash
+AGENTENV_RUN_MICROVM_INTEGRATION=1 \
+cargo test -p sandbox-microvm --features integration -- --ignored
+```
+
+Live tests require Linux, `/dev/kvm`, a `firecracker` binary on `PATH`, and a
+bootable kernel/rootfs pair prepared by the operator.

--- a/crates/drivers/sandbox-microvm/README.md
+++ b/crates/drivers/sandbox-microvm/README.md
@@ -2,10 +2,14 @@
 
 Built-in `SandboxDriver` for microVM-backed agent environments.
 
-The driver currently implements the Firecracker runtime on Linux/KVM hosts and
-reserves the same driver surface for future Apple Container and Kata support.
-Those runtime names are parsed but return explicit capability errors until their
-host integrations are implemented.
+The driver supports two host-specific runtime paths:
+
+- `runtime: firecracker` on Linux hosts with KVM access through `/dev/kvm`.
+- `runtime: apple-container` on Apple silicon Macs with Apple's `container`
+  CLI installed and `container system start` completed.
+
+`runtime: kata` is reserved and returns an explicit capability error until that
+host integration is implemented.
 
 Example sandbox section:
 
@@ -18,6 +22,17 @@ sandbox:
   memory_mb: 2048
   cpus: 2
   tap: tap-agentenv0
+```
+
+macOS example:
+
+```yaml
+sandbox:
+  driver: microvm
+  runtime: apple-container
+  image: ubuntu:24.04
+  memory_mb: 2048
+  cpus: 2
 ```
 
 Optional SSH metadata enables `connect`, `exec`, `copy_in`, and `copy_out` when
@@ -38,8 +53,19 @@ Run live integration tests with:
 
 ```bash
 AGENTENV_RUN_MICROVM_INTEGRATION=1 \
-cargo test -p sandbox-microvm --features integration -- --ignored
+AGENTENV_MICROVM_KERNEL=/var/lib/agentenv/kernel/vmlinux-6.8 \
+AGENTENV_MICROVM_ROOTFS=/var/lib/agentenv/rootfs.ext4 \
+cargo test -p sandbox-microvm --features integration firecracker_process_lifecycle_on_linux_kvm -- --ignored
 ```
 
-Live tests require Linux, `/dev/kvm`, a `firecracker` binary on `PATH`, and a
-bootable kernel/rootfs pair prepared by the operator.
+For macOS:
+
+```bash
+AGENTENV_RUN_APPLE_CONTAINER_INTEGRATION=1 \
+cargo test -p sandbox-microvm --features integration apple_container_lifecycle_on_macos -- --ignored
+```
+
+The Firecracker test requires Linux, readable/writable `/dev/kvm`, a
+`firecracker` binary on `PATH`, and a bootable kernel/rootfs pair prepared by the
+operator. Docker on macOS does not satisfy this requirement unless its Linux VM
+itself exposes `/dev/kvm`.

--- a/crates/drivers/sandbox-microvm/src/lib.rs
+++ b/crates/drivers/sandbox-microvm/src/lib.rs
@@ -17,9 +17,10 @@ use agentenv_proto::{
     Capabilities, ConnectParams, CopyInParams, CopyOutParams, CreateSessionParams, DestroyParams,
     DriverInfo, DriverKind, EmptyResult, ExecParams, ExecResult, InitializeParams,
     InitializeResult, IssueSeverity, KillSessionParams, ListSessionsParams, ListSessionsResult,
-    LogEntry, LogLevel, LogsParams, LogsResult, LogsStreamParams, PreflightIssue, PreflightParams,
-    PreflightResult, SandboxCapabilities, SandboxHandle, SandboxPhase, SandboxSpec, SandboxStatus,
-    SandboxStatusParams, SessionHandle, ShellHandle, ShutdownParams, StopParams, SCHEMA_VERSION,
+    LogEntry, LogLevel, LogsParams, LogsResult, LogsStreamParams, NetworkPolicy, PreflightIssue,
+    PreflightParams, PreflightResult, SandboxCapabilities, SandboxHandle, SandboxPhase,
+    SandboxSpec, SandboxStatus, SandboxStatusParams, SessionHandle, ShellHandle, ShutdownParams,
+    StopParams, SCHEMA_VERSION,
 };
 use serde::{Deserialize, Serialize};
 use serde_json::Value;
@@ -28,12 +29,16 @@ use url::Url;
 const DRIVER_NAME: &str = "microvm";
 const DEFAULT_RUNTIME: &str = "firecracker";
 const FIRECRACKER_BINARY: &str = "firecracker";
+const APPLE_CONTAINER_BINARY: &str = "container";
 const SSH_BINARY: &str = "ssh";
 const SCP_BINARY: &str = "scp";
 const MICROVM_SSH_CAPABILITY: &str = "microvm_ssh";
 const MICROVM_POLICY_CAPABILITY: &str = "microvm_policy_translation";
 const UNSUPPORTED_RUNTIME_CAPABILITY: &str = "microvm_runtime";
 const DEFAULT_KERNEL_ARGS: &str = "console=ttyS0 reboot=k panic=1 pci=off";
+const SANDBOX_MOUNT: &str = "/sandbox";
+const GUEST_ENV_DIR: &str = "/sandbox/.agentenv/env";
+const DEFAULT_APPLE_CONTAINER_COMMAND: &str = "trap : TERM INT; sleep infinity & wait";
 
 #[derive(Debug, Clone, PartialEq, Eq)]
 struct CommandRequest {
@@ -137,15 +142,17 @@ fn command_failed(program: &str, request: &CommandRequest, output: CommandOutput
     }
 }
 
-fn preflight_failure(code: &str, message: String, remediation: Option<String>) -> PreflightResult {
-    PreflightResult {
-        ok: false,
-        issues: vec![PreflightIssue {
-            severity: IssueSeverity::Error,
-            code: code.to_owned(),
-            message,
-            remediation,
-        }],
+fn preflight_issue(
+    severity: IssueSeverity,
+    code: &str,
+    message: String,
+    remediation: Option<String>,
+) -> PreflightIssue {
+    PreflightIssue {
+        severity,
+        code: code.to_owned(),
+        message,
+        remediation,
     }
 }
 
@@ -157,6 +164,7 @@ fn capability_missing(capability: &str) -> DriverError {
 
 pub struct MicroVmDriver {
     firecracker_binary: String,
+    apple_container_binary: String,
     ssh_binary: String,
     scp_binary: String,
     runner: Arc<dyn CommandRunner>,
@@ -168,6 +176,7 @@ impl Default for MicroVmDriver {
     fn default() -> Self {
         Self {
             firecracker_binary: FIRECRACKER_BINARY.to_owned(),
+            apple_container_binary: APPLE_CONTAINER_BINARY.to_owned(),
             ssh_binary: SSH_BINARY.to_owned(),
             scp_binary: SCP_BINARY.to_owned(),
             runner: Arc::new(ProcessCommandRunner),
@@ -183,20 +192,215 @@ impl MicroVmDriver {
     where
         T: CommandRunner + 'static,
     {
+        Self::for_tests_host(
+            runner,
+            HostChecks {
+                is_linux,
+                is_macos: false,
+                is_apple_silicon: false,
+                has_kvm,
+            },
+        )
+    }
+
+    fn for_tests_host<T>(runner: Arc<T>, host: HostChecks) -> Self
+    where
+        T: CommandRunner + 'static,
+    {
         Self {
             firecracker_binary: FIRECRACKER_BINARY.to_owned(),
+            apple_container_binary: APPLE_CONTAINER_BINARY.to_owned(),
             ssh_binary: SSH_BINARY.to_owned(),
             scp_binary: SCP_BINARY.to_owned(),
             runner,
-            host: HostChecks { is_linux, has_kvm },
+            host,
             workdir: Mutex::new(None),
         }
+    }
+}
+
+impl MicroVmDriver {
+    fn firecracker_preflight_issue(&self) -> Option<PreflightIssue> {
+        if !self.host.is_linux {
+            return Some(preflight_issue(
+                IssueSeverity::Error,
+                "microvm_linux_required",
+                "Firecracker microVMs require a Linux host".to_owned(),
+                Some(
+                    "Use a Linux host with KVM, or select runtime: apple-container on macOS"
+                        .to_owned(),
+                ),
+            ));
+        }
+        if !self.host.has_kvm {
+            return Some(preflight_issue(
+                IssueSeverity::Error,
+                "microvm_kvm_missing",
+                "/dev/kvm is not available on this host".to_owned(),
+                Some(
+                    "Enable KVM virtualization and ensure the current user can access /dev/kvm"
+                        .to_owned(),
+                ),
+            ));
+        }
+        if let Err(source) = self
+            .runner
+            .run(&self.firecracker_binary, &command_request(&["--version"]))
+        {
+            return Some(preflight_issue(
+                IssueSeverity::Error,
+                "microvm_firecracker_missing",
+                format!(
+                    "Firecracker binary `{}` is not available: {source}",
+                    self.firecracker_binary
+                ),
+                Some("Install Firecracker and ensure it is on PATH".to_owned()),
+            ));
+        }
+        None
+    }
+
+    fn apple_container_preflight_issue(&self) -> Option<PreflightIssue> {
+        if !self.host.is_macos {
+            return Some(preflight_issue(
+                IssueSeverity::Error,
+                "microvm_apple_container_macos_required",
+                "Apple Container microVMs require macOS".to_owned(),
+                Some("Use runtime: firecracker on a Linux/KVM host".to_owned()),
+            ));
+        }
+        if !self.host.is_apple_silicon {
+            return Some(preflight_issue(
+                IssueSeverity::Error,
+                "microvm_apple_container_silicon_required",
+                "Apple Container requires Apple silicon".to_owned(),
+                Some(
+                    "Use a Mac with Apple silicon, or use runtime: firecracker on Linux/KVM"
+                        .to_owned(),
+                ),
+            ));
+        }
+
+        let request = command_request(&["system", "status", "--format", "json"]);
+        match self.runner.run(&self.apple_container_binary, &request) {
+            Ok(output) if output.status == Some(0) => None,
+            Ok(output) => Some(preflight_issue(
+                IssueSeverity::Error,
+                "microvm_apple_container_not_running",
+                "Apple Container system service is not running".to_owned(),
+                Some(format!(
+                    "Run `{} system start` and retry. stdout: {} stderr: {}",
+                    self.apple_container_binary, output.stdout, output.stderr
+                )),
+            )),
+            Err(source) => Some(preflight_issue(
+                IssueSeverity::Error,
+                "microvm_apple_container_missing",
+                format!(
+                    "Apple Container CLI `{}` is not available: {source}",
+                    self.apple_container_binary
+                ),
+                Some("Install Apple Container from https://github.com/apple/container/releases and run `container system start`".to_owned()),
+            )),
+        }
+    }
+
+    fn workdir_parent(&self) -> DriverResult<PathBuf> {
+        self.workdir
+            .lock()
+            .map_err(|_| DriverError::InvalidInput {
+                message: "microvm workdir lock poisoned".to_owned(),
+            })?
+            .clone()
+            .ok_or_else(|| DriverError::InvalidInput {
+                message: "microvm driver must be initialized before create".to_owned(),
+            })
+    }
+
+    fn ensure_firecracker_create_host(&self) -> DriverResult<()> {
+        if let Some(issue) = self.firecracker_preflight_issue() {
+            return Err(DriverError::InvalidInput {
+                message: issue.message,
+            });
+        }
+        Ok(())
+    }
+
+    fn ensure_apple_container_create_host(&self) -> DriverResult<()> {
+        if let Some(issue) = self.apple_container_preflight_issue() {
+            return Err(DriverError::InvalidInput {
+                message: issue.message,
+            });
+        }
+        Ok(())
+    }
+
+    async fn create_firecracker(&self, spec: SandboxSpec) -> DriverResult<SandboxHandle> {
+        self.ensure_firecracker_create_host()?;
+        let spec = FirecrackerSpec::from_sandbox_spec(spec)?;
+        let parent = self.workdir_parent()?;
+        let workdir = ensure_workdir(&parent, &spec.name)?;
+        let handle = MicroVmHandle::new_firecracker(&spec, workdir.clone());
+        let config_path = workdir.join("firecracker.json");
+        write_json(&config_path, &spec.config())?;
+
+        let request = CommandRequest {
+            args: vec![
+                "--api-sock".to_owned(),
+                handle.api_sock.to_string_lossy().into_owned(),
+                "--config-file".to_owned(),
+                config_path.to_string_lossy().into_owned(),
+            ],
+            env: BTreeMap::new(),
+            stdin: None,
+        };
+        let pid = self
+            .runner
+            .spawn(&self.firecracker_binary, &request)
+            .map_err(|source| DriverError::CommandSpawn {
+                command: command_string(&self.firecracker_binary, &request.args),
+                source,
+            })?;
+        write_pid(&handle.pid_file, pid)?;
+
+        Ok(SandboxHandle {
+            handle: handle.to_handle()?,
+        })
+    }
+
+    async fn create_apple_container(&self, spec: SandboxSpec) -> DriverResult<SandboxHandle> {
+        self.ensure_apple_container_create_host()?;
+        let spec = AppleContainerSpec::from_sandbox_spec(spec)?;
+        let parent = self.workdir_parent()?;
+        let workdir = ensure_apple_workdir(&parent, &spec)?;
+        let handle = MicroVmHandle::new_apple_container(&spec, workdir.clone());
+        let request = apple_container_run_request(&spec, &workdir);
+        let output = self
+            .runner
+            .run(&self.apple_container_binary, &request)
+            .map_err(|source| DriverError::CommandSpawn {
+                command: command_string(&self.apple_container_binary, &request.args),
+                source,
+            })?;
+        if output.status != Some(0) {
+            return Err(command_failed(
+                &self.apple_container_binary,
+                &request,
+                output,
+            ));
+        }
+
+        Ok(SandboxHandle {
+            handle: handle.to_handle()?,
+        })
     }
 }
 
 #[derive(Debug, Clone, Copy)]
 struct HostChecks {
     is_linux: bool,
+    is_macos: bool,
+    is_apple_silicon: bool,
     has_kvm: bool,
 }
 
@@ -204,6 +408,8 @@ impl HostChecks {
     fn detect() -> Self {
         Self {
             is_linux: std::env::consts::OS == "linux",
+            is_macos: std::env::consts::OS == "macos",
+            is_apple_silicon: std::env::consts::ARCH == "aarch64",
             has_kvm: Path::new("/dev/kvm").exists(),
         }
     }
@@ -249,16 +455,6 @@ impl MicroVmRuntime {
             Self::Kata => "kata",
         }
     }
-
-    fn ensure_implemented(&self) -> DriverResult<()> {
-        match self {
-            Self::Firecracker => Ok(()),
-            Self::AppleContainer | Self::Kata => Err(capability_missing(&format!(
-                "{UNSUPPORTED_RUNTIME_CAPABILITY}:{}",
-                self.label()
-            ))),
-        }
-    }
 }
 
 #[derive(Debug, Clone)]
@@ -275,16 +471,12 @@ struct FirecrackerSpec {
 
 impl FirecrackerSpec {
     fn from_sandbox_spec(spec: SandboxSpec) -> DriverResult<Self> {
-        if spec.policy.is_some() {
-            return Err(capability_missing(MICROVM_POLICY_CAPABILITY));
-        }
+        validate_create_policy(spec.policy.as_ref())?;
         if !spec.env.is_empty() {
             return Err(DriverError::InvalidInput {
                 message: "SandboxSpec.env is not supported by sandbox-microvm without a guest env injection path".to_owned(),
             });
         }
-        let runtime = MicroVmRuntime::parse(spec.metadata.get("runtime"))?;
-        runtime.ensure_implemented()?;
 
         let name = optional_metadata_string(&spec.metadata, "name")?
             .unwrap_or_else(|| format!("agentenv-{}", uuid_like_suffix()));
@@ -346,6 +538,100 @@ impl FirecrackerSpec {
                 })
                 .unwrap_or_default(),
         }
+    }
+}
+
+#[derive(Debug, Clone)]
+struct AppleContainerSpec {
+    name: String,
+    image: String,
+    command: String,
+    memory_mb: u32,
+    cpus: u8,
+    platform: Option<String>,
+    arch: Option<String>,
+    kernel: Option<String>,
+    env: BTreeMap<String, String>,
+    guest_env_file: Option<String>,
+}
+
+impl AppleContainerSpec {
+    fn from_sandbox_spec(spec: SandboxSpec) -> DriverResult<Self> {
+        validate_create_policy(spec.policy.as_ref())?;
+        let name = optional_metadata_string(&spec.metadata, "name")?
+            .unwrap_or_else(|| format!("agentenv-{}", uuid_like_suffix()));
+        validate_name(&name, "metadata.name")?;
+        let image = optional_metadata_string(&spec.metadata, "image")?
+            .or(spec.image)
+            .ok_or_else(|| DriverError::InvalidInput {
+                message: "SandboxSpec.image or metadata.image is required for apple-container"
+                    .to_owned(),
+            })?;
+        let command = optional_metadata_string(&spec.metadata, "command")?
+            .unwrap_or_else(|| DEFAULT_APPLE_CONTAINER_COMMAND.to_owned());
+        let memory_mb = metadata_u32(&spec.metadata, "memory_mb", 2048)?;
+        let cpus = metadata_u8(&spec.metadata, "cpus", 2)?;
+        let platform = optional_metadata_string(&spec.metadata, "platform")?;
+        let arch = optional_metadata_string(&spec.metadata, "arch")?;
+        let kernel = optional_metadata_string(&spec.metadata, "kernel")?;
+        validate_env(&spec.env)?;
+        let guest_env_file = (!spec.env.is_empty()).then(|| format!("{GUEST_ENV_DIR}/{name}.env"));
+
+        Ok(Self {
+            name,
+            image,
+            command,
+            memory_mb,
+            cpus,
+            platform,
+            arch,
+            kernel,
+            env: spec.env,
+            guest_env_file,
+        })
+    }
+}
+
+fn apple_container_run_request(spec: &AppleContainerSpec, workdir: &Path) -> CommandRequest {
+    let mut args = vec![
+        "run".to_owned(),
+        "--detach".to_owned(),
+        "--name".to_owned(),
+        spec.name.clone(),
+        "--cpus".to_owned(),
+        spec.cpus.to_string(),
+        "--memory".to_owned(),
+        format!("{}M", spec.memory_mb),
+        "--mount".to_owned(),
+        format!(
+            "type=bind,source={},target={SANDBOX_MOUNT}",
+            sandbox_dir(workdir).to_string_lossy()
+        ),
+    ];
+    if !spec.env.is_empty() {
+        args.push("--env-file".to_owned());
+        args.push(workdir.join("container.env").to_string_lossy().into_owned());
+    }
+    if let Some(platform) = spec.platform.as_deref() {
+        args.push("--platform".to_owned());
+        args.push(platform.to_owned());
+    }
+    if let Some(arch) = spec.arch.as_deref() {
+        args.push("--arch".to_owned());
+        args.push(arch.to_owned());
+    }
+    if let Some(kernel) = spec.kernel.as_deref() {
+        args.push("--kernel".to_owned());
+        args.push(kernel.to_owned());
+    }
+    args.push(spec.image.clone());
+    args.push("sh".to_owned());
+    args.push("-lc".to_owned());
+    args.push(spec.command.clone());
+    CommandRequest {
+        args,
+        env: BTreeMap::new(),
+        stdin: None,
     }
 }
 
@@ -445,17 +731,31 @@ struct MicroVmHandle {
     api_sock: PathBuf,
     pid_file: PathBuf,
     ssh: Option<SshTarget>,
+    env_file: Option<String>,
 }
 
 impl MicroVmHandle {
-    fn new(runtime: MicroVmRuntime, spec: &FirecrackerSpec, workdir: PathBuf) -> Self {
+    fn new_firecracker(spec: &FirecrackerSpec, workdir: PathBuf) -> Self {
         Self {
-            runtime,
+            runtime: MicroVmRuntime::Firecracker,
             name: spec.name.clone(),
             api_sock: workdir.join("api.sock"),
             pid_file: workdir.join("firecracker.pid"),
             workdir,
             ssh: spec.ssh.clone(),
+            env_file: None,
+        }
+    }
+
+    fn new_apple_container(spec: &AppleContainerSpec, workdir: PathBuf) -> Self {
+        Self {
+            runtime: MicroVmRuntime::AppleContainer,
+            name: spec.name.clone(),
+            api_sock: workdir.join("api.sock"),
+            pid_file: workdir.join("container.pid"),
+            workdir,
+            ssh: None,
+            env_file: spec.guest_env_file.clone(),
         }
     }
 
@@ -472,6 +772,9 @@ impl MicroVmHandle {
         }
         if let Some(ssh) = self.ssh.as_ref() {
             ssh.to_query(&mut url);
+        }
+        if let Some(env_file) = self.env_file.as_deref() {
+            url.query_pairs_mut().append_pair("env_file", env_file);
         }
         Ok(url.to_string())
     }
@@ -508,6 +811,11 @@ impl MicroVmHandle {
             .map(PathBuf::from)
             .unwrap_or_else(|| workdir.join("firecracker.pid"));
         let ssh = SshTarget::from_query(&url, handle)?;
+        let env_file = query.get("env_file").cloned();
+        if let Some(env_file) = env_file.as_deref() {
+            validate_guest_env_file_path(env_file)
+                .map_err(|err| invalid_handle(handle, err.to_string()))?;
+        }
         Ok(Self {
             runtime,
             name,
@@ -515,6 +823,7 @@ impl MicroVmHandle {
             api_sock,
             pid_file,
             ssh,
+            env_file,
         })
     }
 
@@ -715,6 +1024,55 @@ fn validate_host(host: &str, label: &str) -> DriverResult<()> {
     Ok(())
 }
 
+fn validate_create_policy(policy: Option<&NetworkPolicy>) -> DriverResult<()> {
+    let Some(policy) = policy else {
+        return Ok(());
+    };
+    if !policy.network.allow.is_empty()
+        || !policy.network.deny.is_empty()
+        || !policy.network.approval_required.is_empty()
+        || !policy.inference.routes.is_empty()
+    {
+        return Err(capability_missing(MICROVM_POLICY_CAPABILITY));
+    }
+    Ok(())
+}
+
+fn validate_env(env: &BTreeMap<String, String>) -> DriverResult<()> {
+    for (key, value) in env {
+        validate_env_key(key)?;
+        if value.contains('\0') || value.contains('\n') || value.contains('\r') {
+            return Err(DriverError::InvalidInput {
+                message: format!("env.{key} must not contain NUL or newline characters"),
+            });
+        }
+    }
+    Ok(())
+}
+
+fn validate_env_key(key: &str) -> DriverResult<()> {
+    let valid = !key.is_empty()
+        && !key.starts_with(|ch: char| ch.is_ascii_digit())
+        && key
+            .chars()
+            .all(|ch| ch.is_ascii_alphanumeric() || ch == '_');
+    if !valid {
+        return Err(DriverError::InvalidInput {
+            message: format!("env key `{key}` is not a portable shell identifier"),
+        });
+    }
+    Ok(())
+}
+
+fn validate_guest_env_file_path(path: &str) -> DriverResult<()> {
+    if !path.starts_with(GUEST_ENV_DIR) || !path.ends_with(".env") {
+        return Err(DriverError::InvalidInput {
+            message: format!("env_file must be under {GUEST_ENV_DIR} and end with .env"),
+        });
+    }
+    Ok(())
+}
+
 fn ensure_workdir(parent: &Path, name: &str) -> DriverResult<PathBuf> {
     let dir = parent.join(name);
     fs::create_dir_all(&dir).map_err(|source| DriverError::InvalidInput {
@@ -724,6 +1082,61 @@ fn ensure_workdir(parent: &Path, name: &str) -> DriverResult<PathBuf> {
         ),
     })?;
     Ok(dir)
+}
+
+fn sandbox_dir(workdir: &Path) -> PathBuf {
+    workdir.join("sandbox")
+}
+
+fn ensure_apple_workdir(parent: &Path, spec: &AppleContainerSpec) -> DriverResult<PathBuf> {
+    let workdir = ensure_workdir(parent, &spec.name)?;
+    let sandbox = sandbox_dir(&workdir);
+    fs::create_dir_all(&sandbox).map_err(|source| DriverError::InvalidInput {
+        message: format!(
+            "failed to create apple-container sandbox dir `{}`: {source}",
+            sandbox.display()
+        ),
+    })?;
+    if !spec.env.is_empty() {
+        let env_dir = sandbox.join(".agentenv").join("env");
+        fs::create_dir_all(&env_dir).map_err(|source| DriverError::InvalidInput {
+            message: format!(
+                "failed to create apple-container env dir `{}`: {source}",
+                env_dir.display()
+            ),
+        })?;
+        fs::write(
+            env_dir.join(format!("{}.env", spec.name)),
+            shell_env_file(&spec.env)?,
+        )
+        .map_err(|source| DriverError::InvalidInput {
+            message: format!("failed to write guest env file: {source}"),
+        })?;
+        fs::write(
+            workdir.join("container.env"),
+            container_env_file(&spec.env)?,
+        )
+        .map_err(|source| DriverError::InvalidInput {
+            message: format!("failed to write container env file: {source}"),
+        })?;
+    }
+    Ok(workdir)
+}
+
+fn container_env_file(env: &BTreeMap<String, String>) -> DriverResult<String> {
+    validate_env(env)?;
+    Ok(env
+        .iter()
+        .map(|(key, value)| format!("{key}={value}\n"))
+        .collect())
+}
+
+fn shell_env_file(env: &BTreeMap<String, String>) -> DriverResult<String> {
+    validate_env(env)?;
+    Ok(env
+        .iter()
+        .map(|(key, value)| format!("export {key}={}\n", shell_single_quote(value)))
+        .collect())
 }
 
 fn write_json(path: &Path, value: &impl Serialize) -> DriverResult<()> {
@@ -783,6 +1196,40 @@ fn remote_path(target: &SshTarget, path: &str) -> String {
     format!("{}@{}:{path}", target.user, target.host)
 }
 
+fn shell_single_quote(value: &str) -> String {
+    format!("'{}'", value.replace('\'', "'\"'\"'"))
+}
+
+fn shell_command(
+    cmd: &str,
+    env_file: Option<&str>,
+    env: &BTreeMap<String, String>,
+) -> DriverResult<String> {
+    validate_env(env)?;
+    if let Some(env_file) = env_file {
+        validate_guest_env_file_path(env_file)?;
+    }
+
+    let mut prefix = format!("cd {SANDBOX_MOUNT}");
+    if let Some(env_file) = env_file {
+        prefix.push_str(" && . ");
+        prefix.push_str(&shell_single_quote(env_file));
+    }
+    if env.is_empty() {
+        return Ok(format!("{prefix} && {cmd}"));
+    }
+
+    let assignments = env
+        .iter()
+        .map(|(key, value)| format!("{key}={}", shell_single_quote(value)))
+        .collect::<Vec<_>>()
+        .join(" ");
+    Ok(format!(
+        "{prefix} && env {assignments} sh -lc {}",
+        shell_single_quote(cmd)
+    ))
+}
+
 fn validate_copy_path(field: &str, path: &str) -> DriverResult<()> {
     if path.is_empty() || path.starts_with('-') {
         return Err(DriverError::InvalidInput {
@@ -790,6 +1237,33 @@ fn validate_copy_path(field: &str, path: &str) -> DriverResult<()> {
         });
     }
     Ok(())
+}
+
+fn mounted_sandbox_path(handle: &MicroVmHandle, path: &str) -> DriverResult<PathBuf> {
+    validate_copy_path("sandbox_path", path)?;
+    if path != SANDBOX_MOUNT && !path.starts_with("/sandbox/") {
+        return Err(DriverError::InvalidInput {
+            message: format!("apple-container copy paths must be under {SANDBOX_MOUNT}"),
+        });
+    }
+    let relative = path
+        .strip_prefix(SANDBOX_MOUNT)
+        .ok_or_else(|| DriverError::InvalidInput {
+            message: format!("apple-container copy paths must be under {SANDBOX_MOUNT}"),
+        })?
+        .trim_start_matches('/');
+    let relative_path = Path::new(relative);
+    if relative_path.components().any(|component| {
+        !matches!(
+            component,
+            std::path::Component::Normal(_) | std::path::Component::CurDir
+        )
+    }) {
+        return Err(DriverError::InvalidInput {
+            message: "apple-container copy paths must not escape /sandbox".to_owned(),
+        });
+    }
+    Ok(sandbox_dir(&handle.workdir).join(relative_path))
 }
 
 fn log_entries_for_handle(handle: &MicroVmHandle) -> Vec<LogEntry> {
@@ -843,103 +1317,72 @@ impl SandboxDriver for MicroVmDriver {
     }
 
     async fn preflight(&self, _params: PreflightParams) -> DriverResult<PreflightResult> {
-        if !self.host.is_linux {
-            return Ok(preflight_failure(
-                "microvm_linux_required",
-                "Firecracker microVMs require a Linux host".to_owned(),
-                Some("Use a Linux host with KVM, or select a different sandbox runtime".to_owned()),
-            ));
-        }
-        if !self.host.has_kvm {
-            return Ok(preflight_failure(
-                "microvm_kvm_missing",
-                "/dev/kvm is not available on this host".to_owned(),
-                Some(
-                    "Enable KVM virtualization and ensure the current user can access /dev/kvm"
-                        .to_owned(),
-                ),
-            ));
-        }
-        if let Err(source) = self
-            .runner
-            .run(&self.firecracker_binary, &command_request(&["--version"]))
+        let mut firecracker_issue = self.firecracker_preflight_issue();
+        let mut apple_container_issue = self.apple_container_preflight_issue();
+        let ok = firecracker_issue.is_none() || apple_container_issue.is_none();
+        let mut issues = Vec::new();
+        for issue in [&mut firecracker_issue, &mut apple_container_issue]
+            .into_iter()
+            .flatten()
         {
-            return Ok(preflight_failure(
-                "microvm_firecracker_missing",
-                format!(
-                    "Firecracker binary `{}` is not available: {source}",
-                    self.firecracker_binary
-                ),
-                Some("Install Firecracker and ensure it is on PATH".to_owned()),
-            ));
+            if ok {
+                issue.severity = IssueSeverity::Warning;
+            }
+            issues.push(issue.clone());
         }
-        Ok(PreflightResult {
-            ok: true,
-            issues: Vec::new(),
-        })
+        Ok(PreflightResult { ok, issues })
     }
 
     async fn create(&self, spec: SandboxSpec) -> DriverResult<SandboxHandle> {
-        let spec = FirecrackerSpec::from_sandbox_spec(spec)?;
-        let parent = self
-            .workdir
-            .lock()
-            .map_err(|_| DriverError::InvalidInput {
-                message: "microvm workdir lock poisoned".to_owned(),
-            })?
-            .clone()
-            .ok_or_else(|| DriverError::InvalidInput {
-                message: "microvm driver must be initialized before create".to_owned(),
-            })?;
-        let workdir = ensure_workdir(&parent, &spec.name)?;
-        let handle = MicroVmHandle::new(MicroVmRuntime::Firecracker, &spec, workdir.clone());
-        let config_path = workdir.join("firecracker.json");
-        write_json(&config_path, &spec.config())?;
-
-        let request = CommandRequest {
-            args: vec![
-                "--api-sock".to_owned(),
-                handle.api_sock.to_string_lossy().into_owned(),
-                "--config-file".to_owned(),
-                config_path.to_string_lossy().into_owned(),
-            ],
-            env: BTreeMap::new(),
-            stdin: None,
-        };
-        let pid = self
-            .runner
-            .spawn(&self.firecracker_binary, &request)
-            .map_err(|source| DriverError::CommandSpawn {
-                command: command_string(&self.firecracker_binary, &request.args),
-                source,
-            })?;
-        write_pid(&handle.pid_file, pid)?;
-
-        Ok(SandboxHandle {
-            handle: handle.to_handle()?,
-        })
+        match MicroVmRuntime::parse(spec.metadata.get("runtime"))? {
+            MicroVmRuntime::Firecracker => self.create_firecracker(spec).await,
+            MicroVmRuntime::AppleContainer => self.create_apple_container(spec).await,
+            MicroVmRuntime::Kata => Err(capability_missing(&format!(
+                "{UNSUPPORTED_RUNTIME_CAPABILITY}:kata"
+            ))),
+        }
     }
 
     async fn connect(&self, params: ConnectParams) -> DriverResult<ShellHandle> {
         let handle = MicroVmHandle::from_handle(&params.handle)?;
-        let ssh = handle.ssh()?;
-        let mut args = ssh_args(ssh);
-        args.push("--".to_owned());
-        args.push("true".to_owned());
-        let request = CommandRequest {
-            args,
-            env: BTreeMap::new(),
-            stdin: None,
+        let (program, request) = match handle.runtime {
+            MicroVmRuntime::Firecracker => {
+                let ssh = handle.ssh()?;
+                let mut args = ssh_args(ssh);
+                args.push("--".to_owned());
+                args.push("true".to_owned());
+                (
+                    self.ssh_binary.as_str(),
+                    CommandRequest {
+                        args,
+                        env: BTreeMap::new(),
+                        stdin: None,
+                    },
+                )
+            }
+            MicroVmRuntime::AppleContainer => (
+                self.apple_container_binary.as_str(),
+                CommandRequest {
+                    args: vec!["exec".to_owned(), handle.name.clone(), "true".to_owned()],
+                    env: BTreeMap::new(),
+                    stdin: None,
+                },
+            ),
+            MicroVmRuntime::Kata => {
+                return Err(capability_missing(&format!(
+                    "{UNSUPPORTED_RUNTIME_CAPABILITY}:kata"
+                )))
+            }
         };
-        let output = self
-            .runner
-            .run(&self.ssh_binary, &request)
-            .map_err(|source| DriverError::CommandSpawn {
-                command: command_string(&self.ssh_binary, &request.args),
-                source,
-            })?;
+        let output =
+            self.runner
+                .run(program, &request)
+                .map_err(|source| DriverError::CommandSpawn {
+                    command: command_string(program, &request.args),
+                    source,
+                })?;
         if output.status != Some(0) {
-            return Err(command_failed(&self.ssh_binary, &request, output));
+            return Err(command_failed(program, &request, output));
         }
         Ok(ShellHandle {
             session_id: params.handle,
@@ -966,22 +1409,70 @@ impl SandboxDriver for MicroVmDriver {
 
     async fn exec(&self, params: ExecParams) -> DriverResult<ExecResult> {
         let handle = MicroVmHandle::from_handle(&params.handle)?;
-        let ssh = handle.ssh()?;
-        let mut args = ssh_args(ssh);
-        args.push("--".to_owned());
-        args.push(params.cmd);
-        let request = CommandRequest {
-            args,
-            env: params.env,
-            stdin: None,
+        let command = shell_command(&params.cmd, handle.env_file.as_deref(), &params.env)?;
+        let (program, request) = match handle.runtime {
+            MicroVmRuntime::Firecracker => {
+                let ssh = handle.ssh()?;
+                let mut args = ssh_args(ssh);
+                if params.tty {
+                    args.insert(0, "-tt".to_owned());
+                }
+                args.push("--".to_owned());
+                args.push(command);
+                (
+                    self.ssh_binary.as_str(),
+                    CommandRequest {
+                        args,
+                        env: BTreeMap::new(),
+                        stdin: None,
+                    },
+                )
+            }
+            MicroVmRuntime::AppleContainer => {
+                let mut args = vec!["exec".to_owned()];
+                if params.tty {
+                    args.push("--tty".to_owned());
+                    args.push("--interactive".to_owned());
+                }
+                args.push(handle.name.clone());
+                args.push("sh".to_owned());
+                args.push("-lc".to_owned());
+                args.push(command);
+                (
+                    self.apple_container_binary.as_str(),
+                    CommandRequest {
+                        args,
+                        env: BTreeMap::new(),
+                        stdin: None,
+                    },
+                )
+            }
+            MicroVmRuntime::Kata => {
+                return Err(capability_missing(&format!(
+                    "{UNSUPPORTED_RUNTIME_CAPABILITY}:kata"
+                )))
+            }
         };
-        let output = self
-            .runner
-            .run(&self.ssh_binary, &request)
-            .map_err(|source| DriverError::CommandSpawn {
-                command: command_string(&self.ssh_binary, &request.args),
-                source,
+        if params.tty {
+            let status = self.runner.status(program, &request).map_err(|source| {
+                DriverError::CommandSpawn {
+                    command: command_string(program, &request.args),
+                    source,
+                }
             })?;
+            return Ok(ExecResult {
+                status: status.unwrap_or(1),
+                stdout: String::new(),
+                stderr: String::new(),
+            });
+        }
+        let output =
+            self.runner
+                .run(program, &request)
+                .map_err(|source| DriverError::CommandSpawn {
+                    command: command_string(program, &request.args),
+                    source,
+                })?;
         Ok(ExecResult {
             status: output.status.unwrap_or(1),
             stdout: output.stdout,
@@ -991,9 +1482,25 @@ impl SandboxDriver for MicroVmDriver {
 
     async fn copy_in(&self, params: CopyInParams) -> DriverResult<EmptyResult> {
         let handle = MicroVmHandle::from_handle(&params.handle)?;
-        let ssh = handle.ssh()?;
         validate_copy_path("src_host_path", &params.src_host_path)?;
         validate_copy_path("dst_sandbox_path", &params.dst_sandbox_path)?;
+        if handle.runtime == MicroVmRuntime::AppleContainer {
+            let dst = mounted_sandbox_path(&handle, &params.dst_sandbox_path)?;
+            if let Some(parent) = dst.parent() {
+                fs::create_dir_all(parent).map_err(|source| DriverError::InvalidInput {
+                    message: format!("failed to create `{}`: {source}", parent.display()),
+                })?;
+            }
+            fs::copy(&params.src_host_path, &dst).map_err(|source| DriverError::InvalidInput {
+                message: format!(
+                    "failed to copy `{}` to `{}`: {source}",
+                    params.src_host_path,
+                    dst.display()
+                ),
+            })?;
+            return Ok(EmptyResult::default());
+        }
+        let ssh = handle.ssh()?;
         let mut args = scp_args(ssh);
         args.push("--".to_owned());
         args.push(params.src_host_path);
@@ -1018,9 +1525,27 @@ impl SandboxDriver for MicroVmDriver {
 
     async fn copy_out(&self, params: CopyOutParams) -> DriverResult<EmptyResult> {
         let handle = MicroVmHandle::from_handle(&params.handle)?;
-        let ssh = handle.ssh()?;
         validate_copy_path("src_sandbox_path", &params.src_sandbox_path)?;
         validate_copy_path("dst_host_path", &params.dst_host_path)?;
+        if handle.runtime == MicroVmRuntime::AppleContainer {
+            let src = mounted_sandbox_path(&handle, &params.src_sandbox_path)?;
+            if let Some(parent) = Path::new(&params.dst_host_path).parent() {
+                if !parent.as_os_str().is_empty() {
+                    fs::create_dir_all(parent).map_err(|source| DriverError::InvalidInput {
+                        message: format!("failed to create `{}`: {source}", parent.display()),
+                    })?;
+                }
+            }
+            fs::copy(&src, &params.dst_host_path).map_err(|source| DriverError::InvalidInput {
+                message: format!(
+                    "failed to copy `{}` to `{}`: {source}",
+                    src.display(),
+                    params.dst_host_path
+                ),
+            })?;
+            return Ok(EmptyResult::default());
+        }
+        let ssh = handle.ssh()?;
         let mut args = scp_args(ssh);
         args.push("--".to_owned());
         args.push(remote_path(ssh, &params.src_sandbox_path));
@@ -1049,18 +1574,37 @@ impl SandboxDriver for MicroVmDriver {
 
     async fn status(&self, params: SandboxStatusParams) -> DriverResult<SandboxStatus> {
         let handle = MicroVmHandle::from_handle(&params.handle)?;
-        handle.runtime.ensure_implemented()?;
-        let pid = read_pid(&handle.pid_file)?;
-        let request = CommandRequest {
-            args: vec!["-0".to_owned(), pid.to_string()],
-            env: BTreeMap::new(),
-            stdin: None,
+        let (program, request) = match handle.runtime {
+            MicroVmRuntime::Firecracker => {
+                let pid = read_pid(&handle.pid_file)?;
+                (
+                    "kill",
+                    CommandRequest {
+                        args: vec!["-0".to_owned(), pid.to_string()],
+                        env: BTreeMap::new(),
+                        stdin: None,
+                    },
+                )
+            }
+            MicroVmRuntime::AppleContainer => (
+                self.apple_container_binary.as_str(),
+                CommandRequest {
+                    args: vec!["exec".to_owned(), handle.name.clone(), "true".to_owned()],
+                    env: BTreeMap::new(),
+                    stdin: None,
+                },
+            ),
+            MicroVmRuntime::Kata => {
+                return Err(capability_missing(&format!(
+                    "{UNSUPPORTED_RUNTIME_CAPABILITY}:kata"
+                )))
+            }
         };
         let status =
             self.runner
-                .status("kill", &request)
+                .status(program, &request)
                 .map_err(|source| DriverError::CommandSpawn {
-                    command: command_string("kill", &request.args),
+                    command: command_string(program, &request.args),
                     source,
                 })?;
         let healthy = status == Some(0);
@@ -1077,6 +1621,38 @@ impl SandboxDriver for MicroVmDriver {
 
     async fn logs(&self, params: LogsParams) -> DriverResult<LogsResult> {
         let handle = MicroVmHandle::from_handle(&params.handle)?;
+        if handle.runtime == MicroVmRuntime::AppleContainer {
+            let request = CommandRequest {
+                args: vec!["logs".to_owned(), handle.name.clone()],
+                env: BTreeMap::new(),
+                stdin: None,
+            };
+            let output = self
+                .runner
+                .run(&self.apple_container_binary, &request)
+                .map_err(|source| DriverError::CommandSpawn {
+                    command: command_string(&self.apple_container_binary, &request.args),
+                    source,
+                })?;
+            if output.status != Some(0) {
+                return Err(command_failed(
+                    &self.apple_container_binary,
+                    &request,
+                    output,
+                ));
+            }
+            return Ok(LogsResult {
+                entries: vec![LogEntry {
+                    level: LogLevel::Info,
+                    ts: String::new(),
+                    msg: output.stdout,
+                    kv: BTreeMap::from([(
+                        "runtime".to_owned(),
+                        Value::String("apple-container".to_owned()),
+                    )]),
+                }],
+            });
+        }
         Ok(LogsResult {
             entries: log_entries_for_handle(&handle),
         })
@@ -1088,21 +1664,41 @@ impl SandboxDriver for MicroVmDriver {
 
     async fn stop(&self, params: StopParams) -> DriverResult<EmptyResult> {
         let handle = MicroVmHandle::from_handle(&params.handle)?;
-        let pid = read_pid(&handle.pid_file)?;
-        let request = CommandRequest {
-            args: vec![pid.to_string()],
-            env: BTreeMap::new(),
-            stdin: None,
+        let (program, request) = match handle.runtime {
+            MicroVmRuntime::Firecracker => {
+                let pid = read_pid(&handle.pid_file)?;
+                (
+                    "kill",
+                    CommandRequest {
+                        args: vec![pid.to_string()],
+                        env: BTreeMap::new(),
+                        stdin: None,
+                    },
+                )
+            }
+            MicroVmRuntime::AppleContainer => (
+                self.apple_container_binary.as_str(),
+                CommandRequest {
+                    args: vec!["stop".to_owned(), handle.name.clone()],
+                    env: BTreeMap::new(),
+                    stdin: None,
+                },
+            ),
+            MicroVmRuntime::Kata => {
+                return Err(capability_missing(&format!(
+                    "{UNSUPPORTED_RUNTIME_CAPABILITY}:kata"
+                )))
+            }
         };
         let output =
             self.runner
-                .run("kill", &request)
+                .run(program, &request)
                 .map_err(|source| DriverError::CommandSpawn {
-                    command: command_string("kill", &request.args),
+                    command: command_string(program, &request.args),
                     source,
                 })?;
         if output.status != Some(0) {
-            return Err(command_failed("kill", &request, output));
+            return Err(command_failed(program, &request, output));
         }
         let _ = fs::remove_file(&handle.pid_file);
         Ok(EmptyResult::default())
@@ -1110,6 +1706,29 @@ impl SandboxDriver for MicroVmDriver {
 
     async fn destroy(&self, params: DestroyParams) -> DriverResult<EmptyResult> {
         let handle = MicroVmHandle::from_handle(&params.handle)?;
+        if handle.runtime == MicroVmRuntime::AppleContainer {
+            let request = CommandRequest {
+                args: vec!["delete".to_owned(), "--force".to_owned(), handle.name],
+                env: BTreeMap::new(),
+                stdin: None,
+            };
+            let output = self
+                .runner
+                .run(&self.apple_container_binary, &request)
+                .map_err(|source| DriverError::CommandSpawn {
+                    command: command_string(&self.apple_container_binary, &request.args),
+                    source,
+                })?;
+            if output.status != Some(0) {
+                return Err(command_failed(
+                    &self.apple_container_binary,
+                    &request,
+                    output,
+                ));
+            }
+            let _ = fs::remove_dir_all(handle.workdir);
+            return Ok(EmptyResult::default());
+        }
         if handle.pid_file.exists() {
             let _ = self
                 .stop(StopParams {
@@ -1145,23 +1764,38 @@ mod tests {
 
     use agentenv_core::driver::{DriverError, SandboxDriver};
     use agentenv_proto::{
-        Capabilities, ConnectParams, DriverKind, InitializeParams, LogLevel, PreflightParams,
-        SandboxSpec, SCHEMA_VERSION,
+        Capabilities, ConnectParams, CopyInParams, CopyOutParams, DriverKind, ExecParams,
+        FilesystemPolicy, InferencePolicy, InitializeParams, LogLevel, NetworkAccessPolicy,
+        NetworkPolicy, NetworkRule, NetworkTarget, PolicyReloadability, PreflightParams,
+        ProcessPolicy, SandboxSpec, SCHEMA_VERSION,
     };
     use serde_json::json;
 
-    use super::{CommandOutput, CommandRequest, FirecrackerConfig, MicroVmDriver};
+    use super::{CommandOutput, CommandRequest, FirecrackerConfig, HostChecks, MicroVmDriver};
 
     #[derive(Debug, Default)]
     struct RecordingRunner {
         calls: Mutex<Vec<CommandRequest>>,
+        call_programs: Mutex<Vec<String>>,
         outputs: Mutex<VecDeque<io::Result<CommandOutput>>>,
         spawned: Mutex<Vec<CommandRequest>>,
+        spawn_programs: Mutex<Vec<String>>,
     }
 
     impl RecordingRunner {
+        fn new(outputs: Vec<io::Result<CommandOutput>>) -> Self {
+            Self {
+                outputs: Mutex::new(outputs.into()),
+                ..Self::default()
+            }
+        }
+
         fn calls(&self) -> Vec<CommandRequest> {
             self.calls.lock().unwrap().clone()
+        }
+
+        fn call_programs(&self) -> Vec<String> {
+            self.call_programs.lock().unwrap().clone()
         }
 
         fn spawned(&self) -> Vec<CommandRequest> {
@@ -1170,7 +1804,8 @@ mod tests {
     }
 
     impl super::CommandRunner for RecordingRunner {
-        fn run(&self, _program: &str, request: &CommandRequest) -> io::Result<CommandOutput> {
+        fn run(&self, program: &str, request: &CommandRequest) -> io::Result<CommandOutput> {
+            self.call_programs.lock().unwrap().push(program.to_owned());
             self.calls.lock().unwrap().push(request.clone());
             self.outputs.lock().unwrap().pop_front().unwrap_or_else(|| {
                 Ok(CommandOutput {
@@ -1181,7 +1816,8 @@ mod tests {
             })
         }
 
-        fn spawn(&self, _program: &str, request: &CommandRequest) -> io::Result<u32> {
+        fn spawn(&self, program: &str, request: &CommandRequest) -> io::Result<u32> {
+            self.spawn_programs.lock().unwrap().push(program.to_owned());
             self.spawned.lock().unwrap().push(request.clone());
             Ok(4242)
         }
@@ -1193,6 +1829,43 @@ mod tests {
             core_version: "0.0.1".to_owned(),
             workdir: workdir.to_string_lossy().into_owned(),
             log_level: LogLevel::Info,
+        }
+    }
+
+    fn apple_host() -> HostChecks {
+        HostChecks {
+            is_linux: false,
+            is_macos: true,
+            is_apple_silicon: true,
+            has_kvm: false,
+        }
+    }
+
+    fn restricted_policy() -> NetworkPolicy {
+        NetworkPolicy {
+            network: NetworkAccessPolicy {
+                reloadability: PolicyReloadability::HotReload,
+                allow: Vec::new(),
+                deny: Vec::new(),
+                approval_required: Vec::new(),
+            },
+            filesystem: FilesystemPolicy {
+                reloadability: PolicyReloadability::LockedAtCreate,
+                read_only: vec!["/usr".to_owned(), "/lib".to_owned(), "/etc".to_owned()],
+                read_write: vec!["/sandbox".to_owned(), "/tmp".to_owned()],
+            },
+            process: ProcessPolicy {
+                reloadability: PolicyReloadability::LockedAtCreate,
+                run_as_user: "sandbox".to_owned(),
+                run_as_group: "sandbox".to_owned(),
+                profile: "restricted".to_owned(),
+                allow_syscalls: Vec::new(),
+                deny_syscalls: Vec::new(),
+            },
+            inference: InferencePolicy {
+                reloadability: PolicyReloadability::HotReload,
+                routes: Vec::new(),
+            },
         }
     }
 
@@ -1231,6 +1904,55 @@ mod tests {
         assert!(!preflight.ok);
         assert_eq!(preflight.issues[0].code, "microvm_linux_required");
         assert!(runner.calls().is_empty());
+    }
+
+    #[tokio::test]
+    async fn preflight_accepts_apple_container_on_apple_silicon_macos() {
+        let temp = tempfile::tempdir().unwrap();
+        let runner = Arc::new(RecordingRunner::default());
+        let mut driver = MicroVmDriver::for_tests_host(Arc::clone(&runner), apple_host());
+        driver.initialize(init_params(temp.path())).await.unwrap();
+
+        let preflight = driver.preflight(PreflightParams::default()).await.unwrap();
+
+        assert!(preflight.ok);
+        assert_eq!(
+            preflight.issues[0].severity,
+            agentenv_proto::IssueSeverity::Warning
+        );
+        assert_eq!(runner.call_programs(), vec!["container".to_owned()]);
+        assert_eq!(
+            runner.calls()[0].args,
+            vec![
+                "system".to_owned(),
+                "status".to_owned(),
+                "--format".to_owned(),
+                "json".to_owned()
+            ]
+        );
+    }
+
+    #[tokio::test]
+    async fn preflight_rejects_macos_when_apple_container_cli_is_missing() {
+        let temp = tempfile::tempdir().unwrap();
+        let runner = Arc::new(RecordingRunner::new(vec![Err(io::Error::new(
+            io::ErrorKind::NotFound,
+            "container missing",
+        ))]));
+        let mut driver = MicroVmDriver::for_tests_host(Arc::clone(&runner), apple_host());
+        driver.initialize(init_params(temp.path())).await.unwrap();
+
+        let preflight = driver.preflight(PreflightParams::default()).await.unwrap();
+
+        assert!(!preflight.ok);
+        assert!(preflight
+            .issues
+            .iter()
+            .any(|issue| issue.code == "microvm_linux_required"));
+        assert!(preflight
+            .issues
+            .iter()
+            .any(|issue| issue.code == "microvm_apple_container_missing"));
     }
 
     #[tokio::test]
@@ -1284,6 +2006,97 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn create_apple_container_mounts_sandbox_and_runs_keepalive() {
+        let temp = tempfile::tempdir().unwrap();
+        let runner = Arc::new(RecordingRunner::default());
+        let mut driver = MicroVmDriver::for_tests_host(Arc::clone(&runner), apple_host());
+        driver.initialize(init_params(temp.path())).await.unwrap();
+
+        let handle = driver
+            .create(SandboxSpec {
+                image: Some("ubuntu:24.04".to_owned()),
+                env: BTreeMap::from([("OPENAI_API_KEY".to_owned(), "test-key".to_owned())]),
+                policy: Some(restricted_policy()),
+                metadata: BTreeMap::from([
+                    ("name".to_owned(), json!("apple-test")),
+                    ("runtime".to_owned(), json!("apple-container")),
+                    ("memory_mb".to_owned(), json!(1024)),
+                    ("cpus".to_owned(), json!(2)),
+                ]),
+            })
+            .await
+            .unwrap();
+
+        assert!(handle
+            .handle
+            .starts_with("microvm://apple-container/apple-test?"));
+        assert!(handle.handle.contains("env_file="), "handle: {handle:?}");
+        let calls = runner.calls();
+        assert_eq!(
+            runner.call_programs(),
+            vec!["container".to_owned(), "container".to_owned()]
+        );
+        assert_eq!(calls[1].args[0], "run");
+        assert!(calls[1].args.contains(&"--detach".to_owned()));
+        assert!(calls[1].args.contains(&"--env-file".to_owned()));
+        assert!(calls[1]
+            .args
+            .iter()
+            .any(|arg| arg.starts_with("type=bind,source=") && arg.ends_with(",target=/sandbox")));
+        assert_eq!(calls[1].args[calls[1].args.len() - 4], "ubuntu:24.04");
+        assert_eq!(calls[1].args[calls[1].args.len() - 3], "sh");
+        assert_eq!(calls[1].args[calls[1].args.len() - 2], "-lc");
+        assert_eq!(
+            calls[1].args[calls[1].args.len() - 1],
+            "trap : TERM INT; sleep infinity & wait"
+        );
+
+        let env_file = temp
+            .path()
+            .join("microvm")
+            .join("apple-test")
+            .join("sandbox")
+            .join(".agentenv")
+            .join("env")
+            .join("apple-test.env");
+        let env_file_content = std::fs::read_to_string(env_file).unwrap();
+        assert!(env_file_content.contains("export OPENAI_API_KEY='test-key'"));
+    }
+
+    #[tokio::test]
+    async fn create_rejects_network_policy_before_launch() {
+        let temp = tempfile::tempdir().unwrap();
+        let runner = Arc::new(RecordingRunner::default());
+        let mut driver = MicroVmDriver::for_tests_host(Arc::clone(&runner), apple_host());
+        driver.initialize(init_params(temp.path())).await.unwrap();
+        let mut policy = restricted_policy();
+        policy.network.allow.push(NetworkRule {
+            target: NetworkTarget::Host {
+                host: "example.com".to_owned(),
+                port: Some(443),
+                scheme: Some("https".to_owned()),
+                http_access: None,
+            },
+        });
+
+        let err = driver
+            .create(SandboxSpec {
+                image: Some("ubuntu:24.04".to_owned()),
+                env: BTreeMap::new(),
+                policy: Some(policy),
+                metadata: BTreeMap::from([
+                    ("name".to_owned(), json!("apple-test")),
+                    ("runtime".to_owned(), json!("apple-container")),
+                ]),
+            })
+            .await
+            .unwrap_err();
+
+        assert!(matches!(err, DriverError::CapabilityMissing { .. }));
+        assert_eq!(runner.calls().len(), 1, "only preflight should run");
+    }
+
+    #[tokio::test]
     async fn create_rejects_non_firecracker_runtime_explicitly() {
         let temp = tempfile::tempdir().unwrap();
         let runner = Arc::new(RecordingRunner::default());
@@ -1305,6 +2118,80 @@ mod tests {
 
         assert!(matches!(err, DriverError::CapabilityMissing { .. }));
         assert!(runner.spawned().is_empty());
+    }
+
+    #[tokio::test]
+    async fn apple_container_exec_sources_env_file_and_runs_in_sandbox() {
+        let temp = tempfile::tempdir().unwrap();
+        let runner = Arc::new(RecordingRunner::default());
+        let mut driver = MicroVmDriver::for_tests_host(Arc::clone(&runner), apple_host());
+        driver.initialize(init_params(temp.path())).await.unwrap();
+        let handle = format!(
+            "microvm://apple-container/apple-test?workdir={}&env_file=%2Fsandbox%2F.agentenv%2Fenv%2Fapple-test.env",
+            temp.path().join("microvm").join("apple-test").display()
+        );
+
+        let result = driver
+            .exec(ExecParams {
+                handle,
+                cmd: "codex --version".to_owned(),
+                tty: false,
+                env: BTreeMap::from([("EXTRA".to_owned(), "value".to_owned())]),
+            })
+            .await
+            .unwrap();
+
+        assert_eq!(result.status, 0);
+        assert_eq!(runner.call_programs(), vec!["container".to_owned()]);
+        let args = &runner.calls()[0].args;
+        assert_eq!(args[0], "exec");
+        assert_eq!(args[1], "apple-test");
+        assert_eq!(args[2], "sh");
+        assert_eq!(args[3], "-lc");
+        assert!(args[4].contains("cd /sandbox && . '/sandbox/.agentenv/env/apple-test.env'"));
+        assert!(args[4].contains("env EXTRA='value' sh -lc 'codex --version'"));
+    }
+
+    #[tokio::test]
+    async fn apple_container_copy_uses_mounted_sandbox_directory() {
+        let temp = tempfile::tempdir().unwrap();
+        let runner = Arc::new(RecordingRunner::default());
+        let mut driver = MicroVmDriver::for_tests_host(Arc::clone(&runner), apple_host());
+        driver.initialize(init_params(temp.path())).await.unwrap();
+        let workdir = temp.path().join("microvm").join("apple-test");
+        let host_src = temp.path().join("entrypoint");
+        std::fs::write(&host_src, "#!/bin/sh\n").unwrap();
+        let handle = format!(
+            "microvm://apple-container/apple-test?workdir={}",
+            workdir.display()
+        );
+
+        driver
+            .copy_in(CopyInParams {
+                handle: handle.clone(),
+                src_host_path: host_src.display().to_string(),
+                dst_sandbox_path: "/sandbox/.agentenv/bin/agentenv-agent".to_owned(),
+            })
+            .await
+            .unwrap();
+        let mounted = workdir
+            .join("sandbox")
+            .join(".agentenv")
+            .join("bin")
+            .join("agentenv-agent");
+        assert_eq!(std::fs::read_to_string(&mounted).unwrap(), "#!/bin/sh\n");
+
+        let host_dst = temp.path().join("copied-out");
+        driver
+            .copy_out(CopyOutParams {
+                handle,
+                src_sandbox_path: "/sandbox/.agentenv/bin/agentenv-agent".to_owned(),
+                dst_host_path: host_dst.display().to_string(),
+            })
+            .await
+            .unwrap();
+        assert_eq!(std::fs::read_to_string(host_dst).unwrap(), "#!/bin/sh\n");
+        assert!(runner.calls().is_empty());
     }
 
     #[tokio::test]

--- a/crates/drivers/sandbox-microvm/src/lib.rs
+++ b/crates/drivers/sandbox-microvm/src/lib.rs
@@ -1,0 +1,1336 @@
+#![forbid(unsafe_code)]
+
+use std::{
+    collections::BTreeMap,
+    fs,
+    io::{self, Write},
+    path::{Path, PathBuf},
+    process::{Command, Stdio},
+    sync::{Arc, Mutex},
+};
+
+use agentenv_core::driver::{
+    persistent_sessions_missing, DriverError, DriverResult, SandboxDriver,
+};
+use agentenv_proto::{
+    assert_compatible_schema_version, ApplyPolicyParams, ApplyPolicyResult, AttachSessionParams,
+    Capabilities, ConnectParams, CopyInParams, CopyOutParams, CreateSessionParams, DestroyParams,
+    DriverInfo, DriverKind, EmptyResult, ExecParams, ExecResult, InitializeParams,
+    InitializeResult, IssueSeverity, KillSessionParams, ListSessionsParams, ListSessionsResult,
+    LogEntry, LogLevel, LogsParams, LogsResult, LogsStreamParams, PreflightIssue, PreflightParams,
+    PreflightResult, SandboxCapabilities, SandboxHandle, SandboxPhase, SandboxSpec, SandboxStatus,
+    SandboxStatusParams, SessionHandle, ShellHandle, ShutdownParams, StopParams, SCHEMA_VERSION,
+};
+use serde::{Deserialize, Serialize};
+use serde_json::Value;
+use url::Url;
+
+const DRIVER_NAME: &str = "microvm";
+const DEFAULT_RUNTIME: &str = "firecracker";
+const FIRECRACKER_BINARY: &str = "firecracker";
+const SSH_BINARY: &str = "ssh";
+const SCP_BINARY: &str = "scp";
+const MICROVM_SSH_CAPABILITY: &str = "microvm_ssh";
+const MICROVM_POLICY_CAPABILITY: &str = "microvm_policy_translation";
+const UNSUPPORTED_RUNTIME_CAPABILITY: &str = "microvm_runtime";
+const DEFAULT_KERNEL_ARGS: &str = "console=ttyS0 reboot=k panic=1 pci=off";
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+struct CommandRequest {
+    args: Vec<String>,
+    env: BTreeMap<String, String>,
+    stdin: Option<String>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+struct CommandOutput {
+    status: Option<i32>,
+    stdout: String,
+    stderr: String,
+}
+
+trait CommandRunner: Send + Sync {
+    fn run(&self, program: &str, request: &CommandRequest) -> io::Result<CommandOutput>;
+
+    fn status(&self, program: &str, request: &CommandRequest) -> io::Result<Option<i32>> {
+        self.run(program, request).map(|output| output.status)
+    }
+
+    fn spawn(&self, program: &str, request: &CommandRequest) -> io::Result<u32>;
+}
+
+#[derive(Debug, Default)]
+struct ProcessCommandRunner;
+
+impl CommandRunner for ProcessCommandRunner {
+    fn run(&self, program: &str, request: &CommandRequest) -> io::Result<CommandOutput> {
+        let mut command = Command::new(program);
+        command.args(&request.args).envs(&request.env);
+        if request.stdin.is_some() {
+            command.stdin(Stdio::piped());
+        }
+        let mut child = command
+            .stdout(Stdio::piped())
+            .stderr(Stdio::piped())
+            .spawn()?;
+        if let Some(stdin) = request.stdin.as_deref() {
+            let mut child_stdin = child
+                .stdin
+                .take()
+                .ok_or_else(|| io::Error::new(io::ErrorKind::BrokenPipe, "stdin unavailable"))?;
+            if let Err(err) = child_stdin.write_all(stdin.as_bytes()) {
+                let _ = child.wait();
+                return Err(err);
+            }
+        }
+        let output = child.wait_with_output()?;
+        Ok(CommandOutput {
+            status: output.status.code(),
+            stdout: String::from_utf8_lossy(&output.stdout).into_owned(),
+            stderr: String::from_utf8_lossy(&output.stderr).into_owned(),
+        })
+    }
+
+    fn status(&self, program: &str, request: &CommandRequest) -> io::Result<Option<i32>> {
+        debug_assert!(request.stdin.is_none());
+        Command::new(program)
+            .args(&request.args)
+            .envs(&request.env)
+            .status()
+            .map(|status| status.code())
+    }
+
+    fn spawn(&self, program: &str, request: &CommandRequest) -> io::Result<u32> {
+        debug_assert!(request.stdin.is_none());
+        let child = Command::new(program)
+            .args(&request.args)
+            .envs(&request.env)
+            .stdin(Stdio::null())
+            .stdout(Stdio::null())
+            .stderr(Stdio::null())
+            .spawn()?;
+        Ok(child.id())
+    }
+}
+
+fn command_request(args: &[&str]) -> CommandRequest {
+    CommandRequest {
+        args: args.iter().map(|arg| (*arg).to_owned()).collect(),
+        env: BTreeMap::new(),
+        stdin: None,
+    }
+}
+
+fn command_string(program: &str, args: &[String]) -> String {
+    std::iter::once(program)
+        .chain(args.iter().map(String::as_str))
+        .collect::<Vec<_>>()
+        .join(" ")
+}
+
+fn command_failed(program: &str, request: &CommandRequest, output: CommandOutput) -> DriverError {
+    DriverError::CommandFailed {
+        command: command_string(program, &request.args),
+        status: output.status,
+        stdout: output.stdout,
+        stderr: output.stderr,
+    }
+}
+
+fn preflight_failure(code: &str, message: String, remediation: Option<String>) -> PreflightResult {
+    PreflightResult {
+        ok: false,
+        issues: vec![PreflightIssue {
+            severity: IssueSeverity::Error,
+            code: code.to_owned(),
+            message,
+            remediation,
+        }],
+    }
+}
+
+fn capability_missing(capability: &str) -> DriverError {
+    DriverError::CapabilityMissing {
+        capability: capability.to_owned(),
+    }
+}
+
+pub struct MicroVmDriver {
+    firecracker_binary: String,
+    ssh_binary: String,
+    scp_binary: String,
+    runner: Arc<dyn CommandRunner>,
+    host: HostChecks,
+    workdir: Mutex<Option<PathBuf>>,
+}
+
+impl Default for MicroVmDriver {
+    fn default() -> Self {
+        Self {
+            firecracker_binary: FIRECRACKER_BINARY.to_owned(),
+            ssh_binary: SSH_BINARY.to_owned(),
+            scp_binary: SCP_BINARY.to_owned(),
+            runner: Arc::new(ProcessCommandRunner),
+            host: HostChecks::detect(),
+            workdir: Mutex::new(None),
+        }
+    }
+}
+
+#[cfg(test)]
+impl MicroVmDriver {
+    fn for_tests<T>(runner: Arc<T>, is_linux: bool, has_kvm: bool) -> Self
+    where
+        T: CommandRunner + 'static,
+    {
+        Self {
+            firecracker_binary: FIRECRACKER_BINARY.to_owned(),
+            ssh_binary: SSH_BINARY.to_owned(),
+            scp_binary: SCP_BINARY.to_owned(),
+            runner,
+            host: HostChecks { is_linux, has_kvm },
+            workdir: Mutex::new(None),
+        }
+    }
+}
+
+#[derive(Debug, Clone, Copy)]
+struct HostChecks {
+    is_linux: bool,
+    has_kvm: bool,
+}
+
+impl HostChecks {
+    fn detect() -> Self {
+        Self {
+            is_linux: std::env::consts::OS == "linux",
+            has_kvm: Path::new("/dev/kvm").exists(),
+        }
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+enum MicroVmRuntime {
+    Firecracker,
+    AppleContainer,
+    Kata,
+}
+
+impl MicroVmRuntime {
+    fn parse(value: Option<&Value>) -> DriverResult<Self> {
+        let runtime = match value {
+            None | Some(Value::Null) => DEFAULT_RUNTIME,
+            Some(Value::String(value)) if value == "firecracker" => "firecracker",
+            Some(Value::String(value)) if value == "apple-container" => "apple-container",
+            Some(Value::String(value)) if value == "kata" => "kata",
+            Some(Value::String(value)) => {
+                return Err(DriverError::InvalidInput {
+                    message: format!("metadata.runtime `{value}` is not supported"),
+                });
+            }
+            Some(_) => {
+                return Err(DriverError::InvalidInput {
+                    message: "metadata.runtime must be a string when set".to_owned(),
+                });
+            }
+        };
+        Ok(match runtime {
+            "firecracker" => Self::Firecracker,
+            "apple-container" => Self::AppleContainer,
+            "kata" => Self::Kata,
+            _ => unreachable!("runtime was normalized above"),
+        })
+    }
+
+    fn label(&self) -> &'static str {
+        match self {
+            Self::Firecracker => "firecracker",
+            Self::AppleContainer => "apple-container",
+            Self::Kata => "kata",
+        }
+    }
+
+    fn ensure_implemented(&self) -> DriverResult<()> {
+        match self {
+            Self::Firecracker => Ok(()),
+            Self::AppleContainer | Self::Kata => Err(capability_missing(&format!(
+                "{UNSUPPORTED_RUNTIME_CAPABILITY}:{}",
+                self.label()
+            ))),
+        }
+    }
+}
+
+#[derive(Debug, Clone)]
+struct FirecrackerSpec {
+    name: String,
+    kernel: String,
+    rootfs: String,
+    kernel_args: String,
+    memory_mb: u32,
+    cpus: u8,
+    tap: Option<String>,
+    ssh: Option<SshTarget>,
+}
+
+impl FirecrackerSpec {
+    fn from_sandbox_spec(spec: SandboxSpec) -> DriverResult<Self> {
+        if spec.policy.is_some() {
+            return Err(capability_missing(MICROVM_POLICY_CAPABILITY));
+        }
+        if !spec.env.is_empty() {
+            return Err(DriverError::InvalidInput {
+                message: "SandboxSpec.env is not supported by sandbox-microvm without a guest env injection path".to_owned(),
+            });
+        }
+        let runtime = MicroVmRuntime::parse(spec.metadata.get("runtime"))?;
+        runtime.ensure_implemented()?;
+
+        let name = optional_metadata_string(&spec.metadata, "name")?
+            .unwrap_or_else(|| format!("agentenv-{}", uuid_like_suffix()));
+        validate_name(&name, "metadata.name")?;
+        let kernel = required_metadata_string(&spec.metadata, "kernel")?;
+        let rootfs = optional_metadata_string(&spec.metadata, "rootfs")?
+            .or(spec.image)
+            .ok_or_else(|| DriverError::InvalidInput {
+                message: "metadata.rootfs or SandboxSpec.image is required for firecracker"
+                    .to_owned(),
+            })?;
+        let kernel_args = optional_metadata_string(&spec.metadata, "kernel_args")?
+            .unwrap_or_else(|| DEFAULT_KERNEL_ARGS.to_owned());
+        let memory_mb = metadata_u32(&spec.metadata, "memory_mb", 2048)?;
+        let cpus = metadata_u8(&spec.metadata, "cpus", 2)?;
+        let tap = optional_metadata_string(&spec.metadata, "tap")?;
+        if let Some(tap) = tap.as_deref() {
+            validate_tap(tap)?;
+        }
+        let ssh = SshTarget::from_metadata(&spec.metadata)?;
+
+        Ok(Self {
+            name,
+            kernel,
+            rootfs,
+            kernel_args,
+            memory_mb,
+            cpus,
+            tap,
+            ssh,
+        })
+    }
+
+    fn config(&self) -> FirecrackerConfig {
+        FirecrackerConfig {
+            boot_source: BootSource {
+                kernel_image_path: self.kernel.clone(),
+                boot_args: self.kernel_args.clone(),
+            },
+            drives: vec![Drive {
+                drive_id: "rootfs".to_owned(),
+                path_on_host: self.rootfs.clone(),
+                is_root_device: true,
+                is_read_only: false,
+            }],
+            machine_config: MachineConfig {
+                vcpu_count: self.cpus,
+                mem_size_mib: self.memory_mb,
+                smt: false,
+            },
+            network_interfaces: self
+                .tap
+                .as_ref()
+                .map(|tap| {
+                    vec![NetworkInterface {
+                        iface_id: "eth0".to_owned(),
+                        host_dev_name: tap.clone(),
+                    }]
+                })
+                .unwrap_or_default(),
+        }
+    }
+}
+
+fn uuid_like_suffix() -> String {
+    use std::time::{SystemTime, UNIX_EPOCH};
+
+    SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .map(|duration| duration.as_nanos().to_string())
+        .unwrap_or_else(|_| "0".to_owned())
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+struct SshTarget {
+    host: String,
+    user: String,
+    port: u16,
+    identity_file: Option<String>,
+}
+
+impl SshTarget {
+    fn from_metadata(metadata: &BTreeMap<String, Value>) -> DriverResult<Option<Self>> {
+        let host = optional_metadata_string(metadata, "ssh_host")?;
+        let Some(host) = host else {
+            return Ok(None);
+        };
+        validate_host(&host, "metadata.ssh_host")?;
+        let user =
+            optional_metadata_string(metadata, "ssh_user")?.unwrap_or_else(|| "root".to_owned());
+        validate_user(&user, "metadata.ssh_user")?;
+        let port = metadata_u16(metadata, "ssh_port", 22)?;
+        let identity_file = optional_metadata_string(metadata, "ssh_identity_file")?;
+        Ok(Some(Self {
+            host,
+            user,
+            port,
+            identity_file,
+        }))
+    }
+
+    fn to_query(&self, url: &mut Url) {
+        let mut pairs = url.query_pairs_mut();
+        pairs.append_pair("ssh_host", &self.host);
+        pairs.append_pair("ssh_user", &self.user);
+        pairs.append_pair("ssh_port", &self.port.to_string());
+        if let Some(identity_file) = self.identity_file.as_deref() {
+            pairs.append_pair("ssh_identity_file", identity_file);
+        }
+    }
+
+    fn from_query(url: &Url, handle: &str) -> DriverResult<Option<Self>> {
+        let mut host = None;
+        let mut user = None;
+        let mut port = None;
+        let mut identity_file = None;
+        for (key, value) in url.query_pairs() {
+            match key.as_ref() {
+                "ssh_host" => host = Some(value.into_owned()),
+                "ssh_user" => user = Some(value.into_owned()),
+                "ssh_port" => port = Some(value.into_owned()),
+                "ssh_identity_file" => identity_file = Some(value.into_owned()),
+                _ => {}
+            }
+        }
+        let Some(host) = host else {
+            return Ok(None);
+        };
+        validate_host(&host, "handle ssh_host")
+            .map_err(|err| invalid_handle(handle, err.to_string()))?;
+        let user = user.unwrap_or_else(|| "root".to_owned());
+        validate_user(&user, "handle ssh_user")
+            .map_err(|err| invalid_handle(handle, err.to_string()))?;
+        let port = match port {
+            Some(value) => value
+                .parse::<u16>()
+                .ok()
+                .filter(|value| *value > 0)
+                .ok_or_else(|| {
+                    invalid_handle(handle, "handle ssh_port must be in range 1..=65535")
+                })?,
+            None => 22,
+        };
+        Ok(Some(Self {
+            host,
+            user,
+            port,
+            identity_file,
+        }))
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+struct MicroVmHandle {
+    runtime: MicroVmRuntime,
+    name: String,
+    workdir: PathBuf,
+    api_sock: PathBuf,
+    pid_file: PathBuf,
+    ssh: Option<SshTarget>,
+}
+
+impl MicroVmHandle {
+    fn new(runtime: MicroVmRuntime, spec: &FirecrackerSpec, workdir: PathBuf) -> Self {
+        Self {
+            runtime,
+            name: spec.name.clone(),
+            api_sock: workdir.join("api.sock"),
+            pid_file: workdir.join("firecracker.pid"),
+            workdir,
+            ssh: spec.ssh.clone(),
+        }
+    }
+
+    fn to_handle(&self) -> DriverResult<String> {
+        let base = format!("microvm://{}/{}", self.runtime.label(), self.name);
+        let mut url = Url::parse(&base).map_err(|source| DriverError::InvalidInput {
+            message: format!("failed to build microvm handle: {source}"),
+        })?;
+        {
+            let mut pairs = url.query_pairs_mut();
+            pairs.append_pair("workdir", &self.workdir.to_string_lossy());
+            pairs.append_pair("api_sock", &self.api_sock.to_string_lossy());
+            pairs.append_pair("pid_file", &self.pid_file.to_string_lossy());
+        }
+        if let Some(ssh) = self.ssh.as_ref() {
+            ssh.to_query(&mut url);
+        }
+        Ok(url.to_string())
+    }
+
+    fn from_handle(handle: &str) -> DriverResult<Self> {
+        let url =
+            Url::parse(handle).map_err(|source| invalid_handle(handle, source.to_string()))?;
+        if url.scheme() != "microvm" {
+            return Err(invalid_handle(handle, "expected microvm scheme"));
+        }
+        let runtime = match url.host_str() {
+            Some("firecracker") => MicroVmRuntime::Firecracker,
+            Some("apple-container") => MicroVmRuntime::AppleContainer,
+            Some("kata") => MicroVmRuntime::Kata,
+            Some(other) => {
+                return Err(invalid_handle(
+                    handle,
+                    format!("unsupported runtime `{other}`"),
+                ))
+            }
+            None => return Err(invalid_handle(handle, "missing runtime")),
+        };
+        let name = url.path().trim_start_matches('/').to_owned();
+        validate_name(&name, "handle name")
+            .map_err(|err| invalid_handle(handle, err.to_string()))?;
+        let query = query_map(&url);
+        let workdir = required_query_path(&query, handle, "workdir")?;
+        let api_sock = query
+            .get("api_sock")
+            .map(PathBuf::from)
+            .unwrap_or_else(|| workdir.join("api.sock"));
+        let pid_file = query
+            .get("pid_file")
+            .map(PathBuf::from)
+            .unwrap_or_else(|| workdir.join("firecracker.pid"));
+        let ssh = SshTarget::from_query(&url, handle)?;
+        Ok(Self {
+            runtime,
+            name,
+            workdir,
+            api_sock,
+            pid_file,
+            ssh,
+        })
+    }
+
+    fn ssh(&self) -> DriverResult<&SshTarget> {
+        self.ssh
+            .as_ref()
+            .ok_or_else(|| capability_missing(MICROVM_SSH_CAPABILITY))
+    }
+}
+
+fn query_map(url: &Url) -> BTreeMap<String, String> {
+    url.query_pairs()
+        .map(|(key, value)| (key.into_owned(), value.into_owned()))
+        .collect()
+}
+
+fn required_query_path(
+    query: &BTreeMap<String, String>,
+    handle: &str,
+    key: &str,
+) -> DriverResult<PathBuf> {
+    query
+        .get(key)
+        .map(PathBuf::from)
+        .ok_or_else(|| invalid_handle(handle, format!("missing {key} query parameter")))
+}
+
+fn invalid_handle(handle: &str, message: impl Into<String>) -> DriverError {
+    DriverError::InvalidHandle {
+        handle: handle.to_owned(),
+        message: message.into(),
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+struct FirecrackerConfig {
+    #[serde(rename = "boot-source")]
+    boot_source: BootSource,
+    drives: Vec<Drive>,
+    #[serde(rename = "machine-config")]
+    machine_config: MachineConfig,
+    #[serde(
+        rename = "network-interfaces",
+        default,
+        skip_serializing_if = "Vec::is_empty"
+    )]
+    network_interfaces: Vec<NetworkInterface>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+struct BootSource {
+    kernel_image_path: String,
+    boot_args: String,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+struct Drive {
+    drive_id: String,
+    path_on_host: String,
+    is_root_device: bool,
+    is_read_only: bool,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+struct MachineConfig {
+    vcpu_count: u8,
+    mem_size_mib: u32,
+    smt: bool,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+struct NetworkInterface {
+    iface_id: String,
+    host_dev_name: String,
+}
+
+fn required_metadata_string(metadata: &BTreeMap<String, Value>, key: &str) -> DriverResult<String> {
+    optional_metadata_string(metadata, key)?.ok_or_else(|| DriverError::InvalidInput {
+        message: format!("metadata.{key} is required"),
+    })
+}
+
+fn optional_metadata_string(
+    metadata: &BTreeMap<String, Value>,
+    key: &str,
+) -> DriverResult<Option<String>> {
+    match metadata.get(key) {
+        Some(Value::String(value)) if value.is_empty() => Ok(None),
+        Some(Value::String(value)) => Ok(Some(value.clone())),
+        Some(Value::Null) | None => Ok(None),
+        Some(_) => Err(DriverError::InvalidInput {
+            message: format!("metadata.{key} must be a string when set"),
+        }),
+    }
+}
+
+fn metadata_u32(metadata: &BTreeMap<String, Value>, key: &str, default: u32) -> DriverResult<u32> {
+    match metadata.get(key) {
+        None | Some(Value::Null) => Ok(default),
+        Some(Value::Number(number)) => number
+            .as_u64()
+            .and_then(|value| u32::try_from(value).ok())
+            .filter(|value| *value > 0)
+            .ok_or_else(|| DriverError::InvalidInput {
+                message: format!("metadata.{key} must be in range 1..=4294967295"),
+            }),
+        Some(Value::String(value)) => value
+            .parse::<u32>()
+            .ok()
+            .filter(|value| *value > 0)
+            .ok_or_else(|| DriverError::InvalidInput {
+                message: format!("metadata.{key} must be a positive integer"),
+            }),
+        Some(_) => Err(DriverError::InvalidInput {
+            message: format!("metadata.{key} must be an integer or numeric string when set"),
+        }),
+    }
+}
+
+fn metadata_u16(metadata: &BTreeMap<String, Value>, key: &str, default: u16) -> DriverResult<u16> {
+    let value = metadata_u32(metadata, key, u32::from(default))?;
+    u16::try_from(value)
+        .ok()
+        .filter(|value| *value > 0)
+        .ok_or_else(|| DriverError::InvalidInput {
+            message: format!("metadata.{key} must be in range 1..=65535"),
+        })
+}
+
+fn metadata_u8(metadata: &BTreeMap<String, Value>, key: &str, default: u8) -> DriverResult<u8> {
+    let value = metadata_u32(metadata, key, u32::from(default))?;
+    u8::try_from(value)
+        .ok()
+        .filter(|value| *value > 0)
+        .ok_or_else(|| DriverError::InvalidInput {
+            message: format!("metadata.{key} must be in range 1..=255"),
+        })
+}
+
+fn validate_name(name: &str, label: &str) -> DriverResult<()> {
+    if name.is_empty()
+        || name.starts_with('-')
+        || name
+            .chars()
+            .any(|ch| !ch.is_ascii_alphanumeric() && !matches!(ch, '_' | '-' | '.'))
+    {
+        return Err(DriverError::InvalidInput {
+            message: format!("{label} contains unsupported characters"),
+        });
+    }
+    Ok(())
+}
+
+fn validate_tap(tap: &str) -> DriverResult<()> {
+    if tap.is_empty()
+        || tap.starts_with('-')
+        || tap
+            .chars()
+            .any(|ch| !ch.is_ascii_alphanumeric() && !matches!(ch, '_' | '-' | '.'))
+    {
+        return Err(DriverError::InvalidInput {
+            message: "metadata.tap contains unsupported characters".to_owned(),
+        });
+    }
+    Ok(())
+}
+
+fn validate_user(user: &str, label: &str) -> DriverResult<()> {
+    if user.is_empty()
+        || user.starts_with('-')
+        || user
+            .chars()
+            .any(|ch| !ch.is_ascii_alphanumeric() && !matches!(ch, '_' | '-' | '.'))
+    {
+        return Err(DriverError::InvalidInput {
+            message: format!("{label} contains unsupported characters"),
+        });
+    }
+    Ok(())
+}
+
+fn validate_host(host: &str, label: &str) -> DriverResult<()> {
+    let valid_chars = host
+        .chars()
+        .all(|ch| ch.is_ascii_alphanumeric() || matches!(ch, '.' | '-'));
+    let valid_shape = !host.is_empty()
+        && !host.starts_with('.')
+        && !host.ends_with('.')
+        && !host.contains("..")
+        && host
+            .split('.')
+            .all(|part| !part.is_empty() && !part.starts_with('-') && !part.ends_with('-'));
+    if !valid_chars || !valid_shape {
+        return Err(DriverError::InvalidInput {
+            message: format!("{label} contains unsupported characters or label syntax"),
+        });
+    }
+    Ok(())
+}
+
+fn ensure_workdir(parent: &Path, name: &str) -> DriverResult<PathBuf> {
+    let dir = parent.join(name);
+    fs::create_dir_all(&dir).map_err(|source| DriverError::InvalidInput {
+        message: format!(
+            "failed to create microvm workdir `{}`: {source}",
+            dir.display()
+        ),
+    })?;
+    Ok(dir)
+}
+
+fn write_json(path: &Path, value: &impl Serialize) -> DriverResult<()> {
+    let bytes = serde_json::to_vec_pretty(value).map_err(|source| DriverError::InvalidInput {
+        message: format!("failed to serialize firecracker config: {source}"),
+    })?;
+    fs::write(path, bytes).map_err(|source| DriverError::InvalidInput {
+        message: format!("failed to write `{}`: {source}", path.display()),
+    })
+}
+
+fn write_pid(path: &Path, pid: u32) -> DriverResult<()> {
+    fs::write(path, format!("{pid}\n")).map_err(|source| DriverError::InvalidInput {
+        message: format!("failed to write `{}`: {source}", path.display()),
+    })
+}
+
+fn read_pid(path: &Path) -> DriverResult<u32> {
+    let content = fs::read_to_string(path).map_err(|source| DriverError::InvalidHandle {
+        handle: path.display().to_string(),
+        message: format!("failed to read pid file: {source}"),
+    })?;
+    content
+        .trim()
+        .parse::<u32>()
+        .map_err(|source| DriverError::InvalidHandle {
+            handle: path.display().to_string(),
+            message: format!("invalid pid file: {source}"),
+        })
+}
+
+fn ssh_args(target: &SshTarget) -> Vec<String> {
+    let mut args = vec![
+        "-o".to_owned(),
+        "BatchMode=yes".to_owned(),
+        "-p".to_owned(),
+        target.port.to_string(),
+    ];
+    if let Some(identity_file) = target.identity_file.as_deref() {
+        args.push("-i".to_owned());
+        args.push(identity_file.to_owned());
+    }
+    args.push(format!("{}@{}", target.user, target.host));
+    args
+}
+
+fn scp_args(target: &SshTarget) -> Vec<String> {
+    let mut args = vec!["-P".to_owned(), target.port.to_string()];
+    if let Some(identity_file) = target.identity_file.as_deref() {
+        args.push("-i".to_owned());
+        args.push(identity_file.to_owned());
+    }
+    args
+}
+
+fn remote_path(target: &SshTarget, path: &str) -> String {
+    format!("{}@{}:{path}", target.user, target.host)
+}
+
+fn validate_copy_path(field: &str, path: &str) -> DriverResult<()> {
+    if path.is_empty() || path.starts_with('-') {
+        return Err(DriverError::InvalidInput {
+            message: format!("{field} must not be empty or start with '-'"),
+        });
+    }
+    Ok(())
+}
+
+fn log_entries_for_handle(handle: &MicroVmHandle) -> Vec<LogEntry> {
+    let mut entries = Vec::new();
+    for file in ["firecracker.stdout", "firecracker.stderr"] {
+        let path = handle.workdir.join(file);
+        let Ok(content) = fs::read_to_string(&path) else {
+            continue;
+        };
+        if content.trim().is_empty() {
+            continue;
+        }
+        entries.push(LogEntry {
+            level: if file.ends_with("stderr") {
+                LogLevel::Warn
+            } else {
+                LogLevel::Info
+            },
+            ts: String::new(),
+            msg: content,
+            kv: BTreeMap::from([("path".to_owned(), Value::String(path.display().to_string()))]),
+        });
+    }
+    entries
+}
+
+#[async_trait::async_trait]
+impl SandboxDriver for MicroVmDriver {
+    async fn initialize(&mut self, params: InitializeParams) -> DriverResult<InitializeResult> {
+        assert_compatible_schema_version(&params.schema_version)?;
+        *self.workdir.lock().map_err(|_| DriverError::InvalidInput {
+            message: "microvm workdir lock poisoned".to_owned(),
+        })? = Some(PathBuf::from(params.workdir).join("microvm"));
+
+        Ok(InitializeResult {
+            driver: DriverInfo {
+                name: DRIVER_NAME.to_owned(),
+                kind: DriverKind::Sandbox,
+                version: env!("CARGO_PKG_VERSION").to_owned(),
+                protocol_version: SCHEMA_VERSION.to_owned(),
+            },
+            capabilities: Capabilities::Sandbox(SandboxCapabilities {
+                supports_hot_reload_policy: false,
+                supports_filesystem_lockdown: true,
+                supports_syscall_filter: true,
+                supports_native_inference_routing: false,
+                supports_remote_host: false,
+                supports_persistent_sessions: false,
+            }),
+        })
+    }
+
+    async fn preflight(&self, _params: PreflightParams) -> DriverResult<PreflightResult> {
+        if !self.host.is_linux {
+            return Ok(preflight_failure(
+                "microvm_linux_required",
+                "Firecracker microVMs require a Linux host".to_owned(),
+                Some("Use a Linux host with KVM, or select a different sandbox runtime".to_owned()),
+            ));
+        }
+        if !self.host.has_kvm {
+            return Ok(preflight_failure(
+                "microvm_kvm_missing",
+                "/dev/kvm is not available on this host".to_owned(),
+                Some(
+                    "Enable KVM virtualization and ensure the current user can access /dev/kvm"
+                        .to_owned(),
+                ),
+            ));
+        }
+        if let Err(source) = self
+            .runner
+            .run(&self.firecracker_binary, &command_request(&["--version"]))
+        {
+            return Ok(preflight_failure(
+                "microvm_firecracker_missing",
+                format!(
+                    "Firecracker binary `{}` is not available: {source}",
+                    self.firecracker_binary
+                ),
+                Some("Install Firecracker and ensure it is on PATH".to_owned()),
+            ));
+        }
+        Ok(PreflightResult {
+            ok: true,
+            issues: Vec::new(),
+        })
+    }
+
+    async fn create(&self, spec: SandboxSpec) -> DriverResult<SandboxHandle> {
+        let spec = FirecrackerSpec::from_sandbox_spec(spec)?;
+        let parent = self
+            .workdir
+            .lock()
+            .map_err(|_| DriverError::InvalidInput {
+                message: "microvm workdir lock poisoned".to_owned(),
+            })?
+            .clone()
+            .ok_or_else(|| DriverError::InvalidInput {
+                message: "microvm driver must be initialized before create".to_owned(),
+            })?;
+        let workdir = ensure_workdir(&parent, &spec.name)?;
+        let handle = MicroVmHandle::new(MicroVmRuntime::Firecracker, &spec, workdir.clone());
+        let config_path = workdir.join("firecracker.json");
+        write_json(&config_path, &spec.config())?;
+
+        let request = CommandRequest {
+            args: vec![
+                "--api-sock".to_owned(),
+                handle.api_sock.to_string_lossy().into_owned(),
+                "--config-file".to_owned(),
+                config_path.to_string_lossy().into_owned(),
+            ],
+            env: BTreeMap::new(),
+            stdin: None,
+        };
+        let pid = self
+            .runner
+            .spawn(&self.firecracker_binary, &request)
+            .map_err(|source| DriverError::CommandSpawn {
+                command: command_string(&self.firecracker_binary, &request.args),
+                source,
+            })?;
+        write_pid(&handle.pid_file, pid)?;
+
+        Ok(SandboxHandle {
+            handle: handle.to_handle()?,
+        })
+    }
+
+    async fn connect(&self, params: ConnectParams) -> DriverResult<ShellHandle> {
+        let handle = MicroVmHandle::from_handle(&params.handle)?;
+        let ssh = handle.ssh()?;
+        let mut args = ssh_args(ssh);
+        args.push("--".to_owned());
+        args.push("true".to_owned());
+        let request = CommandRequest {
+            args,
+            env: BTreeMap::new(),
+            stdin: None,
+        };
+        let output = self
+            .runner
+            .run(&self.ssh_binary, &request)
+            .map_err(|source| DriverError::CommandSpawn {
+                command: command_string(&self.ssh_binary, &request.args),
+                source,
+            })?;
+        if output.status != Some(0) {
+            return Err(command_failed(&self.ssh_binary, &request, output));
+        }
+        Ok(ShellHandle {
+            session_id: params.handle,
+            tty: true,
+            working_dir: Some("/sandbox".to_owned()),
+        })
+    }
+
+    async fn create_session(&self, _params: CreateSessionParams) -> DriverResult<SessionHandle> {
+        Err(persistent_sessions_missing())
+    }
+
+    async fn attach_session(&self, _params: AttachSessionParams) -> DriverResult<ExecResult> {
+        Err(persistent_sessions_missing())
+    }
+
+    async fn list_sessions(&self, _params: ListSessionsParams) -> DriverResult<ListSessionsResult> {
+        Err(persistent_sessions_missing())
+    }
+
+    async fn kill_session(&self, _params: KillSessionParams) -> DriverResult<EmptyResult> {
+        Err(persistent_sessions_missing())
+    }
+
+    async fn exec(&self, params: ExecParams) -> DriverResult<ExecResult> {
+        let handle = MicroVmHandle::from_handle(&params.handle)?;
+        let ssh = handle.ssh()?;
+        let mut args = ssh_args(ssh);
+        args.push("--".to_owned());
+        args.push(params.cmd);
+        let request = CommandRequest {
+            args,
+            env: params.env,
+            stdin: None,
+        };
+        let output = self
+            .runner
+            .run(&self.ssh_binary, &request)
+            .map_err(|source| DriverError::CommandSpawn {
+                command: command_string(&self.ssh_binary, &request.args),
+                source,
+            })?;
+        Ok(ExecResult {
+            status: output.status.unwrap_or(1),
+            stdout: output.stdout,
+            stderr: output.stderr,
+        })
+    }
+
+    async fn copy_in(&self, params: CopyInParams) -> DriverResult<EmptyResult> {
+        let handle = MicroVmHandle::from_handle(&params.handle)?;
+        let ssh = handle.ssh()?;
+        validate_copy_path("src_host_path", &params.src_host_path)?;
+        validate_copy_path("dst_sandbox_path", &params.dst_sandbox_path)?;
+        let mut args = scp_args(ssh);
+        args.push("--".to_owned());
+        args.push(params.src_host_path);
+        args.push(remote_path(ssh, &params.dst_sandbox_path));
+        let request = CommandRequest {
+            args,
+            env: BTreeMap::new(),
+            stdin: None,
+        };
+        let output = self
+            .runner
+            .run(&self.scp_binary, &request)
+            .map_err(|source| DriverError::CommandSpawn {
+                command: command_string(&self.scp_binary, &request.args),
+                source,
+            })?;
+        if output.status != Some(0) {
+            return Err(command_failed(&self.scp_binary, &request, output));
+        }
+        Ok(EmptyResult::default())
+    }
+
+    async fn copy_out(&self, params: CopyOutParams) -> DriverResult<EmptyResult> {
+        let handle = MicroVmHandle::from_handle(&params.handle)?;
+        let ssh = handle.ssh()?;
+        validate_copy_path("src_sandbox_path", &params.src_sandbox_path)?;
+        validate_copy_path("dst_host_path", &params.dst_host_path)?;
+        let mut args = scp_args(ssh);
+        args.push("--".to_owned());
+        args.push(remote_path(ssh, &params.src_sandbox_path));
+        args.push(params.dst_host_path);
+        let request = CommandRequest {
+            args,
+            env: BTreeMap::new(),
+            stdin: None,
+        };
+        let output = self
+            .runner
+            .run(&self.scp_binary, &request)
+            .map_err(|source| DriverError::CommandSpawn {
+                command: command_string(&self.scp_binary, &request.args),
+                source,
+            })?;
+        if output.status != Some(0) {
+            return Err(command_failed(&self.scp_binary, &request, output));
+        }
+        Ok(EmptyResult::default())
+    }
+
+    async fn apply_policy(&self, _params: ApplyPolicyParams) -> DriverResult<ApplyPolicyResult> {
+        Err(capability_missing(MICROVM_POLICY_CAPABILITY))
+    }
+
+    async fn status(&self, params: SandboxStatusParams) -> DriverResult<SandboxStatus> {
+        let handle = MicroVmHandle::from_handle(&params.handle)?;
+        handle.runtime.ensure_implemented()?;
+        let pid = read_pid(&handle.pid_file)?;
+        let request = CommandRequest {
+            args: vec!["-0".to_owned(), pid.to_string()],
+            env: BTreeMap::new(),
+            stdin: None,
+        };
+        let status =
+            self.runner
+                .status("kill", &request)
+                .map_err(|source| DriverError::CommandSpawn {
+                    command: command_string("kill", &request.args),
+                    source,
+                })?;
+        let healthy = status == Some(0);
+        Ok(SandboxStatus {
+            phase: if healthy {
+                SandboxPhase::Running
+            } else {
+                SandboxPhase::Error
+            },
+            healthy,
+            last_ping: None,
+        })
+    }
+
+    async fn logs(&self, params: LogsParams) -> DriverResult<LogsResult> {
+        let handle = MicroVmHandle::from_handle(&params.handle)?;
+        Ok(LogsResult {
+            entries: log_entries_for_handle(&handle),
+        })
+    }
+
+    async fn logs_stream(&self, _params: LogsStreamParams) -> DriverResult<EmptyResult> {
+        Err(capability_missing("microvm_log_stream"))
+    }
+
+    async fn stop(&self, params: StopParams) -> DriverResult<EmptyResult> {
+        let handle = MicroVmHandle::from_handle(&params.handle)?;
+        let pid = read_pid(&handle.pid_file)?;
+        let request = CommandRequest {
+            args: vec![pid.to_string()],
+            env: BTreeMap::new(),
+            stdin: None,
+        };
+        let output =
+            self.runner
+                .run("kill", &request)
+                .map_err(|source| DriverError::CommandSpawn {
+                    command: command_string("kill", &request.args),
+                    source,
+                })?;
+        if output.status != Some(0) {
+            return Err(command_failed("kill", &request, output));
+        }
+        let _ = fs::remove_file(&handle.pid_file);
+        Ok(EmptyResult::default())
+    }
+
+    async fn destroy(&self, params: DestroyParams) -> DriverResult<EmptyResult> {
+        let handle = MicroVmHandle::from_handle(&params.handle)?;
+        if handle.pid_file.exists() {
+            let _ = self
+                .stop(StopParams {
+                    handle: params.handle,
+                })
+                .await;
+        }
+        for path in [
+            handle.workdir.join("firecracker.json"),
+            handle.api_sock,
+            handle.pid_file,
+            handle.workdir.join("firecracker.stdout"),
+            handle.workdir.join("firecracker.stderr"),
+        ] {
+            let _ = fs::remove_file(path);
+        }
+        Ok(EmptyResult::default())
+    }
+
+    async fn shutdown(&mut self, _params: ShutdownParams) -> DriverResult<EmptyResult> {
+        Ok(EmptyResult::default())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::{
+        collections::{BTreeMap, VecDeque},
+        io,
+        path::Path,
+        sync::{Arc, Mutex},
+    };
+
+    use agentenv_core::driver::{DriverError, SandboxDriver};
+    use agentenv_proto::{
+        Capabilities, ConnectParams, DriverKind, InitializeParams, LogLevel, PreflightParams,
+        SandboxSpec, SCHEMA_VERSION,
+    };
+    use serde_json::json;
+
+    use super::{CommandOutput, CommandRequest, FirecrackerConfig, MicroVmDriver};
+
+    #[derive(Debug, Default)]
+    struct RecordingRunner {
+        calls: Mutex<Vec<CommandRequest>>,
+        outputs: Mutex<VecDeque<io::Result<CommandOutput>>>,
+        spawned: Mutex<Vec<CommandRequest>>,
+    }
+
+    impl RecordingRunner {
+        fn calls(&self) -> Vec<CommandRequest> {
+            self.calls.lock().unwrap().clone()
+        }
+
+        fn spawned(&self) -> Vec<CommandRequest> {
+            self.spawned.lock().unwrap().clone()
+        }
+    }
+
+    impl super::CommandRunner for RecordingRunner {
+        fn run(&self, _program: &str, request: &CommandRequest) -> io::Result<CommandOutput> {
+            self.calls.lock().unwrap().push(request.clone());
+            self.outputs.lock().unwrap().pop_front().unwrap_or_else(|| {
+                Ok(CommandOutput {
+                    status: Some(0),
+                    stdout: String::new(),
+                    stderr: String::new(),
+                })
+            })
+        }
+
+        fn spawn(&self, _program: &str, request: &CommandRequest) -> io::Result<u32> {
+            self.spawned.lock().unwrap().push(request.clone());
+            Ok(4242)
+        }
+    }
+
+    fn init_params(workdir: &Path) -> InitializeParams {
+        InitializeParams {
+            schema_version: SCHEMA_VERSION.to_owned(),
+            core_version: "0.0.1".to_owned(),
+            workdir: workdir.to_string_lossy().into_owned(),
+            log_level: LogLevel::Info,
+        }
+    }
+
+    #[tokio::test]
+    async fn initialize_declares_microvm_capabilities() {
+        let temp = tempfile::tempdir().unwrap();
+        let runner = Arc::new(RecordingRunner::default());
+        let mut driver = MicroVmDriver::for_tests(Arc::clone(&runner), true, true);
+
+        let result = driver.initialize(init_params(temp.path())).await.unwrap();
+
+        assert_eq!(result.driver.name, "microvm");
+        assert_eq!(result.driver.kind, DriverKind::Sandbox);
+        match result.capabilities {
+            Capabilities::Sandbox(capabilities) => {
+                assert!(!capabilities.supports_hot_reload_policy);
+                assert!(capabilities.supports_filesystem_lockdown);
+                assert!(capabilities.supports_syscall_filter);
+                assert!(!capabilities.supports_native_inference_routing);
+                assert!(!capabilities.supports_remote_host);
+                assert!(!capabilities.supports_persistent_sessions);
+            }
+            other => panic!("expected sandbox capabilities, got {other:?}"),
+        }
+    }
+
+    #[tokio::test]
+    async fn preflight_requires_linux_kvm_and_firecracker() {
+        let temp = tempfile::tempdir().unwrap();
+        let runner = Arc::new(RecordingRunner::default());
+        let mut driver = MicroVmDriver::for_tests(Arc::clone(&runner), false, true);
+        driver.initialize(init_params(temp.path())).await.unwrap();
+
+        let preflight = driver.preflight(PreflightParams::default()).await.unwrap();
+
+        assert!(!preflight.ok);
+        assert_eq!(preflight.issues[0].code, "microvm_linux_required");
+        assert!(runner.calls().is_empty());
+    }
+
+    #[tokio::test]
+    async fn create_firecracker_writes_config_and_spawns_process() {
+        let temp = tempfile::tempdir().unwrap();
+        let runner = Arc::new(RecordingRunner::default());
+        let mut driver = MicroVmDriver::for_tests(Arc::clone(&runner), true, true);
+        driver.initialize(init_params(temp.path())).await.unwrap();
+
+        let handle = driver
+            .create(SandboxSpec {
+                image: None,
+                env: BTreeMap::new(),
+                policy: None,
+                metadata: BTreeMap::from([
+                    ("name".to_owned(), json!("fc-test")),
+                    ("runtime".to_owned(), json!("firecracker")),
+                    (
+                        "kernel".to_owned(),
+                        json!("/var/lib/agentenv/kernel/vmlinux"),
+                    ),
+                    ("rootfs".to_owned(), json!("/var/lib/agentenv/rootfs.ext4")),
+                    ("memory_mb".to_owned(), json!(1024)),
+                    ("cpus".to_owned(), json!(2)),
+                    ("tap".to_owned(), json!("tap-agentenv0")),
+                ]),
+            })
+            .await
+            .unwrap();
+
+        assert!(handle.handle.starts_with("microvm://firecracker/fc-test?"));
+        let spawned = runner.spawned();
+        assert_eq!(spawned.len(), 1);
+        assert_eq!(spawned[0].args[0], "--api-sock");
+        assert_eq!(spawned[0].args[2], "--config-file");
+
+        let config_path = Path::new(&spawned[0].args[3]);
+        let config: FirecrackerConfig =
+            serde_json::from_slice(&std::fs::read(config_path).unwrap()).unwrap();
+        assert_eq!(
+            config.boot_source.kernel_image_path,
+            "/var/lib/agentenv/kernel/vmlinux"
+        );
+        assert_eq!(
+            config.drives[0].path_on_host,
+            "/var/lib/agentenv/rootfs.ext4"
+        );
+        assert_eq!(config.machine_config.mem_size_mib, 1024);
+        assert_eq!(config.machine_config.vcpu_count, 2);
+        assert_eq!(config.network_interfaces[0].host_dev_name, "tap-agentenv0");
+    }
+
+    #[tokio::test]
+    async fn create_rejects_non_firecracker_runtime_explicitly() {
+        let temp = tempfile::tempdir().unwrap();
+        let runner = Arc::new(RecordingRunner::default());
+        let mut driver = MicroVmDriver::for_tests(Arc::clone(&runner), true, true);
+        driver.initialize(init_params(temp.path())).await.unwrap();
+
+        let err = driver
+            .create(SandboxSpec {
+                image: None,
+                env: BTreeMap::new(),
+                policy: None,
+                metadata: BTreeMap::from([
+                    ("name".to_owned(), json!("kata-test")),
+                    ("runtime".to_owned(), json!("kata")),
+                ]),
+            })
+            .await
+            .unwrap_err();
+
+        assert!(matches!(err, DriverError::CapabilityMissing { .. }));
+        assert!(runner.spawned().is_empty());
+    }
+
+    #[tokio::test]
+    async fn connect_requires_ssh_metadata_in_handle() {
+        let temp = tempfile::tempdir().unwrap();
+        let runner = Arc::new(RecordingRunner::default());
+        let mut driver = MicroVmDriver::for_tests(Arc::clone(&runner), true, true);
+        driver.initialize(init_params(temp.path())).await.unwrap();
+
+        let err = driver
+            .connect(ConnectParams {
+                handle: "microvm://firecracker/fc-test?workdir=/tmp/fc-test".to_owned(),
+            })
+            .await
+            .unwrap_err();
+
+        assert!(matches!(err, DriverError::CapabilityMissing { .. }));
+    }
+
+    #[tokio::test]
+    async fn conformance_contract_passes_with_fake_host() {
+        let runner = Arc::new(RecordingRunner::default());
+        let mut driver = MicroVmDriver::for_tests(Arc::clone(&runner), true, true);
+
+        driver_conformance::assert_sandbox_driver_contract(&mut driver)
+            .await
+            .unwrap();
+    }
+}

--- a/crates/drivers/sandbox-microvm/tests/integration.rs
+++ b/crates/drivers/sandbox-microvm/tests/integration.rs
@@ -1,0 +1,224 @@
+use std::{collections::BTreeMap, env, path::Path};
+
+use agentenv_core::driver::SandboxDriver;
+use agentenv_proto::{
+    CopyInParams, CopyOutParams, DestroyParams, ExecParams, InitializeParams, LogLevel, LogsParams,
+    PreflightParams, SandboxSpec, SandboxStatusParams, StopParams, SCHEMA_VERSION,
+};
+use sandbox_microvm::MicroVmDriver;
+use serde_json::json;
+
+fn init_params(workdir: &Path) -> InitializeParams {
+    InitializeParams {
+        schema_version: SCHEMA_VERSION.to_owned(),
+        core_version: env!("CARGO_PKG_VERSION").to_owned(),
+        workdir: workdir.to_string_lossy().into_owned(),
+        log_level: LogLevel::Info,
+    }
+}
+
+fn env_var(name: &str) -> Option<String> {
+    env::var(name).ok().filter(|value| !value.trim().is_empty())
+}
+
+#[tokio::test]
+#[ignore]
+async fn firecracker_process_lifecycle_on_linux_kvm() {
+    if env_var("AGENTENV_RUN_MICROVM_INTEGRATION").is_none() {
+        eprintln!("set AGENTENV_RUN_MICROVM_INTEGRATION=1 to run this test");
+        return;
+    }
+    let Some(kernel) = env_var("AGENTENV_MICROVM_KERNEL") else {
+        eprintln!("set AGENTENV_MICROVM_KERNEL to a bootable Firecracker kernel path");
+        return;
+    };
+    let Some(rootfs) = env_var("AGENTENV_MICROVM_ROOTFS") else {
+        eprintln!("set AGENTENV_MICROVM_ROOTFS to a bootable Firecracker rootfs path");
+        return;
+    };
+
+    let temp = tempfile::tempdir().expect("tempdir");
+    let mut driver = MicroVmDriver::default();
+    driver
+        .initialize(init_params(temp.path()))
+        .await
+        .expect("initialize");
+    let preflight = driver
+        .preflight(PreflightParams::default())
+        .await
+        .expect("preflight");
+    assert!(preflight.ok, "preflight failed: {preflight:?}");
+
+    let mut metadata = BTreeMap::from([
+        ("name".to_owned(), json!("agentenv-fc-it")),
+        ("runtime".to_owned(), json!("firecracker")),
+        ("kernel".to_owned(), json!(kernel)),
+        ("rootfs".to_owned(), json!(rootfs)),
+        (
+            "memory_mb".to_owned(),
+            json!(env_var("AGENTENV_MICROVM_MEMORY_MB").unwrap_or_else(|| "512".to_owned())),
+        ),
+        (
+            "cpus".to_owned(),
+            json!(env_var("AGENTENV_MICROVM_CPUS").unwrap_or_else(|| "1".to_owned())),
+        ),
+    ]);
+    if let Some(tap) = env_var("AGENTENV_MICROVM_TAP") {
+        metadata.insert("tap".to_owned(), json!(tap));
+    }
+    if let Some(host) = env_var("AGENTENV_MICROVM_SSH_HOST") {
+        metadata.insert("ssh_host".to_owned(), json!(host));
+    }
+    if let Some(port) = env_var("AGENTENV_MICROVM_SSH_PORT") {
+        metadata.insert("ssh_port".to_owned(), json!(port));
+    }
+    if let Some(user) = env_var("AGENTENV_MICROVM_SSH_USER") {
+        metadata.insert("ssh_user".to_owned(), json!(user));
+    }
+    if let Some(identity_file) = env_var("AGENTENV_MICROVM_SSH_IDENTITY_FILE") {
+        metadata.insert("ssh_identity_file".to_owned(), json!(identity_file));
+    }
+
+    let handle = driver
+        .create(SandboxSpec {
+            image: None,
+            env: BTreeMap::new(),
+            policy: None,
+            metadata,
+        })
+        .await
+        .expect("create firecracker");
+    let status = driver
+        .status(SandboxStatusParams {
+            handle: handle.handle.clone(),
+        })
+        .await
+        .expect("status");
+    assert!(status.healthy, "status: {status:?}");
+
+    if env_var("AGENTENV_MICROVM_SSH_HOST").is_some() {
+        let result = driver
+            .exec(ExecParams {
+                handle: handle.handle.clone(),
+                cmd: "true".to_owned(),
+                tty: false,
+                env: BTreeMap::new(),
+            })
+            .await
+            .expect("exec true over ssh");
+        assert_eq!(result.status, 0, "exec failed: {result:?}");
+    }
+
+    driver
+        .stop(StopParams {
+            handle: handle.handle.clone(),
+        })
+        .await
+        .expect("stop");
+    driver
+        .destroy(DestroyParams {
+            handle: handle.handle,
+        })
+        .await
+        .expect("destroy");
+}
+
+#[tokio::test]
+#[ignore]
+async fn apple_container_lifecycle_on_macos() {
+    if env_var("AGENTENV_RUN_APPLE_CONTAINER_INTEGRATION").is_none() {
+        eprintln!("set AGENTENV_RUN_APPLE_CONTAINER_INTEGRATION=1 to run this test");
+        return;
+    }
+    let image =
+        env_var("AGENTENV_APPLE_CONTAINER_IMAGE").unwrap_or_else(|| "alpine:latest".to_owned());
+    let temp = tempfile::tempdir().expect("tempdir");
+    let mut driver = MicroVmDriver::default();
+    driver
+        .initialize(init_params(temp.path()))
+        .await
+        .expect("initialize");
+    let preflight = driver
+        .preflight(PreflightParams::default())
+        .await
+        .expect("preflight");
+    assert!(preflight.ok, "preflight failed: {preflight:?}");
+
+    let handle = driver
+        .create(SandboxSpec {
+            image: Some(image),
+            env: BTreeMap::from([("AGENTENV_APPLE_CONTAINER_IT".to_owned(), "ok".to_owned())]),
+            policy: None,
+            metadata: BTreeMap::from([
+                ("name".to_owned(), json!("agentenv-apple-it")),
+                ("runtime".to_owned(), json!("apple-container")),
+                ("memory_mb".to_owned(), json!(512)),
+                ("cpus".to_owned(), json!(1)),
+            ]),
+        })
+        .await
+        .expect("create apple-container");
+
+    let result = driver
+        .exec(ExecParams {
+            handle: handle.handle.clone(),
+            cmd: "test \"$AGENTENV_APPLE_CONTAINER_IT\" = ok".to_owned(),
+            tty: false,
+            env: BTreeMap::new(),
+        })
+        .await
+        .expect("exec env probe");
+    assert_eq!(result.status, 0, "exec failed: {result:?}");
+
+    let src = temp.path().join("copy-in.txt");
+    std::fs::write(&src, "hello\n").expect("write copy source");
+    driver
+        .copy_in(CopyInParams {
+            handle: handle.handle.clone(),
+            src_host_path: src.display().to_string(),
+            dst_sandbox_path: "/sandbox/copy-in.txt".to_owned(),
+        })
+        .await
+        .expect("copy in");
+    let result = driver
+        .exec(ExecParams {
+            handle: handle.handle.clone(),
+            cmd: "cat /sandbox/copy-in.txt".to_owned(),
+            tty: false,
+            env: BTreeMap::new(),
+        })
+        .await
+        .expect("cat copied file");
+    assert_eq!(result.stdout, "hello\n");
+
+    let dst = temp.path().join("copy-out.txt");
+    driver
+        .copy_out(CopyOutParams {
+            handle: handle.handle.clone(),
+            src_sandbox_path: "/sandbox/copy-in.txt".to_owned(),
+            dst_host_path: dst.display().to_string(),
+        })
+        .await
+        .expect("copy out");
+    assert_eq!(
+        std::fs::read_to_string(dst).expect("read copy out"),
+        "hello\n"
+    );
+
+    let logs = driver
+        .logs(LogsParams {
+            handle: handle.handle.clone(),
+            since: None,
+            follow: false,
+        })
+        .await
+        .expect("logs");
+    assert!(logs.entries.len() <= 1);
+
+    driver
+        .destroy(DestroyParams {
+            handle: handle.handle,
+        })
+        .await
+        .expect("destroy");
+}

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -57,7 +57,7 @@
 
 ### `SandboxDriver` — how do we create and run an isolated environment?
 
-Concrete: OpenShell (first-class), microVM/Firecracker (first-class hardening path), Docker (post-MVP), E2B (post-MVP).
+Concrete: OpenShell (first-class), microVM/Firecracker on Linux/KVM and Apple Container on macOS (first-class hardening path), Docker (post-MVP), E2B (post-MVP).
 
 Responsibilities:
 - Preflight checks (runtime installed, versions compatible)
@@ -373,7 +373,7 @@ agentenv/
 │   ├── agentenv-plugin/        # subprocess driver host
 │   ├── drivers/
 │   │   ├── sandbox-openshell/  # built-in, first-class
-│   │   ├── sandbox-microvm/    # built-in, Firecracker first
+│   │   ├── sandbox-microvm/    # built-in, Firecracker + Apple Container
 │   │   ├── sandbox-docker/     # built-in, post-MVP
 │   │   ├── agent-claude/       # built-in
 │   │   ├── agent-codex/        # built-in

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -57,7 +57,7 @@
 
 ### `SandboxDriver` — how do we create and run an isolated environment?
 
-Concrete: OpenShell (first-class), Docker (post-MVP), E2B (post-MVP), Firecracker (post-MVP).
+Concrete: OpenShell (first-class), microVM/Firecracker (first-class hardening path), Docker (post-MVP), E2B (post-MVP).
 
 Responsibilities:
 - Preflight checks (runtime installed, versions compatible)
@@ -373,6 +373,7 @@ agentenv/
 │   ├── agentenv-plugin/        # subprocess driver host
 │   ├── drivers/
 │   │   ├── sandbox-openshell/  # built-in, first-class
+│   │   ├── sandbox-microvm/    # built-in, Firecracker first
 │   │   ├── sandbox-docker/     # built-in, post-MVP
 │   │   ├── agent-claude/       # built-in
 │   │   ├── agent-codex/        # built-in

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -25,7 +25,7 @@ Exit criterion: an empty workspace compiles, CI is green, and a mock driver can 
 First-class Rust drivers for the critical path.
 
 - **M2-1** — `sandbox-openshell` (built-in)
-- **H-2** — `sandbox-microvm` (built-in, Firecracker first; Apple Container / Kata reserved)
+- **H-2** — `sandbox-microvm` (built-in, Firecracker on Linux/KVM; Apple Container on macOS; Kata reserved)
 - **M2-2** — Built-in agent drivers: Claude, Codex, OpenClaw
 - **M2-3** — Built-in context drivers: filesystem, mcp-generic, none
 - **M2-4** — Built-in inference drivers: openai, anthropic, ollama, passthrough

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -25,6 +25,7 @@ Exit criterion: an empty workspace compiles, CI is green, and a mock driver can 
 First-class Rust drivers for the critical path.
 
 - **M2-1** — `sandbox-openshell` (built-in)
+- **H-2** — `sandbox-microvm` (built-in, Firecracker first; Apple Container / Kata reserved)
 - **M2-2** — Built-in agent drivers: Claude, Codex, OpenClaw
 - **M2-3** — Built-in context drivers: filesystem, mcp-generic, none
 - **M2-4** — Built-in inference drivers: openai, anthropic, ollama, passthrough
@@ -81,7 +82,6 @@ Exit criterion: an operator can observe live activity, approve unlisted egress r
 
 - Docker sandbox driver
 - E2B sandbox driver
-- Firecracker sandbox driver
 - Community catalog (`agentenv-community` repo)
 - Web dashboard for multi-env operators
 - Hub-mode approvals with ReBAC


### PR DESCRIPTION
## Summary

- Adds a built-in `sandbox-microvm` crate with `microvm` / `sandbox-microvm` aliases.
- Implements Firecracker lifecycle support for Linux/KVM hosts through the existing `SandboxDriver` contract.
- Implements Apple Container lifecycle support for Apple silicon macOS hosts: create, exec, copy in/out through a mounted `/sandbox`, status, logs, stop, and destroy.
- Makes preflight host-aware: Firecracker reports Linux/KVM requirements, Apple Container reports macOS/Apple silicon/`container system start` requirements, and the driver accepts the host when at least one runtime is available.
- Adds ignored live integration tests for Firecracker-on-Linux/KVM and Apple-Container-on-macOS, plus docs for running them.
- Keeps `runtime: kata` reserved with an explicit capability error.
- Fixes an E2E-discovered SQLite event/audit contention issue by setting a busy timeout on event-store connections.

Fixes #38.

## Validation

Post-final-commit checks:

- `cargo fmt --all -- --check`
- `cargo clippy --workspace --all-targets -- -D warnings`
- `cargo test --workspace`
- `cargo test -p sandbox-microvm`
- `AGENTENV_RUN_APPLE_CONTAINER_INTEGRATION=1 cargo test -p sandbox-microvm --features integration apple_container_lifecycle_on_macos -- --ignored --nocapture`
- Full live CLI E2E on macOS Apple Container with `container` 0.12.3 and `container system status: running`:
  - `agentenv create apple-cli-e2e --preflight-only --json --non-interactive` accepted.
  - `agentenv create apple-cli-e2e --json --non-interactive` accepted and created `microvm://apple-container/apple-cli-e2e`.
  - `agentenv status apple-cli-e2e --json` reported `healthy: true`, sandbox `running`, context mounted.
  - `agentenv exec apple-cli-e2e -- 'printf agentenv-live-cli-e2e && test -d /sandbox && command -v codex >/dev/null'` printed `agentenv-live-cli-e2e` and exited 0.
  - `agentenv logs apple-cli-e2e --json` returned lifecycle events including `sandbox_create`, `policy_applied`, `spawn_ready`, and `exec`.
  - `agentenv destroy apple-cli-e2e --yes --non-interactive` destroyed the env.

Firecracker live execution was not run on this Mac because Docker/OrbStack does not expose `/dev/kvm`; `--device /dev/kvm` fails because the device is absent. The Firecracker E2E path is covered by the new ignored `firecracker_process_lifecycle_on_linux_kvm` test, which must be run on a Linux/KVM host with `AGENTENV_MICROVM_KERNEL` and `AGENTENV_MICROVM_ROOTFS`.
