### PR TITLE
[codex] Implement agentenv skills lifecycle CLI

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -151,6 +151,7 @@ dependencies = [
  "toml",
  "url",
  "uuid",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -136,7 +136,9 @@ dependencies = [
  "ed25519-dalek",
  "hex",
  "ipnet",
+ "libc",
  "rand_core",
+ "reqwest",
  "schemars",
  "semver",
  "serde",
@@ -146,6 +148,7 @@ dependencies = [
  "thiserror 1.0.69",
  "time",
  "tokio",
+ "toml",
  "url",
  "uuid",
 ]
@@ -2515,7 +2518,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7f4c021e1093a56626774e81216a4ce732a735e5bad4868a03f3ed65ca0c3919"
 dependencies = [
  "once_cell",
- "toml_edit",
+ "toml_edit 0.19.15",
 ]
 
 [[package]]
@@ -3021,6 +3024,15 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn 2.0.117",
+]
+
+[[package]]
+name = "serde_spanned"
+version = "0.6.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bf41e0cfaf7226dca15e8197172c295a782857fcb97fad1808a166870dee75a3"
+dependencies = [
+ "serde",
 ]
 
 [[package]]
@@ -3539,10 +3551,25 @@ dependencies = [
 ]
 
 [[package]]
+name = "toml"
+version = "0.8.23"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dc1beb996b9d83529a9e75c17a1686767d148d70663143c7854d8b4a09ced362"
+dependencies = [
+ "serde",
+ "serde_spanned",
+ "toml_datetime",
+ "toml_edit 0.22.27",
+]
+
+[[package]]
 name = "toml_datetime"
 version = "0.6.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "22cddaf88f4fbc13c51aebbf5f8eceb5c7c5a9da2ac40a13519eb5b0a0e8f11c"
+dependencies = [
+ "serde",
+]
 
 [[package]]
 name = "toml_edit"
@@ -3552,8 +3579,28 @@ checksum = "1b5bb770da30e5cbfde35a2d7b9b8a2c4b8ef89548a7a6aeab5c9a576e3e7421"
 dependencies = [
  "indexmap",
  "toml_datetime",
- "winnow",
+ "winnow 0.5.40",
 ]
+
+[[package]]
+name = "toml_edit"
+version = "0.22.27"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "41fe8c660ae4257887cf66394862d21dbca4a6ddd26f04a3560410406a2f819a"
+dependencies = [
+ "indexmap",
+ "serde",
+ "serde_spanned",
+ "toml_datetime",
+ "toml_write",
+ "winnow 0.7.15",
+]
+
+[[package]]
+name = "toml_write"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5d99f8c9a7727884afe522e9bd5edbfc91a3312b36a77b5fb8926e4c31a41801"
 
 [[package]]
 name = "tonic"
@@ -4180,6 +4227,15 @@ name = "winnow"
 version = "0.5.40"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f593a95398737aeed53e489c785df13f3618e41dbcd6718c6addbf1395aa6876"
+dependencies = [
+ "memchr",
+]
+
+[[package]]
+name = "winnow"
+version = "0.7.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "df79d97927682d2fd8adb29682d1140b343be4ac0f08fd68b7765d9c059d3945"
 dependencies = [
  "memchr",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -51,6 +51,7 @@ tracing-subscriber = { version = "0.3", features = ["env-filter", "json"] }
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
 serde_yaml = "0.9"
+toml = "0.8"
 schemars = "0.8"
 rusqlite = { version = "0.32", features = ["bundled"] }
 
@@ -86,6 +87,7 @@ keyring = "2"
 dirs = "5"
 uuid = { version = "1", features = ["v4", "v7"] }
 once_cell = "1"
+libc = "0.2"
 humantime = "2"
 humantime-serde = "1"
 time = { version = "0.3", features = ["serde", "macros", "formatting", "parsing"] }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -88,6 +88,7 @@ dirs = "5"
 uuid = { version = "1", features = ["v4", "v7"] }
 once_cell = "1"
 libc = "0.2"
+windows-sys = { version = "0.61", features = ["Win32_Storage_FileSystem"] }
 humantime = "2"
 humantime-serde = "1"
 time = { version = "0.3", features = ["serde", "macros", "formatting", "parsing"] }

--- a/crates/agentenv-core/Cargo.toml
+++ b/crates/agentenv-core/Cargo.toml
@@ -19,15 +19,18 @@ async-trait.workspace = true
 serde.workspace = true
 serde_json.workspace = true
 serde_yaml.workspace = true
+toml.workspace = true
 schemars.workspace = true
 thiserror.workspace = true
 ipnet.workspace = true
 url.workspace = true
+reqwest.workspace = true
 sha2.workspace = true
 ed25519-dalek.workspace = true
 hex.workspace = true
 rand_core.workspace = true
 dirs.workspace = true
+libc.workspace = true
 time = { workspace = true, features = ["formatting"] }
 tokio = { workspace = true }
 uuid.workspace = true

--- a/crates/agentenv-core/Cargo.toml
+++ b/crates/agentenv-core/Cargo.toml
@@ -31,6 +31,7 @@ hex.workspace = true
 rand_core.workspace = true
 dirs.workspace = true
 libc.workspace = true
+windows-sys.workspace = true
 time = { workspace = true, features = ["formatting"] }
 tokio = { workspace = true }
 uuid.workspace = true

--- a/crates/agentenv-core/src/lib.rs
+++ b/crates/agentenv-core/src/lib.rs
@@ -19,6 +19,7 @@ pub mod registry;
 pub mod runtime;
 pub mod security;
 pub mod sessions;
+pub mod skills;
 pub mod snapshot;
 
 /// Placeholder surface for the M1 workspace scaffold.

--- a/crates/agentenv-core/src/security/ssrf.rs
+++ b/crates/agentenv-core/src/security/ssrf.rs
@@ -12,6 +12,7 @@ use agentenv_events::{ActivityEvent, ActivityKind, ActivityResult};
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct SsrfOptions {
     pub allow_private: bool,
+    pub allow_loopback: bool,
     pub allow_ssh_http: bool,
     pub extra_deny_cidrs: Vec<IpNet>,
     pub max_redirects: usize,
@@ -22,6 +23,7 @@ impl Default for SsrfOptions {
     fn default() -> Self {
         Self {
             allow_private: false,
+            allow_loopback: false,
             allow_ssh_http: false,
             extra_deny_cidrs: Vec::new(),
             max_redirects: 3,
@@ -350,7 +352,7 @@ fn check_ip(url: &Url, host: &str, ip: IpAddr, opts: &SsrfOptions) -> Result<(),
         }
     }
 
-    if let Some(category) = denied_category(ip, opts.allow_private) {
+    if let Some(category) = denied_category(ip, opts.allow_private, opts.allow_loopback) {
         return Err(block(
             url,
             Some(host.to_owned()),
@@ -371,10 +373,10 @@ fn is_cloud_metadata(ip: IpAddr) -> bool {
     }
 }
 
-fn denied_category(ip: IpAddr, allow_private: bool) -> Option<IpCategory> {
+fn denied_category(ip: IpAddr, allow_private: bool, allow_loopback: bool) -> Option<IpCategory> {
     match ip {
         IpAddr::V4(ip) => {
-            if ip.is_loopback() {
+            if ip.is_loopback() && !allow_loopback {
                 Some(IpCategory::Loopback)
             } else if ip.is_link_local() {
                 Some(IpCategory::LinkLocal)
@@ -396,7 +398,7 @@ fn denied_category(ip: IpAddr, allow_private: bool) -> Option<IpCategory> {
         }
         IpAddr::V6(ip) => {
             let wrapped = IpAddr::V6(ip);
-            if ip.is_loopback() {
+            if ip.is_loopback() && !allow_loopback {
                 Some(IpCategory::Loopback)
             } else if in_any_net(wrapped, IPV6_LINK_LOCAL_NETS) {
                 Some(IpCategory::LinkLocal)

--- a/crates/agentenv-core/src/skills/config.rs
+++ b/crates/agentenv-core/src/skills/config.rs
@@ -1,0 +1,492 @@
+use std::{
+    collections::{BTreeMap, BTreeSet},
+    path::{Path, PathBuf},
+};
+
+use serde::Deserialize;
+use serde_yaml::Value;
+use url::Url;
+
+use super::{
+    registry::{RegistryConfig, RegistryKind},
+    validate_skill_name, SkillError,
+};
+
+const CLI_REGISTRY_NAME: &str = "cli";
+const PROJECT_CONFIG_PATH: &str = "agentenv.yaml";
+
+#[derive(Debug, Clone, Default, serde::Serialize, serde::Deserialize, PartialEq, Eq)]
+pub struct SkillsConfig {
+    #[serde(default)]
+    pub registries: Vec<RegistryConfig>,
+    #[serde(default)]
+    pub registry_order: Vec<String>,
+}
+
+#[derive(Debug, Clone, Default, PartialEq, Eq)]
+pub struct SkillsConfigOverride {
+    pub registry: Option<String>,
+}
+
+pub fn load_project_skills_config(yaml: &str) -> Result<SkillsConfig, SkillError> {
+    let value: Value = serde_yaml::from_str(yaml).map_err(|source| SkillError::Yaml {
+        path: PathBuf::from(PROJECT_CONFIG_PATH),
+        source,
+    })?;
+
+    let Some(skills) = value
+        .as_mapping()
+        .and_then(|mapping| mapping.get(Value::String("skills".to_owned())))
+    else {
+        return Ok(SkillsConfig::default());
+    };
+
+    if skills.is_null() {
+        return Ok(SkillsConfig::default());
+    }
+
+    let config = serde_yaml::from_value(skills.clone()).map_err(|source| SkillError::Yaml {
+        path: PathBuf::from(PROJECT_CONFIG_PATH),
+        source,
+    })?;
+
+    normalize_config(config)
+}
+
+pub fn load_user_skills_config(toml_text: &str) -> Result<SkillsConfig, SkillError> {
+    let config: UserConfig =
+        toml::from_str(toml_text).map_err(|source| SkillError::Toml { source })?;
+
+    normalize_config(config.skills)
+}
+
+pub fn merge_skills_config(
+    user: SkillsConfig,
+    project: Option<SkillsConfig>,
+    override_config: SkillsConfigOverride,
+) -> Result<SkillsConfig, SkillError> {
+    let config = match project {
+        Some(project) if has_skills_config(&project) => merge_project_over_user(user, project)?,
+        _ => user,
+    };
+
+    if let Some(registry) = override_config.registry {
+        return apply_registry_override(config, &registry);
+    }
+
+    normalize_config(config)
+}
+
+#[derive(Debug, Default, Deserialize)]
+struct UserConfig {
+    #[serde(default)]
+    skills: SkillsConfig,
+}
+
+fn apply_registry_override(
+    config: SkillsConfig,
+    registry: &str,
+) -> Result<SkillsConfig, SkillError> {
+    let registry = registry.trim();
+    if registry.is_empty() {
+        return Err(invalid_config("registry override must not be empty"));
+    }
+
+    if let Some(registry) = registry_from_override_source(registry)? {
+        return normalize_config(SkillsConfig {
+            registries: vec![registry],
+            registry_order: vec![CLI_REGISTRY_NAME.to_owned()],
+        });
+    }
+
+    if is_bare_oci_reference(registry) {
+        return normalize_config(SkillsConfig {
+            registries: vec![RegistryConfig::oci(CLI_REGISTRY_NAME, registry, None)],
+            registry_order: vec![CLI_REGISTRY_NAME.to_owned()],
+        });
+    }
+    if registry.contains('/') {
+        return Err(invalid_config(format!(
+            "invalid registry override `{registry}`"
+        )));
+    }
+
+    validate_skill_name(registry)?;
+    let config = normalize_config(config)?;
+    let selected = config
+        .registries
+        .into_iter()
+        .find(|candidate| candidate.name == registry)
+        .ok_or_else(|| SkillError::RegistryNotFound {
+            name: registry.to_owned(),
+        })?;
+
+    Ok(SkillsConfig {
+        registries: vec![selected],
+        registry_order: vec![registry.to_owned()],
+    })
+}
+
+fn registry_from_override_source(source: &str) -> Result<Option<RegistryConfig>, SkillError> {
+    if Path::new(source).is_absolute() {
+        return Ok(Some(RegistryConfig::filesystem(
+            CLI_REGISTRY_NAME,
+            PathBuf::from(source),
+        )));
+    }
+    if !source.contains("://") && source.contains('/') {
+        return Ok(None);
+    }
+
+    let Ok(url) = Url::parse(source) else {
+        return Ok(None);
+    };
+
+    match url.scheme() {
+        "file" => Ok(Some(RegistryConfig::filesystem(
+            CLI_REGISTRY_NAME,
+            url.to_file_path()
+                .map_err(|()| invalid_config(format!("invalid file registry URL `{source}`")))?,
+        ))),
+        "http" | "https" => Ok(Some(RegistryConfig::http(
+            CLI_REGISTRY_NAME,
+            url.as_str(),
+            None,
+        ))),
+        "oci" => Ok(Some(RegistryConfig::oci(
+            CLI_REGISTRY_NAME,
+            normalize_oci_reference(&oci_reference_from_url(&url)?)?,
+            None,
+        ))),
+        scheme => Err(invalid_config(format!(
+            "unsupported registry URL scheme `{scheme}`"
+        ))),
+    }
+}
+
+fn oci_reference_from_url(url: &Url) -> Result<String, SkillError> {
+    if !url.username().is_empty() || url.password().is_some() {
+        return Err(invalid_config(
+            "oci registry URL must not include user info",
+        ));
+    }
+    if url.query().is_some() || url.fragment().is_some() {
+        return Err(invalid_config(
+            "oci registry URL must not include query or fragment",
+        ));
+    }
+
+    let host = url
+        .host_str()
+        .ok_or_else(|| invalid_config("oci registry URL must include a host"))?;
+
+    let mut reference = host.to_owned();
+    if let Some(port) = url.port() {
+        reference.push(':');
+        reference.push_str(&port.to_string());
+    }
+    if url.path() != "/" {
+        reference.push_str(url.path());
+    }
+
+    if reference.is_empty() {
+        return Err(invalid_config("oci registry reference must not be empty"));
+    }
+
+    Ok(reference)
+}
+
+fn normalize_config(mut config: SkillsConfig) -> Result<SkillsConfig, SkillError> {
+    normalize_registry_values(&mut config)?;
+    validate_registries(&config.registries)?;
+
+    if config.registry_order.is_empty() {
+        config.registry_order = config
+            .registries
+            .iter()
+            .map(|registry| registry.name.clone())
+            .collect();
+    }
+
+    validate_registry_order(&config)?;
+
+    Ok(config)
+}
+
+fn normalize_registry_values(config: &mut SkillsConfig) -> Result<(), SkillError> {
+    for registry in &mut config.registries {
+        match registry.kind {
+            RegistryKind::Filesystem => {}
+            RegistryKind::Http => {
+                if let Some(url) = registry.url.as_mut() {
+                    *url = url.trim().to_owned();
+                }
+            }
+            RegistryKind::Oci => {
+                if let Some(reference) = registry.url.as_mut() {
+                    *reference = normalize_oci_reference(reference)?;
+                }
+            }
+        }
+    }
+
+    Ok(())
+}
+
+fn merge_project_over_user(
+    user: SkillsConfig,
+    project: SkillsConfig,
+) -> Result<SkillsConfig, SkillError> {
+    let user = normalize_config(user)?;
+    let project = normalize_config(project)?;
+    let mut by_name = BTreeMap::new();
+    let mut order = Vec::new();
+
+    for registry in user.registries {
+        order.push(registry.name.clone());
+        by_name.insert(registry.name.clone(), registry);
+    }
+
+    for registry in project.registries {
+        if !by_name.contains_key(&registry.name) {
+            order.push(registry.name.clone());
+        }
+        by_name.insert(registry.name.clone(), registry);
+    }
+
+    if !project.registry_order.is_empty() {
+        let project_order = project.registry_order.iter().collect::<BTreeSet<_>>();
+        order.retain(|name| !project_order.contains(name));
+        let mut merged_order = project.registry_order;
+        merged_order.extend(order);
+        order = merged_order;
+    }
+
+    normalize_config(SkillsConfig {
+        registries: by_name.into_values().collect(),
+        registry_order: order,
+    })
+}
+
+fn validate_registries(registries: &[RegistryConfig]) -> Result<(), SkillError> {
+    let mut names = BTreeSet::new();
+    for registry in registries {
+        validate_skill_name(&registry.name)?;
+        if !names.insert(registry.name.as_str()) {
+            return Err(invalid_config(format!(
+                "duplicate registry name `{}`",
+                registry.name
+            )));
+        }
+        validate_registry_required_fields(registry)?;
+    }
+
+    Ok(())
+}
+
+fn validate_registry_required_fields(registry: &RegistryConfig) -> Result<(), SkillError> {
+    match registry.kind {
+        RegistryKind::Filesystem => {
+            if registry
+                .path
+                .as_ref()
+                .is_none_or(|path| path.as_os_str().is_empty())
+            {
+                return Err(invalid_config(format!(
+                    "filesystem registry `{}` requires path",
+                    registry.name
+                )));
+            }
+        }
+        RegistryKind::Http => {
+            let Some(url) = registry
+                .url
+                .as_deref()
+                .map(str::trim)
+                .filter(|url| !url.is_empty())
+            else {
+                return Err(invalid_config(format!(
+                    "http registry `{}` requires url",
+                    registry.name
+                )));
+            };
+            validate_http_url(&registry.name, url)?;
+        }
+        RegistryKind::Oci => {
+            let Some(reference) = registry
+                .url
+                .as_deref()
+                .map(str::trim)
+                .filter(|reference| !reference.is_empty())
+            else {
+                return Err(invalid_config(format!(
+                    "oci registry `{}` requires url",
+                    registry.name
+                )));
+            };
+            normalize_oci_reference(reference)?;
+        }
+    }
+
+    Ok(())
+}
+
+fn validate_http_url(name: &str, value: &str) -> Result<(), SkillError> {
+    let url = Url::parse(value).map_err(|source| {
+        invalid_config(format!(
+            "http registry `{name}` has invalid url `{value}`: {source}"
+        ))
+    })?;
+    if !matches!(url.scheme(), "http" | "https") {
+        return Err(invalid_config(format!(
+            "http registry `{name}` uses unsupported url scheme `{}`",
+            url.scheme()
+        )));
+    }
+    if url.host_str().is_none_or(str::is_empty) {
+        return Err(invalid_config(format!(
+            "http registry `{name}` url must include a host"
+        )));
+    }
+    if !url.username().is_empty() || url.password().is_some() {
+        return Err(invalid_config(format!(
+            "http registry `{name}` url must not include user info"
+        )));
+    }
+    Ok(())
+}
+
+fn normalize_oci_reference(reference: &str) -> Result<String, SkillError> {
+    let reference = reference.trim();
+    if let Ok(url) = Url::parse(reference) {
+        if url.scheme() == "oci" {
+            return normalize_oci_reference(&oci_reference_from_url(&url)?);
+        }
+    }
+
+    if !is_bare_oci_reference(reference) {
+        return Err(invalid_config(format!(
+            "invalid oci registry reference `{reference}`"
+        )));
+    }
+    Ok(reference.to_owned())
+}
+
+fn is_bare_oci_reference(value: &str) -> bool {
+    let value = value.trim();
+    if value.is_empty()
+        || value.contains(char::is_whitespace)
+        || value.contains("://")
+        || value.contains('@')
+        || value.starts_with('/')
+        || value.ends_with('/')
+        || value.contains("//")
+    {
+        return false;
+    }
+
+    let mut parts = value.split('/');
+    let Some(host) = parts.next() else {
+        return false;
+    };
+    let Some(first_path) = parts.next() else {
+        return false;
+    };
+    if first_path.is_empty() || parts.clone().any(str::is_empty) {
+        return false;
+    }
+
+    is_valid_oci_host(host)
+        && is_valid_oci_path_component(first_path)
+        && parts.all(is_valid_oci_path_component)
+}
+
+fn is_valid_oci_host(host: &str) -> bool {
+    let Some((domain, port)) = split_host_port(host) else {
+        return false;
+    };
+    if !(domain == "localhost" || domain.contains('.')) {
+        return false;
+    }
+    if !domain.split('.').all(|label| {
+        is_valid_oci_host_label(label) && !label.starts_with('-') && !label.ends_with('-')
+    }) {
+        return false;
+    }
+
+    port.is_none_or(|port| !port.is_empty() && port.bytes().all(|byte| byte.is_ascii_digit()))
+}
+
+fn split_host_port(host: &str) -> Option<(&str, Option<&str>)> {
+    let (domain, port) = match host.split_once(':') {
+        Some((domain, port)) => {
+            if port.contains(':') {
+                return None;
+            }
+            (domain, Some(port))
+        }
+        None => (host, None),
+    };
+
+    if domain.is_empty() {
+        None
+    } else {
+        Some((domain, port))
+    }
+}
+
+fn is_valid_oci_host_label(label: &str) -> bool {
+    !label.is_empty()
+        && label
+            .bytes()
+            .all(|byte| byte.is_ascii_alphanumeric() || byte == b'-')
+}
+
+fn is_valid_oci_path_component(component: &str) -> bool {
+    let bytes = component.as_bytes();
+    if bytes.is_empty()
+        || !bytes[0].is_ascii_lowercase()
+        || !bytes[bytes.len() - 1].is_ascii_alphanumeric()
+    {
+        return false;
+    }
+
+    bytes.iter().all(|byte| {
+        byte.is_ascii_lowercase() || byte.is_ascii_digit() || matches!(byte, b'.' | b'_' | b'-')
+    })
+}
+
+fn validate_registry_order(config: &SkillsConfig) -> Result<(), SkillError> {
+    let registry_names = config
+        .registries
+        .iter()
+        .map(|registry| registry.name.as_str())
+        .collect::<BTreeSet<_>>();
+    let mut order_names = BTreeSet::new();
+
+    for name in &config.registry_order {
+        validate_skill_name(name)?;
+        if !order_names.insert(name.as_str()) {
+            return Err(invalid_config(format!(
+                "duplicate registry order entry `{name}`"
+            )));
+        }
+        if !registry_names.contains(name.as_str()) {
+            return Err(invalid_config(format!(
+                "registry_order references unknown registry `{name}`"
+            )));
+        }
+    }
+
+    Ok(())
+}
+
+fn has_skills_config(config: &SkillsConfig) -> bool {
+    !config.registries.is_empty() || !config.registry_order.is_empty()
+}
+
+fn invalid_config(message: impl Into<String>) -> SkillError {
+    SkillError::InvalidConfig {
+        message: message.into(),
+    }
+}

--- a/crates/agentenv-core/src/skills/digest.rs
+++ b/crates/agentenv-core/src/skills/digest.rs
@@ -1,0 +1,76 @@
+use std::{
+    collections::BTreeMap,
+    fs,
+    path::{Path, PathBuf},
+};
+
+use sha2::{Digest, Sha256};
+
+use super::{
+    manifest::{normalize_bundle_path, validated_bundle_file},
+    SkillError, SkillManifest,
+};
+
+const DIGEST_HEADER: &[u8] = b"agentenv-skill-v1\n";
+
+pub fn compute_bundle_digest(
+    root: impl AsRef<Path>,
+    manifest: &SkillManifest,
+) -> Result<String, SkillError> {
+    let root = root.as_ref();
+    let mut files = BTreeMap::new();
+    for file in &manifest.declared_files {
+        let normalized = normalize_bundle_path(file)?;
+        files.insert(canonical_relative_path(&normalized)?, normalized);
+    }
+
+    let mut hasher = Sha256::new();
+    hasher.update(DIGEST_HEADER);
+
+    for (relative_path, file) in files {
+        let absolute_path = validated_bundle_file(root, &file)?;
+        let bytes = fs::read(&absolute_path).map_err(|source| {
+            if source.kind() == std::io::ErrorKind::NotFound {
+                SkillError::MissingDeclaredFile { path: file.clone() }
+            } else {
+                SkillError::Io {
+                    path: absolute_path,
+                    source,
+                }
+            }
+        })?;
+
+        hasher.update(relative_path.as_bytes());
+        hasher.update([0]);
+        hasher.update(bytes.len().to_string().as_bytes());
+        hasher.update([0]);
+        hasher.update(bytes);
+        hasher.update(b"\n");
+    }
+
+    Ok(format!("sha256:{}", hex::encode(hasher.finalize())))
+}
+
+fn canonical_relative_path(path: &Path) -> Result<String, SkillError> {
+    let normalized = normalize_bundle_path(path)?;
+    let mut parts = Vec::new();
+    for component in normalized.components() {
+        let std::path::Component::Normal(part) = component else {
+            return Err(SkillError::UnsafeBundlePath {
+                path: path.to_path_buf(),
+            });
+        };
+        let part = part.to_str().ok_or_else(|| SkillError::UnsafeBundlePath {
+            path: path.to_path_buf(),
+        })?;
+        parts.push(part);
+    }
+
+    if parts.is_empty() {
+        return Err(SkillError::UnsafeBundlePath {
+            path: PathBuf::from(path),
+        });
+    }
+
+    Ok(parts.join("/"))
+}

--- a/crates/agentenv-core/src/skills/error.rs
+++ b/crates/agentenv-core/src/skills/error.rs
@@ -55,13 +55,13 @@ pub enum SkillError {
     SkillNotInstalled { name: String },
     #[error("skill `{name}` has multiple installed versions: {versions}")]
     AmbiguousInstalledVersion { name: String, versions: String },
-    #[error("skill `{name}` version `{version}` is already installed with digest `{existing}`")]
+    #[error("skill `{name}` version `{version}` already exists with digest `{existing}`")]
     AlreadyInstalledDifferentDigest {
         name: String,
         version: String,
         existing: String,
     },
-    #[error("failed to parse or serialize installed skill YAML at `{path}`: {source}")]
+    #[error("failed to parse or serialize skill YAML at `{path}`: {source}")]
     Serde {
         path: PathBuf,
         #[source]

--- a/crates/agentenv-core/src/skills/error.rs
+++ b/crates/agentenv-core/src/skills/error.rs
@@ -25,6 +25,25 @@ pub enum SkillError {
     InvalidSkillName { name: String },
     #[error("registry `{name}` was not found")]
     RegistryNotFound { name: String },
+    #[error("registry URL `{url}` was blocked by SSRF policy: {source}")]
+    RegistryUrlBlocked {
+        url: String,
+        #[source]
+        source: Box<crate::security::ssrf::SsrfBlocked>,
+    },
+    #[error("HTTP registry request failed for `{url}`: {source}")]
+    HttpRegistry {
+        url: String,
+        #[source]
+        source: Box<reqwest::Error>,
+    },
+    #[error("HTTP registry `{url}` returned status {status}")]
+    HttpStatus {
+        url: String,
+        status: reqwest::StatusCode,
+    },
+    #[error("credential reference `{name}` is not available")]
+    CredentialReferenceUnavailable { name: String },
     #[error("invalid skills config: {message}")]
     InvalidConfig { message: String },
     #[error("invalid skill version `{version}`: {source}")]

--- a/crates/agentenv-core/src/skills/error.rs
+++ b/crates/agentenv-core/src/skills/error.rs
@@ -44,6 +44,10 @@ pub enum SkillError {
     },
     #[error("credential reference `{name}` is not available")]
     CredentialReferenceUnavailable { name: String },
+    #[error("unsupported registry authentication scheme `{scheme}`")]
+    UnsupportedRegistryAuth { scheme: String },
+    #[error("invalid OCI registry reference `{reference}`")]
+    InvalidOciReference { reference: String },
     #[error("invalid skills config: {message}")]
     InvalidConfig { message: String },
     #[error("invalid skill version `{version}`: {source}")]

--- a/crates/agentenv-core/src/skills/error.rs
+++ b/crates/agentenv-core/src/skills/error.rs
@@ -1,0 +1,37 @@
+use std::path::PathBuf;
+
+use thiserror::Error;
+
+#[derive(Debug, Error)]
+pub enum SkillError {
+    #[error("failed to read or write skill path `{path}`: {source}")]
+    Io {
+        path: PathBuf,
+        #[source]
+        source: std::io::Error,
+    },
+    #[error("failed to parse skill YAML at `{path}`: {source}")]
+    Yaml {
+        path: PathBuf,
+        #[source]
+        source: serde_yaml::Error,
+    },
+    #[error("invalid skill name `{name}`")]
+    InvalidSkillName { name: String },
+    #[error("invalid skill version `{version}`: {source}")]
+    InvalidVersion {
+        version: String,
+        #[source]
+        source: semver::Error,
+    },
+    #[error("unsafe skill bundle path `{path}`")]
+    UnsafeBundlePath { path: PathBuf },
+    #[error("declared skill file `{path}` is missing")]
+    MissingDeclaredFile { path: PathBuf },
+    #[error("declared skill pattern `{pattern}` matched no files")]
+    EmptyFilePattern { pattern: String },
+    #[error("skill manifest `{path}` is missing required field `{field}`")]
+    MissingManifestField { path: PathBuf, field: &'static str },
+    #[error("skill digest mismatch: expected `{expected}`, found `{actual}`")]
+    DigestMismatch { expected: String, actual: String },
+}

--- a/crates/agentenv-core/src/skills/error.rs
+++ b/crates/agentenv-core/src/skills/error.rs
@@ -34,4 +34,34 @@ pub enum SkillError {
     MissingManifestField { path: PathBuf, field: &'static str },
     #[error("skill digest mismatch: expected `{expected}`, found `{actual}`")]
     DigestMismatch { expected: String, actual: String },
+    #[error("missing Ed25519 signature for skill `{name}` version `{version}`")]
+    MissingSignature { name: String, version: String },
+    #[error("invalid Ed25519 signature for skill `{name}` version `{version}`: {message}")]
+    InvalidSignature {
+        name: String,
+        version: String,
+        message: String,
+    },
+    #[error("skill `{name}` is not installed")]
+    SkillNotInstalled { name: String },
+    #[error("skill `{name}` has multiple installed versions: {versions}")]
+    AmbiguousInstalledVersion { name: String, versions: String },
+    #[error("skill `{name}` version `{version}` is already installed with digest `{existing}`")]
+    AlreadyInstalledDifferentDigest {
+        name: String,
+        version: String,
+        existing: String,
+    },
+    #[error("failed to parse or serialize installed skill YAML at `{path}`: {source}")]
+    Serde {
+        path: PathBuf,
+        #[source]
+        source: serde_yaml::Error,
+    },
+    #[error("skill `{name}` version `{version}` self-test failed with status {status}")]
+    SelfTestFailed {
+        name: String,
+        version: String,
+        status: i32,
+    },
 }

--- a/crates/agentenv-core/src/skills/error.rs
+++ b/crates/agentenv-core/src/skills/error.rs
@@ -16,8 +16,17 @@ pub enum SkillError {
         #[source]
         source: serde_yaml::Error,
     },
+    #[error("failed to parse skills config TOML: {source}")]
+    Toml {
+        #[source]
+        source: toml::de::Error,
+    },
     #[error("invalid skill name `{name}`")]
     InvalidSkillName { name: String },
+    #[error("registry `{name}` was not found")]
+    RegistryNotFound { name: String },
+    #[error("invalid skills config: {message}")]
+    InvalidConfig { message: String },
     #[error("invalid skill version `{version}`: {source}")]
     InvalidVersion {
         version: String,

--- a/crates/agentenv-core/src/skills/index.rs
+++ b/crates/agentenv-core/src/skills/index.rs
@@ -1,0 +1,306 @@
+use std::{
+    fs,
+    path::{Path, PathBuf},
+};
+
+use serde::{Deserialize, Serialize};
+
+use super::{store::InstalledSkill, validate_skill_name, SkillError};
+
+const SKILLS_DIR: &str = "skills";
+const INDEX_FILE: &str = "index.yaml";
+const INSTALLED_FILE: &str = "installed.yaml";
+
+#[derive(Debug, Default, Serialize, Deserialize)]
+struct InstalledSkillsIndex {
+    skills: Vec<InstalledSkill>,
+}
+
+pub(crate) fn skills_root(root: &Path) -> PathBuf {
+    root.join(SKILLS_DIR)
+}
+
+pub(crate) fn index_path(root: &Path) -> PathBuf {
+    skills_root(root).join(INDEX_FILE)
+}
+
+pub(crate) fn installed_record_path(install_dir: &Path) -> PathBuf {
+    install_dir.join(INSTALLED_FILE)
+}
+
+pub(crate) fn rebuild(root: &Path) -> Result<Vec<InstalledSkill>, SkillError> {
+    let skills_root = skills_root(root);
+    let root_metadata = match fs::symlink_metadata(&skills_root) {
+        Ok(metadata) => metadata,
+        Err(source) if source.kind() == std::io::ErrorKind::NotFound => return Ok(Vec::new()),
+        Err(source) => {
+            return Err(SkillError::Io {
+                path: skills_root.clone(),
+                source,
+            });
+        }
+    };
+    if !root_metadata.file_type().is_dir() {
+        return Err(SkillError::UnsafeBundlePath { path: skills_root });
+    }
+
+    let mut installed = Vec::new();
+    for name_entry in fs::read_dir(&skills_root).map_err(|source| SkillError::Io {
+        path: skills_root.clone(),
+        source,
+    })? {
+        let name_entry = name_entry.map_err(|source| SkillError::Io {
+            path: skills_root.clone(),
+            source,
+        })?;
+        let name_path = name_entry.path();
+        let Some(name) = path_component_string(&name_path) else {
+            return Err(SkillError::UnsafeBundlePath { path: name_path });
+        };
+        if name.starts_with('.') {
+            continue;
+        }
+        let name_file_type = symlink_file_type(&name_path)?;
+        if name_file_type.is_symlink() {
+            return Err(SkillError::UnsafeBundlePath { path: name_path });
+        }
+        if !name_file_type.is_dir() {
+            continue;
+        }
+        validate_skill_name(&name)?;
+
+        for version_entry in fs::read_dir(&name_path).map_err(|source| SkillError::Io {
+            path: name_path.clone(),
+            source,
+        })? {
+            let version_entry = version_entry.map_err(|source| SkillError::Io {
+                path: name_path.clone(),
+                source,
+            })?;
+            let install_dir = version_entry.path();
+            let Some(version) = path_component_string(&install_dir) else {
+                return Err(SkillError::UnsafeBundlePath { path: install_dir });
+            };
+            if version.starts_with('.') {
+                continue;
+            }
+            let version_file_type = symlink_file_type(&install_dir)?;
+            if version_file_type.is_symlink() {
+                return Err(SkillError::UnsafeBundlePath { path: install_dir });
+            }
+            if !version_file_type.is_dir() {
+                continue;
+            }
+            version
+                .parse::<semver::Version>()
+                .map_err(|source| SkillError::InvalidVersion {
+                    version: version.clone(),
+                    source,
+                })?;
+
+            let record_path = installed_record_path(&install_dir);
+            match symlink_file_type(&record_path) {
+                Ok(file_type) if file_type.is_symlink() => {
+                    return Err(SkillError::UnsafeBundlePath { path: record_path });
+                }
+                Ok(file_type) if file_type.is_file() => {}
+                Ok(_) => continue,
+                Err(SkillError::Io { source, .. })
+                    if source.kind() == std::io::ErrorKind::NotFound =>
+                {
+                    continue;
+                }
+                Err(error) => return Err(error),
+            }
+
+            let mut record = read_record(&record_path)?;
+            if record.name != name || record.version != version {
+                return Err(SkillError::UnsafeBundlePath { path: record_path });
+            }
+            record.path = install_dir.clone();
+            installed.push(record);
+        }
+    }
+
+    sort_installed(&mut installed);
+    write(root, &installed)?;
+    Ok(installed)
+}
+
+pub(crate) fn write(root: &Path, installed: &[InstalledSkill]) -> Result<(), SkillError> {
+    let mut installed = installed.to_vec();
+    sort_installed(&mut installed);
+    let index = InstalledSkillsIndex { skills: installed };
+    let path = index_path(root);
+    write_yaml_atomic(&path, &index)
+}
+
+pub(crate) fn read_record(path: &Path) -> Result<InstalledSkill, SkillError> {
+    let content = read_regular_string(path)?;
+    serde_yaml::from_str(&content).map_err(|source| SkillError::Serde {
+        path: path.to_path_buf(),
+        source,
+    })
+}
+
+pub(crate) fn write_record(path: &Path, installed: &InstalledSkill) -> Result<(), SkillError> {
+    write_yaml_atomic(path, installed)
+}
+
+fn sort_installed(installed: &mut [InstalledSkill]) {
+    installed.sort_by(|left, right| {
+        left.name
+            .cmp(&right.name)
+            .then_with(|| left.version.cmp(&right.version))
+    });
+}
+
+fn path_component_string(path: &Path) -> Option<String> {
+    path.file_name()?.to_str().map(ToOwned::to_owned)
+}
+
+fn symlink_file_type(path: &Path) -> Result<fs::FileType, SkillError> {
+    fs::symlink_metadata(path)
+        .map(|metadata| metadata.file_type())
+        .map_err(|source| SkillError::Io {
+            path: path.to_path_buf(),
+            source,
+        })
+}
+
+fn read_regular_string(path: &Path) -> Result<String, SkillError> {
+    let file_type = symlink_file_type(path)?;
+    if !file_type.is_file() {
+        return Err(SkillError::UnsafeBundlePath {
+            path: path.to_path_buf(),
+        });
+    }
+
+    read_regular_string_no_follow(path)
+}
+
+#[cfg(unix)]
+fn read_regular_string_no_follow(path: &Path) -> Result<String, SkillError> {
+    use std::{fs::OpenOptions, io::Read, os::unix::fs::OpenOptionsExt};
+
+    let mut file = OpenOptions::new()
+        .read(true)
+        .custom_flags(libc::O_NOFOLLOW)
+        .open(path)
+        .map_err(|source| SkillError::Io {
+            path: path.to_path_buf(),
+            source,
+        })?;
+    let metadata = file.metadata().map_err(|source| SkillError::Io {
+        path: path.to_path_buf(),
+        source,
+    })?;
+    if !metadata.file_type().is_file() {
+        return Err(SkillError::UnsafeBundlePath {
+            path: path.to_path_buf(),
+        });
+    }
+
+    let mut content = String::new();
+    file.read_to_string(&mut content)
+        .map_err(|source| SkillError::Io {
+            path: path.to_path_buf(),
+            source,
+        })?;
+    Ok(content)
+}
+
+#[cfg(not(unix))]
+fn read_regular_string_no_follow(path: &Path) -> Result<String, SkillError> {
+    fs::read_to_string(path).map_err(|source| SkillError::Io {
+        path: path.to_path_buf(),
+        source,
+    })
+}
+
+fn write_yaml_atomic<T>(path: &Path, value: &T) -> Result<(), SkillError>
+where
+    T: Serialize,
+{
+    let parent = path.parent().ok_or_else(|| SkillError::UnsafeBundlePath {
+        path: path.to_path_buf(),
+    })?;
+    fs::create_dir_all(parent).map_err(|source| SkillError::Io {
+        path: parent.to_path_buf(),
+        source,
+    })?;
+
+    let yaml = serde_yaml::to_string(value).map_err(|source| SkillError::Serde {
+        path: path.to_path_buf(),
+        source,
+    })?;
+    let tmp_path = temporary_path(path);
+    fs::write(&tmp_path, yaml).map_err(|source| SkillError::Io {
+        path: tmp_path.clone(),
+        source,
+    })?;
+    replace_file(&tmp_path, path).map_err(|source| {
+        let _ = fs::remove_file(&tmp_path);
+        SkillError::Io {
+            path: path.to_path_buf(),
+            source,
+        }
+    })
+}
+
+#[cfg(windows)]
+fn replace_file(from: &Path, to: &Path) -> std::io::Result<()> {
+    use std::os::windows::ffi::OsStrExt;
+    use windows_sys::Win32::Storage::FileSystem::{
+        MoveFileExW, MOVEFILE_REPLACE_EXISTING, MOVEFILE_WRITE_THROUGH,
+    };
+
+    let from = from
+        .as_os_str()
+        .encode_wide()
+        .chain(std::iter::once(0))
+        .collect::<Vec<_>>();
+    let to = to
+        .as_os_str()
+        .encode_wide()
+        .chain(std::iter::once(0))
+        .collect::<Vec<_>>();
+
+    let replaced = unsafe {
+        MoveFileExW(
+            from.as_ptr(),
+            to.as_ptr(),
+            MOVEFILE_REPLACE_EXISTING | MOVEFILE_WRITE_THROUGH,
+        )
+    };
+    if replaced == 0 {
+        Err(std::io::Error::last_os_error())
+    } else {
+        Ok(())
+    }
+}
+
+#[cfg(not(windows))]
+fn replace_file(from: &Path, to: &Path) -> std::io::Result<()> {
+    fs::rename(from, to)
+}
+
+fn temporary_path(path: &Path) -> PathBuf {
+    let mut file_name = path
+        .file_name()
+        .map(|name| name.to_os_string())
+        .unwrap_or_default();
+    file_name.push(format!(
+        ".tmp-{}-{}",
+        std::process::id(),
+        temporary_suffix()
+    ));
+    path.with_file_name(file_name)
+}
+
+fn temporary_suffix() -> u128 {
+    match std::time::SystemTime::now().duration_since(std::time::UNIX_EPOCH) {
+        Ok(duration) => duration.as_nanos(),
+        Err(_) => 0,
+    }
+}

--- a/crates/agentenv-core/src/skills/manifest.rs
+++ b/crates/agentenv-core/src/skills/manifest.rs
@@ -1,0 +1,355 @@
+use std::{
+    collections::{BTreeMap, BTreeSet},
+    fs,
+    path::{Component, Path, PathBuf},
+};
+
+use semver::Version;
+use serde::Deserialize;
+use serde_yaml::Value;
+
+use super::SkillError;
+
+const MANIFEST_FILE: &str = "skill.yaml";
+
+#[derive(Debug, Clone, PartialEq)]
+pub struct SkillManifest {
+    pub name: String,
+    pub version: Version,
+    pub description: Option<String>,
+    pub entry: PathBuf,
+    pub declared_files: Vec<PathBuf>,
+    pub self_test_command: Option<String>,
+    pub signature_ed25519: Option<String>,
+    pub extra: BTreeMap<String, Value>,
+}
+
+#[derive(Debug, Deserialize)]
+struct RawSkillManifest {
+    name: Option<String>,
+    version: Option<String>,
+    description: Option<String>,
+    entry: Option<String>,
+    files: Option<Vec<String>>,
+    self_test: Option<RawSelfTest>,
+    signatures: Option<RawSignatures>,
+    #[serde(flatten)]
+    extra: BTreeMap<String, Value>,
+}
+
+#[derive(Debug, Deserialize)]
+struct RawSelfTest {
+    command: Option<String>,
+}
+
+#[derive(Debug, Deserialize)]
+struct RawSignatures {
+    ed25519: Option<String>,
+}
+
+pub fn load_skill_manifest(root: impl AsRef<Path>) -> Result<SkillManifest, SkillError> {
+    let root = root.as_ref();
+    let manifest_path = root.join(MANIFEST_FILE);
+    let content = read_manifest_file(&manifest_path)?;
+    let raw: RawSkillManifest =
+        serde_yaml::from_str(&content).map_err(|source| SkillError::Yaml {
+            path: manifest_path.clone(),
+            source,
+        })?;
+
+    let name = required(raw.name, &manifest_path, "name")?;
+    validate_skill_name(&name)?;
+
+    let version = required(raw.version, &manifest_path, "version")?;
+    let version = version
+        .parse::<Version>()
+        .map_err(|source| SkillError::InvalidVersion {
+            version: version.clone(),
+            source,
+        })?;
+
+    let entry = required(raw.entry, &manifest_path, "entry")?;
+    let entry = normalize_bundle_path(Path::new(&entry))?;
+    ensure_declared_file(root, &entry)?;
+
+    let files = raw.files.ok_or_else(|| SkillError::MissingManifestField {
+        path: manifest_path.clone(),
+        field: "files",
+    })?;
+    let declared_files = expand_declared_files(root, files)?;
+    if !declared_files.contains(&entry) {
+        return Err(SkillError::MissingDeclaredFile { path: entry });
+    }
+
+    Ok(SkillManifest {
+        name,
+        version,
+        description: raw.description,
+        entry,
+        declared_files,
+        self_test_command: raw.self_test.and_then(|self_test| self_test.command),
+        signature_ed25519: raw.signatures.and_then(|signatures| signatures.ed25519),
+        extra: raw.extra,
+    })
+}
+
+pub fn validate_skill_name(name: &str) -> Result<(), SkillError> {
+    if name.is_empty()
+        || name.starts_with('.')
+        || !name.bytes().all(|byte| {
+            byte.is_ascii_lowercase() || byte.is_ascii_digit() || matches!(byte, b'-' | b'_' | b'.')
+        })
+    {
+        return Err(SkillError::InvalidSkillName {
+            name: name.to_owned(),
+        });
+    }
+
+    Ok(())
+}
+
+pub(crate) fn normalize_bundle_path(path: &Path) -> Result<PathBuf, SkillError> {
+    if path.as_os_str().is_empty() || path.to_string_lossy().contains('\\') {
+        return Err(SkillError::UnsafeBundlePath {
+            path: path.to_path_buf(),
+        });
+    }
+
+    let mut normalized = PathBuf::new();
+    for component in path.components() {
+        match component {
+            Component::Normal(part) => normalized.push(part),
+            Component::CurDir => {}
+            Component::ParentDir | Component::RootDir | Component::Prefix(_) => {
+                return Err(SkillError::UnsafeBundlePath {
+                    path: path.to_path_buf(),
+                });
+            }
+        }
+    }
+
+    if normalized.as_os_str().is_empty() {
+        return Err(SkillError::UnsafeBundlePath {
+            path: path.to_path_buf(),
+        });
+    }
+
+    Ok(normalized)
+}
+
+fn required(
+    value: Option<String>,
+    manifest_path: &Path,
+    field: &'static str,
+) -> Result<String, SkillError> {
+    value.ok_or_else(|| SkillError::MissingManifestField {
+        path: manifest_path.to_path_buf(),
+        field,
+    })
+}
+
+fn read_manifest_file(path: &Path) -> Result<String, SkillError> {
+    let metadata = fs::symlink_metadata(path).map_err(|source| SkillError::Io {
+        path: path.to_path_buf(),
+        source,
+    })?;
+    if !metadata.file_type().is_file() {
+        return Err(SkillError::UnsafeBundlePath {
+            path: path.to_path_buf(),
+        });
+    }
+
+    read_manifest_file_no_follow(path)
+}
+
+#[cfg(unix)]
+fn read_manifest_file_no_follow(path: &Path) -> Result<String, SkillError> {
+    use std::{fs::OpenOptions, io::Read, os::unix::fs::OpenOptionsExt};
+
+    let mut file = OpenOptions::new()
+        .read(true)
+        .custom_flags(libc::O_NOFOLLOW)
+        .open(path)
+        .map_err(|source| SkillError::Io {
+            path: path.to_path_buf(),
+            source,
+        })?;
+    let metadata = file.metadata().map_err(|source| SkillError::Io {
+        path: path.to_path_buf(),
+        source,
+    })?;
+    if !metadata.file_type().is_file() {
+        return Err(SkillError::UnsafeBundlePath {
+            path: path.to_path_buf(),
+        });
+    }
+
+    let mut content = String::new();
+    file.read_to_string(&mut content)
+        .map_err(|source| SkillError::Io {
+            path: path.to_path_buf(),
+            source,
+        })?;
+    Ok(content)
+}
+
+#[cfg(not(unix))]
+fn read_manifest_file_no_follow(path: &Path) -> Result<String, SkillError> {
+    fs::read_to_string(path).map_err(|source| SkillError::Io {
+        path: path.to_path_buf(),
+        source,
+    })
+}
+
+fn expand_declared_files(root: &Path, patterns: Vec<String>) -> Result<Vec<PathBuf>, SkillError> {
+    let mut files = BTreeSet::new();
+
+    for pattern in patterns {
+        if let Some(directory) = pattern.strip_suffix("/**") {
+            let directory = normalize_bundle_path(Path::new(directory))?;
+            let matched = collect_declared_files(root, &directory, &mut files)?;
+            if matched == 0 {
+                return Err(SkillError::EmptyFilePattern { pattern });
+            }
+        } else {
+            let file = normalize_bundle_path(Path::new(&pattern))?;
+            ensure_declared_file(root, &file)?;
+            files.insert(file);
+        }
+    }
+
+    Ok(files.into_iter().collect())
+}
+
+fn collect_declared_files(
+    root: &Path,
+    directory: &Path,
+    files: &mut BTreeSet<PathBuf>,
+) -> Result<usize, SkillError> {
+    validated_bundle_directory(root, directory)?;
+    collect_declared_files_inner(root, directory, files)
+}
+
+fn collect_declared_files_inner(
+    root: &Path,
+    directory: &Path,
+    files: &mut BTreeSet<PathBuf>,
+) -> Result<usize, SkillError> {
+    let absolute_directory = root.join(directory);
+    let entries = fs::read_dir(&absolute_directory).map_err(|source| SkillError::Io {
+        path: absolute_directory.clone(),
+        source,
+    })?;
+    let mut matched = 0;
+
+    for entry in entries {
+        let entry = entry.map_err(|source| SkillError::Io {
+            path: absolute_directory.clone(),
+            source,
+        })?;
+        let file_name = entry.file_name();
+        let relative_path = normalize_bundle_path(&directory.join(file_name))?;
+        let absolute_path = root.join(&relative_path);
+        let metadata = fs::symlink_metadata(&absolute_path)
+            .map_err(|source| missing_or_io_error(source, &absolute_path, &relative_path))?;
+        let file_type = metadata.file_type();
+
+        if file_type.is_dir() {
+            matched += collect_declared_files_inner(root, &relative_path, files)?;
+        } else if file_type.is_file() {
+            files.insert(relative_path);
+            matched += 1;
+        } else {
+            return Err(SkillError::MissingDeclaredFile {
+                path: relative_path,
+            });
+        }
+    }
+
+    Ok(matched)
+}
+
+fn ensure_declared_file(root: &Path, relative_path: &Path) -> Result<(), SkillError> {
+    validated_bundle_file(root, relative_path).map(|_| ())
+}
+
+pub(crate) fn validated_bundle_file(
+    root: &Path,
+    relative_path: &Path,
+) -> Result<PathBuf, SkillError> {
+    validate_bundle_path_kind(root, relative_path, BundlePathKind::File)
+}
+
+fn validated_bundle_directory(root: &Path, relative_path: &Path) -> Result<PathBuf, SkillError> {
+    validate_bundle_path_kind(root, relative_path, BundlePathKind::Directory)
+}
+
+#[derive(Debug, Clone, Copy)]
+enum BundlePathKind {
+    File,
+    Directory,
+}
+
+fn validate_bundle_path_kind(
+    root: &Path,
+    relative_path: &Path,
+    expected: BundlePathKind,
+) -> Result<PathBuf, SkillError> {
+    let relative_path = normalize_bundle_path(relative_path)?;
+    let mut absolute_path = root.to_path_buf();
+    let mut components = relative_path.components().peekable();
+
+    while let Some(component) = components.next() {
+        let Component::Normal(part) = component else {
+            return Err(SkillError::UnsafeBundlePath {
+                path: relative_path.clone(),
+            });
+        };
+        absolute_path.push(part);
+        let metadata = fs::symlink_metadata(&absolute_path)
+            .map_err(|source| missing_or_io_error(source, &absolute_path, &relative_path))?;
+        let file_type = metadata.file_type();
+
+        if components.peek().is_some() {
+            if !file_type.is_dir() {
+                return Err(SkillError::MissingDeclaredFile {
+                    path: relative_path.clone(),
+                });
+            }
+            continue;
+        }
+
+        let matches_expected = match expected {
+            BundlePathKind::File => file_type.is_file(),
+            BundlePathKind::Directory => file_type.is_dir(),
+        };
+        if matches_expected {
+            return Ok(absolute_path);
+        }
+
+        return Err(SkillError::MissingDeclaredFile {
+            path: relative_path.clone(),
+        });
+    }
+
+    Err(SkillError::UnsafeBundlePath {
+        path: relative_path,
+    })
+}
+
+fn missing_or_io_error(
+    source: std::io::Error,
+    absolute_path: &Path,
+    relative_path: &Path,
+) -> SkillError {
+    if source.kind() == std::io::ErrorKind::NotFound {
+        SkillError::MissingDeclaredFile {
+            path: relative_path.to_path_buf(),
+        }
+    } else {
+        SkillError::Io {
+            path: absolute_path.to_path_buf(),
+            source,
+        }
+    }
+}

--- a/crates/agentenv-core/src/skills/manifest.rs
+++ b/crates/agentenv-core/src/skills/manifest.rs
@@ -54,16 +54,34 @@ pub fn load_skill_manifest(root: impl AsRef<Path>) -> Result<SkillManifest, Skil
     let root = root.as_ref();
     let manifest_path = root.join(MANIFEST_FILE);
     let content = read_manifest_file(&manifest_path)?;
-    let raw: RawSkillManifest =
-        serde_yaml::from_str(&content).map_err(|source| SkillError::Yaml {
-            path: manifest_path.clone(),
-            source,
-        })?;
+    let raw = parse_raw_manifest(&content, &manifest_path)?;
+    manifest_from_raw(raw, &manifest_path, Some(root))
+}
 
-    let name = required(raw.name, &manifest_path, "name")?;
+pub(crate) fn load_remote_skill_manifest(
+    content: &str,
+    manifest_path: &Path,
+) -> Result<SkillManifest, SkillError> {
+    let raw = parse_raw_manifest(content, manifest_path)?;
+    manifest_from_raw(raw, manifest_path, None)
+}
+
+fn parse_raw_manifest(content: &str, manifest_path: &Path) -> Result<RawSkillManifest, SkillError> {
+    serde_yaml::from_str(content).map_err(|source| SkillError::Yaml {
+        path: manifest_path.to_path_buf(),
+        source,
+    })
+}
+
+fn manifest_from_raw(
+    raw: RawSkillManifest,
+    manifest_path: &Path,
+    root: Option<&Path>,
+) -> Result<SkillManifest, SkillError> {
+    let name = required(raw.name, manifest_path, "name")?;
     validate_skill_name(&name)?;
 
-    let version = required(raw.version, &manifest_path, "version")?;
+    let version = required(raw.version, manifest_path, "version")?;
     let version = version
         .parse::<Version>()
         .map_err(|source| SkillError::InvalidVersion {
@@ -71,15 +89,20 @@ pub fn load_skill_manifest(root: impl AsRef<Path>) -> Result<SkillManifest, Skil
             source,
         })?;
 
-    let entry = required(raw.entry, &manifest_path, "entry")?;
+    let entry = required(raw.entry, manifest_path, "entry")?;
     let entry = normalize_bundle_path(Path::new(&entry))?;
-    ensure_declared_file(root, &entry)?;
+    if let Some(root) = root {
+        ensure_declared_file(root, &entry)?;
+    }
 
     let files = raw.files.ok_or_else(|| SkillError::MissingManifestField {
-        path: manifest_path.clone(),
+        path: manifest_path.to_path_buf(),
         field: "files",
     })?;
-    let declared_files = expand_declared_files(root, files)?;
+    let declared_files = match root {
+        Some(root) => expand_declared_files(root, files)?,
+        None => normalize_explicit_declared_files(files)?,
+    };
     if !declared_files.contains(&entry) {
         return Err(SkillError::MissingDeclaredFile { path: entry });
     }
@@ -227,6 +250,21 @@ fn expand_declared_files(root: &Path, patterns: Vec<String>) -> Result<Vec<PathB
         }
     }
 
+    Ok(files.into_iter().collect())
+}
+
+fn normalize_explicit_declared_files(patterns: Vec<String>) -> Result<Vec<PathBuf>, SkillError> {
+    let mut files = BTreeSet::new();
+    for pattern in patterns {
+        if pattern.ends_with("/**") {
+            return Err(SkillError::InvalidConfig {
+                message: format!(
+                    "HTTP registry fetch requires explicit file entries; recursive pattern `{pattern}` is not fetchable"
+                ),
+            });
+        }
+        files.insert(normalize_bundle_path(Path::new(&pattern))?);
+    }
     Ok(files.into_iter().collect())
 }
 

--- a/crates/agentenv-core/src/skills/manifest.rs
+++ b/crates/agentenv-core/src/skills/manifest.rs
@@ -21,6 +21,7 @@ pub struct SkillManifest {
     pub declared_files: Vec<PathBuf>,
     pub self_test_command: Option<String>,
     pub signature_ed25519: Option<String>,
+    pub signature_public_key_ed25519: Option<String>,
     pub extra: BTreeMap<String, Value>,
 }
 
@@ -45,6 +46,8 @@ struct RawSelfTest {
 #[derive(Debug, Deserialize)]
 struct RawSignatures {
     ed25519: Option<String>,
+    public_key: Option<String>,
+    public_key_ed25519: Option<String>,
 }
 
 pub fn load_skill_manifest(root: impl AsRef<Path>) -> Result<SkillManifest, SkillError> {
@@ -88,7 +91,13 @@ pub fn load_skill_manifest(root: impl AsRef<Path>) -> Result<SkillManifest, Skil
         entry,
         declared_files,
         self_test_command: raw.self_test.and_then(|self_test| self_test.command),
-        signature_ed25519: raw.signatures.and_then(|signatures| signatures.ed25519),
+        signature_ed25519: raw
+            .signatures
+            .as_ref()
+            .and_then(|signatures| signatures.ed25519.clone()),
+        signature_public_key_ed25519: raw
+            .signatures
+            .and_then(|signatures| signatures.public_key_ed25519.or(signatures.public_key)),
         extra: raw.extra,
     })
 }

--- a/crates/agentenv-core/src/skills/mod.rs
+++ b/crates/agentenv-core/src/skills/mod.rs
@@ -6,6 +6,7 @@ mod manifest;
 mod registry;
 mod registry_filesystem;
 mod registry_http;
+mod registry_oci;
 mod service;
 mod signature;
 mod store;

--- a/crates/agentenv-core/src/skills/mod.rs
+++ b/crates/agentenv-core/src/skills/mod.rs
@@ -1,0 +1,7 @@
+mod digest;
+mod error;
+mod manifest;
+
+pub use digest::compute_bundle_digest;
+pub use error::SkillError;
+pub use manifest::{load_skill_manifest, validate_skill_name, SkillManifest};

--- a/crates/agentenv-core/src/skills/mod.rs
+++ b/crates/agentenv-core/src/skills/mod.rs
@@ -4,6 +4,8 @@ mod error;
 mod index;
 mod manifest;
 mod registry;
+mod registry_filesystem;
+mod service;
 mod signature;
 mod store;
 
@@ -14,7 +16,8 @@ pub use config::{
 pub use digest::compute_bundle_digest;
 pub use error::SkillError;
 pub use manifest::{load_skill_manifest, validate_skill_name, SkillManifest};
-pub use registry::{RegistryConfig, RegistryKind};
+pub use registry::{FetchedSkill, RegistryAdapter, RegistryConfig, RegistryKind, SkillSearchHit};
+pub use service::{SkillAddRequest, SkillPublishRequest, SkillService};
 pub use signature::{signature_payload, verify_ed25519_signature};
 pub use store::{
     info_installed_skill, install_local_skill, list_installed_skills, remove_installed_skill,

--- a/crates/agentenv-core/src/skills/mod.rs
+++ b/crates/agentenv-core/src/skills/mod.rs
@@ -1,13 +1,20 @@
+mod config;
 mod digest;
 mod error;
 mod index;
 mod manifest;
+mod registry;
 mod signature;
 mod store;
 
+pub use config::{
+    load_project_skills_config, load_user_skills_config, merge_skills_config, SkillsConfig,
+    SkillsConfigOverride,
+};
 pub use digest::compute_bundle_digest;
 pub use error::SkillError;
 pub use manifest::{load_skill_manifest, validate_skill_name, SkillManifest};
+pub use registry::{RegistryConfig, RegistryKind};
 pub use signature::{signature_payload, verify_ed25519_signature};
 pub use store::{
     info_installed_skill, install_local_skill, list_installed_skills, remove_installed_skill,

--- a/crates/agentenv-core/src/skills/mod.rs
+++ b/crates/agentenv-core/src/skills/mod.rs
@@ -5,6 +5,7 @@ mod index;
 mod manifest;
 mod registry;
 mod registry_filesystem;
+mod registry_http;
 mod service;
 mod signature;
 mod store;
@@ -17,7 +18,7 @@ pub use digest::compute_bundle_digest;
 pub use error::SkillError;
 pub use manifest::{load_skill_manifest, validate_skill_name, SkillManifest};
 pub use registry::{FetchedSkill, RegistryAdapter, RegistryConfig, RegistryKind, SkillSearchHit};
-pub use service::{SkillAddRequest, SkillPublishRequest, SkillService};
+pub use service::{SkillAddRequest, SkillCredentialResolver, SkillPublishRequest, SkillService};
 pub use signature::{signature_payload, verify_ed25519_signature};
 pub use store::{
     info_installed_skill, install_local_skill, list_installed_skills, remove_installed_skill,

--- a/crates/agentenv-core/src/skills/mod.rs
+++ b/crates/agentenv-core/src/skills/mod.rs
@@ -1,7 +1,15 @@
 mod digest;
 mod error;
+mod index;
 mod manifest;
+mod signature;
+mod store;
 
 pub use digest::compute_bundle_digest;
 pub use error::SkillError;
 pub use manifest::{load_skill_manifest, validate_skill_name, SkillManifest};
+pub use signature::{signature_payload, verify_ed25519_signature};
+pub use store::{
+    info_installed_skill, install_local_skill, list_installed_skills, remove_installed_skill,
+    verify_installed_skill, InstalledSkill, InstalledSkillSelector, SkillInstallOptions,
+};

--- a/crates/agentenv-core/src/skills/registry.rs
+++ b/crates/agentenv-core/src/skills/registry.rs
@@ -1,4 +1,6 @@
-use std::path::PathBuf;
+use std::path::{Path, PathBuf};
+
+use super::SkillError;
 
 #[derive(Debug, Clone, serde::Serialize, serde::Deserialize, PartialEq, Eq)]
 pub struct RegistryConfig {
@@ -55,4 +57,35 @@ pub enum RegistryKind {
     Filesystem,
     Http,
     Oci,
+}
+
+#[derive(Debug, Clone, serde::Serialize, serde::Deserialize, PartialEq, Eq)]
+pub struct SkillSearchHit {
+    pub name: String,
+    pub version: String,
+    pub description: Option<String>,
+    pub registry: String,
+    pub digest: Option<String>,
+    pub signature_ed25519: Option<String>,
+    pub public_key_ed25519: Option<String>,
+}
+
+#[derive(Debug, Clone)]
+pub struct FetchedSkill {
+    pub staging_path: PathBuf,
+    pub registry: String,
+    pub source_type: String,
+    pub name: String,
+    pub version: String,
+}
+
+#[async_trait::async_trait]
+pub trait RegistryAdapter {
+    async fn search(&self, query: &str) -> Result<Vec<SkillSearchHit>, SkillError>;
+    async fn fetch(&self, name: &str, version: Option<&str>) -> Result<FetchedSkill, SkillError>;
+    async fn publish(
+        &self,
+        bundle_path: &Path,
+        allow_unsigned: bool,
+    ) -> Result<SkillSearchHit, SkillError>;
 }

--- a/crates/agentenv-core/src/skills/registry.rs
+++ b/crates/agentenv-core/src/skills/registry.rs
@@ -1,0 +1,58 @@
+use std::path::PathBuf;
+
+#[derive(Debug, Clone, serde::Serialize, serde::Deserialize, PartialEq, Eq)]
+pub struct RegistryConfig {
+    pub name: String,
+    #[serde(rename = "type")]
+    pub kind: RegistryKind,
+    #[serde(default)]
+    pub url: Option<String>,
+    #[serde(default)]
+    pub path: Option<PathBuf>,
+    #[serde(default)]
+    pub auth: Option<String>,
+}
+
+impl RegistryConfig {
+    pub fn filesystem(name: impl Into<String>, path: impl Into<PathBuf>) -> Self {
+        Self {
+            name: name.into(),
+            kind: RegistryKind::Filesystem,
+            url: None,
+            path: Some(path.into()),
+            auth: None,
+        }
+    }
+
+    pub fn http(name: impl Into<String>, url: impl Into<String>, auth: Option<String>) -> Self {
+        Self {
+            name: name.into(),
+            kind: RegistryKind::Http,
+            url: Some(url.into()),
+            path: None,
+            auth,
+        }
+    }
+
+    pub fn oci(
+        name: impl Into<String>,
+        reference: impl Into<String>,
+        auth: Option<String>,
+    ) -> Self {
+        Self {
+            name: name.into(),
+            kind: RegistryKind::Oci,
+            url: Some(reference.into()),
+            path: None,
+            auth,
+        }
+    }
+}
+
+#[derive(Debug, Clone, Copy, serde::Serialize, serde::Deserialize, PartialEq, Eq)]
+#[serde(rename_all = "kebab-case")]
+pub enum RegistryKind {
+    Filesystem,
+    Http,
+    Oci,
+}

--- a/crates/agentenv-core/src/skills/registry_filesystem.rs
+++ b/crates/agentenv-core/src/skills/registry_filesystem.rs
@@ -1,0 +1,637 @@
+use std::{
+    cmp::Ordering,
+    fs,
+    path::{Path, PathBuf},
+};
+
+use semver::Version;
+use serde::{Deserialize, Serialize};
+
+use super::{
+    compute_bundle_digest, manifest::validated_bundle_file, validate_skill_name,
+    verify_ed25519_signature, FetchedSkill, RegistryAdapter, SkillError, SkillManifest,
+    SkillSearchHit,
+};
+
+const BUNDLES_DIR: &str = "bundles";
+const INDEX_FILE: &str = "index.yaml";
+const MANIFEST_FILE: &str = "skill.yaml";
+const SOURCE_TYPE: &str = "filesystem";
+
+#[derive(Debug, Clone)]
+pub(crate) struct FilesystemRegistryAdapter {
+    name: String,
+    root: PathBuf,
+}
+
+#[derive(Debug, Default, Serialize, Deserialize)]
+struct FilesystemRegistryIndex {
+    #[serde(default)]
+    skills: Vec<SkillSearchHit>,
+}
+
+impl FilesystemRegistryAdapter {
+    pub(crate) fn new(name: impl Into<String>, root: impl Into<PathBuf>) -> Self {
+        Self {
+            name: name.into(),
+            root: root.into(),
+        }
+    }
+
+    fn index_path(&self) -> PathBuf {
+        self.root.join(INDEX_FILE)
+    }
+
+    fn read_index(&self) -> Result<FilesystemRegistryIndex, SkillError> {
+        let path = self.index_path();
+        match fs::symlink_metadata(&path) {
+            Ok(metadata) if metadata.file_type().is_file() => {}
+            Ok(_) => return Err(SkillError::UnsafeBundlePath { path }),
+            Err(source) if source.kind() == std::io::ErrorKind::NotFound => {
+                return Ok(FilesystemRegistryIndex::default());
+            }
+            Err(source) => {
+                return Err(SkillError::Io { path, source });
+            }
+        }
+
+        let content = read_regular_string(&path)?;
+        let mut index: FilesystemRegistryIndex =
+            serde_yaml::from_str(&content).map_err(|source| SkillError::Yaml { path, source })?;
+        for hit in &mut index.skills {
+            self.validate_hit(hit)?;
+        }
+        Ok(index)
+    }
+
+    fn validate_hit(&self, hit: &mut SkillSearchHit) -> Result<(), SkillError> {
+        validate_skill_name(&hit.name)?;
+        hit.version
+            .parse::<Version>()
+            .map_err(|source| SkillError::InvalidVersion {
+                version: hit.version.clone(),
+                source,
+            })?;
+        hit.registry = self.name.clone();
+        Ok(())
+    }
+
+    fn write_index(&self, mut index: FilesystemRegistryIndex) -> Result<(), SkillError> {
+        sort_hits(&mut index.skills);
+        write_yaml_atomic(&self.index_path(), &index)
+    }
+
+    fn upsert_hit(&self, hit: SkillSearchHit) -> Result<(), SkillError> {
+        let mut index = self.read_index()?;
+        index
+            .skills
+            .retain(|existing| existing.name != hit.name || existing.version != hit.version);
+        index.skills.push(hit);
+        self.write_index(index)
+    }
+
+    fn hit_for_manifest(&self, manifest: &SkillManifest, digest: String) -> SkillSearchHit {
+        SkillSearchHit {
+            name: manifest.name.clone(),
+            version: manifest.version.to_string(),
+            description: manifest.description.clone(),
+            registry: self.name.clone(),
+            digest: Some(digest),
+            signature_ed25519: manifest.signature_ed25519.clone(),
+            public_key_ed25519: manifest.signature_public_key_ed25519.clone(),
+        }
+    }
+
+    fn existing_bundle_digest(
+        &self,
+        name: &str,
+        version: &str,
+    ) -> Result<Option<String>, SkillError> {
+        let Some(path) = existing_child_directory(&self.root, &[BUNDLES_DIR, name, version])?
+        else {
+            return Ok(None);
+        };
+
+        let manifest = super::load_skill_manifest(&path)?;
+        if manifest.name != name || manifest.version.to_string() != version {
+            return Err(SkillError::UnsafeBundlePath {
+                path: path.join(MANIFEST_FILE),
+            });
+        }
+        compute_bundle_digest(path, &manifest).map(Some)
+    }
+
+    fn resolved_hit(
+        &self,
+        name: &str,
+        version: Option<&str>,
+    ) -> Result<SkillSearchHit, SkillError> {
+        validate_skill_name(name)?;
+        if let Some(version) = version {
+            version
+                .parse::<Version>()
+                .map_err(|source| SkillError::InvalidVersion {
+                    version: version.to_owned(),
+                    source,
+                })?;
+        }
+
+        let index = self.read_index()?;
+        let matches = index
+            .skills
+            .into_iter()
+            .filter(|hit| hit.name == name)
+            .collect::<Vec<_>>();
+
+        if let Some(version) = version {
+            return matches
+                .into_iter()
+                .find(|hit| hit.version == version)
+                .ok_or_else(|| SkillError::SkillNotInstalled {
+                    name: name.to_owned(),
+                });
+        }
+
+        matches
+            .into_iter()
+            .max_by(|left, right| compare_versions(&left.version, &right.version))
+            .ok_or_else(|| SkillError::SkillNotInstalled {
+                name: name.to_owned(),
+            })
+    }
+}
+
+#[async_trait::async_trait]
+impl RegistryAdapter for FilesystemRegistryAdapter {
+    async fn search(&self, query: &str) -> Result<Vec<SkillSearchHit>, SkillError> {
+        ensure_directory(&self.root)?;
+        let query = query.to_ascii_lowercase();
+        let index = self.read_index()?;
+        let mut hits = index
+            .skills
+            .into_iter()
+            .filter_map(|mut hit| {
+                let searchable_description = hit.description.as_deref().unwrap_or_default();
+                let matches = query.is_empty()
+                    || hit.name.to_ascii_lowercase().contains(&query)
+                    || searchable_description.to_ascii_lowercase().contains(&query);
+                if matches {
+                    hit.registry = self.name.clone();
+                    Some(hit)
+                } else {
+                    None
+                }
+            })
+            .collect::<Vec<_>>();
+        sort_hits(&mut hits);
+        Ok(hits)
+    }
+
+    async fn fetch(&self, name: &str, version: Option<&str>) -> Result<FetchedSkill, SkillError> {
+        ensure_directory(&self.root)?;
+        let hit = self.resolved_hit(name, version)?;
+        let bundle_path =
+            existing_child_directory(&self.root, &[BUNDLES_DIR, &hit.name, &hit.version])?
+                .ok_or_else(|| SkillError::SkillNotInstalled {
+                    name: hit.name.clone(),
+                })?;
+        let manifest = super::load_skill_manifest(&bundle_path)?;
+        if manifest.name != hit.name || manifest.version.to_string() != hit.version {
+            return Err(SkillError::UnsafeBundlePath {
+                path: bundle_path.join(MANIFEST_FILE),
+            });
+        }
+        let digest = compute_bundle_digest(&bundle_path, &manifest)?;
+        if let Some(expected) = hit.digest.as_deref() {
+            if expected != digest {
+                return Err(SkillError::DigestMismatch {
+                    expected: expected.to_owned(),
+                    actual: digest,
+                });
+            }
+        }
+
+        let staging_path = staging_fetch_path(&hit.name, &hit.version);
+        remove_directory_if_exists(&staging_path)?;
+        copy_bundle_contents(&bundle_path, &staging_path, &manifest)?;
+
+        Ok(FetchedSkill {
+            staging_path,
+            registry: self.name.clone(),
+            source_type: SOURCE_TYPE.to_owned(),
+            name: manifest.name,
+            version: manifest.version.to_string(),
+        })
+    }
+
+    async fn publish(
+        &self,
+        bundle_path: &Path,
+        allow_unsigned: bool,
+    ) -> Result<SkillSearchHit, SkillError> {
+        ensure_directory(&self.root)?;
+        ensure_directory(&self.root.join(BUNDLES_DIR))?;
+        let manifest = super::load_skill_manifest(bundle_path)?;
+        let digest = compute_bundle_digest(bundle_path, &manifest)?;
+        verify_publish_signature(&manifest, &digest, allow_unsigned)?;
+        let version = manifest.version.to_string();
+        let hit = self.hit_for_manifest(&manifest, digest.clone());
+
+        if let Some(existing_digest) = self.existing_bundle_digest(&manifest.name, &version)? {
+            if existing_digest != digest {
+                return Err(SkillError::AlreadyInstalledDifferentDigest {
+                    name: manifest.name,
+                    version,
+                    existing: existing_digest,
+                });
+            }
+            self.upsert_hit(hit.clone())?;
+            return Ok(hit);
+        }
+
+        let bundle_parent = ensure_child_directory(&self.root, &[BUNDLES_DIR, &manifest.name])?;
+        let destination = bundle_parent.join(&version);
+        let staging = staging_publish_path(&bundle_parent, &version)?;
+        remove_directory_if_exists(&staging)?;
+        copy_bundle_contents(bundle_path, &staging, &manifest)?;
+        rename_directory(&staging, &destination)?;
+        self.upsert_hit(hit.clone())?;
+        Ok(hit)
+    }
+}
+
+fn verify_publish_signature(
+    manifest: &SkillManifest,
+    digest: &str,
+    allow_unsigned: bool,
+) -> Result<(), SkillError> {
+    if allow_unsigned {
+        return Ok(());
+    }
+
+    let signature =
+        manifest
+            .signature_ed25519
+            .as_deref()
+            .ok_or_else(|| SkillError::MissingSignature {
+                name: manifest.name.clone(),
+                version: manifest.version.to_string(),
+            })?;
+    let public_key = manifest
+        .signature_public_key_ed25519
+        .as_deref()
+        .ok_or_else(|| SkillError::MissingSignature {
+            name: manifest.name.clone(),
+            version: manifest.version.to_string(),
+        })?;
+
+    verify_ed25519_signature(manifest, digest, signature, public_key)
+}
+
+fn copy_bundle_contents(
+    source_root: &Path,
+    destination_root: &Path,
+    manifest: &SkillManifest,
+) -> Result<(), SkillError> {
+    ensure_directory(destination_root)?;
+    copy_regular_file(
+        &source_root.join(MANIFEST_FILE),
+        &destination_root.join(MANIFEST_FILE),
+    )?;
+    for declared_file in &manifest.declared_files {
+        let source = validated_bundle_file(source_root, declared_file)?;
+        copy_regular_file(&source, &destination_root.join(declared_file))?;
+    }
+    Ok(())
+}
+
+fn ensure_directory(path: &Path) -> Result<(), SkillError> {
+    match fs::symlink_metadata(path) {
+        Ok(metadata) if metadata.file_type().is_dir() => Ok(()),
+        Ok(_) => Err(SkillError::UnsafeBundlePath {
+            path: path.to_path_buf(),
+        }),
+        Err(source) if source.kind() == std::io::ErrorKind::NotFound => {
+            fs::create_dir_all(path).map_err(|source| SkillError::Io {
+                path: path.to_path_buf(),
+                source,
+            })?;
+            ensure_existing_directory(path)
+        }
+        Err(source) => Err(SkillError::Io {
+            path: path.to_path_buf(),
+            source,
+        }),
+    }
+}
+
+fn ensure_existing_directory(path: &Path) -> Result<(), SkillError> {
+    let metadata = fs::symlink_metadata(path).map_err(|source| SkillError::Io {
+        path: path.to_path_buf(),
+        source,
+    })?;
+    if metadata.file_type().is_dir() {
+        Ok(())
+    } else {
+        Err(SkillError::UnsafeBundlePath {
+            path: path.to_path_buf(),
+        })
+    }
+}
+
+fn existing_child_directory(
+    root: &Path,
+    components: &[&str],
+) -> Result<Option<PathBuf>, SkillError> {
+    ensure_existing_directory(root)?;
+    let mut path = root.to_path_buf();
+    for component in components {
+        path.push(component);
+        match fs::symlink_metadata(&path) {
+            Ok(metadata) if metadata.file_type().is_dir() => {}
+            Ok(_) => return Err(SkillError::UnsafeBundlePath { path }),
+            Err(source) if source.kind() == std::io::ErrorKind::NotFound => return Ok(None),
+            Err(source) => return Err(SkillError::Io { path, source }),
+        }
+    }
+    Ok(Some(path))
+}
+
+fn ensure_child_directory(root: &Path, components: &[&str]) -> Result<PathBuf, SkillError> {
+    ensure_existing_directory(root)?;
+    let mut path = root.to_path_buf();
+    for component in components {
+        path.push(component);
+        match fs::symlink_metadata(&path) {
+            Ok(metadata) if metadata.file_type().is_dir() => {}
+            Ok(_) => return Err(SkillError::UnsafeBundlePath { path }),
+            Err(source) if source.kind() == std::io::ErrorKind::NotFound => {
+                fs::create_dir(&path).map_err(|source| SkillError::Io {
+                    path: path.clone(),
+                    source,
+                })?;
+                ensure_existing_directory(&path)?;
+            }
+            Err(source) => return Err(SkillError::Io { path, source }),
+        }
+    }
+    Ok(path)
+}
+
+fn remove_directory_if_exists(path: &Path) -> Result<(), SkillError> {
+    match fs::symlink_metadata(path) {
+        Ok(metadata) if metadata.file_type().is_dir() => {
+            fs::remove_dir_all(path).map_err(|source| SkillError::Io {
+                path: path.to_path_buf(),
+                source,
+            })
+        }
+        Ok(_) => Err(SkillError::UnsafeBundlePath {
+            path: path.to_path_buf(),
+        }),
+        Err(source) if source.kind() == std::io::ErrorKind::NotFound => Ok(()),
+        Err(source) => Err(SkillError::Io {
+            path: path.to_path_buf(),
+            source,
+        }),
+    }
+}
+
+fn rename_directory(from: &Path, to: &Path) -> Result<(), SkillError> {
+    if let Ok(metadata) = fs::symlink_metadata(to) {
+        if !metadata.file_type().is_dir() {
+            return Err(SkillError::UnsafeBundlePath {
+                path: to.to_path_buf(),
+            });
+        }
+    }
+    fs::rename(from, to).map_err(|source| SkillError::Io {
+        path: to.to_path_buf(),
+        source,
+    })
+}
+
+fn copy_regular_file(source: &Path, destination: &Path) -> Result<(), SkillError> {
+    if let Some(parent) = destination.parent() {
+        ensure_directory(parent)?;
+    }
+    let mut source_file = open_regular_file(source)?;
+    let mut destination_file = fs::File::create(destination).map_err(|source| SkillError::Io {
+        path: destination.to_path_buf(),
+        source,
+    })?;
+    std::io::copy(&mut source_file, &mut destination_file).map_err(|source| SkillError::Io {
+        path: destination.to_path_buf(),
+        source,
+    })?;
+    Ok(())
+}
+
+#[cfg(unix)]
+fn open_regular_file(path: &Path) -> Result<fs::File, SkillError> {
+    use std::{fs::OpenOptions, os::unix::fs::OpenOptionsExt};
+
+    let file = OpenOptions::new()
+        .read(true)
+        .custom_flags(libc::O_NOFOLLOW)
+        .open(path)
+        .map_err(|source| SkillError::Io {
+            path: path.to_path_buf(),
+            source,
+        })?;
+    ensure_opened_regular_file(path, &file)?;
+    Ok(file)
+}
+
+#[cfg(not(unix))]
+fn open_regular_file(path: &Path) -> Result<fs::File, SkillError> {
+    let file = fs::File::open(path).map_err(|source| SkillError::Io {
+        path: path.to_path_buf(),
+        source,
+    })?;
+    ensure_opened_regular_file(path, &file)?;
+    Ok(file)
+}
+
+fn ensure_opened_regular_file(path: &Path, file: &fs::File) -> Result<(), SkillError> {
+    let metadata = file.metadata().map_err(|source| SkillError::Io {
+        path: path.to_path_buf(),
+        source,
+    })?;
+    if metadata.file_type().is_file() {
+        Ok(())
+    } else {
+        Err(SkillError::UnsafeBundlePath {
+            path: path.to_path_buf(),
+        })
+    }
+}
+
+fn read_regular_string(path: &Path) -> Result<String, SkillError> {
+    let metadata = fs::symlink_metadata(path).map_err(|source| SkillError::Io {
+        path: path.to_path_buf(),
+        source,
+    })?;
+    if !metadata.file_type().is_file() {
+        return Err(SkillError::UnsafeBundlePath {
+            path: path.to_path_buf(),
+        });
+    }
+
+    read_regular_string_no_follow(path)
+}
+
+#[cfg(unix)]
+fn read_regular_string_no_follow(path: &Path) -> Result<String, SkillError> {
+    use std::{fs::OpenOptions, io::Read, os::unix::fs::OpenOptionsExt};
+
+    let mut file = OpenOptions::new()
+        .read(true)
+        .custom_flags(libc::O_NOFOLLOW)
+        .open(path)
+        .map_err(|source| SkillError::Io {
+            path: path.to_path_buf(),
+            source,
+        })?;
+    let metadata = file.metadata().map_err(|source| SkillError::Io {
+        path: path.to_path_buf(),
+        source,
+    })?;
+    if !metadata.file_type().is_file() {
+        return Err(SkillError::UnsafeBundlePath {
+            path: path.to_path_buf(),
+        });
+    }
+
+    let mut content = String::new();
+    file.read_to_string(&mut content)
+        .map_err(|source| SkillError::Io {
+            path: path.to_path_buf(),
+            source,
+        })?;
+    Ok(content)
+}
+
+#[cfg(not(unix))]
+fn read_regular_string_no_follow(path: &Path) -> Result<String, SkillError> {
+    fs::read_to_string(path).map_err(|source| SkillError::Io {
+        path: path.to_path_buf(),
+        source,
+    })
+}
+
+fn write_yaml_atomic<T>(path: &Path, value: &T) -> Result<(), SkillError>
+where
+    T: Serialize,
+{
+    let parent = path.parent().ok_or_else(|| SkillError::UnsafeBundlePath {
+        path: path.to_path_buf(),
+    })?;
+    ensure_directory(parent)?;
+
+    let yaml = serde_yaml::to_string(value).map_err(|source| SkillError::Serde {
+        path: path.to_path_buf(),
+        source,
+    })?;
+    let tmp_path = temporary_path(path);
+    fs::write(&tmp_path, yaml).map_err(|source| SkillError::Io {
+        path: tmp_path.clone(),
+        source,
+    })?;
+    replace_file(&tmp_path, path).map_err(|source| {
+        let _ = fs::remove_file(&tmp_path);
+        SkillError::Io {
+            path: path.to_path_buf(),
+            source,
+        }
+    })
+}
+
+#[cfg(windows)]
+fn replace_file(from: &Path, to: &Path) -> std::io::Result<()> {
+    use std::os::windows::ffi::OsStrExt;
+    use windows_sys::Win32::Storage::FileSystem::{
+        MoveFileExW, MOVEFILE_REPLACE_EXISTING, MOVEFILE_WRITE_THROUGH,
+    };
+
+    let from = from
+        .as_os_str()
+        .encode_wide()
+        .chain(std::iter::once(0))
+        .collect::<Vec<_>>();
+    let to = to
+        .as_os_str()
+        .encode_wide()
+        .chain(std::iter::once(0))
+        .collect::<Vec<_>>();
+
+    let replaced = unsafe {
+        MoveFileExW(
+            from.as_ptr(),
+            to.as_ptr(),
+            MOVEFILE_REPLACE_EXISTING | MOVEFILE_WRITE_THROUGH,
+        )
+    };
+    if replaced == 0 {
+        Err(std::io::Error::last_os_error())
+    } else {
+        Ok(())
+    }
+}
+
+#[cfg(not(windows))]
+fn replace_file(from: &Path, to: &Path) -> std::io::Result<()> {
+    fs::rename(from, to)
+}
+
+fn temporary_path(path: &Path) -> PathBuf {
+    let mut file_name = path
+        .file_name()
+        .map(|name| name.to_os_string())
+        .unwrap_or_default();
+    file_name.push(format!(
+        ".tmp-{}-{}",
+        std::process::id(),
+        temporary_suffix()
+    ));
+    path.with_file_name(file_name)
+}
+
+fn staging_publish_path(parent: &Path, version: &str) -> Result<PathBuf, SkillError> {
+    ensure_existing_directory(parent)?;
+    Ok(parent.join(format!(
+        ".{version}.publish-{}-{}",
+        std::process::id(),
+        temporary_suffix()
+    )))
+}
+
+fn staging_fetch_path(name: &str, version: &str) -> PathBuf {
+    std::env::temp_dir().join(format!(
+        "agentenv-skill-fetch-{name}-{version}-{}-{}",
+        std::process::id(),
+        temporary_suffix()
+    ))
+}
+
+fn temporary_suffix() -> u128 {
+    match std::time::SystemTime::now().duration_since(std::time::UNIX_EPOCH) {
+        Ok(duration) => duration.as_nanos(),
+        Err(_) => 0,
+    }
+}
+
+fn sort_hits(hits: &mut [SkillSearchHit]) {
+    hits.sort_by(|left, right| {
+        left.name
+            .cmp(&right.name)
+            .then_with(|| compare_versions(&left.version, &right.version))
+    });
+}
+
+fn compare_versions(left: &str, right: &str) -> Ordering {
+    match (left.parse::<Version>(), right.parse::<Version>()) {
+        (Ok(left), Ok(right)) => left.cmp(&right),
+        _ => left.cmp(right),
+    }
+}

--- a/crates/agentenv-core/src/skills/registry_http.rs
+++ b/crates/agentenv-core/src/skills/registry_http.rs
@@ -1,0 +1,571 @@
+use std::{
+    cmp::Ordering,
+    fs,
+    io::Read,
+    path::{Component, Path, PathBuf},
+};
+
+use reqwest::{redirect::Policy, Client, Method};
+use semver::Version;
+use serde::{Deserialize, Serialize};
+use url::Url;
+
+use crate::security::ssrf::{validate_outbound, SsrfOptions};
+
+use super::{
+    compute_bundle_digest,
+    manifest::{load_remote_skill_manifest, validated_bundle_file},
+    validate_skill_name, verify_ed25519_signature, FetchedSkill, RegistryAdapter, SkillError,
+    SkillManifest, SkillSearchHit,
+};
+
+const BUNDLES_DIR: &str = "bundles";
+const CONTENT_DIR: &str = "content";
+const INDEX_FILE: &str = "index.yaml";
+const MANIFEST_FILE: &str = "skill.yaml";
+const SOURCE_TYPE: &str = "http";
+
+#[derive(Debug, Clone)]
+pub(crate) struct HttpRegistryAdapter {
+    name: String,
+    base_url: Url,
+    bearer_token: Option<String>,
+    client: Client,
+    ssrf_options: SsrfOptions,
+}
+
+#[derive(Debug, Default, Serialize, Deserialize)]
+struct HttpRegistryIndex {
+    #[serde(default, alias = "entries")]
+    skills: Vec<SkillSearchHit>,
+}
+
+impl HttpRegistryAdapter {
+    pub(crate) fn new(
+        name: impl Into<String>,
+        base_url: impl AsRef<str>,
+        bearer_token: Option<String>,
+        ssrf_options: SsrfOptions,
+    ) -> Result<Self, SkillError> {
+        let base_url =
+            Url::parse(base_url.as_ref()).map_err(|source| SkillError::InvalidConfig {
+                message: format!("invalid HTTP registry URL: {source}"),
+            })?;
+        validate_registry_url(&base_url, &ssrf_options)?;
+        let client = Client::builder()
+            .redirect(Policy::none())
+            .no_proxy()
+            .build()
+            .map_err(|source| SkillError::HttpRegistry {
+                url: base_url.to_string(),
+                source: Box::new(source),
+            })?;
+        Ok(Self {
+            name: name.into(),
+            base_url,
+            bearer_token,
+            client,
+            ssrf_options,
+        })
+    }
+
+    fn index_url(&self) -> Result<Url, SkillError> {
+        self.url_for(&[INDEX_FILE])
+    }
+
+    fn manifest_url(&self, name: &str, version: &str) -> Result<Url, SkillError> {
+        self.url_for(&[BUNDLES_DIR, name, version, MANIFEST_FILE])
+    }
+
+    fn content_url(
+        &self,
+        name: &str,
+        version: &str,
+        relative_path: &Path,
+    ) -> Result<Url, SkillError> {
+        let mut segments = vec![BUNDLES_DIR, name, version, CONTENT_DIR];
+        let path_segments = relative_path
+            .components()
+            .map(|component| match component {
+                Component::Normal(part) => {
+                    part.to_str().ok_or_else(|| SkillError::UnsafeBundlePath {
+                        path: relative_path.to_path_buf(),
+                    })
+                }
+                _ => Err(SkillError::UnsafeBundlePath {
+                    path: relative_path.to_path_buf(),
+                }),
+            })
+            .collect::<Result<Vec<_>, _>>()?;
+        segments.extend(path_segments);
+        self.url_for(&segments)
+    }
+
+    fn url_for(&self, segments: &[&str]) -> Result<Url, SkillError> {
+        let mut url = self.base_url.clone();
+        {
+            let mut path_segments =
+                url.path_segments_mut()
+                    .map_err(|_| SkillError::InvalidConfig {
+                        message: format!(
+                            "HTTP registry `{}` cannot be used as a base URL",
+                            self.base_url
+                        ),
+                    })?;
+            path_segments.pop_if_empty();
+            for segment in segments {
+                path_segments.push(segment);
+            }
+        }
+        validate_registry_url(&url, &self.ssrf_options)?;
+        Ok(url)
+    }
+
+    async fn read_index(&self) -> Result<HttpRegistryIndex, SkillError> {
+        let url = self.index_url()?;
+        let Some(content) = self.get_optional_text(url).await? else {
+            return Ok(HttpRegistryIndex::default());
+        };
+        let mut index: HttpRegistryIndex =
+            serde_yaml::from_str(&content).map_err(|source| SkillError::Yaml {
+                path: PathBuf::from(INDEX_FILE),
+                source,
+            })?;
+        for hit in &mut index.skills {
+            self.validate_hit(hit)?;
+        }
+        Ok(index)
+    }
+
+    async fn write_index(&self, mut index: HttpRegistryIndex) -> Result<(), SkillError> {
+        sort_hits(&mut index.skills);
+        let content = serde_yaml::to_string(&index).map_err(|source| SkillError::Serde {
+            path: PathBuf::from(INDEX_FILE),
+            source,
+        })?;
+        self.put_bytes(self.index_url()?, content.into_bytes())
+            .await
+    }
+
+    fn validate_hit(&self, hit: &mut SkillSearchHit) -> Result<(), SkillError> {
+        validate_skill_name(&hit.name)?;
+        hit.version
+            .parse::<Version>()
+            .map_err(|source| SkillError::InvalidVersion {
+                version: hit.version.clone(),
+                source,
+            })?;
+        hit.registry = self.name.clone();
+        Ok(())
+    }
+
+    fn hit_for_manifest(&self, manifest: &SkillManifest, digest: String) -> SkillSearchHit {
+        SkillSearchHit {
+            name: manifest.name.clone(),
+            version: manifest.version.to_string(),
+            description: manifest.description.clone(),
+            registry: self.name.clone(),
+            digest: Some(digest),
+            signature_ed25519: manifest.signature_ed25519.clone(),
+            public_key_ed25519: manifest.signature_public_key_ed25519.clone(),
+        }
+    }
+
+    async fn resolved_hit(
+        &self,
+        name: &str,
+        version: Option<&str>,
+    ) -> Result<SkillSearchHit, SkillError> {
+        validate_skill_name(name)?;
+        if let Some(version) = version {
+            version
+                .parse::<Version>()
+                .map_err(|source| SkillError::InvalidVersion {
+                    version: version.to_owned(),
+                    source,
+                })?;
+        }
+
+        let index = self.read_index().await?;
+        let matches = index
+            .skills
+            .into_iter()
+            .filter(|hit| hit.name == name)
+            .collect::<Vec<_>>();
+
+        if let Some(version) = version {
+            return matches
+                .into_iter()
+                .find(|hit| hit.version == version)
+                .ok_or_else(|| SkillError::SkillNotInstalled {
+                    name: name.to_owned(),
+                });
+        }
+
+        matches
+            .into_iter()
+            .max_by(|left, right| compare_versions(&left.version, &right.version))
+            .ok_or_else(|| SkillError::SkillNotInstalled {
+                name: name.to_owned(),
+            })
+    }
+
+    async fn get_optional_text(&self, url: Url) -> Result<Option<String>, SkillError> {
+        let url_text = url.to_string();
+        let response = self
+            .request(Method::GET, url.clone(), None)
+            .await
+            .map_err(|source| map_request_error(url_text.clone(), source))?;
+        if response.status() == reqwest::StatusCode::NOT_FOUND {
+            return Ok(None);
+        }
+        ensure_success(&url, response.status())?;
+        response
+            .text()
+            .await
+            .map(Some)
+            .map_err(|source| SkillError::HttpRegistry {
+                url: url.to_string(),
+                source: Box::new(source),
+            })
+    }
+
+    async fn get_text(&self, url: Url) -> Result<String, SkillError> {
+        self.get_optional_text(url.clone())
+            .await?
+            .ok_or_else(|| SkillError::HttpStatus {
+                url: url.to_string(),
+                status: reqwest::StatusCode::NOT_FOUND,
+            })
+    }
+
+    async fn get_bytes(&self, url: Url) -> Result<Vec<u8>, SkillError> {
+        let response = self.request(Method::GET, url.clone(), None).await?;
+        ensure_success(&url, response.status())?;
+        response
+            .bytes()
+            .await
+            .map(|bytes| bytes.to_vec())
+            .map_err(|source| SkillError::HttpRegistry {
+                url: url.to_string(),
+                source: Box::new(source),
+            })
+    }
+
+    async fn put_bytes(&self, url: Url, body: Vec<u8>) -> Result<(), SkillError> {
+        let response = self.request(Method::PUT, url.clone(), Some(body)).await?;
+        ensure_success(&url, response.status())
+    }
+
+    async fn request(
+        &self,
+        method: Method,
+        url: Url,
+        body: Option<Vec<u8>>,
+    ) -> Result<reqwest::Response, SkillError> {
+        let mut request = self.client.request(method, url.clone());
+        if let Some(token) = self.bearer_token.as_deref() {
+            request = request.bearer_auth(token);
+        }
+        if let Some(body) = body {
+            request = request.body(body);
+        }
+        request
+            .send()
+            .await
+            .map_err(|source| SkillError::HttpRegistry {
+                url: url.to_string(),
+                source: Box::new(source),
+            })
+    }
+}
+
+#[async_trait::async_trait]
+impl RegistryAdapter for HttpRegistryAdapter {
+    async fn search(&self, query: &str) -> Result<Vec<SkillSearchHit>, SkillError> {
+        let query = query.to_ascii_lowercase();
+        let index = self.read_index().await?;
+        let mut hits = index
+            .skills
+            .into_iter()
+            .filter(|hit| {
+                let searchable_description = hit.description.as_deref().unwrap_or_default();
+                query.is_empty()
+                    || hit.name.to_ascii_lowercase().contains(&query)
+                    || searchable_description.to_ascii_lowercase().contains(&query)
+            })
+            .collect::<Vec<_>>();
+        sort_hits(&mut hits);
+        Ok(hits)
+    }
+
+    async fn fetch(&self, name: &str, version: Option<&str>) -> Result<FetchedSkill, SkillError> {
+        let hit = self.resolved_hit(name, version).await?;
+        let staging_path = staging_fetch_path(&hit.name, &hit.version);
+        remove_directory_if_exists(&staging_path)?;
+        fs::create_dir_all(&staging_path).map_err(|source| SkillError::Io {
+            path: staging_path.clone(),
+            source,
+        })?;
+
+        let manifest_url = self.manifest_url(&hit.name, &hit.version)?;
+        let manifest_content = self.get_text(manifest_url).await?;
+        let remote_manifest =
+            load_remote_skill_manifest(&manifest_content, Path::new(MANIFEST_FILE))?;
+        if remote_manifest.name != hit.name || remote_manifest.version.to_string() != hit.version {
+            return Err(SkillError::InvalidConfig {
+                message: format!(
+                    "HTTP registry index selected `{}` version `{}`, but manifest is `{}` version `{}`",
+                    hit.name, hit.version, remote_manifest.name, remote_manifest.version
+                ),
+            });
+        }
+        write_file(
+            &staging_path.join(MANIFEST_FILE),
+            manifest_content.as_bytes(),
+        )?;
+
+        for declared_file in &remote_manifest.declared_files {
+            let content = self
+                .get_bytes(self.content_url(&hit.name, &hit.version, declared_file)?)
+                .await?;
+            write_file(&staging_path.join(declared_file), &content)?;
+        }
+
+        let manifest = super::load_skill_manifest(&staging_path)?;
+        let digest = compute_bundle_digest(&staging_path, &manifest)?;
+        if let Some(expected) = hit.digest.as_deref() {
+            if expected != digest {
+                return Err(SkillError::DigestMismatch {
+                    expected: expected.to_owned(),
+                    actual: digest,
+                });
+            }
+        }
+
+        Ok(FetchedSkill {
+            staging_path,
+            registry: self.name.clone(),
+            source_type: SOURCE_TYPE.to_owned(),
+            name: manifest.name,
+            version: manifest.version.to_string(),
+        })
+    }
+
+    async fn publish(
+        &self,
+        bundle_path: &Path,
+        allow_unsigned: bool,
+    ) -> Result<SkillSearchHit, SkillError> {
+        let manifest = super::load_skill_manifest(bundle_path)?;
+        let digest = compute_bundle_digest(bundle_path, &manifest)?;
+        verify_publish_signature(&manifest, &digest, allow_unsigned)?;
+        let version = manifest.version.to_string();
+        let hit = self.hit_for_manifest(&manifest, digest.clone());
+        let mut index = self.read_index().await?;
+
+        if let Some(existing) = index
+            .skills
+            .iter()
+            .find(|hit| hit.name == manifest.name && hit.version == version)
+        {
+            if existing.digest.as_deref() != Some(digest.as_str()) {
+                return Err(SkillError::AlreadyInstalledDifferentDigest {
+                    name: manifest.name,
+                    version,
+                    existing: existing
+                        .digest
+                        .clone()
+                        .unwrap_or_else(|| "unknown".to_owned()),
+                });
+            }
+        }
+
+        let manifest_bytes = read_regular_file(&bundle_path.join(MANIFEST_FILE))?;
+        self.put_bytes(self.manifest_url(&manifest.name, &version)?, manifest_bytes)
+            .await?;
+        for declared_file in &manifest.declared_files {
+            let source = validated_bundle_file(bundle_path, declared_file)?;
+            let bytes = read_regular_file(&source)?;
+            self.put_bytes(
+                self.content_url(&manifest.name, &version, declared_file)?,
+                bytes,
+            )
+            .await?;
+        }
+
+        index
+            .skills
+            .retain(|existing| existing.name != hit.name || existing.version != hit.version);
+        index.skills.push(hit.clone());
+        self.write_index(index).await?;
+        Ok(hit)
+    }
+}
+
+fn validate_registry_url(url: &Url, options: &SsrfOptions) -> Result<(), SkillError> {
+    validate_outbound(url, options.clone())
+        .map(|_| ())
+        .map_err(|source| SkillError::RegistryUrlBlocked {
+            url: url.to_string(),
+            source: Box::new(source),
+        })
+}
+
+fn ensure_success(url: &Url, status: reqwest::StatusCode) -> Result<(), SkillError> {
+    if status.is_success() {
+        Ok(())
+    } else {
+        Err(SkillError::HttpStatus {
+            url: url.to_string(),
+            status,
+        })
+    }
+}
+
+fn map_request_error(url: String, source: SkillError) -> SkillError {
+    match source {
+        SkillError::HttpRegistry { source, .. } => SkillError::HttpRegistry { url, source },
+        other => other,
+    }
+}
+
+fn verify_publish_signature(
+    manifest: &SkillManifest,
+    digest: &str,
+    allow_unsigned: bool,
+) -> Result<(), SkillError> {
+    if allow_unsigned {
+        return Ok(());
+    }
+
+    let signature =
+        manifest
+            .signature_ed25519
+            .as_deref()
+            .ok_or_else(|| SkillError::MissingSignature {
+                name: manifest.name.clone(),
+                version: manifest.version.to_string(),
+            })?;
+    let public_key = manifest
+        .signature_public_key_ed25519
+        .as_deref()
+        .ok_or_else(|| SkillError::MissingSignature {
+            name: manifest.name.clone(),
+            version: manifest.version.to_string(),
+        })?;
+
+    verify_ed25519_signature(manifest, digest, signature, public_key)
+}
+
+fn remove_directory_if_exists(path: &Path) -> Result<(), SkillError> {
+    match fs::symlink_metadata(path) {
+        Ok(metadata) if metadata.file_type().is_dir() => {
+            fs::remove_dir_all(path).map_err(|source| SkillError::Io {
+                path: path.to_path_buf(),
+                source,
+            })
+        }
+        Ok(_) => Err(SkillError::UnsafeBundlePath {
+            path: path.to_path_buf(),
+        }),
+        Err(source) if source.kind() == std::io::ErrorKind::NotFound => Ok(()),
+        Err(source) => Err(SkillError::Io {
+            path: path.to_path_buf(),
+            source,
+        }),
+    }
+}
+
+fn write_file(path: &Path, content: &[u8]) -> Result<(), SkillError> {
+    if let Some(parent) = path.parent() {
+        fs::create_dir_all(parent).map_err(|source| SkillError::Io {
+            path: parent.to_path_buf(),
+            source,
+        })?;
+    }
+    fs::write(path, content).map_err(|source| SkillError::Io {
+        path: path.to_path_buf(),
+        source,
+    })
+}
+
+#[cfg(unix)]
+fn read_regular_file(path: &Path) -> Result<Vec<u8>, SkillError> {
+    use std::{fs::OpenOptions, os::unix::fs::OpenOptionsExt};
+
+    let mut file = OpenOptions::new()
+        .read(true)
+        .custom_flags(libc::O_NOFOLLOW)
+        .open(path)
+        .map_err(|source| SkillError::Io {
+            path: path.to_path_buf(),
+            source,
+        })?;
+    ensure_opened_regular_file(path, &file)?;
+    read_opened_file(path, &mut file)
+}
+
+#[cfg(not(unix))]
+fn read_regular_file(path: &Path) -> Result<Vec<u8>, SkillError> {
+    let mut file = fs::File::open(path).map_err(|source| SkillError::Io {
+        path: path.to_path_buf(),
+        source,
+    })?;
+    ensure_opened_regular_file(path, &file)?;
+    read_opened_file(path, &mut file)
+}
+
+fn ensure_opened_regular_file(path: &Path, file: &fs::File) -> Result<(), SkillError> {
+    let metadata = file.metadata().map_err(|source| SkillError::Io {
+        path: path.to_path_buf(),
+        source,
+    })?;
+    if metadata.file_type().is_file() {
+        Ok(())
+    } else {
+        Err(SkillError::UnsafeBundlePath {
+            path: path.to_path_buf(),
+        })
+    }
+}
+
+fn read_opened_file(path: &Path, file: &mut fs::File) -> Result<Vec<u8>, SkillError> {
+    let mut content = Vec::new();
+    file.read_to_end(&mut content)
+        .map_err(|source| SkillError::Io {
+            path: path.to_path_buf(),
+            source,
+        })?;
+    Ok(content)
+}
+
+fn staging_fetch_path(name: &str, version: &str) -> PathBuf {
+    std::env::temp_dir().join(format!(
+        "agentenv-skill-http-fetch-{name}-{version}-{}-{}",
+        std::process::id(),
+        temporary_suffix()
+    ))
+}
+
+fn temporary_suffix() -> u128 {
+    match std::time::SystemTime::now().duration_since(std::time::UNIX_EPOCH) {
+        Ok(duration) => duration.as_nanos(),
+        Err(_) => 0,
+    }
+}
+
+fn sort_hits(hits: &mut [SkillSearchHit]) {
+    hits.sort_by(|left, right| {
+        left.name
+            .cmp(&right.name)
+            .then_with(|| compare_versions(&left.version, &right.version))
+    });
+}
+
+fn compare_versions(left: &str, right: &str) -> Ordering {
+    match (left.parse::<Version>(), right.parse::<Version>()) {
+        (Ok(left), Ok(right)) => left.cmp(&right),
+        _ => left.cmp(right),
+    }
+}

--- a/crates/agentenv-core/src/skills/registry_oci.rs
+++ b/crates/agentenv-core/src/skills/registry_oci.rs
@@ -1,0 +1,796 @@
+use std::{
+    cmp::Ordering,
+    collections::BTreeMap,
+    fs,
+    io::Read,
+    path::{Component, Path, PathBuf},
+};
+
+use reqwest::{header, redirect::Policy, Client, Method, StatusCode};
+use semver::Version;
+use serde::{Deserialize, Serialize};
+use sha2::{Digest, Sha256};
+use url::Url;
+
+use crate::security::ssrf::{validate_outbound, SsrfOptions};
+
+use super::{
+    compute_bundle_digest,
+    manifest::{normalize_bundle_path, validated_bundle_file},
+    validate_skill_name, verify_ed25519_signature, FetchedSkill, RegistryAdapter, SkillError,
+    SkillManifest, SkillSearchHit,
+};
+
+const OCI_IMAGE_MANIFEST: &str = "application/vnd.oci.image.manifest.v1+json";
+const AGENTENV_SKILL_CONFIG: &str = "application/vnd.agentenv.skill.config.v1+json";
+const AGENTENV_SKILL_MANIFEST: &str = "application/vnd.agentenv.skill.manifest.v1+yaml";
+const AGENTENV_SKILL_FILE: &str = "application/vnd.agentenv.skill.file.v1";
+const AGENTENV_SKILLS_INDEX: &str = "application/vnd.agentenv.skills.index.v1+yaml";
+const SKILL_PATH_ANNOTATION: &str = "io.agentenv.skill.path";
+const INDEX_TAG: &str = "skills-index";
+const MANIFEST_FILE: &str = "skill.yaml";
+const SOURCE_TYPE: &str = "oci";
+
+#[derive(Debug, Clone)]
+pub(crate) struct OciRegistryAdapter {
+    name: String,
+    reference: OciReference,
+    base_url: Url,
+    bearer_token: Option<String>,
+    client: Client,
+    ssrf_options: SsrfOptions,
+}
+
+#[derive(Debug, Clone)]
+struct OciReference {
+    registry: String,
+    repository: String,
+}
+
+#[derive(Debug, Default, Serialize, Deserialize)]
+struct OciSkillIndex {
+    #[serde(default, alias = "entries")]
+    skills: Vec<SkillSearchHit>,
+}
+
+#[derive(Debug, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+struct OciImageManifest {
+    schema_version: u32,
+    media_type: String,
+    config: OciDescriptor,
+    layers: Vec<OciDescriptor>,
+}
+
+#[derive(Debug, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+struct OciDescriptor {
+    media_type: String,
+    digest: String,
+    size: u64,
+    #[serde(default, skip_serializing_if = "BTreeMap::is_empty")]
+    annotations: BTreeMap<String, String>,
+}
+
+impl OciRegistryAdapter {
+    pub(crate) fn new(
+        name: impl Into<String>,
+        reference: impl AsRef<str>,
+        bearer_token: Option<String>,
+        ssrf_options: SsrfOptions,
+    ) -> Result<Self, SkillError> {
+        let reference = OciReference::parse(reference.as_ref())?;
+        let base_url = registry_base_url(&reference, &ssrf_options)?;
+        validate_registry_url(&base_url, &ssrf_options)?;
+        let client = Client::builder()
+            .redirect(Policy::none())
+            .no_proxy()
+            .build()
+            .map_err(|source| SkillError::HttpRegistry {
+                url: base_url.to_string(),
+                source: Box::new(source),
+            })?;
+        Ok(Self {
+            name: name.into(),
+            reference,
+            base_url,
+            bearer_token,
+            client,
+            ssrf_options,
+        })
+    }
+
+    fn manifest_url(&self, tag: &str) -> Result<Url, SkillError> {
+        self.url_for(&["manifests", tag])
+    }
+
+    fn blob_url(&self, digest: &str) -> Result<Url, SkillError> {
+        self.url_for(&["blobs", digest])
+    }
+
+    fn upload_url(&self) -> Result<Url, SkillError> {
+        self.url_for(&["blobs", "uploads"])
+    }
+
+    fn url_for(&self, tail_segments: &[&str]) -> Result<Url, SkillError> {
+        let mut url = self.base_url.clone();
+        {
+            let mut segments =
+                url.path_segments_mut()
+                    .map_err(|_| SkillError::InvalidOciReference {
+                        reference: self.reference.as_string(),
+                    })?;
+            segments.pop_if_empty();
+            segments.push("v2");
+            for component in self.reference.repository.split('/') {
+                segments.push(component);
+            }
+            for segment in tail_segments {
+                segments.push(segment);
+            }
+            if matches!(tail_segments, ["blobs", "uploads"]) {
+                segments.push("");
+            }
+        }
+        validate_registry_url(&url, &self.ssrf_options)?;
+        Ok(url)
+    }
+
+    async fn read_index(&self) -> Result<OciSkillIndex, SkillError> {
+        let Some(manifest) = self.get_optional_manifest(INDEX_TAG).await? else {
+            return Ok(OciSkillIndex::default());
+        };
+        let Some(index_layer) = manifest
+            .layers
+            .iter()
+            .find(|layer| layer.media_type == AGENTENV_SKILLS_INDEX)
+        else {
+            return Ok(OciSkillIndex::default());
+        };
+        let content = self.get_blob_text(&index_layer.digest).await?;
+        let mut index: OciSkillIndex =
+            serde_yaml::from_str(&content).map_err(|source| SkillError::Yaml {
+                path: PathBuf::from(INDEX_TAG),
+                source,
+            })?;
+        for hit in &mut index.skills {
+            self.validate_hit(hit)?;
+        }
+        Ok(index)
+    }
+
+    async fn write_index(&self, mut index: OciSkillIndex) -> Result<(), SkillError> {
+        sort_hits(&mut index.skills);
+        let content = serde_yaml::to_string(&index).map_err(|source| SkillError::Serde {
+            path: PathBuf::from(INDEX_TAG),
+            source,
+        })?;
+        let config = self
+            .upload_blob(AGENTENV_SKILL_CONFIG, b"{}".to_vec())
+            .await?;
+        let layer = self
+            .upload_blob(AGENTENV_SKILLS_INDEX, content.into_bytes())
+            .await?;
+        self.put_manifest(
+            INDEX_TAG,
+            OciImageManifest {
+                schema_version: 2,
+                media_type: OCI_IMAGE_MANIFEST.to_owned(),
+                config,
+                layers: vec![layer],
+            },
+        )
+        .await
+    }
+
+    fn validate_hit(&self, hit: &mut SkillSearchHit) -> Result<(), SkillError> {
+        validate_skill_name(&hit.name)?;
+        hit.version
+            .parse::<Version>()
+            .map_err(|source| SkillError::InvalidVersion {
+                version: hit.version.clone(),
+                source,
+            })?;
+        hit.registry = self.name.clone();
+        Ok(())
+    }
+
+    fn hit_for_manifest(&self, manifest: &SkillManifest, digest: String) -> SkillSearchHit {
+        SkillSearchHit {
+            name: manifest.name.clone(),
+            version: manifest.version.to_string(),
+            description: manifest.description.clone(),
+            registry: self.name.clone(),
+            digest: Some(digest),
+            signature_ed25519: manifest.signature_ed25519.clone(),
+            public_key_ed25519: manifest.signature_public_key_ed25519.clone(),
+        }
+    }
+
+    async fn resolved_hit(
+        &self,
+        name: &str,
+        version: Option<&str>,
+    ) -> Result<SkillSearchHit, SkillError> {
+        validate_skill_name(name)?;
+        if let Some(version) = version {
+            version
+                .parse::<Version>()
+                .map_err(|source| SkillError::InvalidVersion {
+                    version: version.to_owned(),
+                    source,
+                })?;
+        }
+
+        let index = self.read_index().await?;
+        let matches = index
+            .skills
+            .into_iter()
+            .filter(|hit| hit.name == name)
+            .collect::<Vec<_>>();
+
+        if let Some(version) = version {
+            return matches
+                .into_iter()
+                .find(|hit| hit.version == version)
+                .ok_or_else(|| SkillError::SkillNotInstalled {
+                    name: name.to_owned(),
+                });
+        }
+
+        matches
+            .into_iter()
+            .max_by(|left, right| compare_versions(&left.version, &right.version))
+            .ok_or_else(|| SkillError::SkillNotInstalled {
+                name: name.to_owned(),
+            })
+    }
+
+    async fn get_optional_manifest(
+        &self,
+        tag: &str,
+    ) -> Result<Option<OciImageManifest>, SkillError> {
+        let url = self.manifest_url(tag)?;
+        let response = self
+            .request(Method::GET, url.clone(), None, Some(OCI_IMAGE_MANIFEST))
+            .await?;
+        if response.status() == StatusCode::NOT_FOUND {
+            return Ok(None);
+        }
+        ensure_success(&url, response.status())?;
+        let text = response
+            .text()
+            .await
+            .map_err(|source| SkillError::HttpRegistry {
+                url: url.to_string(),
+                source: Box::new(source),
+            })?;
+        serde_json::from_str(&text)
+            .map(Some)
+            .map_err(|source| SkillError::InvalidConfig {
+                message: format!("invalid OCI manifest for `{tag}`: {source}"),
+            })
+    }
+
+    async fn get_blob(&self, digest: &str) -> Result<Vec<u8>, SkillError> {
+        let url = self.blob_url(digest)?;
+        let response = self.request(Method::GET, url.clone(), None, None).await?;
+        ensure_success(&url, response.status())?;
+        response
+            .bytes()
+            .await
+            .map(|bytes| bytes.to_vec())
+            .map_err(|source| SkillError::HttpRegistry {
+                url: url.to_string(),
+                source: Box::new(source),
+            })
+    }
+
+    async fn get_blob_text(&self, digest: &str) -> Result<String, SkillError> {
+        let bytes = self.get_blob(digest).await?;
+        String::from_utf8(bytes).map_err(|source| SkillError::InvalidConfig {
+            message: format!("OCI blob `{digest}` is not UTF-8: {source}"),
+        })
+    }
+
+    async fn upload_blob(
+        &self,
+        media_type: &str,
+        content: Vec<u8>,
+    ) -> Result<OciDescriptor, SkillError> {
+        let digest = sha256_digest(&content);
+        let upload_start = self.upload_url()?;
+        let response = self
+            .request(Method::POST, upload_start.clone(), None, None)
+            .await?;
+        ensure_success(&upload_start, response.status())?;
+        let location = self.upload_location(&upload_start, &response)?;
+
+        let response = self
+            .request(Method::PATCH, location.clone(), Some(content.clone()), None)
+            .await?;
+        ensure_success(&location, response.status())?;
+        let mut location = self.upload_location(&location, &response)?;
+        location.query_pairs_mut().append_pair("digest", &digest);
+        validate_registry_url(&location, &self.ssrf_options)?;
+
+        let response = self
+            .request(Method::PUT, location.clone(), None, None)
+            .await?;
+        ensure_success(&location, response.status())?;
+        Ok(OciDescriptor {
+            media_type: media_type.to_owned(),
+            digest,
+            size: content.len() as u64,
+            annotations: BTreeMap::new(),
+        })
+    }
+
+    async fn put_manifest(&self, tag: &str, manifest: OciImageManifest) -> Result<(), SkillError> {
+        let url = self.manifest_url(tag)?;
+        let content =
+            serde_json::to_vec(&manifest).map_err(|source| SkillError::InvalidConfig {
+                message: format!("failed to serialize OCI manifest `{tag}`: {source}"),
+            })?;
+        let response = self
+            .request(
+                Method::PUT,
+                url.clone(),
+                Some(content),
+                Some(OCI_IMAGE_MANIFEST),
+            )
+            .await?;
+        ensure_success(&url, response.status())
+    }
+
+    fn upload_location(
+        &self,
+        base_url: &Url,
+        response: &reqwest::Response,
+    ) -> Result<Url, SkillError> {
+        let value = response
+            .headers()
+            .get(header::LOCATION)
+            .ok_or_else(|| SkillError::InvalidConfig {
+                message: "OCI upload response missing Location header".to_owned(),
+            })?
+            .to_str()
+            .map_err(|source| SkillError::InvalidConfig {
+                message: format!("OCI upload Location header is not valid UTF-8: {source}"),
+            })?;
+        let location = base_url
+            .join(value)
+            .map_err(|source| SkillError::InvalidConfig {
+                message: format!("OCI upload Location header is invalid: {source}"),
+            })?;
+        validate_registry_url(&location, &self.ssrf_options)?;
+        Ok(location)
+    }
+
+    async fn request(
+        &self,
+        method: Method,
+        url: Url,
+        body: Option<Vec<u8>>,
+        content_type: Option<&str>,
+    ) -> Result<reqwest::Response, SkillError> {
+        let mut request = self.client.request(method, url.clone());
+        if let Some(token) = self.bearer_token.as_deref() {
+            request = request.bearer_auth(token);
+        }
+        if let Some(content_type) = content_type {
+            request = request.header(header::CONTENT_TYPE, content_type);
+            request = request.header(header::ACCEPT, content_type);
+        }
+        if let Some(body) = body {
+            request = request.body(body);
+        }
+        request
+            .send()
+            .await
+            .map_err(|source| SkillError::HttpRegistry {
+                url: url.to_string(),
+                source: Box::new(source),
+            })
+    }
+}
+
+#[async_trait::async_trait]
+impl RegistryAdapter for OciRegistryAdapter {
+    async fn search(&self, query: &str) -> Result<Vec<SkillSearchHit>, SkillError> {
+        let query = query.to_ascii_lowercase();
+        let index = self.read_index().await?;
+        let mut hits = index
+            .skills
+            .into_iter()
+            .filter(|hit| {
+                let searchable_description = hit.description.as_deref().unwrap_or_default();
+                query.is_empty()
+                    || hit.name.to_ascii_lowercase().contains(&query)
+                    || searchable_description.to_ascii_lowercase().contains(&query)
+            })
+            .collect::<Vec<_>>();
+        sort_hits(&mut hits);
+        Ok(hits)
+    }
+
+    async fn fetch(&self, name: &str, version: Option<&str>) -> Result<FetchedSkill, SkillError> {
+        let hit = self.resolved_hit(name, version).await?;
+        let tag = skill_tag(&hit.name, &hit.version);
+        let manifest = self.get_optional_manifest(&tag).await?.ok_or_else(|| {
+            SkillError::SkillNotInstalled {
+                name: hit.name.clone(),
+            }
+        })?;
+        let staging_path = staging_fetch_path(&hit.name, &hit.version);
+        remove_directory_if_exists(&staging_path)?;
+        fs::create_dir_all(&staging_path).map_err(|source| SkillError::Io {
+            path: staging_path.clone(),
+            source,
+        })?;
+
+        let manifest_layer = manifest
+            .layers
+            .iter()
+            .find(|layer| layer.media_type == AGENTENV_SKILL_MANIFEST)
+            .ok_or_else(|| SkillError::InvalidConfig {
+                message: format!("OCI skill `{}` missing skill manifest layer", hit.name),
+            })?;
+        let manifest_content = self.get_blob(&manifest_layer.digest).await?;
+        write_file(&staging_path.join(MANIFEST_FILE), &manifest_content)?;
+
+        for layer in manifest
+            .layers
+            .iter()
+            .filter(|layer| layer.media_type == AGENTENV_SKILL_FILE)
+        {
+            let relative_path = layer
+                .annotations
+                .get(SKILL_PATH_ANNOTATION)
+                .ok_or_else(|| SkillError::InvalidConfig {
+                    message: format!(
+                        "OCI skill `{}` file layer missing path annotation",
+                        hit.name
+                    ),
+                })?;
+            let relative_path = normalize_bundle_path(Path::new(relative_path))?;
+            let content = self.get_blob(&layer.digest).await?;
+            write_file(&staging_path.join(relative_path), &content)?;
+        }
+
+        let manifest = super::load_skill_manifest(&staging_path)?;
+        if manifest.name != hit.name || manifest.version.to_string() != hit.version {
+            return Err(SkillError::InvalidConfig {
+                message: format!(
+                    "OCI index selected `{}` version `{}`, but manifest is `{}` version `{}`",
+                    hit.name, hit.version, manifest.name, manifest.version
+                ),
+            });
+        }
+        let digest = compute_bundle_digest(&staging_path, &manifest)?;
+        if let Some(expected) = hit.digest.as_deref() {
+            if expected != digest {
+                return Err(SkillError::DigestMismatch {
+                    expected: expected.to_owned(),
+                    actual: digest,
+                });
+            }
+        }
+
+        Ok(FetchedSkill {
+            staging_path,
+            registry: self.name.clone(),
+            source_type: SOURCE_TYPE.to_owned(),
+            name: manifest.name,
+            version: manifest.version.to_string(),
+        })
+    }
+
+    async fn publish(
+        &self,
+        bundle_path: &Path,
+        allow_unsigned: bool,
+    ) -> Result<SkillSearchHit, SkillError> {
+        let manifest = super::load_skill_manifest(bundle_path)?;
+        let digest = compute_bundle_digest(bundle_path, &manifest)?;
+        verify_publish_signature(&manifest, &digest, allow_unsigned)?;
+        let version = manifest.version.to_string();
+        let hit = self.hit_for_manifest(&manifest, digest.clone());
+        let mut index = self.read_index().await?;
+
+        if let Some(existing) = index
+            .skills
+            .iter()
+            .find(|hit| hit.name == manifest.name && hit.version == version)
+        {
+            if existing.digest.as_deref() != Some(digest.as_str()) {
+                return Err(SkillError::AlreadyInstalledDifferentDigest {
+                    name: manifest.name,
+                    version,
+                    existing: existing
+                        .digest
+                        .clone()
+                        .unwrap_or_else(|| "unknown".to_owned()),
+                });
+            }
+        }
+
+        let config = self
+            .upload_blob(
+                AGENTENV_SKILL_CONFIG,
+                serde_json::to_vec(&hit).map_err(|source| SkillError::InvalidConfig {
+                    message: format!("failed to serialize skill config: {source}"),
+                })?,
+            )
+            .await?;
+        let manifest_bytes = read_regular_file(&bundle_path.join(MANIFEST_FILE))?;
+        let manifest_layer = self
+            .upload_blob(AGENTENV_SKILL_MANIFEST, manifest_bytes)
+            .await?;
+        let mut layers = vec![manifest_layer];
+        for declared_file in &manifest.declared_files {
+            let source = validated_bundle_file(bundle_path, declared_file)?;
+            let bytes = read_regular_file(&source)?;
+            let mut descriptor = self.upload_blob(AGENTENV_SKILL_FILE, bytes).await?;
+            descriptor.annotations.insert(
+                SKILL_PATH_ANNOTATION.to_owned(),
+                path_to_annotation(declared_file)?,
+            );
+            layers.push(descriptor);
+        }
+        self.put_manifest(
+            &skill_tag(&manifest.name, &version),
+            OciImageManifest {
+                schema_version: 2,
+                media_type: OCI_IMAGE_MANIFEST.to_owned(),
+                config,
+                layers,
+            },
+        )
+        .await?;
+
+        index
+            .skills
+            .retain(|existing| existing.name != hit.name || existing.version != hit.version);
+        index.skills.push(hit.clone());
+        self.write_index(index).await?;
+        Ok(hit)
+    }
+}
+
+impl OciReference {
+    fn parse(reference: &str) -> Result<Self, SkillError> {
+        let reference = reference.trim();
+        let Some((registry, repository)) = reference.split_once('/') else {
+            return Err(SkillError::InvalidOciReference {
+                reference: reference.to_owned(),
+            });
+        };
+        if registry.is_empty()
+            || repository.is_empty()
+            || reference.contains("://")
+            || reference.contains(char::is_whitespace)
+        {
+            return Err(SkillError::InvalidOciReference {
+                reference: reference.to_owned(),
+            });
+        }
+        Ok(Self {
+            registry: registry.to_owned(),
+            repository: repository.to_owned(),
+        })
+    }
+
+    fn as_string(&self) -> String {
+        format!("{}/{}", self.registry, self.repository)
+    }
+}
+
+fn registry_base_url(reference: &OciReference, options: &SsrfOptions) -> Result<Url, SkillError> {
+    let scheme = if options.allow_loopback && is_loopback_registry(&reference.registry) {
+        "http"
+    } else {
+        "https"
+    };
+    Url::parse(&format!("{scheme}://{}", reference.registry)).map_err(|_| {
+        SkillError::InvalidOciReference {
+            reference: reference.as_string(),
+        }
+    })
+}
+
+fn is_loopback_registry(registry: &str) -> bool {
+    let host = registry
+        .split_once(':')
+        .map(|(host, _)| host)
+        .unwrap_or(registry);
+    host == "localhost" || host == "127.0.0.1" || host.starts_with("127.")
+}
+
+fn validate_registry_url(url: &Url, options: &SsrfOptions) -> Result<(), SkillError> {
+    validate_outbound(url, options.clone())
+        .map(|_| ())
+        .map_err(|source| SkillError::RegistryUrlBlocked {
+            url: url.to_string(),
+            source: Box::new(source),
+        })
+}
+
+fn ensure_success(url: &Url, status: StatusCode) -> Result<(), SkillError> {
+    if status.is_success() {
+        Ok(())
+    } else {
+        Err(SkillError::HttpStatus {
+            url: url.to_string(),
+            status,
+        })
+    }
+}
+
+fn verify_publish_signature(
+    manifest: &SkillManifest,
+    digest: &str,
+    allow_unsigned: bool,
+) -> Result<(), SkillError> {
+    if allow_unsigned {
+        return Ok(());
+    }
+
+    let signature =
+        manifest
+            .signature_ed25519
+            .as_deref()
+            .ok_or_else(|| SkillError::MissingSignature {
+                name: manifest.name.clone(),
+                version: manifest.version.to_string(),
+            })?;
+    let public_key = manifest
+        .signature_public_key_ed25519
+        .as_deref()
+        .ok_or_else(|| SkillError::MissingSignature {
+            name: manifest.name.clone(),
+            version: manifest.version.to_string(),
+        })?;
+
+    verify_ed25519_signature(manifest, digest, signature, public_key)
+}
+
+fn sha256_digest(content: &[u8]) -> String {
+    let mut hasher = Sha256::new();
+    hasher.update(content);
+    format!("sha256:{:x}", hasher.finalize())
+}
+
+fn skill_tag(name: &str, version: &str) -> String {
+    format!("{name}:{version}")
+}
+
+fn path_to_annotation(path: &Path) -> Result<String, SkillError> {
+    path.components()
+        .map(|component| match component {
+            Component::Normal(part) => {
+                part.to_str()
+                    .map(str::to_owned)
+                    .ok_or_else(|| SkillError::UnsafeBundlePath {
+                        path: path.to_path_buf(),
+                    })
+            }
+            _ => Err(SkillError::UnsafeBundlePath {
+                path: path.to_path_buf(),
+            }),
+        })
+        .collect::<Result<Vec<_>, _>>()
+        .map(|components| components.join("/"))
+}
+
+fn remove_directory_if_exists(path: &Path) -> Result<(), SkillError> {
+    match fs::symlink_metadata(path) {
+        Ok(metadata) if metadata.file_type().is_dir() => {
+            fs::remove_dir_all(path).map_err(|source| SkillError::Io {
+                path: path.to_path_buf(),
+                source,
+            })
+        }
+        Ok(_) => Err(SkillError::UnsafeBundlePath {
+            path: path.to_path_buf(),
+        }),
+        Err(source) if source.kind() == std::io::ErrorKind::NotFound => Ok(()),
+        Err(source) => Err(SkillError::Io {
+            path: path.to_path_buf(),
+            source,
+        }),
+    }
+}
+
+fn write_file(path: &Path, content: &[u8]) -> Result<(), SkillError> {
+    if let Some(parent) = path.parent() {
+        fs::create_dir_all(parent).map_err(|source| SkillError::Io {
+            path: parent.to_path_buf(),
+            source,
+        })?;
+    }
+    fs::write(path, content).map_err(|source| SkillError::Io {
+        path: path.to_path_buf(),
+        source,
+    })
+}
+
+#[cfg(unix)]
+fn read_regular_file(path: &Path) -> Result<Vec<u8>, SkillError> {
+    use std::{fs::OpenOptions, os::unix::fs::OpenOptionsExt};
+
+    let mut file = OpenOptions::new()
+        .read(true)
+        .custom_flags(libc::O_NOFOLLOW)
+        .open(path)
+        .map_err(|source| SkillError::Io {
+            path: path.to_path_buf(),
+            source,
+        })?;
+    ensure_opened_regular_file(path, &file)?;
+    read_opened_file(path, &mut file)
+}
+
+#[cfg(not(unix))]
+fn read_regular_file(path: &Path) -> Result<Vec<u8>, SkillError> {
+    let mut file = fs::File::open(path).map_err(|source| SkillError::Io {
+        path: path.to_path_buf(),
+        source,
+    })?;
+    ensure_opened_regular_file(path, &file)?;
+    read_opened_file(path, &mut file)
+}
+
+fn ensure_opened_regular_file(path: &Path, file: &fs::File) -> Result<(), SkillError> {
+    let metadata = file.metadata().map_err(|source| SkillError::Io {
+        path: path.to_path_buf(),
+        source,
+    })?;
+    if metadata.file_type().is_file() {
+        Ok(())
+    } else {
+        Err(SkillError::UnsafeBundlePath {
+            path: path.to_path_buf(),
+        })
+    }
+}
+
+fn read_opened_file(path: &Path, file: &mut fs::File) -> Result<Vec<u8>, SkillError> {
+    let mut content = Vec::new();
+    file.read_to_end(&mut content)
+        .map_err(|source| SkillError::Io {
+            path: path.to_path_buf(),
+            source,
+        })?;
+    Ok(content)
+}
+
+fn staging_fetch_path(name: &str, version: &str) -> PathBuf {
+    std::env::temp_dir().join(format!(
+        "agentenv-skill-oci-fetch-{name}-{version}-{}-{}",
+        std::process::id(),
+        temporary_suffix()
+    ))
+}
+
+fn temporary_suffix() -> u128 {
+    match std::time::SystemTime::now().duration_since(std::time::UNIX_EPOCH) {
+        Ok(duration) => duration.as_nanos(),
+        Err(_) => 0,
+    }
+}
+
+fn sort_hits(hits: &mut [SkillSearchHit]) {
+    hits.sort_by(|left, right| {
+        left.name
+            .cmp(&right.name)
+            .then_with(|| compare_versions(&left.version, &right.version))
+    });
+}
+
+fn compare_versions(left: &str, right: &str) -> Ordering {
+    match (left.parse::<Version>(), right.parse::<Version>()) {
+        (Ok(left), Ok(right)) => left.cmp(&right),
+        _ => left.cmp(right),
+    }
+}

--- a/crates/agentenv-core/src/skills/service.rs
+++ b/crates/agentenv-core/src/skills/service.rs
@@ -1,0 +1,253 @@
+use std::{
+    fs,
+    path::{Path, PathBuf},
+};
+
+use semver::Version;
+
+use super::{
+    info_installed_skill, install_local_skill, list_installed_skills, registry_filesystem,
+    remove_installed_skill, validate_skill_name, verify_installed_skill, InstalledSkill,
+    InstalledSkillSelector, RegistryAdapter, RegistryConfig, RegistryKind, SkillError,
+    SkillInstallOptions, SkillSearchHit, SkillsConfig,
+};
+
+#[derive(Debug, Clone)]
+pub struct SkillService {
+    root: PathBuf,
+    config: SkillsConfig,
+}
+
+#[derive(Debug, Clone)]
+pub struct SkillAddRequest {
+    pub handle: String,
+    pub registry: Option<String>,
+    pub allow_unsigned: bool,
+}
+
+#[derive(Debug, Clone)]
+pub struct SkillPublishRequest {
+    pub bundle_path: PathBuf,
+    pub registry: Option<String>,
+    pub allow_unsigned: bool,
+}
+
+impl SkillService {
+    pub fn new(root: impl Into<PathBuf>, config: SkillsConfig) -> Self {
+        Self {
+            root: root.into(),
+            config,
+        }
+    }
+
+    pub async fn search(&self, query: &str) -> Result<Vec<SkillSearchHit>, SkillError> {
+        let mut hits = Vec::new();
+        for registry in self.ordered_registries()? {
+            let adapter = self.adapter_for(registry)?;
+            hits.extend(adapter.search(query).await?);
+        }
+        sort_hits(&mut hits);
+        Ok(hits)
+    }
+
+    pub async fn add(&self, request: SkillAddRequest) -> Result<InstalledSkill, SkillError> {
+        let parsed = ParsedSkillHandle::parse(&request.handle)?;
+        let registries = match request.registry.as_deref() {
+            Some(registry) => vec![self.registry_by_name(registry)?],
+            None => self.ordered_registries()?,
+        };
+
+        for registry in registries {
+            let adapter = self.adapter_for(registry)?;
+            match adapter.fetch(&parsed.name, parsed.version.as_deref()).await {
+                Ok(fetched) => {
+                    let source_label = format!(
+                        "{}:{}:{}@{}",
+                        fetched.source_type, fetched.registry, fetched.name, fetched.version
+                    );
+                    let installed = install_local_skill(
+                        &self.root,
+                        &fetched.staging_path,
+                        SkillInstallOptions {
+                            allow_unsigned: request.allow_unsigned,
+                            source_type: fetched.source_type.clone(),
+                            source_label,
+                        },
+                    );
+                    cleanup_staging_path(&fetched.staging_path);
+                    return installed;
+                }
+                Err(SkillError::SkillNotInstalled { .. }) => {
+                    continue;
+                }
+                Err(error) => return Err(error),
+            }
+        }
+
+        Err(SkillError::SkillNotInstalled { name: parsed.name })
+    }
+
+    pub async fn publish(
+        &self,
+        request: SkillPublishRequest,
+    ) -> Result<SkillSearchHit, SkillError> {
+        let registry = match request.registry.as_deref() {
+            Some(registry) => self.registry_by_name(registry)?,
+            None => self
+                .ordered_registries()?
+                .into_iter()
+                .next()
+                .ok_or_else(|| SkillError::InvalidConfig {
+                    message: "no skill registries configured".to_owned(),
+                })?,
+        };
+        let adapter = self.adapter_for(registry)?;
+        adapter
+            .publish(&request.bundle_path, request.allow_unsigned)
+            .await
+    }
+
+    pub fn install_from_path(
+        &self,
+        bundle_path: impl AsRef<Path>,
+        allow_unsigned: bool,
+        source_label: impl Into<String>,
+    ) -> Result<InstalledSkill, SkillError> {
+        install_local_skill(
+            &self.root,
+            bundle_path,
+            SkillInstallOptions {
+                allow_unsigned,
+                source_type: "local".to_owned(),
+                source_label: source_label.into(),
+            },
+        )
+    }
+
+    pub fn list(&self) -> Result<Vec<InstalledSkill>, SkillError> {
+        list_installed_skills(&self.root)
+    }
+
+    pub fn info(&self, selector: InstalledSkillSelector) -> Result<InstalledSkill, SkillError> {
+        info_installed_skill(&self.root, selector)
+    }
+
+    pub fn remove(&self, selector: InstalledSkillSelector) -> Result<InstalledSkill, SkillError> {
+        remove_installed_skill(&self.root, selector)
+    }
+
+    pub fn verify(&self, selector: InstalledSkillSelector) -> Result<InstalledSkill, SkillError> {
+        verify_installed_skill(&self.root, selector)
+    }
+
+    fn ordered_registries(&self) -> Result<Vec<&RegistryConfig>, SkillError> {
+        if self.config.registry_order.is_empty() {
+            return Ok(self.config.registries.iter().collect());
+        }
+
+        self.config
+            .registry_order
+            .iter()
+            .map(|name| self.registry_by_name(name))
+            .collect()
+    }
+
+    fn registry_by_name(&self, name: &str) -> Result<&RegistryConfig, SkillError> {
+        self.config
+            .registries
+            .iter()
+            .find(|registry| registry.name == name)
+            .ok_or_else(|| SkillError::RegistryNotFound {
+                name: name.to_owned(),
+            })
+    }
+
+    fn adapter_for(
+        &self,
+        registry: &RegistryConfig,
+    ) -> Result<registry_filesystem::FilesystemRegistryAdapter, SkillError> {
+        match registry.kind {
+            RegistryKind::Filesystem => {
+                let path = registry
+                    .path
+                    .clone()
+                    .ok_or_else(|| SkillError::InvalidConfig {
+                        message: format!("filesystem registry `{}` requires path", registry.name),
+                    })?;
+                Ok(registry_filesystem::FilesystemRegistryAdapter::new(
+                    registry.name.clone(),
+                    path,
+                ))
+            }
+            RegistryKind::Http | RegistryKind::Oci => Err(SkillError::InvalidConfig {
+                message: format!(
+                    "registry `{}` uses unsupported adapter kind `{:?}`",
+                    registry.name, registry.kind
+                ),
+            }),
+        }
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+struct ParsedSkillHandle {
+    name: String,
+    version: Option<String>,
+}
+
+impl ParsedSkillHandle {
+    fn parse(handle: &str) -> Result<Self, SkillError> {
+        let handle = handle.trim();
+        let (name, version) = match handle.rsplit_once('@') {
+            Some((name, version)) => {
+                if version.is_empty() {
+                    return Err(SkillError::InvalidConfig {
+                        message: "skill handle version must not be empty".to_owned(),
+                    });
+                }
+                (name, Some(version.to_owned()))
+            }
+            None => (handle, None),
+        };
+
+        validate_skill_name(name)?;
+        if let Some(version) = version.as_deref() {
+            version
+                .parse::<Version>()
+                .map_err(|source| SkillError::InvalidVersion {
+                    version: version.to_owned(),
+                    source,
+                })?;
+        }
+
+        Ok(Self {
+            name: name.to_owned(),
+            version,
+        })
+    }
+}
+
+fn cleanup_staging_path(path: &Path) {
+    let Ok(metadata) = fs::symlink_metadata(path) else {
+        return;
+    };
+    if metadata.file_type().is_dir() {
+        let _ = fs::remove_dir_all(path);
+    }
+}
+
+fn sort_hits(hits: &mut [SkillSearchHit]) {
+    hits.sort_by(|left, right| {
+        left.name
+            .cmp(&right.name)
+            .then_with(|| compare_versions(&left.version, &right.version))
+            .then_with(|| left.registry.cmp(&right.registry))
+    });
+}
+
+fn compare_versions(left: &str, right: &str) -> std::cmp::Ordering {
+    match (left.parse::<Version>(), right.parse::<Version>()) {
+        (Ok(left), Ok(right)) => left.cmp(&right),
+        _ => left.cmp(right),
+    }
+}

--- a/crates/agentenv-core/src/skills/service.rs
+++ b/crates/agentenv-core/src/skills/service.rs
@@ -10,9 +10,9 @@ use crate::security::ssrf::SsrfOptions;
 
 use super::{
     info_installed_skill, install_local_skill, list_installed_skills, registry_filesystem,
-    registry_http, remove_installed_skill, validate_skill_name, verify_installed_skill,
-    InstalledSkill, InstalledSkillSelector, RegistryAdapter, RegistryConfig, RegistryKind,
-    SkillError, SkillInstallOptions, SkillSearchHit, SkillsConfig,
+    registry_http, registry_oci, remove_installed_skill, validate_skill_name,
+    verify_installed_skill, InstalledSkill, InstalledSkillSelector, RegistryAdapter,
+    RegistryConfig, RegistryKind, SkillError, SkillInstallOptions, SkillSearchHit, SkillsConfig,
 };
 
 pub type SkillCredentialResolver =
@@ -215,12 +215,20 @@ impl SkillService {
                     self.ssrf_options.clone(),
                 )?))
             }
-            RegistryKind::Oci => Err(SkillError::InvalidConfig {
-                message: format!(
-                    "registry `{}` uses unsupported adapter kind `{:?}`",
-                    registry.name, registry.kind
-                ),
-            }),
+            RegistryKind::Oci => {
+                let reference = registry
+                    .url
+                    .clone()
+                    .ok_or_else(|| SkillError::InvalidConfig {
+                        message: format!("oci registry `{}` requires url", registry.name),
+                    })?;
+                Ok(Box::new(registry_oci::OciRegistryAdapter::new(
+                    registry.name.clone(),
+                    reference,
+                    self.bearer_token_for(registry)?,
+                    self.ssrf_options.clone(),
+                )?))
+            }
         }
     }
 
@@ -242,11 +250,12 @@ impl SkillService {
             }
             name.to_owned()
         } else {
-            return Err(SkillError::InvalidConfig {
-                message: format!(
-                    "http registry `{}` uses unsupported auth `{auth}`",
-                    registry.name
-                ),
+            return Err(SkillError::UnsupportedRegistryAuth {
+                scheme: auth
+                    .split_once(':')
+                    .map(|(scheme, _)| scheme)
+                    .unwrap_or(auth)
+                    .to_owned(),
             });
         };
 

--- a/crates/agentenv-core/src/skills/service.rs
+++ b/crates/agentenv-core/src/skills/service.rs
@@ -1,21 +1,29 @@
 use std::{
     fs,
     path::{Path, PathBuf},
+    sync::Arc,
 };
 
 use semver::Version;
 
+use crate::security::ssrf::SsrfOptions;
+
 use super::{
     info_installed_skill, install_local_skill, list_installed_skills, registry_filesystem,
-    remove_installed_skill, validate_skill_name, verify_installed_skill, InstalledSkill,
-    InstalledSkillSelector, RegistryAdapter, RegistryConfig, RegistryKind, SkillError,
-    SkillInstallOptions, SkillSearchHit, SkillsConfig,
+    registry_http, remove_installed_skill, validate_skill_name, verify_installed_skill,
+    InstalledSkill, InstalledSkillSelector, RegistryAdapter, RegistryConfig, RegistryKind,
+    SkillError, SkillInstallOptions, SkillSearchHit, SkillsConfig,
 };
 
-#[derive(Debug, Clone)]
+pub type SkillCredentialResolver =
+    Arc<dyn Fn(&str) -> Result<Option<String>, SkillError> + Send + Sync>;
+
+#[derive(Clone)]
 pub struct SkillService {
     root: PathBuf,
     config: SkillsConfig,
+    credential_resolver: SkillCredentialResolver,
+    ssrf_options: SsrfOptions,
 }
 
 #[derive(Debug, Clone)]
@@ -37,7 +45,19 @@ impl SkillService {
         Self {
             root: root.into(),
             config,
+            credential_resolver: Arc::new(|_| Ok(None)),
+            ssrf_options: SsrfOptions::default(),
         }
+    }
+
+    pub fn with_credential_resolver(mut self, resolver: SkillCredentialResolver) -> Self {
+        self.credential_resolver = resolver;
+        self
+    }
+
+    pub fn with_ssrf_options(mut self, options: SsrfOptions) -> Self {
+        self.ssrf_options = options;
+        self
     }
 
     pub async fn search(&self, query: &str) -> Result<Vec<SkillSearchHit>, SkillError> {
@@ -165,7 +185,7 @@ impl SkillService {
     fn adapter_for(
         &self,
         registry: &RegistryConfig,
-    ) -> Result<registry_filesystem::FilesystemRegistryAdapter, SkillError> {
+    ) -> Result<Box<dyn RegistryAdapter + Send + Sync>, SkillError> {
         match registry.kind {
             RegistryKind::Filesystem => {
                 let path = registry
@@ -174,18 +194,67 @@ impl SkillService {
                     .ok_or_else(|| SkillError::InvalidConfig {
                         message: format!("filesystem registry `{}` requires path", registry.name),
                     })?;
-                Ok(registry_filesystem::FilesystemRegistryAdapter::new(
-                    registry.name.clone(),
-                    path,
+                Ok(Box::new(
+                    registry_filesystem::FilesystemRegistryAdapter::new(
+                        registry.name.clone(),
+                        path,
+                    ),
                 ))
             }
-            RegistryKind::Http | RegistryKind::Oci => Err(SkillError::InvalidConfig {
+            RegistryKind::Http => {
+                let url = registry
+                    .url
+                    .clone()
+                    .ok_or_else(|| SkillError::InvalidConfig {
+                        message: format!("http registry `{}` requires url", registry.name),
+                    })?;
+                Ok(Box::new(registry_http::HttpRegistryAdapter::new(
+                    registry.name.clone(),
+                    url,
+                    self.bearer_token_for(registry)?,
+                    self.ssrf_options.clone(),
+                )?))
+            }
+            RegistryKind::Oci => Err(SkillError::InvalidConfig {
                 message: format!(
                     "registry `{}` uses unsupported adapter kind `{:?}`",
                     registry.name, registry.kind
                 ),
             }),
         }
+    }
+
+    fn bearer_token_for(&self, registry: &RegistryConfig) -> Result<Option<String>, SkillError> {
+        let Some(auth) = registry.auth.as_deref() else {
+            return Ok(None);
+        };
+
+        let credential_name = if auth == "bearer-from-credstore" {
+            default_bearer_credential_name(&registry.name)
+        } else if let Some(name) = auth.strip_prefix("bearer-from-credstore:") {
+            if name.is_empty() {
+                return Err(SkillError::InvalidConfig {
+                    message: format!(
+                        "http registry `{}` has an empty bearer credential reference",
+                        registry.name
+                    ),
+                });
+            }
+            name.to_owned()
+        } else {
+            return Err(SkillError::InvalidConfig {
+                message: format!(
+                    "http registry `{}` uses unsupported auth `{auth}`",
+                    registry.name
+                ),
+            });
+        };
+
+        (self.credential_resolver)(&credential_name)?
+            .ok_or_else(|| SkillError::CredentialReferenceUnavailable {
+                name: credential_name,
+            })
+            .map(Some)
     }
 }
 
@@ -250,4 +319,18 @@ fn compare_versions(left: &str, right: &str) -> std::cmp::Ordering {
         (Ok(left), Ok(right)) => left.cmp(&right),
         _ => left.cmp(right),
     }
+}
+
+fn default_bearer_credential_name(registry_name: &str) -> String {
+    let normalized = registry_name
+        .chars()
+        .map(|character| {
+            if character.is_ascii_alphanumeric() {
+                character.to_ascii_uppercase()
+            } else {
+                '_'
+            }
+        })
+        .collect::<String>();
+    format!("AGENTENV_SKILLS_{normalized}_TOKEN")
 }

--- a/crates/agentenv-core/src/skills/signature.rs
+++ b/crates/agentenv-core/src/skills/signature.rs
@@ -1,0 +1,121 @@
+use std::collections::BTreeMap;
+
+use ed25519_dalek::{Signature, Verifier, VerifyingKey};
+use serde::Serialize;
+use serde_yaml::Value;
+
+use super::{SkillError, SkillManifest};
+
+const SIGNATURE_PAYLOAD_HEADER: &[u8] = b"agentenv-skill-signature-v1\n";
+
+#[derive(Serialize)]
+struct SignedManifest<'a> {
+    name: &'a str,
+    version: String,
+    description: &'a Option<String>,
+    entry: String,
+    files: Vec<String>,
+    self_test_command: &'a Option<String>,
+    extra: BTreeMap<&'a str, &'a Value>,
+}
+
+pub fn signature_payload(manifest: &SkillManifest, digest: &str) -> Result<Vec<u8>, SkillError> {
+    let normalized = SignedManifest {
+        name: &manifest.name,
+        version: manifest.version.to_string(),
+        description: &manifest.description,
+        entry: manifest.entry.to_string_lossy().replace('\\', "/"),
+        files: manifest
+            .declared_files
+            .iter()
+            .map(|path| path.to_string_lossy().replace('\\', "/"))
+            .collect(),
+        self_test_command: &manifest.self_test_command,
+        extra: signed_extra(&manifest.extra),
+    };
+
+    let json = serde_json::to_vec(&normalized).map_err(|source| SkillError::InvalidSignature {
+        name: manifest.name.clone(),
+        version: manifest.version.to_string(),
+        message: source.to_string(),
+    })?;
+
+    let mut payload = SIGNATURE_PAYLOAD_HEADER.to_vec();
+    payload.extend(json);
+    payload.push(b'\n');
+    payload.extend(digest.as_bytes());
+    Ok(payload)
+}
+
+pub fn verify_ed25519_signature(
+    manifest: &SkillManifest,
+    digest: &str,
+    signature_hex: &str,
+    public_key_hex: &str,
+) -> Result<(), SkillError> {
+    let public_key_bytes =
+        hex::decode(public_key_hex).map_err(|source| invalid_signature(manifest, source))?;
+    let signature_bytes =
+        hex::decode(signature_hex).map_err(|source| invalid_signature(manifest, source))?;
+
+    let public_key_array: [u8; 32] =
+        public_key_bytes
+            .as_slice()
+            .try_into()
+            .map_err(|_| SkillError::InvalidSignature {
+                name: manifest.name.clone(),
+                version: manifest.version.to_string(),
+                message: "public key must be 32 bytes".to_owned(),
+            })?;
+    let signature = Signature::try_from(signature_bytes.as_slice()).map_err(|source| {
+        SkillError::InvalidSignature {
+            name: manifest.name.clone(),
+            version: manifest.version.to_string(),
+            message: source.to_string(),
+        }
+    })?;
+    let verifying_key = VerifyingKey::from_bytes(&public_key_array).map_err(|source| {
+        SkillError::InvalidSignature {
+            name: manifest.name.clone(),
+            version: manifest.version.to_string(),
+            message: source.to_string(),
+        }
+    })?;
+    let payload = signature_payload(manifest, digest)?;
+
+    verifying_key
+        .verify(&payload, &signature)
+        .map_err(|source| SkillError::InvalidSignature {
+            name: manifest.name.clone(),
+            version: manifest.version.to_string(),
+            message: source.to_string(),
+        })
+}
+
+fn invalid_signature(manifest: &SkillManifest, source: impl std::fmt::Display) -> SkillError {
+    SkillError::InvalidSignature {
+        name: manifest.name.clone(),
+        version: manifest.version.to_string(),
+        message: source.to_string(),
+    }
+}
+
+fn signed_extra(extra: &BTreeMap<String, Value>) -> BTreeMap<&str, &Value> {
+    extra
+        .iter()
+        .filter_map(|(key, value)| {
+            if is_signature_extra_key(key) {
+                None
+            } else {
+                Some((key.as_str(), value))
+            }
+        })
+        .collect()
+}
+
+fn is_signature_extra_key(key: &str) -> bool {
+    matches!(
+        key,
+        "ed25519_public_key" | "public_key_ed25519" | "signature_public_key_ed25519"
+    )
+}

--- a/crates/agentenv-core/src/skills/store.rs
+++ b/crates/agentenv-core/src/skills/store.rs
@@ -1,0 +1,863 @@
+use std::{
+    collections::{BTreeMap, BTreeSet},
+    fs,
+    path::{Component, Path, PathBuf},
+    process::Command,
+    thread,
+    time::{Duration, Instant},
+};
+
+use semver::Version;
+use serde::Deserialize;
+use serde_yaml::Value;
+use time::{format_description::well_known::Rfc3339, OffsetDateTime};
+
+use super::{
+    compute_bundle_digest, index,
+    manifest::{normalize_bundle_path, validated_bundle_file},
+    validate_skill_name, verify_ed25519_signature, SkillError, SkillManifest,
+};
+
+const MANIFEST_FILE: &str = "skill.yaml";
+const CONTENT_DIR: &str = "content";
+const SIGNATURE_STATUS_UNSIGNED: &str = "unsigned";
+const SELF_TEST_TIMEOUT: Duration = Duration::from_secs(30);
+
+#[derive(Debug, Clone, serde::Serialize, serde::Deserialize, PartialEq, Eq)]
+pub struct InstalledSkill {
+    pub name: String,
+    pub version: String,
+    pub source_type: String,
+    pub source_label: String,
+    pub digest: String,
+    pub signature_status: String,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub signature_public_key_ed25519: Option<String>,
+    pub entry: PathBuf,
+    pub installed_at: String,
+    pub path: PathBuf,
+}
+
+#[derive(Debug, Clone)]
+pub struct SkillInstallOptions {
+    pub allow_unsigned: bool,
+    pub source_label: String,
+}
+
+#[derive(Debug, Clone)]
+pub enum InstalledSkillSelector {
+    Name(String),
+    NameVersion { name: String, version: String },
+}
+
+#[derive(Debug, Deserialize)]
+struct RawSkillManifest {
+    name: Option<String>,
+    version: Option<String>,
+    description: Option<String>,
+    entry: Option<String>,
+    files: Option<Vec<String>>,
+    self_test: Option<RawSelfTest>,
+    signatures: Option<RawSignatures>,
+    #[serde(flatten)]
+    extra: BTreeMap<String, Value>,
+}
+
+#[derive(Debug, Deserialize)]
+struct RawSelfTest {
+    command: Option<String>,
+}
+
+#[derive(Debug, Deserialize)]
+struct RawSignatures {
+    ed25519: Option<String>,
+    public_key: Option<String>,
+    public_key_ed25519: Option<String>,
+}
+
+pub fn install_local_skill(
+    root: impl AsRef<Path>,
+    bundle: impl AsRef<Path>,
+    options: SkillInstallOptions,
+) -> Result<InstalledSkill, SkillError> {
+    let root = root.as_ref();
+    let bundle = bundle.as_ref();
+    let manifest = super::load_skill_manifest(bundle)?;
+    let digest = compute_bundle_digest(bundle, &manifest)?;
+
+    let signature_status = if options.allow_unsigned {
+        SIGNATURE_STATUS_UNSIGNED.to_owned()
+    } else {
+        return Err(SkillError::MissingSignature {
+            name: manifest.name,
+            version: manifest.version.to_string(),
+        });
+    };
+
+    let version = manifest.version.to_string();
+    let install_dir = install_dir(root, &manifest.name, &version);
+    if let Some(existing) = read_existing_install(root, &manifest.name, &version)? {
+        if existing.digest != digest {
+            return Err(SkillError::AlreadyInstalledDifferentDigest {
+                name: manifest.name,
+                version,
+                existing: existing.digest,
+            });
+        }
+        if cached_install_matches_record(&existing)? {
+            return Ok(existing);
+        }
+    }
+
+    let installed = InstalledSkill {
+        name: manifest.name.clone(),
+        version: version.clone(),
+        source_type: "local".to_owned(),
+        source_label: options.source_label,
+        digest,
+        signature_status,
+        signature_public_key_ed25519: None,
+        entry: PathBuf::from(CONTENT_DIR).join(&manifest.entry),
+        installed_at: installed_at_now(),
+        path: install_dir.clone(),
+    };
+
+    let staging_dir = staging_install_dir(&install_dir)?;
+    if staging_dir.exists() {
+        fs::remove_dir_all(&staging_dir).map_err(|source| SkillError::Io {
+            path: staging_dir.clone(),
+            source,
+        })?;
+    }
+    fs::create_dir_all(staging_dir.join(CONTENT_DIR)).map_err(|source| SkillError::Io {
+        path: staging_dir.join(CONTENT_DIR),
+        source,
+    })?;
+
+    copy_regular_file(
+        &bundle.join(MANIFEST_FILE),
+        &staging_dir.join(MANIFEST_FILE),
+    )?;
+    for declared_file in &manifest.declared_files {
+        let source = validated_bundle_file(bundle, declared_file)?;
+        let destination = staging_dir.join(CONTENT_DIR).join(declared_file);
+        copy_regular_file(&source, &destination)?;
+    }
+    index::write_record(&index::installed_record_path(&staging_dir), &installed)?;
+    replace_install_dir(&staging_dir, &install_dir)?;
+    index::rebuild(root)?;
+
+    Ok(installed)
+}
+
+pub fn list_installed_skills(root: impl AsRef<Path>) -> Result<Vec<InstalledSkill>, SkillError> {
+    index::rebuild(root.as_ref())
+}
+
+pub fn info_installed_skill(
+    root: impl AsRef<Path>,
+    selector: InstalledSkillSelector,
+) -> Result<InstalledSkill, SkillError> {
+    let resolved = resolve_installed(root.as_ref(), selector)?;
+    let mut installed = index::read_record(&index::installed_record_path(&resolved.path))?;
+    installed.path = resolved.path;
+    Ok(installed)
+}
+
+pub fn remove_installed_skill(
+    root: impl AsRef<Path>,
+    selector: InstalledSkillSelector,
+) -> Result<InstalledSkill, SkillError> {
+    let root = root.as_ref();
+    let installed = info_installed_skill(root, selector)?;
+    match fs::symlink_metadata(&installed.path) {
+        Ok(metadata) if metadata.file_type().is_dir() => {
+            fs::remove_dir_all(&installed.path).map_err(|source| SkillError::Io {
+                path: installed.path.clone(),
+                source,
+            })?;
+        }
+        Ok(_) => {
+            return Err(SkillError::UnsafeBundlePath {
+                path: installed.path.clone(),
+            });
+        }
+        Err(source) if source.kind() == std::io::ErrorKind::NotFound => {}
+        Err(source) => {
+            return Err(SkillError::Io {
+                path: installed.path.clone(),
+                source,
+            });
+        }
+    }
+    remove_empty_parent(&installed.path)?;
+    index::rebuild(root)?;
+    Ok(installed)
+}
+
+pub fn verify_installed_skill(
+    root: impl AsRef<Path>,
+    selector: InstalledSkillSelector,
+) -> Result<InstalledSkill, SkillError> {
+    let installed = info_installed_skill(root, selector)?;
+    ensure_content_directory(&installed.path)?;
+    let manifest = load_cached_manifest(&installed.path)?;
+    validate_installed_record(&installed, &manifest)?;
+    let content_root = installed.path.join(CONTENT_DIR);
+    let actual_digest = compute_bundle_digest(&content_root, &manifest)?;
+    if actual_digest != installed.digest {
+        return Err(SkillError::DigestMismatch {
+            expected: installed.digest,
+            actual: actual_digest,
+        });
+    }
+
+    verify_signature_if_required(&installed, &manifest)?;
+    if let Some(command) = manifest.self_test_command.as_deref() {
+        run_self_test(&installed, command)?;
+    }
+
+    Ok(installed)
+}
+
+fn verify_signature_if_required(
+    installed: &InstalledSkill,
+    manifest: &SkillManifest,
+) -> Result<(), SkillError> {
+    if installed.signature_status == SIGNATURE_STATUS_UNSIGNED
+        && manifest.signature_ed25519.is_none()
+        && installed.signature_public_key_ed25519.is_none()
+    {
+        return Ok(());
+    }
+
+    let Some(signature) = manifest.signature_ed25519.as_deref() else {
+        return Err(SkillError::MissingSignature {
+            name: installed.name.clone(),
+            version: installed.version.clone(),
+        });
+    };
+
+    let public_key = installed
+        .signature_public_key_ed25519
+        .as_deref()
+        .ok_or_else(|| SkillError::MissingSignature {
+            name: installed.name.clone(),
+            version: installed.version.clone(),
+        })?;
+    verify_ed25519_signature(manifest, &installed.digest, signature, public_key)?;
+
+    Ok(())
+}
+
+fn run_self_test(installed: &InstalledSkill, command: &str) -> Result<(), SkillError> {
+    let content_root = installed.path.join(CONTENT_DIR);
+    let mut command = shell_command(command);
+    command.current_dir(&content_root).env_clear();
+    let mut child = command.spawn().map_err(|source| SkillError::Io {
+        path: content_root.clone(),
+        source,
+    })?;
+    let deadline = Instant::now() + SELF_TEST_TIMEOUT;
+
+    loop {
+        if let Some(status) = child.try_wait().map_err(|source| SkillError::Io {
+            path: content_root.clone(),
+            source,
+        })? {
+            if status.success() {
+                return Ok(());
+            }
+            return Err(SkillError::SelfTestFailed {
+                name: installed.name.clone(),
+                version: installed.version.clone(),
+                status: status.code().map_or(-1, |code| code),
+            });
+        }
+
+        if Instant::now() >= deadline {
+            let _ = child.kill();
+            let _ = child.wait();
+            return Err(SkillError::SelfTestFailed {
+                name: installed.name.clone(),
+                version: installed.version.clone(),
+                status: -1,
+            });
+        }
+
+        thread::sleep(Duration::from_millis(50));
+    }
+}
+
+#[cfg(windows)]
+fn shell_command(command: &str) -> Command {
+    let mut shell = Command::new("cmd.exe");
+    shell.args(["/C", command]);
+    shell
+}
+
+#[cfg(not(windows))]
+fn shell_command(command: &str) -> Command {
+    let mut shell = Command::new("/bin/sh");
+    shell.args(["-c", command]);
+    shell
+}
+
+fn resolve_installed(
+    root: &Path,
+    selector: InstalledSkillSelector,
+) -> Result<InstalledSkill, SkillError> {
+    let installed = index::rebuild(root)?;
+    match selector {
+        InstalledSkillSelector::Name(name) => resolve_by_name(installed, name),
+        InstalledSkillSelector::NameVersion { name, version } => installed
+            .into_iter()
+            .find(|skill| skill.name == name && skill.version == version)
+            .ok_or(SkillError::SkillNotInstalled { name }),
+    }
+}
+
+fn resolve_by_name(
+    installed: Vec<InstalledSkill>,
+    name: String,
+) -> Result<InstalledSkill, SkillError> {
+    let matches = installed
+        .into_iter()
+        .filter(|skill| skill.name == name)
+        .collect::<Vec<_>>();
+
+    match matches.as_slice() {
+        [] => Err(SkillError::SkillNotInstalled { name }),
+        [installed] => Ok(installed.clone()),
+        _ => {
+            let versions = matches
+                .iter()
+                .map(|skill| skill.version.as_str())
+                .collect::<Vec<_>>()
+                .join(", ");
+            Err(SkillError::AmbiguousInstalledVersion { name, versions })
+        }
+    }
+}
+
+fn install_dir(root: &Path, name: &str, version: &str) -> PathBuf {
+    index::skills_root(root).join(name).join(version)
+}
+
+fn read_existing_install(
+    root: &Path,
+    name: &str,
+    version: &str,
+) -> Result<Option<InstalledSkill>, SkillError> {
+    let Some(install_dir) = existing_install_dir(root, name, version)? else {
+        return Ok(None);
+    };
+    let record_path = index::installed_record_path(&install_dir);
+    let mut installed = index::read_record(&record_path)?;
+    if installed.name != name || installed.version != version {
+        return Err(SkillError::UnsafeBundlePath { path: record_path });
+    }
+    installed.path = install_dir.to_path_buf();
+    Ok(Some(installed))
+}
+
+fn existing_install_dir(
+    root: &Path,
+    name: &str,
+    version: &str,
+) -> Result<Option<PathBuf>, SkillError> {
+    let skills_root = index::skills_root(root);
+    let Some(()) = existing_directory(&skills_root)? else {
+        return Ok(None);
+    };
+    let name_dir = skills_root.join(name);
+    let Some(()) = existing_directory(&name_dir)? else {
+        return Ok(None);
+    };
+    let install_dir = name_dir.join(version);
+    let Some(()) = existing_directory(&install_dir)? else {
+        return Ok(None);
+    };
+    Ok(Some(install_dir))
+}
+
+fn existing_directory(path: &Path) -> Result<Option<()>, SkillError> {
+    let metadata = match fs::symlink_metadata(path) {
+        Ok(metadata) => metadata,
+        Err(source) if source.kind() == std::io::ErrorKind::NotFound => return Ok(None),
+        Err(source) => {
+            return Err(SkillError::Io {
+                path: path.to_path_buf(),
+                source,
+            });
+        }
+    };
+    let file_type = metadata.file_type();
+    if file_type.is_symlink() || !file_type.is_dir() {
+        return Err(SkillError::UnsafeBundlePath {
+            path: path.to_path_buf(),
+        });
+    }
+    Ok(Some(()))
+}
+
+fn cached_install_matches_record(installed: &InstalledSkill) -> Result<bool, SkillError> {
+    ensure_content_directory(&installed.path)?;
+    let manifest = match load_cached_manifest(&installed.path) {
+        Ok(manifest) => manifest,
+        Err(error) if cache_can_be_repaired(&error) => return Ok(false),
+        Err(error) => return Err(error),
+    };
+    validate_installed_record(installed, &manifest)?;
+    let content_root = installed.path.join(CONTENT_DIR);
+    match compute_bundle_digest(&content_root, &manifest) {
+        Ok(actual) => Ok(actual == installed.digest),
+        Err(error) if cache_can_be_repaired(&error) => Ok(false),
+        Err(error) => Err(error),
+    }
+}
+
+fn validate_installed_record(
+    installed: &InstalledSkill,
+    manifest: &SkillManifest,
+) -> Result<(), SkillError> {
+    if installed.name != manifest.name || installed.version != manifest.version.to_string() {
+        return Err(SkillError::UnsafeBundlePath {
+            path: index::installed_record_path(&installed.path),
+        });
+    }
+
+    let expected_entry = PathBuf::from(CONTENT_DIR).join(&manifest.entry);
+    if installed.entry != expected_entry {
+        return Err(SkillError::UnsafeBundlePath {
+            path: installed.entry.clone(),
+        });
+    }
+
+    Ok(())
+}
+
+fn ensure_content_directory(install_dir: &Path) -> Result<(), SkillError> {
+    let path = install_dir.join(CONTENT_DIR);
+    let metadata = fs::symlink_metadata(&path).map_err(|source| SkillError::Io {
+        path: path.clone(),
+        source,
+    })?;
+    let file_type = metadata.file_type();
+    if file_type.is_symlink() || !file_type.is_dir() {
+        return Err(SkillError::UnsafeBundlePath { path });
+    }
+    Ok(())
+}
+
+fn cache_can_be_repaired(error: &SkillError) -> bool {
+    match error {
+        SkillError::Io { source, .. } => source.kind() == std::io::ErrorKind::NotFound,
+        SkillError::Yaml { .. }
+        | SkillError::InvalidSkillName { .. }
+        | SkillError::InvalidVersion { .. }
+        | SkillError::MissingDeclaredFile { .. }
+        | SkillError::EmptyFilePattern { .. }
+        | SkillError::MissingManifestField { .. } => true,
+        SkillError::UnsafeBundlePath { .. }
+        | SkillError::DigestMismatch { .. }
+        | SkillError::MissingSignature { .. }
+        | SkillError::InvalidSignature { .. }
+        | SkillError::SkillNotInstalled { .. }
+        | SkillError::AmbiguousInstalledVersion { .. }
+        | SkillError::AlreadyInstalledDifferentDigest { .. }
+        | SkillError::Serde { .. }
+        | SkillError::SelfTestFailed { .. } => false,
+    }
+}
+
+fn staging_install_dir(install_dir: &Path) -> Result<PathBuf, SkillError> {
+    let parent = install_dir
+        .parent()
+        .ok_or_else(|| SkillError::UnsafeBundlePath {
+            path: install_dir.to_path_buf(),
+        })?;
+    fs::create_dir_all(parent).map_err(|source| SkillError::Io {
+        path: parent.to_path_buf(),
+        source,
+    })?;
+
+    let version = install_dir
+        .file_name()
+        .ok_or_else(|| SkillError::UnsafeBundlePath {
+            path: install_dir.to_path_buf(),
+        })?
+        .to_string_lossy();
+    Ok(parent.join(format!(
+        ".{version}.tmp-{}-{}",
+        std::process::id(),
+        temporary_suffix()
+    )))
+}
+
+fn replace_install_dir(staging_dir: &Path, install_dir: &Path) -> Result<(), SkillError> {
+    if !install_dir.exists() {
+        return fs::rename(staging_dir, install_dir).map_err(|source| SkillError::Io {
+            path: install_dir.to_path_buf(),
+            source,
+        });
+    }
+
+    let backup_dir = backup_install_dir(install_dir)?;
+    if backup_dir.exists() {
+        fs::remove_dir_all(&backup_dir).map_err(|source| SkillError::Io {
+            path: backup_dir.clone(),
+            source,
+        })?;
+    }
+
+    fs::rename(install_dir, &backup_dir).map_err(|source| SkillError::Io {
+        path: install_dir.to_path_buf(),
+        source,
+    })?;
+    match fs::rename(staging_dir, install_dir) {
+        Ok(()) => {
+            fs::remove_dir_all(&backup_dir).map_err(|source| SkillError::Io {
+                path: backup_dir,
+                source,
+            })?;
+            Ok(())
+        }
+        Err(source) => {
+            let _ = fs::rename(&backup_dir, install_dir);
+            Err(SkillError::Io {
+                path: install_dir.to_path_buf(),
+                source,
+            })
+        }
+    }
+}
+
+fn backup_install_dir(install_dir: &Path) -> Result<PathBuf, SkillError> {
+    let parent = install_dir
+        .parent()
+        .ok_or_else(|| SkillError::UnsafeBundlePath {
+            path: install_dir.to_path_buf(),
+        })?;
+    let version = install_dir
+        .file_name()
+        .ok_or_else(|| SkillError::UnsafeBundlePath {
+            path: install_dir.to_path_buf(),
+        })?
+        .to_string_lossy();
+    Ok(parent.join(format!(
+        ".{version}.backup-{}-{}",
+        std::process::id(),
+        temporary_suffix()
+    )))
+}
+
+fn copy_regular_file(source: &Path, destination: &Path) -> Result<(), SkillError> {
+    if let Some(parent) = destination.parent() {
+        fs::create_dir_all(parent).map_err(|source| SkillError::Io {
+            path: parent.to_path_buf(),
+            source,
+        })?;
+    }
+    let mut source_file = open_regular_file(source)?;
+    let mut destination_file = fs::File::create(destination).map_err(|source| SkillError::Io {
+        path: destination.to_path_buf(),
+        source,
+    })?;
+    std::io::copy(&mut source_file, &mut destination_file).map_err(|source| SkillError::Io {
+        path: destination.to_path_buf(),
+        source,
+    })?;
+    Ok(())
+}
+
+#[cfg(unix)]
+fn open_regular_file(path: &Path) -> Result<fs::File, SkillError> {
+    use std::{fs::OpenOptions, os::unix::fs::OpenOptionsExt};
+
+    let file = OpenOptions::new()
+        .read(true)
+        .custom_flags(libc::O_NOFOLLOW)
+        .open(path)
+        .map_err(|source| SkillError::Io {
+            path: path.to_path_buf(),
+            source,
+        })?;
+    ensure_opened_regular_file(path, &file)?;
+    Ok(file)
+}
+
+#[cfg(not(unix))]
+fn open_regular_file(path: &Path) -> Result<fs::File, SkillError> {
+    let metadata = fs::symlink_metadata(path).map_err(|source| SkillError::Io {
+        path: path.to_path_buf(),
+        source,
+    })?;
+    if !metadata.file_type().is_file() {
+        return Err(SkillError::UnsafeBundlePath {
+            path: path.to_path_buf(),
+        });
+    }
+    let file = fs::File::open(path).map_err(|source| SkillError::Io {
+        path: path.to_path_buf(),
+        source,
+    })?;
+    ensure_opened_regular_file(path, &file)?;
+    Ok(file)
+}
+
+fn ensure_opened_regular_file(path: &Path, file: &fs::File) -> Result<(), SkillError> {
+    let metadata = file.metadata().map_err(|source| SkillError::Io {
+        path: path.to_path_buf(),
+        source,
+    })?;
+    if metadata.file_type().is_file() {
+        Ok(())
+    } else {
+        Err(SkillError::UnsafeBundlePath {
+            path: path.to_path_buf(),
+        })
+    }
+}
+
+fn remove_empty_parent(install_dir: &Path) -> Result<(), SkillError> {
+    let Some(parent) = install_dir.parent() else {
+        return Ok(());
+    };
+    if parent
+        .read_dir()
+        .map_err(|source| SkillError::Io {
+            path: parent.to_path_buf(),
+            source,
+        })?
+        .next()
+        .is_none()
+    {
+        fs::remove_dir(parent).map_err(|source| SkillError::Io {
+            path: parent.to_path_buf(),
+            source,
+        })?;
+    }
+    Ok(())
+}
+
+fn load_cached_manifest(install_dir: &Path) -> Result<SkillManifest, SkillError> {
+    let manifest_path = install_dir.join(MANIFEST_FILE);
+    let content_root = install_dir.join(CONTENT_DIR);
+    let content = read_regular_string(&manifest_path)?;
+    let raw: RawSkillManifest =
+        serde_yaml::from_str(&content).map_err(|source| SkillError::Yaml {
+            path: manifest_path.clone(),
+            source,
+        })?;
+
+    let name = required(raw.name, &manifest_path, "name")?;
+    validate_skill_name(&name)?;
+
+    let version = required(raw.version, &manifest_path, "version")?;
+    let version = version
+        .parse::<Version>()
+        .map_err(|source| SkillError::InvalidVersion {
+            version: version.clone(),
+            source,
+        })?;
+
+    let entry = normalize_bundle_path(Path::new(&required(raw.entry, &manifest_path, "entry")?))?;
+    let files = raw.files.ok_or_else(|| SkillError::MissingManifestField {
+        path: manifest_path.clone(),
+        field: "files",
+    })?;
+    let declared_files = expand_declared_files(&content_root, files)?;
+    if !declared_files.contains(&entry) {
+        return Err(SkillError::MissingDeclaredFile { path: entry });
+    }
+
+    let extra = raw.extra;
+    let (signature_ed25519, signature_public_key_ed25519) = raw
+        .signatures
+        .map(|signatures| {
+            (
+                signatures.ed25519,
+                signatures.public_key_ed25519.or(signatures.public_key),
+            )
+        })
+        .unwrap_or((None, None));
+
+    Ok(SkillManifest {
+        name,
+        version,
+        description: raw.description,
+        entry,
+        declared_files,
+        self_test_command: raw.self_test.and_then(|self_test| self_test.command),
+        signature_ed25519,
+        signature_public_key_ed25519,
+        extra,
+    })
+}
+
+fn read_regular_string(path: &Path) -> Result<String, SkillError> {
+    let metadata = fs::symlink_metadata(path).map_err(|source| SkillError::Io {
+        path: path.to_path_buf(),
+        source,
+    })?;
+    if !metadata.file_type().is_file() {
+        return Err(SkillError::UnsafeBundlePath {
+            path: path.to_path_buf(),
+        });
+    }
+
+    fs::read_to_string(path).map_err(|source| SkillError::Io {
+        path: path.to_path_buf(),
+        source,
+    })
+}
+
+fn required(
+    value: Option<String>,
+    manifest_path: &Path,
+    field: &'static str,
+) -> Result<String, SkillError> {
+    value.ok_or_else(|| SkillError::MissingManifestField {
+        path: manifest_path.to_path_buf(),
+        field,
+    })
+}
+
+fn expand_declared_files(root: &Path, patterns: Vec<String>) -> Result<Vec<PathBuf>, SkillError> {
+    let mut files = BTreeSet::new();
+
+    for pattern in patterns {
+        if let Some(directory) = pattern.strip_suffix("/**") {
+            let directory = normalize_bundle_path(Path::new(directory))?;
+            let matched = collect_declared_files(root, &directory, &mut files)?;
+            if matched == 0 {
+                return Err(SkillError::EmptyFilePattern { pattern });
+            }
+        } else {
+            let file = normalize_bundle_path(Path::new(&pattern))?;
+            validated_bundle_file(root, &file)?;
+            files.insert(file);
+        }
+    }
+
+    Ok(files.into_iter().collect())
+}
+
+fn collect_declared_files(
+    root: &Path,
+    directory: &Path,
+    files: &mut BTreeSet<PathBuf>,
+) -> Result<usize, SkillError> {
+    validated_bundle_directory(root, directory)?;
+    collect_declared_files_inner(root, directory, files)
+}
+
+fn collect_declared_files_inner(
+    root: &Path,
+    directory: &Path,
+    files: &mut BTreeSet<PathBuf>,
+) -> Result<usize, SkillError> {
+    let absolute_directory = root.join(directory);
+    let entries = fs::read_dir(&absolute_directory).map_err(|source| SkillError::Io {
+        path: absolute_directory.clone(),
+        source,
+    })?;
+    let mut matched = 0;
+
+    for entry in entries {
+        let entry = entry.map_err(|source| SkillError::Io {
+            path: absolute_directory.clone(),
+            source,
+        })?;
+        let relative_path = normalize_bundle_path(&directory.join(entry.file_name()))?;
+        let absolute_path = root.join(&relative_path);
+        let metadata = fs::symlink_metadata(&absolute_path)
+            .map_err(|source| missing_or_io_error(source, &absolute_path, &relative_path))?;
+        let file_type = metadata.file_type();
+
+        if file_type.is_dir() {
+            matched += collect_declared_files_inner(root, &relative_path, files)?;
+        } else if file_type.is_file() {
+            files.insert(relative_path);
+            matched += 1;
+        } else {
+            return Err(SkillError::MissingDeclaredFile {
+                path: relative_path,
+            });
+        }
+    }
+
+    Ok(matched)
+}
+
+fn validated_bundle_directory(root: &Path, relative_path: &Path) -> Result<PathBuf, SkillError> {
+    let relative_path = normalize_bundle_path(relative_path)?;
+    let mut absolute_path = root.to_path_buf();
+    let mut components = relative_path.components().peekable();
+
+    while let Some(component) = components.next() {
+        let Component::Normal(part) = component else {
+            return Err(SkillError::UnsafeBundlePath {
+                path: relative_path.clone(),
+            });
+        };
+        absolute_path.push(part);
+        let metadata = fs::symlink_metadata(&absolute_path)
+            .map_err(|source| missing_or_io_error(source, &absolute_path, &relative_path))?;
+        let file_type = metadata.file_type();
+
+        if components.peek().is_some() {
+            if !file_type.is_dir() {
+                return Err(SkillError::MissingDeclaredFile {
+                    path: relative_path.clone(),
+                });
+            }
+            continue;
+        }
+
+        if file_type.is_dir() {
+            return Ok(absolute_path);
+        }
+
+        return Err(SkillError::MissingDeclaredFile {
+            path: relative_path.clone(),
+        });
+    }
+
+    Err(SkillError::UnsafeBundlePath {
+        path: relative_path,
+    })
+}
+
+fn missing_or_io_error(
+    source: std::io::Error,
+    absolute_path: &Path,
+    relative_path: &Path,
+) -> SkillError {
+    if source.kind() == std::io::ErrorKind::NotFound {
+        SkillError::MissingDeclaredFile {
+            path: relative_path.to_path_buf(),
+        }
+    } else {
+        SkillError::Io {
+            path: absolute_path.to_path_buf(),
+            source,
+        }
+    }
+}
+
+fn installed_at_now() -> String {
+    let now = OffsetDateTime::now_utc();
+    match now.format(&Rfc3339) {
+        Ok(formatted) => formatted,
+        Err(_) => now.unix_timestamp().to_string(),
+    }
+}
+
+fn temporary_suffix() -> u128 {
+    match std::time::SystemTime::now().duration_since(std::time::UNIX_EPOCH) {
+        Ok(duration) => duration.as_nanos(),
+        Err(_) => 0,
+    }
+}

--- a/crates/agentenv-core/src/skills/store.rs
+++ b/crates/agentenv-core/src/skills/store.rs
@@ -470,6 +470,10 @@ fn cache_can_be_repaired(error: &SkillError) -> bool {
         | SkillError::Serde { .. }
         | SkillError::Toml { .. }
         | SkillError::RegistryNotFound { .. }
+        | SkillError::RegistryUrlBlocked { .. }
+        | SkillError::HttpRegistry { .. }
+        | SkillError::HttpStatus { .. }
+        | SkillError::CredentialReferenceUnavailable { .. }
         | SkillError::InvalidConfig { .. }
         | SkillError::SelfTestFailed { .. } => false,
     }

--- a/crates/agentenv-core/src/skills/store.rs
+++ b/crates/agentenv-core/src/skills/store.rs
@@ -467,6 +467,9 @@ fn cache_can_be_repaired(error: &SkillError) -> bool {
         | SkillError::AmbiguousInstalledVersion { .. }
         | SkillError::AlreadyInstalledDifferentDigest { .. }
         | SkillError::Serde { .. }
+        | SkillError::Toml { .. }
+        | SkillError::RegistryNotFound { .. }
+        | SkillError::InvalidConfig { .. }
         | SkillError::SelfTestFailed { .. } => false,
     }
 }

--- a/crates/agentenv-core/src/skills/store.rs
+++ b/crates/agentenv-core/src/skills/store.rs
@@ -41,6 +41,7 @@ pub struct InstalledSkill {
 #[derive(Debug, Clone)]
 pub struct SkillInstallOptions {
     pub allow_unsigned: bool,
+    pub source_type: String,
     pub source_label: String,
 }
 
@@ -112,7 +113,7 @@ pub fn install_local_skill(
     let installed = InstalledSkill {
         name: manifest.name.clone(),
         version: version.clone(),
-        source_type: "local".to_owned(),
+        source_type: options.source_type,
         source_label: options.source_label,
         digest,
         signature_status,

--- a/crates/agentenv-core/src/skills/store.rs
+++ b/crates/agentenv-core/src/skills/store.rs
@@ -474,6 +474,8 @@ fn cache_can_be_repaired(error: &SkillError) -> bool {
         | SkillError::HttpRegistry { .. }
         | SkillError::HttpStatus { .. }
         | SkillError::CredentialReferenceUnavailable { .. }
+        | SkillError::UnsupportedRegistryAuth { .. }
+        | SkillError::InvalidOciReference { .. }
         | SkillError::InvalidConfig { .. }
         | SkillError::SelfTestFailed { .. } => false,
     }

--- a/crates/agentenv-core/tests/skills.rs
+++ b/crates/agentenv-core/tests/skills.rs
@@ -1,0 +1,308 @@
+use std::{
+    fs,
+    path::{Path, PathBuf},
+};
+
+use agentenv_core::skills::{
+    compute_bundle_digest, load_skill_manifest, validate_skill_name, SkillError,
+};
+
+#[test]
+fn skill_manifest_accepts_minimal_bundle() {
+    let root = temp_dir("skill-manifest-minimal");
+    write_file(&root.join("SKILL.md"), "# Demo\n");
+    write_file(
+        &root.join("skill.yaml"),
+        "name: demo-skill\nversion: 0.1.0\nentry: SKILL.md\nfiles:\n  - SKILL.md\n",
+    );
+
+    let manifest = load_skill_manifest(&root).expect("manifest should load");
+
+    assert_eq!(manifest.name, "demo-skill");
+    assert_eq!(manifest.version.to_string(), "0.1.0");
+    assert_eq!(manifest.entry, PathBuf::from("SKILL.md"));
+    assert_eq!(manifest.declared_files, vec![PathBuf::from("SKILL.md")]);
+}
+
+#[test]
+fn skill_manifest_reads_nested_self_test_and_signature() {
+    let root = temp_dir("skill-manifest-nested-metadata");
+    write_file(&root.join("SKILL.md"), "# Demo\n");
+    write_file(
+        &root.join("skill.yaml"),
+        "name: demo\nversion: 0.1.0\nentry: SKILL.md\nfiles:\n  - SKILL.md\nself_test:\n  command: test -f SKILL.md\nsignatures:\n  ed25519: abc123\n",
+    );
+
+    let manifest = load_skill_manifest(&root).expect("manifest should load");
+
+    assert_eq!(
+        manifest.self_test_command.as_deref(),
+        Some("test -f SKILL.md")
+    );
+    assert_eq!(manifest.signature_ed25519.as_deref(), Some("abc123"));
+}
+
+#[test]
+fn skill_manifest_rejects_invalid_name() {
+    let root = temp_dir("skill-manifest-invalid-name");
+    write_file(&root.join("SKILL.md"), "# Demo\n");
+    write_file(
+        &root.join("skill.yaml"),
+        "name: ../demo\nversion: 0.1.0\nentry: SKILL.md\nfiles:\n  - SKILL.md\n",
+    );
+
+    let error = load_skill_manifest(&root).expect_err("name must be rejected");
+
+    assert!(matches!(error, SkillError::InvalidSkillName { .. }));
+}
+
+#[test]
+fn skill_manifest_rejects_parent_traversal() {
+    let root = temp_dir("skill-manifest-parent-traversal");
+    write_file(&root.join("SKILL.md"), "# Demo\n");
+    write_file(
+        &root.join("skill.yaml"),
+        "name: demo\nversion: 0.1.0\nentry: ../SKILL.md\nfiles:\n  - SKILL.md\n",
+    );
+
+    let error = load_skill_manifest(&root).expect_err("entry traversal must fail");
+
+    assert!(matches!(error, SkillError::UnsafeBundlePath { .. }));
+}
+
+#[test]
+fn skill_manifest_rejects_missing_files_field() {
+    let root = temp_dir("skill-manifest-missing-files");
+    write_file(&root.join("SKILL.md"), "# Demo\n");
+    write_file(
+        &root.join("skill.yaml"),
+        "name: demo\nversion: 0.1.0\nentry: SKILL.md\n",
+    );
+
+    let error = load_skill_manifest(&root).expect_err("files must be required");
+
+    assert!(matches!(
+        error,
+        SkillError::MissingManifestField { field: "files", .. }
+    ));
+}
+
+#[test]
+fn skill_manifest_rejects_entry_not_declared_in_files() {
+    let root = temp_dir("skill-manifest-entry-not-declared");
+    write_file(&root.join("SKILL.md"), "# Demo\n");
+    write_file(&root.join("README.md"), "# Readme\n");
+    write_file(
+        &root.join("skill.yaml"),
+        "name: demo\nversion: 0.1.0\nentry: SKILL.md\nfiles:\n  - README.md\n",
+    );
+
+    let error = load_skill_manifest(&root).expect_err("entry must be declared");
+
+    assert!(matches!(error, SkillError::MissingDeclaredFile { .. }));
+}
+
+#[test]
+fn skill_manifest_rejects_missing_declared_file() {
+    let root = temp_dir("skill-manifest-missing-declared-file");
+    write_file(&root.join("SKILL.md"), "# Demo\n");
+    write_file(
+        &root.join("skill.yaml"),
+        "name: demo\nversion: 0.1.0\nentry: SKILL.md\nfiles:\n  - SKILL.md\n  - missing.md\n",
+    );
+
+    let error = load_skill_manifest(&root).expect_err("declared files must exist");
+
+    assert!(matches!(error, SkillError::MissingDeclaredFile { .. }));
+}
+
+#[cfg(unix)]
+#[test]
+fn skill_manifest_rejects_entry_inside_symlinked_directory() {
+    let root = temp_dir("skill-manifest-symlinked-entry-parent");
+    let outside = temp_dir("skill-manifest-symlinked-entry-outside");
+    write_file(&outside.join("SKILL.md"), "# Outside\n");
+    std::os::unix::fs::symlink(&outside, root.join("linked")).unwrap();
+    write_file(
+        &root.join("skill.yaml"),
+        "name: demo\nversion: 0.1.0\nentry: linked/SKILL.md\nfiles:\n  - linked/SKILL.md\n",
+    );
+
+    let error = load_skill_manifest(&root).expect_err("symlinked parents must be rejected");
+
+    assert!(matches!(error, SkillError::MissingDeclaredFile { .. }));
+}
+
+#[cfg(unix)]
+#[test]
+fn skill_manifest_rejects_symlinked_file_in_recursive_declaration() {
+    let root = temp_dir("skill-manifest-recursive-symlinked-file");
+    fs::create_dir_all(root.join("references")).unwrap();
+    write_file(&root.join("SKILL.md"), "# Demo\n");
+    write_file(&root.join("references/real.md"), "# Real\n");
+    let outside = temp_dir("skill-manifest-recursive-symlinked-file-outside");
+    write_file(&outside.join("linked.md"), "# Outside\n");
+    std::os::unix::fs::symlink(outside.join("linked.md"), root.join("references/linked.md"))
+        .unwrap();
+    write_file(
+        &root.join("skill.yaml"),
+        "name: demo\nversion: 0.1.0\nentry: SKILL.md\nfiles:\n  - SKILL.md\n  - references/**\n",
+    );
+
+    let error = load_skill_manifest(&root).expect_err("recursive symlinked files must fail");
+
+    assert!(matches!(error, SkillError::MissingDeclaredFile { .. }));
+}
+
+#[cfg(unix)]
+#[test]
+fn skill_manifest_rejects_symlinked_directory_in_recursive_declaration() {
+    let root = temp_dir("skill-manifest-recursive-symlinked-dir");
+    fs::create_dir_all(root.join("references")).unwrap();
+    write_file(&root.join("SKILL.md"), "# Demo\n");
+    write_file(&root.join("references/real.md"), "# Real\n");
+    let outside = temp_dir("skill-manifest-recursive-symlinked-dir-outside");
+    write_file(&outside.join("linked.md"), "# Outside\n");
+    std::os::unix::fs::symlink(&outside, root.join("references/linked")).unwrap();
+    write_file(
+        &root.join("skill.yaml"),
+        "name: demo\nversion: 0.1.0\nentry: SKILL.md\nfiles:\n  - SKILL.md\n  - references/**\n",
+    );
+
+    let error = load_skill_manifest(&root).expect_err("recursive symlinked dirs must fail");
+
+    assert!(matches!(error, SkillError::MissingDeclaredFile { .. }));
+}
+
+#[cfg(unix)]
+#[test]
+fn skill_manifest_rejects_symlinked_manifest_file() {
+    let root = temp_dir("skill-manifest-symlinked-manifest");
+    let outside = temp_dir("skill-manifest-symlinked-manifest-outside");
+    write_file(&root.join("SKILL.md"), "# Demo\n");
+    write_file(
+        &outside.join("skill.yaml"),
+        "name: demo\nversion: 0.1.0\nentry: SKILL.md\nfiles:\n  - SKILL.md\n",
+    );
+    std::os::unix::fs::symlink(outside.join("skill.yaml"), root.join("skill.yaml")).unwrap();
+
+    let error = load_skill_manifest(&root).expect_err("manifest symlinks must be rejected");
+
+    assert!(matches!(error, SkillError::UnsafeBundlePath { .. }));
+}
+
+#[test]
+fn skill_digest_is_stable_for_sorted_declared_files() {
+    let root = temp_dir("skill-digest-stable");
+    fs::create_dir_all(root.join("references")).unwrap();
+    write_file(&root.join("SKILL.md"), "# Demo\n");
+    write_file(&root.join("references/a.md"), "A\n");
+    write_file(&root.join("references/b.md"), "B\n");
+    write_file(
+        &root.join("skill.yaml"),
+        "name: demo\nversion: 0.1.0\nentry: SKILL.md\nfiles:\n  - references/**\n  - SKILL.md\n",
+    );
+    let manifest = load_skill_manifest(&root).unwrap();
+
+    let first = compute_bundle_digest(&root, &manifest).unwrap();
+    let second = compute_bundle_digest(&root, &manifest).unwrap();
+
+    assert_eq!(first, second);
+    assert!(first.starts_with("sha256:"));
+    assert_eq!(first.len(), "sha256:".len() + 64);
+}
+
+#[test]
+fn skill_digest_changes_when_content_changes() {
+    let root = temp_dir("skill-digest-changes");
+    write_file(&root.join("SKILL.md"), "# Demo\n");
+    write_file(
+        &root.join("skill.yaml"),
+        "name: demo\nversion: 0.1.0\nentry: SKILL.md\nfiles:\n  - SKILL.md\n",
+    );
+    let manifest = load_skill_manifest(&root).unwrap();
+    let before = compute_bundle_digest(&root, &manifest).unwrap();
+
+    write_file(&root.join("SKILL.md"), "# Changed\n");
+    let after = compute_bundle_digest(&root, &manifest).unwrap();
+
+    assert_ne!(before, after);
+}
+
+#[cfg(unix)]
+#[test]
+fn skill_digest_rejects_declared_symlink() {
+    let root = temp_dir("skill-digest-symlink");
+    write_file(&root.join("target.md"), "# Target\n");
+    std::os::unix::fs::symlink(root.join("target.md"), root.join("SKILL.md")).unwrap();
+    let manifest = agentenv_core::skills::SkillManifest {
+        name: "demo".to_owned(),
+        version: semver::Version::parse("0.1.0").unwrap(),
+        description: None,
+        entry: PathBuf::from("SKILL.md"),
+        declared_files: vec![PathBuf::from("SKILL.md")],
+        self_test_command: None,
+        signature_ed25519: None,
+        extra: Default::default(),
+    };
+
+    let error = compute_bundle_digest(&root, &manifest).expect_err("symlink must be rejected");
+
+    assert!(matches!(error, SkillError::MissingDeclaredFile { .. }));
+}
+
+#[cfg(unix)]
+#[test]
+fn skill_digest_rejects_symlinked_parent_directory() {
+    let root = temp_dir("skill-digest-symlinked-parent");
+    let outside = temp_dir("skill-digest-symlinked-parent-outside");
+    write_file(&outside.join("SKILL.md"), "# Outside\n");
+    std::os::unix::fs::symlink(&outside, root.join("linked")).unwrap();
+    let manifest = agentenv_core::skills::SkillManifest {
+        name: "demo".to_owned(),
+        version: semver::Version::parse("0.1.0").unwrap(),
+        description: None,
+        entry: PathBuf::from("linked/SKILL.md"),
+        declared_files: vec![PathBuf::from("linked/SKILL.md")],
+        self_test_command: None,
+        signature_ed25519: None,
+        extra: Default::default(),
+    };
+
+    let error =
+        compute_bundle_digest(&root, &manifest).expect_err("symlinked parent must be rejected");
+
+    assert!(matches!(error, SkillError::MissingDeclaredFile { .. }));
+}
+
+#[test]
+fn validate_skill_name_accepts_conservative_identifiers() {
+    for name in ["demo", "demo-skill", "demo_skill", "demo.skill", "a1"] {
+        validate_skill_name(name).expect(name);
+    }
+}
+
+fn temp_dir(prefix: &str) -> PathBuf {
+    let mut path = std::env::temp_dir();
+    path.push(format!(
+        "{prefix}-{}-{}",
+        std::process::id(),
+        unique_nanos()
+    ));
+    fs::create_dir_all(&path).unwrap();
+    path
+}
+
+fn write_file(path: &Path, content: &str) {
+    if let Some(parent) = path.parent() {
+        fs::create_dir_all(parent).unwrap();
+    }
+    fs::write(path, content).unwrap();
+}
+
+fn unique_nanos() -> u128 {
+    std::time::SystemTime::now()
+        .duration_since(std::time::UNIX_EPOCH)
+        .unwrap()
+        .as_nanos()
+}

--- a/crates/agentenv-core/tests/skills.rs
+++ b/crates/agentenv-core/tests/skills.rs
@@ -6,8 +6,8 @@ use std::{
 use agentenv_core::skills::{
     compute_bundle_digest, install_local_skill, list_installed_skills, load_project_skills_config,
     load_skill_manifest, load_user_skills_config, merge_skills_config, validate_skill_name,
-    verify_installed_skill, InstalledSkillSelector, RegistryKind, SkillError, SkillInstallOptions,
-    SkillsConfig, SkillsConfigOverride,
+    verify_installed_skill, InstalledSkillSelector, RegistryKind, SkillAddRequest, SkillError,
+    SkillInstallOptions, SkillPublishRequest, SkillService, SkillsConfig, SkillsConfigOverride,
 };
 use ed25519_dalek::{Signer, SigningKey};
 
@@ -379,6 +379,7 @@ fn local_install_writes_cache_and_index() {
         &bundle,
         SkillInstallOptions {
             allow_unsigned: true,
+            source_type: "local".to_owned(),
             source_label: "local-dev".to_owned(),
         },
     )
@@ -404,6 +405,7 @@ fn local_reinstall_same_digest_keeps_existing_record() {
         &bundle,
         SkillInstallOptions {
             allow_unsigned: true,
+            source_type: "local".to_owned(),
             source_label: "first-source".to_owned(),
         },
     )
@@ -414,6 +416,7 @@ fn local_reinstall_same_digest_keeps_existing_record() {
         &bundle,
         SkillInstallOptions {
             allow_unsigned: true,
+            source_type: "local".to_owned(),
             source_label: "second-source".to_owned(),
         },
     )
@@ -437,6 +440,7 @@ fn local_reinstall_repairs_tampered_cached_content() {
         &bundle,
         SkillInstallOptions {
             allow_unsigned: true,
+            source_type: "local".to_owned(),
             source_label: "local-dev".to_owned(),
         },
     )
@@ -448,6 +452,7 @@ fn local_reinstall_repairs_tampered_cached_content() {
         &bundle,
         SkillInstallOptions {
             allow_unsigned: true,
+            source_type: "local".to_owned(),
             source_label: "local-dev".to_owned(),
         },
     )
@@ -489,6 +494,7 @@ fn local_reinstall_rejects_symlinked_existing_version_directory() {
         &bundle,
         SkillInstallOptions {
             allow_unsigned: true,
+            source_type: "local".to_owned(),
             source_label: "local-dev".to_owned(),
         },
     )
@@ -513,6 +519,7 @@ fn local_reinstall_rejects_symlinked_cached_content_directory() {
         &bundle,
         SkillInstallOptions {
             allow_unsigned: true,
+            source_type: "local".to_owned(),
             source_label: "local-dev".to_owned(),
         },
     )
@@ -526,6 +533,7 @@ fn local_reinstall_rejects_symlinked_cached_content_directory() {
         &bundle,
         SkillInstallOptions {
             allow_unsigned: true,
+            source_type: "local".to_owned(),
             source_label: "local-dev".to_owned(),
         },
     )
@@ -550,6 +558,7 @@ fn local_reinstall_rejects_symlinked_cached_content_with_missing_files() {
         &bundle,
         SkillInstallOptions {
             allow_unsigned: true,
+            source_type: "local".to_owned(),
             source_label: "local-dev".to_owned(),
         },
     )
@@ -562,6 +571,7 @@ fn local_reinstall_rejects_symlinked_cached_content_with_missing_files() {
         &bundle,
         SkillInstallOptions {
             allow_unsigned: true,
+            source_type: "local".to_owned(),
             source_label: "local-dev".to_owned(),
         },
     )
@@ -591,6 +601,7 @@ fn local_install_treats_manifest_public_key_as_untrusted() {
         &bundle,
         SkillInstallOptions {
             allow_unsigned: true,
+            source_type: "local".to_owned(),
             source_label: "local-dev".to_owned(),
         },
     )
@@ -613,6 +624,7 @@ fn installed_verify_detects_content_tampering() {
         &bundle,
         SkillInstallOptions {
             allow_unsigned: true,
+            source_type: "local".to_owned(),
             source_label: "local-dev".to_owned(),
         },
     )
@@ -642,6 +654,7 @@ fn installed_verify_rejects_signed_record_without_public_key() {
         &bundle,
         SkillInstallOptions {
             allow_unsigned: true,
+            source_type: "local".to_owned(),
             source_label: "local-dev".to_owned(),
         },
     )
@@ -677,6 +690,7 @@ fn installed_verify_rejects_symlinked_cached_content_directory() {
         &bundle,
         SkillInstallOptions {
             allow_unsigned: true,
+            source_type: "local".to_owned(),
             source_label: "local-dev".to_owned(),
         },
     )
@@ -708,6 +722,7 @@ fn installed_verify_rejects_record_entry_tamper() {
         &bundle,
         SkillInstallOptions {
             allow_unsigned: true,
+            source_type: "local".to_owned(),
             source_label: "local-dev".to_owned(),
         },
     )
@@ -753,6 +768,7 @@ fn installed_verify_rejects_signature_status_downgrade() {
         &bundle,
         SkillInstallOptions {
             allow_unsigned: true,
+            source_type: "local".to_owned(),
             source_label: "local-dev".to_owned(),
         },
     )
@@ -825,6 +841,7 @@ fn installed_index_ignores_stale_staging_directories() {
         &bundle,
         SkillInstallOptions {
             allow_unsigned: true,
+            source_type: "local".to_owned(),
             source_label: "local-dev".to_owned(),
         },
     )
@@ -859,6 +876,7 @@ fn installed_verify_runs_self_test_command() {
         &bundle,
         SkillInstallOptions {
             allow_unsigned: true,
+            source_type: "local".to_owned(),
             source_label: "local-dev".to_owned(),
         },
     )
@@ -1159,6 +1177,263 @@ fn skills_config_rejects_oci_reference_with_invalid_parts() {
     }
 }
 
+#[tokio::test]
+async fn filesystem_registry_search_add_and_publish_work() {
+    let home = temp_dir("skill-fs-home");
+    let registry = temp_dir("skill-fs-registry");
+    let bundle = temp_dir("skill-fs-bundle");
+    write_file(&bundle.join("SKILL.md"), "# Searchable Skill\n");
+    write_file(
+        &bundle.join("skill.yaml"),
+        "name: searchable-skill\nversion: 0.1.0\ndescription: Searchable demo\nentry: SKILL.md\nfiles:\n  - SKILL.md\n",
+    );
+    let service = SkillService::new(
+        home.join(".agentenv"),
+        SkillsConfig {
+            registries: vec![agentenv_core::skills::RegistryConfig::filesystem(
+                "local-dev",
+                registry.clone(),
+            )],
+            registry_order: vec!["local-dev".to_owned()],
+        },
+    );
+
+    service
+        .publish(SkillPublishRequest {
+            bundle_path: bundle,
+            registry: Some("local-dev".to_owned()),
+            allow_unsigned: true,
+        })
+        .await
+        .expect("publish should succeed");
+    let hits = service
+        .search("searchable")
+        .await
+        .expect("search should work");
+    assert_eq!(hits.len(), 1);
+    assert_eq!(hits[0].name, "searchable-skill");
+
+    let installed = service
+        .add(SkillAddRequest {
+            handle: "searchable-skill@0.1.0".to_owned(),
+            registry: None,
+            allow_unsigned: true,
+        })
+        .await
+        .expect("add should install");
+
+    assert_eq!(installed.name, "searchable-skill");
+}
+
+#[tokio::test]
+async fn skill_service_add_without_version_installs_highest_semver() {
+    let home = temp_dir("skill-fs-highest-home");
+    let registry = temp_dir("skill-fs-highest-registry");
+    let service = filesystem_skill_service(&home, &registry);
+
+    publish_test_skill(&service, "versioned-skill", "0.1.0", "Old release").await;
+    publish_test_skill(&service, "versioned-skill", "0.3.0", "New release").await;
+    publish_test_skill(&service, "versioned-skill", "0.2.0", "Middle release").await;
+
+    let installed = service
+        .add(SkillAddRequest {
+            handle: "versioned-skill".to_owned(),
+            registry: None,
+            allow_unsigned: true,
+        })
+        .await
+        .expect("add without version should install highest semver");
+
+    assert_eq!(installed.version, "0.3.0");
+}
+
+#[tokio::test]
+async fn skill_service_rejects_invalid_handle_before_registry_access() {
+    let home = temp_dir("skill-fs-invalid-handle-home");
+    let missing_registry = temp_dir("skill-fs-invalid-handle-missing-registry").join("missing");
+    let service = filesystem_skill_service(&home, &missing_registry);
+
+    let error = service
+        .add(SkillAddRequest {
+            handle: "../bad@0.1.0".to_owned(),
+            registry: None,
+            allow_unsigned: true,
+        })
+        .await
+        .expect_err("invalid handles must fail before registry access");
+
+    assert!(matches!(error, SkillError::InvalidSkillName { .. }));
+}
+
+#[tokio::test]
+async fn filesystem_registry_refuses_same_version_with_different_digest() {
+    let home = temp_dir("skill-fs-overwrite-home");
+    let registry = temp_dir("skill-fs-overwrite-registry");
+    let service = filesystem_skill_service(&home, &registry);
+    publish_test_skill(&service, "overwrite-skill", "0.1.0", "First content").await;
+
+    let changed = skill_bundle("overwrite-skill", "0.1.0", "Changed content");
+    let error = service
+        .publish(SkillPublishRequest {
+            bundle_path: changed,
+            registry: Some("local-dev".to_owned()),
+            allow_unsigned: true,
+        })
+        .await
+        .expect_err("publishing a different digest over the same version must fail");
+
+    assert!(matches!(
+        error,
+        SkillError::AlreadyInstalledDifferentDigest {
+            name,
+            version,
+            ..
+        } if name == "overwrite-skill" && version == "0.1.0"
+    ));
+}
+
+#[tokio::test]
+async fn skill_service_publish_uses_first_ordered_registry_when_unspecified() {
+    let home = temp_dir("skill-fs-publish-default-home");
+    let registry = temp_dir("skill-fs-publish-default-registry");
+    let service = filesystem_skill_service(&home, &registry);
+
+    let published = service
+        .publish(SkillPublishRequest {
+            bundle_path: skill_bundle("default-registry-skill", "0.1.0", "Default registry"),
+            registry: None,
+            allow_unsigned: true,
+        })
+        .await
+        .expect("publish without registry should use configured registry order");
+
+    assert_eq!(published.registry, "local-dev");
+    assert!(registry
+        .join("bundles/default-registry-skill/0.1.0/SKILL.md")
+        .is_file());
+}
+
+#[tokio::test]
+async fn filesystem_registry_rejects_index_hit_with_mismatched_manifest_identity() {
+    let home = temp_dir("skill-fs-mismatched-manifest-home");
+    let registry = temp_dir("skill-fs-mismatched-manifest-registry");
+    let service = filesystem_skill_service(&home, &registry);
+    write_file(
+        &registry.join("index.yaml"),
+        "skills:\n  - name: requested-skill\n    version: 0.1.0\n    registry: local-dev\n",
+    );
+    write_file(
+        &registry.join("bundles/requested-skill/0.1.0/SKILL.md"),
+        "# Other skill\n",
+    );
+    write_file(
+        &registry.join("bundles/requested-skill/0.1.0/skill.yaml"),
+        "name: other-skill\nversion: 0.1.0\nentry: SKILL.md\nfiles:\n  - SKILL.md\n",
+    );
+
+    let error = service
+        .add(SkillAddRequest {
+            handle: "requested-skill@0.1.0".to_owned(),
+            registry: None,
+            allow_unsigned: true,
+        })
+        .await
+        .expect_err("index identity must match fetched manifest identity");
+
+    assert!(matches!(
+        error,
+        SkillError::UnsafeBundlePath { .. } | SkillError::InvalidConfig { .. }
+    ));
+    assert!(service.list().unwrap().is_empty());
+}
+
+#[cfg(unix)]
+#[tokio::test]
+async fn filesystem_registry_rejects_symlinked_bundles_directory() {
+    let home = temp_dir("skill-fs-symlink-bundles-home");
+    let registry = temp_dir("skill-fs-symlink-bundles-registry");
+    let outside = temp_dir("skill-fs-symlink-bundles-outside");
+    let service = filesystem_skill_service(&home, &registry);
+    write_file(
+        &registry.join("index.yaml"),
+        "skills:\n  - name: symlinked-skill\n    version: 0.1.0\n    registry: local-dev\n",
+    );
+    std::os::unix::fs::symlink(&outside, registry.join("bundles")).unwrap();
+    write_file(
+        &outside.join("symlinked-skill/0.1.0/SKILL.md"),
+        "# Symlinked skill\n",
+    );
+    write_file(
+        &outside.join("symlinked-skill/0.1.0/skill.yaml"),
+        "name: symlinked-skill\nversion: 0.1.0\nentry: SKILL.md\nfiles:\n  - SKILL.md\n",
+    );
+
+    let error = service
+        .add(SkillAddRequest {
+            handle: "symlinked-skill@0.1.0".to_owned(),
+            registry: None,
+            allow_unsigned: true,
+        })
+        .await
+        .expect_err("symlinked registry bundle parents must be rejected");
+
+    assert!(matches!(error, SkillError::UnsafeBundlePath { .. }));
+}
+
+#[tokio::test]
+async fn filesystem_registry_publish_repairs_stale_index_without_bundle() {
+    let home = temp_dir("skill-fs-stale-index-home");
+    let registry = temp_dir("skill-fs-stale-index-registry");
+    let service = filesystem_skill_service(&home, &registry);
+    let bundle = skill_bundle("stale-index-skill", "0.1.0", "Stale index");
+    let manifest = load_skill_manifest(&bundle).unwrap();
+    let digest = compute_bundle_digest(&bundle, &manifest).unwrap();
+    write_file(
+        &registry.join("index.yaml"),
+        &format!(
+            "skills:\n  - name: stale-index-skill\n    version: 0.1.0\n    registry: local-dev\n    digest: {digest}\n"
+        ),
+    );
+
+    service
+        .publish(SkillPublishRequest {
+            bundle_path: bundle,
+            registry: Some("local-dev".to_owned()),
+            allow_unsigned: true,
+        })
+        .await
+        .expect("publish should repair stale index entries whose bundle is missing");
+
+    assert!(registry
+        .join("bundles/stale-index-skill/0.1.0/SKILL.md")
+        .is_file());
+}
+
+#[tokio::test]
+async fn skill_service_add_records_registry_source_with_resolved_version() {
+    let home = temp_dir("skill-fs-provenance-home");
+    let registry = temp_dir("skill-fs-provenance-registry");
+    let service = filesystem_skill_service(&home, &registry);
+    publish_test_skill(&service, "provenance-skill", "0.1.0", "Old release").await;
+    publish_test_skill(&service, "provenance-skill", "0.4.0", "New release").await;
+
+    let installed = service
+        .add(SkillAddRequest {
+            handle: "provenance-skill".to_owned(),
+            registry: None,
+            allow_unsigned: true,
+        })
+        .await
+        .expect("add should install from registry");
+
+    assert_eq!(installed.version, "0.4.0");
+    assert_eq!(installed.source_type, "filesystem");
+    assert_eq!(
+        installed.source_label,
+        "filesystem:local-dev:provenance-skill@0.4.0"
+    );
+}
+
 #[cfg(windows)]
 fn self_test_file_exists_command() -> &'static str {
     "if exist SKILL.md (exit /B 0) else (exit /B 1)"
@@ -1185,6 +1460,42 @@ fn write_file(path: &Path, content: &str) {
         fs::create_dir_all(parent).unwrap();
     }
     fs::write(path, content).unwrap();
+}
+
+fn filesystem_skill_service(home: &Path, registry: &Path) -> SkillService {
+    SkillService::new(
+        home.join(".agentenv"),
+        SkillsConfig {
+            registries: vec![agentenv_core::skills::RegistryConfig::filesystem(
+                "local-dev",
+                registry.to_path_buf(),
+            )],
+            registry_order: vec!["local-dev".to_owned()],
+        },
+    )
+}
+
+async fn publish_test_skill(service: &SkillService, name: &str, version: &str, content: &str) {
+    service
+        .publish(SkillPublishRequest {
+            bundle_path: skill_bundle(name, version, content),
+            registry: Some("local-dev".to_owned()),
+            allow_unsigned: true,
+        })
+        .await
+        .expect("publish should succeed");
+}
+
+fn skill_bundle(name: &str, version: &str, content: &str) -> PathBuf {
+    let bundle = temp_dir(&format!("skill-fs-bundle-{name}-{version}"));
+    write_file(&bundle.join("SKILL.md"), &format!("# {content}\n"));
+    write_file(
+        &bundle.join("skill.yaml"),
+        &format!(
+            "name: {name}\nversion: {version}\ndescription: {content}\nentry: SKILL.md\nfiles:\n  - SKILL.md\n"
+        ),
+    );
+    bundle
 }
 
 fn unique_nanos() -> u128 {

--- a/crates/agentenv-core/tests/skills.rs
+++ b/crates/agentenv-core/tests/skills.rs
@@ -4,9 +4,10 @@ use std::{
 };
 
 use agentenv_core::skills::{
-    compute_bundle_digest, install_local_skill, list_installed_skills, load_skill_manifest,
-    validate_skill_name, verify_installed_skill, InstalledSkillSelector, SkillError,
-    SkillInstallOptions,
+    compute_bundle_digest, install_local_skill, list_installed_skills, load_project_skills_config,
+    load_skill_manifest, load_user_skills_config, merge_skills_config, validate_skill_name,
+    verify_installed_skill, InstalledSkillSelector, RegistryKind, SkillError, SkillInstallOptions,
+    SkillsConfig, SkillsConfigOverride,
 };
 use ed25519_dalek::{Signer, SigningKey};
 
@@ -870,6 +871,292 @@ fn installed_verify_runs_self_test_command() {
     .expect("self-test command should pass");
 
     assert_eq!(verified.name, "self-test-demo");
+}
+
+#[test]
+fn skills_config_loads_project_yaml_section() {
+    let yaml = r#"
+version: 0.1.0
+min_agentenv_version: 0.0.1-alpha0
+sandbox: { driver: openshell }
+agent: { driver: codex }
+context: { driver: filesystem, mount: . }
+policy: { tier: balanced, presets: [] }
+skills:
+  registries:
+    - name: local-dev
+      type: filesystem
+      path: /tmp/skills
+"#;
+
+    let config = load_project_skills_config(yaml).unwrap();
+
+    assert_eq!(config.registries.len(), 1);
+    assert_eq!(config.registries[0].name, "local-dev");
+    assert_eq!(config.registries[0].kind, RegistryKind::Filesystem);
+}
+
+#[test]
+fn skills_config_loads_user_toml() {
+    let toml = r#"
+[skills]
+registry_order = ["corp"]
+
+[[skills.registries]]
+name = "corp"
+type = "http"
+url = "https://skills.example.test"
+auth = "bearer-from-credstore:CORP_SKILLS_TOKEN"
+"#;
+
+    let config = load_user_skills_config(toml).unwrap();
+
+    assert_eq!(config.registry_order, vec!["corp"]);
+    assert_eq!(
+        config.registries[0].auth.as_deref(),
+        Some("bearer-from-credstore:CORP_SKILLS_TOKEN")
+    );
+}
+
+#[test]
+fn cli_registry_override_wins_over_project_and_user_config() {
+    let user = SkillsConfig {
+        registries: vec![agentenv_core::skills::RegistryConfig::filesystem(
+            "user-local",
+            PathBuf::from("/user"),
+        )],
+        registry_order: vec!["user-local".to_owned()],
+    };
+    let project = SkillsConfig {
+        registries: vec![agentenv_core::skills::RegistryConfig::filesystem(
+            "project-local",
+            PathBuf::from("/project"),
+        )],
+        registry_order: vec!["project-local".to_owned()],
+    };
+
+    let merged = merge_skills_config(
+        user,
+        Some(project),
+        SkillsConfigOverride {
+            registry: Some("file:///override".to_owned()),
+        },
+    )
+    .unwrap();
+
+    assert_eq!(merged.registries.len(), 1);
+    assert_eq!(merged.registries[0].name, "cli");
+    assert_eq!(merged.registry_order, vec!["cli"]);
+}
+
+#[test]
+fn cli_registry_override_selects_named_registry() {
+    let user = SkillsConfig {
+        registries: vec![
+            agentenv_core::skills::RegistryConfig::filesystem("local", PathBuf::from("/local")),
+            agentenv_core::skills::RegistryConfig::http(
+                "corp",
+                "https://skills.example.test",
+                None,
+            ),
+        ],
+        registry_order: vec!["local".to_owned(), "corp".to_owned()],
+    };
+
+    let merged = merge_skills_config(
+        user,
+        None,
+        SkillsConfigOverride {
+            registry: Some("corp".to_owned()),
+        },
+    )
+    .unwrap();
+
+    assert_eq!(merged.registries.len(), 1);
+    assert_eq!(merged.registries[0].name, "corp");
+    assert_eq!(merged.registry_order, vec!["corp"]);
+}
+
+#[test]
+fn project_config_overrides_user_registries_by_name_without_erasing_others() {
+    let user = SkillsConfig {
+        registries: vec![
+            agentenv_core::skills::RegistryConfig::filesystem("local", PathBuf::from("/user")),
+            agentenv_core::skills::RegistryConfig::http(
+                "corp",
+                "https://skills.example.test",
+                None,
+            ),
+        ],
+        registry_order: vec!["local".to_owned(), "corp".to_owned()],
+    };
+    let project = SkillsConfig {
+        registries: vec![agentenv_core::skills::RegistryConfig::filesystem(
+            "local",
+            PathBuf::from("/project"),
+        )],
+        registry_order: vec!["local".to_owned()],
+    };
+
+    let merged = merge_skills_config(
+        user,
+        Some(project),
+        SkillsConfigOverride {
+            registry: Some("corp".to_owned()),
+        },
+    )
+    .unwrap();
+
+    assert_eq!(merged.registries.len(), 1);
+    assert_eq!(merged.registries[0].name, "corp");
+}
+
+#[test]
+fn cli_registry_override_reports_missing_named_registry() {
+    let user = SkillsConfig {
+        registries: vec![agentenv_core::skills::RegistryConfig::filesystem(
+            "local",
+            PathBuf::from("/local"),
+        )],
+        registry_order: vec!["local".to_owned()],
+    };
+
+    let error = merge_skills_config(
+        user,
+        None,
+        SkillsConfigOverride {
+            registry: Some("corp".to_owned()),
+        },
+    )
+    .expect_err("missing named registry must be reported");
+
+    assert!(matches!(error, SkillError::RegistryNotFound { name } if name == "corp"));
+}
+
+#[test]
+fn cli_registry_override_parses_http_and_oci_sources() {
+    let http = merge_skills_config(
+        SkillsConfig::default(),
+        None,
+        SkillsConfigOverride {
+            registry: Some("https://skills.example.test".to_owned()),
+        },
+    )
+    .unwrap();
+    let oci = merge_skills_config(
+        SkillsConfig::default(),
+        None,
+        SkillsConfigOverride {
+            registry: Some("oci://ghcr.io/agentenv-community".to_owned()),
+        },
+    )
+    .unwrap();
+
+    assert_eq!(http.registries[0].kind, RegistryKind::Http);
+    assert_eq!(oci.registries[0].kind, RegistryKind::Oci);
+}
+
+#[test]
+fn cli_registry_override_parses_bare_oci_reference() {
+    let merged = merge_skills_config(
+        SkillsConfig::default(),
+        None,
+        SkillsConfigOverride {
+            registry: Some("ghcr.io/agentenv-community".to_owned()),
+        },
+    )
+    .unwrap();
+
+    assert_eq!(merged.registries[0].kind, RegistryKind::Oci);
+    assert_eq!(
+        merged.registries[0].url.as_deref(),
+        Some("ghcr.io/agentenv-community")
+    );
+}
+
+#[test]
+fn cli_registry_override_parses_bare_oci_reference_with_port() {
+    let merged = merge_skills_config(
+        SkillsConfig::default(),
+        None,
+        SkillsConfigOverride {
+            registry: Some("ghcr.io:5000/agentenv-community".to_owned()),
+        },
+    )
+    .unwrap();
+
+    assert_eq!(merged.registries[0].kind, RegistryKind::Oci);
+    assert_eq!(
+        merged.registries[0].url.as_deref(),
+        Some("ghcr.io:5000/agentenv-community")
+    );
+}
+
+#[test]
+fn skills_config_rejects_missing_required_registry_fields() {
+    let yaml = r#"
+skills:
+  registries:
+    - name: missing-url
+      type: http
+"#;
+
+    let error = load_project_skills_config(yaml).expect_err("http registry requires url");
+
+    assert!(matches!(error, SkillError::InvalidConfig { .. }));
+}
+
+#[test]
+fn skills_config_rejects_invalid_http_registry_url() {
+    let yaml = r#"
+skills:
+  registries:
+    - name: bad-http
+      type: http
+      url: ftp://skills.example.test
+"#;
+
+    let error = load_project_skills_config(yaml).expect_err("http URL scheme must be validated");
+
+    assert!(matches!(error, SkillError::InvalidConfig { .. }));
+}
+
+#[test]
+fn skills_config_rejects_invalid_oci_registry_reference() {
+    let yaml = r#"
+skills:
+  registries:
+    - name: bad-oci
+      type: oci
+      url: not-a-reference
+"#;
+
+    let error = load_project_skills_config(yaml).expect_err("OCI reference must be validated");
+
+    assert!(matches!(error, SkillError::InvalidConfig { .. }));
+}
+
+#[test]
+fn skills_config_rejects_oci_reference_with_invalid_parts() {
+    for reference in [
+        "ghcr.io/bad$path",
+        "oci://user:pass@ghcr.io/agentenv-community",
+        "oci://ghcr.io/agentenv-community?tag=latest",
+        "oci://ghcr.io/agentenv-community#frag",
+        "ghcr.io:abc/agentenv-community",
+        "ghcr.io:5000:extra/agentenv-community",
+    ] {
+        let error = merge_skills_config(
+            SkillsConfig::default(),
+            None,
+            SkillsConfigOverride {
+                registry: Some(reference.to_owned()),
+            },
+        )
+        .expect_err(reference);
+
+        assert!(matches!(error, SkillError::InvalidConfig { .. }));
+    }
 }
 
 #[cfg(windows)]

--- a/crates/agentenv-core/tests/skills.rs
+++ b/crates/agentenv-core/tests/skills.rs
@@ -1,8 +1,12 @@
 use std::{
+    collections::BTreeMap,
     fs,
+    net::SocketAddr,
     path::{Path, PathBuf},
+    sync::{Arc, Mutex},
 };
 
+use agentenv_core::security::ssrf::SsrfOptions;
 use agentenv_core::skills::{
     compute_bundle_digest, install_local_skill, list_installed_skills, load_project_skills_config,
     load_skill_manifest, load_user_skills_config, merge_skills_config, validate_skill_name,
@@ -1434,6 +1438,124 @@ async fn skill_service_add_records_registry_source_with_resolved_version() {
     );
 }
 
+#[tokio::test]
+async fn http_registry_rejects_unsafe_url_before_request() {
+    let home = temp_dir("skill-http-unsafe-home");
+    let service = SkillService::new(
+        home.join(".agentenv"),
+        SkillsConfig {
+            registries: vec![agentenv_core::skills::RegistryConfig::http(
+                "unsafe",
+                "http://127.0.0.1:9",
+                None,
+            )],
+            registry_order: vec!["unsafe".to_owned()],
+        },
+    );
+
+    let error = service
+        .search("demo")
+        .await
+        .expect_err("loopback URL must be blocked");
+
+    assert!(matches!(error, SkillError::RegistryUrlBlocked { .. }));
+}
+
+#[tokio::test]
+async fn http_registry_search_reads_static_index() {
+    let server = TestHttpRegistry::start().await;
+    server
+        .add_response(
+            "GET",
+            "/index.yaml",
+            "skills:\n  - name: http-demo\n    version: 0.1.0\n    description: HTTP demo\n    registry: ignored\n",
+        )
+        .await;
+    let home = temp_dir("skill-http-home");
+    let service =
+        http_skill_service(&home, &server).with_ssrf_options(test_http_registry_ssrf_options());
+
+    let hits = service.search("http").await.expect("search should succeed");
+
+    assert_eq!(hits[0].name, "http-demo");
+    assert_eq!(hits[0].registry, "http-dev");
+}
+
+#[tokio::test]
+async fn http_registry_publish_and_add_round_trip() {
+    let server = TestHttpRegistry::start().await;
+    server
+        .add_response("GET", "/index.yaml", "skills: []\n")
+        .await;
+    let home = temp_dir("skill-http-round-trip-home");
+    let service =
+        http_skill_service(&home, &server).with_ssrf_options(test_http_registry_ssrf_options());
+
+    service
+        .publish(SkillPublishRequest {
+            bundle_path: skill_bundle("http-skill", "0.1.0", "HTTP skill"),
+            registry: Some("http-dev".to_owned()),
+            allow_unsigned: true,
+        })
+        .await
+        .expect("publish should upload files");
+
+    let installed = service
+        .add(SkillAddRequest {
+            handle: "http-skill@0.1.0".to_owned(),
+            registry: Some("http-dev".to_owned()),
+            allow_unsigned: true,
+        })
+        .await
+        .expect("add should download uploaded files");
+
+    assert_eq!(installed.name, "http-skill");
+    assert_eq!(installed.source_type, "http");
+    assert_eq!(installed.source_label, "http:http-dev:http-skill@0.1.0");
+}
+
+#[tokio::test]
+async fn http_registry_uses_bearer_token_from_credential_resolver() {
+    let server = TestHttpRegistry::start().await;
+    server.require_authorization("secret-token").await;
+    server
+        .add_response(
+            "GET",
+            "/index.yaml",
+            "skills:\n  - name: auth-demo\n    version: 0.1.0\n    registry: ignored\n",
+        )
+        .await;
+    let home = temp_dir("skill-http-auth-home");
+    let service = SkillService::new(
+        home.join(".agentenv"),
+        SkillsConfig {
+            registries: vec![agentenv_core::skills::RegistryConfig::http(
+                "http-dev",
+                server.base_url(),
+                Some("bearer-from-credstore:CUSTOM_SKILLS_TOKEN".to_owned()),
+            )],
+            registry_order: vec!["http-dev".to_owned()],
+        },
+    )
+    .with_ssrf_options(test_http_registry_ssrf_options())
+    .with_credential_resolver(Arc::new(|name| {
+        assert_eq!(name, "CUSTOM_SKILLS_TOKEN");
+        Ok(Some("secret-token".to_owned()))
+    }));
+
+    let hits = service
+        .search("auth")
+        .await
+        .expect("authenticated search should succeed");
+
+    assert_eq!(hits[0].name, "auth-demo");
+    assert!(server
+        .authorization_headers()
+        .await
+        .iter()
+        .any(|header| header.as_deref() == Some("Bearer secret-token")));
+}
+
 #[cfg(windows)]
 fn self_test_file_exists_command() -> &'static str {
     "if exist SKILL.md (exit /B 0) else (exit /B 1)"
@@ -1486,6 +1608,28 @@ async fn publish_test_skill(service: &SkillService, name: &str, version: &str, c
         .expect("publish should succeed");
 }
 
+fn http_skill_service(home: &Path, server: &TestHttpRegistry) -> SkillService {
+    SkillService::new(
+        home.join(".agentenv"),
+        SkillsConfig {
+            registries: vec![agentenv_core::skills::RegistryConfig::http(
+                "http-dev",
+                server.base_url(),
+                None,
+            )],
+            registry_order: vec!["http-dev".to_owned()],
+        },
+    )
+}
+
+fn test_http_registry_ssrf_options() -> SsrfOptions {
+    SsrfOptions {
+        allow_private: true,
+        allow_loopback: true,
+        ..SsrfOptions::default()
+    }
+}
+
 fn skill_bundle(name: &str, version: &str, content: &str) -> PathBuf {
     let bundle = temp_dir(&format!("skill-fs-bundle-{name}-{version}"));
     write_file(&bundle.join("SKILL.md"), &format!("# {content}\n"));
@@ -1496,6 +1640,192 @@ fn skill_bundle(name: &str, version: &str, content: &str) -> PathBuf {
         ),
     );
     bundle
+}
+
+#[derive(Clone)]
+struct TestHttpRegistry {
+    addr: SocketAddr,
+    state: Arc<Mutex<TestHttpRegistryState>>,
+}
+
+#[derive(Default)]
+struct TestHttpRegistryState {
+    responses: BTreeMap<(String, String), Vec<u8>>,
+    requests: Vec<TestHttpRegistryRequest>,
+    required_authorization: Option<String>,
+}
+
+struct TestHttpRegistryRequest {
+    authorization: Option<String>,
+}
+
+impl TestHttpRegistry {
+    async fn start() -> Self {
+        let listener = tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();
+        let addr = listener.local_addr().unwrap();
+        let state = Arc::new(Mutex::new(TestHttpRegistryState::default()));
+        let server = Self {
+            addr,
+            state: state.clone(),
+        };
+
+        tokio::spawn(async move {
+            loop {
+                let Ok((stream, _)) = listener.accept().await else {
+                    break;
+                };
+                let state = state.clone();
+                tokio::spawn(async move {
+                    handle_test_http_registry_connection(stream, state).await;
+                });
+            }
+        });
+
+        server
+    }
+
+    fn base_url(&self) -> String {
+        format!("http://{}", self.addr)
+    }
+
+    async fn add_response(&self, method: &str, path: &str, body: &str) {
+        self.state.lock().unwrap().responses.insert(
+            (method.to_owned(), path.to_owned()),
+            body.as_bytes().to_vec(),
+        );
+    }
+
+    async fn require_authorization(&self, token: &str) {
+        self.state.lock().unwrap().required_authorization = Some(format!("Bearer {token}"));
+    }
+
+    async fn authorization_headers(&self) -> Vec<Option<String>> {
+        self.state
+            .lock()
+            .unwrap()
+            .requests
+            .iter()
+            .map(|request| request.authorization.clone())
+            .collect()
+    }
+}
+
+async fn handle_test_http_registry_connection(
+    mut stream: tokio::net::TcpStream,
+    state: Arc<Mutex<TestHttpRegistryState>>,
+) {
+    use tokio::io::AsyncWriteExt;
+
+    let Some((method, path, headers, body)) = read_test_http_request(&mut stream).await else {
+        return;
+    };
+    let authorization = headers
+        .iter()
+        .find(|(name, _)| name.eq_ignore_ascii_case("authorization"))
+        .map(|(_, value)| value.clone());
+
+    let (status, response_body) = {
+        let mut state = state.lock().unwrap();
+        state.requests.push(TestHttpRegistryRequest {
+            authorization: authorization.clone(),
+        });
+
+        if let Some(required) = state.required_authorization.as_deref() {
+            if authorization.as_deref() != Some(required) {
+                (401, Vec::new())
+            } else {
+                test_http_registry_response(&mut state, &method, &path, body)
+            }
+        } else {
+            test_http_registry_response(&mut state, &method, &path, body)
+        }
+    };
+
+    let status_text = match status {
+        200 => "OK",
+        204 => "No Content",
+        401 => "Unauthorized",
+        404 => "Not Found",
+        _ => "Error",
+    };
+    let response = format!(
+        "HTTP/1.1 {status} {status_text}\r\nContent-Length: {}\r\nConnection: close\r\n\r\n",
+        response_body.len()
+    );
+    let _ = stream.write_all(response.as_bytes()).await;
+    let _ = stream.write_all(&response_body).await;
+}
+
+fn test_http_registry_response(
+    state: &mut TestHttpRegistryState,
+    method: &str,
+    path: &str,
+    body: Vec<u8>,
+) -> (u16, Vec<u8>) {
+    match method {
+        "GET" => state
+            .responses
+            .get(&(method.to_owned(), path.to_owned()))
+            .cloned()
+            .map(|body| (200, body))
+            .unwrap_or_else(|| (404, Vec::new())),
+        "PUT" => {
+            state
+                .responses
+                .insert(("GET".to_owned(), path.to_owned()), body);
+            (204, Vec::new())
+        }
+        _ => (404, Vec::new()),
+    }
+}
+
+async fn read_test_http_request(
+    stream: &mut tokio::net::TcpStream,
+) -> Option<(String, String, Vec<(String, String)>, Vec<u8>)> {
+    use tokio::io::AsyncReadExt;
+
+    let mut buffer = Vec::new();
+    let mut chunk = [0_u8; 1024];
+    let header_end = loop {
+        let read = stream.read(&mut chunk).await.ok()?;
+        if read == 0 {
+            return None;
+        }
+        buffer.extend_from_slice(&chunk[..read]);
+        if let Some(position) = buffer.windows(4).position(|window| window == b"\r\n\r\n") {
+            break position + 4;
+        }
+    };
+
+    let header = String::from_utf8_lossy(&buffer[..header_end]).to_string();
+    let mut lines = header.split("\r\n");
+    let request_line = lines.next()?;
+    let mut request_parts = request_line.split_whitespace();
+    let method = request_parts.next()?.to_owned();
+    let path = request_parts.next()?.to_owned();
+    let headers = lines
+        .filter_map(|line| {
+            let (name, value) = line.split_once(':')?;
+            Some((name.trim().to_owned(), value.trim().to_owned()))
+        })
+        .collect::<Vec<_>>();
+    let content_length = headers
+        .iter()
+        .find(|(name, _)| name.eq_ignore_ascii_case("content-length"))
+        .and_then(|(_, value)| value.parse::<usize>().ok())
+        .unwrap_or(0);
+
+    let mut body = buffer[header_end..].to_vec();
+    while body.len() < content_length {
+        let read = stream.read(&mut chunk).await.ok()?;
+        if read == 0 {
+            break;
+        }
+        body.extend_from_slice(&chunk[..read]);
+    }
+    body.truncate(content_length);
+
+    Some((method, path, headers, body))
 }
 
 fn unique_nanos() -> u128 {

--- a/crates/agentenv-core/tests/skills.rs
+++ b/crates/agentenv-core/tests/skills.rs
@@ -1556,6 +1556,49 @@ async fn http_registry_uses_bearer_token_from_credential_resolver() {
         .any(|header| header.as_deref() == Some("Bearer secret-token")));
 }
 
+#[tokio::test]
+async fn oci_registry_search_add_and_publish_use_distribution_api() {
+    let registry = TestOciRegistry::start().await;
+    let home = temp_dir("skill-oci-home");
+    let service = SkillService::new(
+        home.join(".agentenv"),
+        SkillsConfig {
+            registries: vec![agentenv_core::skills::RegistryConfig::oci(
+                "oci-dev",
+                registry.base_reference("agentenv-test"),
+                None,
+            )],
+            registry_order: vec!["oci-dev".to_owned()],
+        },
+    )
+    .with_ssrf_options(test_http_registry_ssrf_options());
+
+    service
+        .publish(SkillPublishRequest {
+            bundle_path: skill_bundle("oci-skill", "0.1.0", "OCI skill"),
+            registry: Some("oci-dev".to_owned()),
+            allow_unsigned: true,
+        })
+        .await
+        .expect("OCI publish should work against fixture");
+
+    let hits = service.search("oci").await.expect("OCI search should work");
+    assert_eq!(hits[0].name, "oci-skill");
+
+    let installed = service
+        .add(SkillAddRequest {
+            handle: "oci-skill@0.1.0".to_owned(),
+            registry: Some("oci-dev".to_owned()),
+            allow_unsigned: true,
+        })
+        .await
+        .expect("OCI add should install");
+
+    assert_eq!(installed.name, "oci-skill");
+    assert_eq!(installed.source_type, "oci");
+    assert_eq!(installed.source_label, "oci:oci-dev:oci-skill@0.1.0");
+}
+
 #[cfg(windows)]
 fn self_test_file_exists_command() -> &'static str {
     "if exist SKILL.md (exit /B 0) else (exit /B 1)"
@@ -1659,6 +1702,19 @@ struct TestHttpRegistryRequest {
     authorization: Option<String>,
 }
 
+#[derive(Clone)]
+struct TestOciRegistry {
+    addr: SocketAddr,
+}
+
+#[derive(Default)]
+struct TestOciRegistryState {
+    blobs: BTreeMap<String, Vec<u8>>,
+    manifests: BTreeMap<String, Vec<u8>>,
+    uploads: BTreeMap<String, Vec<u8>>,
+    next_upload: u64,
+}
+
 impl TestHttpRegistry {
     async fn start() -> Self {
         let listener = tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();
@@ -1707,6 +1763,35 @@ impl TestHttpRegistry {
             .iter()
             .map(|request| request.authorization.clone())
             .collect()
+    }
+}
+
+impl TestOciRegistry {
+    async fn start() -> Self {
+        let listener = tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();
+        let addr = listener.local_addr().unwrap();
+        let state = Arc::new(Mutex::new(TestOciRegistryState::default()));
+        let registry = Self { addr };
+        let base_url = format!("http://{addr}");
+
+        tokio::spawn(async move {
+            loop {
+                let Ok((stream, _)) = listener.accept().await else {
+                    break;
+                };
+                let state = state.clone();
+                let base_url = base_url.clone();
+                tokio::spawn(async move {
+                    handle_test_oci_registry_connection(stream, state, base_url).await;
+                });
+            }
+        });
+
+        registry
+    }
+
+    fn base_reference(&self, repository: &str) -> String {
+        format!("{}/{}", self.addr, repository)
     }
 }
 
@@ -1826,6 +1911,101 @@ async fn read_test_http_request(
     body.truncate(content_length);
 
     Some((method, path, headers, body))
+}
+
+async fn handle_test_oci_registry_connection(
+    mut stream: tokio::net::TcpStream,
+    state: Arc<Mutex<TestOciRegistryState>>,
+    base_url: String,
+) {
+    use tokio::io::AsyncWriteExt;
+
+    let Some((method, target, _headers, body)) = read_test_http_request(&mut stream).await else {
+        return;
+    };
+    let (status, headers, response_body) =
+        test_oci_registry_response(&state, &base_url, &method, &target, body);
+    let status_text = match status {
+        200 => "OK",
+        201 => "Created",
+        202 => "Accepted",
+        404 => "Not Found",
+        _ => "Error",
+    };
+    let mut response = format!(
+        "HTTP/1.1 {status} {status_text}\r\nContent-Length: {}\r\nConnection: close\r\n",
+        response_body.len()
+    );
+    for (name, value) in headers {
+        response.push_str(&format!("{name}: {value}\r\n"));
+    }
+    response.push_str("\r\n");
+    let _ = stream.write_all(response.as_bytes()).await;
+    let _ = stream.write_all(&response_body).await;
+}
+
+fn test_oci_registry_response(
+    state: &Arc<Mutex<TestOciRegistryState>>,
+    base_url: &str,
+    method: &str,
+    target: &str,
+    body: Vec<u8>,
+) -> (u16, Vec<(String, String)>, Vec<u8>) {
+    let (path, query) = target.split_once('?').unwrap_or((target, ""));
+    let mut state = state.lock().unwrap();
+    match method {
+        "POST" if path.ends_with("/blobs/uploads/") => {
+            state.next_upload += 1;
+            let upload_path = format!("{path}{}", state.next_upload);
+            state.uploads.insert(upload_path.clone(), Vec::new());
+            (
+                202,
+                vec![("Location".to_owned(), format!("{base_url}{upload_path}"))],
+                Vec::new(),
+            )
+        }
+        "PATCH" if path.contains("/blobs/uploads/") => {
+            state.uploads.insert(path.to_owned(), body);
+            (
+                202,
+                vec![("Location".to_owned(), format!("{base_url}{path}"))],
+                Vec::new(),
+            )
+        }
+        "PUT" if path.contains("/blobs/uploads/") => {
+            let Some(digest) = query.strip_prefix("digest=") else {
+                return (404, Vec::new(), Vec::new());
+            };
+            let digest = digest.replace("%3A", ":");
+            let Some(upload) = state.uploads.remove(path) else {
+                return (404, Vec::new(), Vec::new());
+            };
+            state.blobs.insert(digest, upload);
+            (201, Vec::new(), Vec::new())
+        }
+        "PUT" if path.contains("/manifests/") => {
+            state.manifests.insert(path.to_owned(), body);
+            (201, Vec::new(), Vec::new())
+        }
+        "GET" if path.contains("/manifests/") => state
+            .manifests
+            .get(path)
+            .cloned()
+            .map(|body| (200, Vec::new(), body))
+            .unwrap_or_else(|| (404, Vec::new(), Vec::new())),
+        "GET" if path.contains("/blobs/") => {
+            let Some((_, digest)) = path.rsplit_once("/blobs/") else {
+                return (404, Vec::new(), Vec::new());
+            };
+            state
+                .blobs
+                .get(digest)
+                .cloned()
+                .map(|body| (200, Vec::new(), body))
+                .unwrap_or_else(|| (404, Vec::new(), Vec::new()))
+        }
+        _ => (404, Vec::new(), Vec::new()),
+    }
 }
 
 fn unique_nanos() -> u128 {

--- a/crates/agentenv-core/tests/skills.rs
+++ b/crates/agentenv-core/tests/skills.rs
@@ -4,8 +4,11 @@ use std::{
 };
 
 use agentenv_core::skills::{
-    compute_bundle_digest, load_skill_manifest, validate_skill_name, SkillError,
+    compute_bundle_digest, install_local_skill, list_installed_skills, load_skill_manifest,
+    validate_skill_name, verify_installed_skill, InstalledSkillSelector, SkillError,
+    SkillInstallOptions,
 };
+use ed25519_dalek::{Signer, SigningKey};
 
 #[test]
 fn skill_manifest_accepts_minimal_bundle() {
@@ -243,6 +246,7 @@ fn skill_digest_rejects_declared_symlink() {
         declared_files: vec![PathBuf::from("SKILL.md")],
         self_test_command: None,
         signature_ed25519: None,
+        signature_public_key_ed25519: None,
         extra: Default::default(),
     };
 
@@ -266,6 +270,7 @@ fn skill_digest_rejects_symlinked_parent_directory() {
         declared_files: vec![PathBuf::from("linked/SKILL.md")],
         self_test_command: None,
         signature_ed25519: None,
+        signature_public_key_ed25519: None,
         extra: Default::default(),
     };
 
@@ -280,6 +285,601 @@ fn validate_skill_name_accepts_conservative_identifiers() {
     for name in ["demo", "demo-skill", "demo_skill", "demo.skill", "a1"] {
         validate_skill_name(name).expect(name);
     }
+}
+
+#[test]
+fn signature_verification_accepts_signed_bundle() {
+    let root = temp_dir("skill-signature-valid");
+    write_file(&root.join("SKILL.md"), "# Demo\n");
+    write_file(
+        &root.join("skill.yaml"),
+        "name: signed-demo\nversion: 0.1.0\nentry: SKILL.md\nfiles:\n  - SKILL.md\n",
+    );
+    let manifest = load_skill_manifest(&root).unwrap();
+    let digest = compute_bundle_digest(&root, &manifest).unwrap();
+    let signing_key = SigningKey::from_bytes(&[7_u8; 32]);
+    let payload = agentenv_core::skills::signature_payload(&manifest, &digest).unwrap();
+    let signature = hex::encode(signing_key.sign(&payload).to_bytes());
+    let public_key = hex::encode(signing_key.verifying_key().to_bytes());
+
+    agentenv_core::skills::verify_ed25519_signature(&manifest, &digest, &signature, &public_key)
+        .expect("signature should verify");
+}
+
+#[test]
+fn signature_verification_rejects_tampered_digest() {
+    let root = temp_dir("skill-signature-tampered");
+    write_file(&root.join("SKILL.md"), "# Demo\n");
+    write_file(
+        &root.join("skill.yaml"),
+        "name: signed-demo\nversion: 0.1.0\nentry: SKILL.md\nfiles:\n  - SKILL.md\n",
+    );
+    let manifest = load_skill_manifest(&root).unwrap();
+    let digest = compute_bundle_digest(&root, &manifest).unwrap();
+    let signing_key = SigningKey::from_bytes(&[9_u8; 32]);
+    let payload = agentenv_core::skills::signature_payload(&manifest, &digest).unwrap();
+    let signature = hex::encode(signing_key.sign(&payload).to_bytes());
+    let public_key = hex::encode(signing_key.verifying_key().to_bytes());
+
+    let error = agentenv_core::skills::verify_ed25519_signature(
+        &manifest,
+        "sha256:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+        &signature,
+        &public_key,
+    )
+    .expect_err("tampered digest must fail");
+
+    assert!(matches!(error, SkillError::InvalidSignature { .. }));
+}
+
+#[test]
+fn signature_verification_rejects_extra_metadata_tamper() {
+    let root = temp_dir("skill-signature-extra-tamper");
+    write_file(&root.join("SKILL.md"), "# Demo\n");
+    write_file(
+        &root.join("skill.yaml"),
+        "name: signed-demo\nversion: 0.1.0\nentry: SKILL.md\nfiles:\n  - SKILL.md\ncapability: safe\n",
+    );
+    let manifest = load_skill_manifest(&root).unwrap();
+    let digest = compute_bundle_digest(&root, &manifest).unwrap();
+    let signing_key = SigningKey::from_bytes(&[13_u8; 32]);
+    let payload = agentenv_core::skills::signature_payload(&manifest, &digest).unwrap();
+    let signature = hex::encode(signing_key.sign(&payload).to_bytes());
+    let public_key = hex::encode(signing_key.verifying_key().to_bytes());
+    let mut tampered = manifest.clone();
+    tampered.extra.insert(
+        "capability".to_owned(),
+        serde_yaml::Value::String("unsafe".to_owned()),
+    );
+
+    let error = agentenv_core::skills::verify_ed25519_signature(
+        &tampered,
+        &digest,
+        &signature,
+        &public_key,
+    )
+    .expect_err("extra metadata tampering must fail signature verification");
+
+    assert!(matches!(error, SkillError::InvalidSignature { .. }));
+}
+
+#[test]
+fn local_install_writes_cache_and_index() {
+    let home = temp_dir("skill-install-home");
+    let bundle = temp_dir("skill-install-bundle");
+    write_file(&bundle.join("SKILL.md"), "# Demo\n");
+    write_file(
+        &bundle.join("skill.yaml"),
+        "name: local-demo\nversion: 0.1.0\nentry: SKILL.md\nfiles:\n  - SKILL.md\n",
+    );
+
+    let installed = install_local_skill(
+        home.join(".agentenv"),
+        &bundle,
+        SkillInstallOptions {
+            allow_unsigned: true,
+            source_label: "local-dev".to_owned(),
+        },
+    )
+    .expect("install should succeed");
+
+    assert_eq!(installed.name, "local-demo");
+    assert_eq!(installed.version, "0.1.0");
+    assert!(installed.path.join("content/SKILL.md").is_file());
+    assert!(home.join(".agentenv/skills/index.yaml").is_file());
+}
+
+#[test]
+fn local_reinstall_same_digest_keeps_existing_record() {
+    let home = temp_dir("skill-install-idempotent-home");
+    let bundle = temp_dir("skill-install-idempotent-bundle");
+    write_file(&bundle.join("SKILL.md"), "# Demo\n");
+    write_file(
+        &bundle.join("skill.yaml"),
+        "name: idempotent-demo\nversion: 0.1.0\nentry: SKILL.md\nfiles:\n  - SKILL.md\n",
+    );
+    let first = install_local_skill(
+        home.join(".agentenv"),
+        &bundle,
+        SkillInstallOptions {
+            allow_unsigned: true,
+            source_label: "first-source".to_owned(),
+        },
+    )
+    .unwrap();
+
+    let second = install_local_skill(
+        home.join(".agentenv"),
+        &bundle,
+        SkillInstallOptions {
+            allow_unsigned: true,
+            source_label: "second-source".to_owned(),
+        },
+    )
+    .unwrap();
+
+    assert_eq!(second.source_label, "first-source");
+    assert_eq!(second.installed_at, first.installed_at);
+}
+
+#[test]
+fn local_reinstall_repairs_tampered_cached_content() {
+    let home = temp_dir("skill-install-repair-home");
+    let bundle = temp_dir("skill-install-repair-bundle");
+    write_file(&bundle.join("SKILL.md"), "# Demo\n");
+    write_file(
+        &bundle.join("skill.yaml"),
+        "name: repair-demo\nversion: 0.1.0\nentry: SKILL.md\nfiles:\n  - SKILL.md\n",
+    );
+    let installed = install_local_skill(
+        home.join(".agentenv"),
+        &bundle,
+        SkillInstallOptions {
+            allow_unsigned: true,
+            source_label: "local-dev".to_owned(),
+        },
+    )
+    .unwrap();
+    write_file(&installed.path.join("content/SKILL.md"), "# Tampered\n");
+
+    install_local_skill(
+        home.join(".agentenv"),
+        &bundle,
+        SkillInstallOptions {
+            allow_unsigned: true,
+            source_label: "local-dev".to_owned(),
+        },
+    )
+    .expect("reinstall should repair tampered same-digest cache");
+
+    let verified = verify_installed_skill(
+        home.join(".agentenv"),
+        InstalledSkillSelector::Name("repair-demo".to_owned()),
+    )
+    .expect("repaired cache should verify");
+    assert_eq!(verified.name, "repair-demo");
+}
+
+#[cfg(unix)]
+#[test]
+fn local_reinstall_rejects_symlinked_existing_version_directory() {
+    let home = temp_dir("skill-install-existing-symlink-home");
+    let bundle = temp_dir("skill-install-existing-symlink-bundle");
+    let outside = temp_dir("skill-install-existing-symlink-outside");
+    write_file(&bundle.join("SKILL.md"), "# Demo\n");
+    write_file(
+        &bundle.join("skill.yaml"),
+        "name: existing-symlink-demo\nversion: 0.1.0\nentry: SKILL.md\nfiles:\n  - SKILL.md\n",
+    );
+    let manifest = load_skill_manifest(&bundle).unwrap();
+    let digest = compute_bundle_digest(&bundle, &manifest).unwrap();
+    write_file(
+        &outside.join("installed.yaml"),
+        &format!(
+            "name: existing-symlink-demo\nversion: 0.1.0\nsource_type: local\nsource_label: outside\ndigest: {digest}\nsignature_status: unsigned\nentry: content/SKILL.md\ninstalled_at: \"2026-05-08T00:00:00Z\"\npath: ignored\n"
+        ),
+    );
+    let version_parent = home.join(".agentenv/skills/existing-symlink-demo");
+    fs::create_dir_all(&version_parent).unwrap();
+    std::os::unix::fs::symlink(&outside, version_parent.join("0.1.0")).unwrap();
+
+    let error = install_local_skill(
+        home.join(".agentenv"),
+        &bundle,
+        SkillInstallOptions {
+            allow_unsigned: true,
+            source_label: "local-dev".to_owned(),
+        },
+    )
+    .expect_err("reinstall must reject symlinked existing install dirs");
+
+    assert!(matches!(error, SkillError::UnsafeBundlePath { .. }));
+}
+
+#[cfg(unix)]
+#[test]
+fn local_reinstall_rejects_symlinked_cached_content_directory() {
+    let home = temp_dir("skill-install-content-symlink-home");
+    let bundle = temp_dir("skill-install-content-symlink-bundle");
+    let outside = temp_dir("skill-install-content-symlink-outside");
+    write_file(&bundle.join("SKILL.md"), "# Demo\n");
+    write_file(
+        &bundle.join("skill.yaml"),
+        "name: content-symlink-demo\nversion: 0.1.0\nentry: SKILL.md\nfiles:\n  - SKILL.md\n",
+    );
+    let installed = install_local_skill(
+        home.join(".agentenv"),
+        &bundle,
+        SkillInstallOptions {
+            allow_unsigned: true,
+            source_label: "local-dev".to_owned(),
+        },
+    )
+    .unwrap();
+    write_file(&outside.join("SKILL.md"), "# Demo\n");
+    fs::remove_dir_all(installed.path.join("content")).unwrap();
+    std::os::unix::fs::symlink(&outside, installed.path.join("content")).unwrap();
+
+    let error = install_local_skill(
+        home.join(".agentenv"),
+        &bundle,
+        SkillInstallOptions {
+            allow_unsigned: true,
+            source_label: "local-dev".to_owned(),
+        },
+    )
+    .expect_err("reinstall must reject symlinked cached content dirs");
+
+    assert!(matches!(error, SkillError::UnsafeBundlePath { .. }));
+}
+
+#[cfg(unix)]
+#[test]
+fn local_reinstall_rejects_symlinked_cached_content_with_missing_files() {
+    let home = temp_dir("skill-install-content-symlink-missing-home");
+    let bundle = temp_dir("skill-install-content-symlink-missing-bundle");
+    let outside = temp_dir("skill-install-content-symlink-missing-outside");
+    write_file(&bundle.join("SKILL.md"), "# Demo\n");
+    write_file(
+        &bundle.join("skill.yaml"),
+        "name: content-symlink-missing-demo\nversion: 0.1.0\nentry: SKILL.md\nfiles:\n  - SKILL.md\n",
+    );
+    let installed = install_local_skill(
+        home.join(".agentenv"),
+        &bundle,
+        SkillInstallOptions {
+            allow_unsigned: true,
+            source_label: "local-dev".to_owned(),
+        },
+    )
+    .unwrap();
+    fs::remove_dir_all(installed.path.join("content")).unwrap();
+    std::os::unix::fs::symlink(&outside, installed.path.join("content")).unwrap();
+
+    let error = install_local_skill(
+        home.join(".agentenv"),
+        &bundle,
+        SkillInstallOptions {
+            allow_unsigned: true,
+            source_label: "local-dev".to_owned(),
+        },
+    )
+    .expect_err("broken symlinked content dirs must be rejected before repair");
+
+    assert!(matches!(error, SkillError::UnsafeBundlePath { .. }));
+}
+
+#[test]
+fn local_install_treats_manifest_public_key_as_untrusted() {
+    let home = temp_dir("skill-install-untrusted-manifest-key-home");
+    let bundle = temp_dir("skill-install-untrusted-manifest-key-bundle");
+    let signing_key = SigningKey::from_bytes(&[11_u8; 32]);
+    let public_key = hex::encode(signing_key.verifying_key().to_bytes());
+    write_file(&bundle.join("SKILL.md"), "# Demo\n");
+    write_file(
+        &bundle.join("skill.yaml"),
+        &format!(
+            "name: untrusted-key-demo\nversion: 0.1.0\nentry: SKILL.md\nfiles:\n  - SKILL.md\nsignatures:\n  ed25519: {}\n  public_key_ed25519: {}\n",
+            "00".repeat(64),
+            public_key
+        ),
+    );
+
+    let installed = install_local_skill(
+        home.join(".agentenv"),
+        &bundle,
+        SkillInstallOptions {
+            allow_unsigned: true,
+            source_label: "local-dev".to_owned(),
+        },
+    )
+    .expect("self-supplied keys should not be treated as trusted signatures");
+
+    assert_eq!(installed.signature_status, "unsigned");
+}
+
+#[test]
+fn installed_verify_detects_content_tampering() {
+    let home = temp_dir("skill-verify-home");
+    let bundle = temp_dir("skill-verify-bundle");
+    write_file(&bundle.join("SKILL.md"), "# Demo\n");
+    write_file(
+        &bundle.join("skill.yaml"),
+        "name: verify-demo\nversion: 0.1.0\nentry: SKILL.md\nfiles:\n  - SKILL.md\n",
+    );
+    let installed = install_local_skill(
+        home.join(".agentenv"),
+        &bundle,
+        SkillInstallOptions {
+            allow_unsigned: true,
+            source_label: "local-dev".to_owned(),
+        },
+    )
+    .unwrap();
+    write_file(&installed.path.join("content/SKILL.md"), "# Tampered\n");
+
+    let error = verify_installed_skill(
+        home.join(".agentenv"),
+        InstalledSkillSelector::Name("verify-demo".to_owned()),
+    )
+    .expect_err("tampering must fail");
+
+    assert!(matches!(error, SkillError::DigestMismatch { .. }));
+}
+
+#[test]
+fn installed_verify_rejects_signed_record_without_public_key() {
+    let home = temp_dir("skill-verify-missing-public-key-home");
+    let bundle = temp_dir("skill-verify-missing-public-key-bundle");
+    write_file(&bundle.join("SKILL.md"), "# Demo\n");
+    write_file(
+        &bundle.join("skill.yaml"),
+        "name: missing-public-key-demo\nversion: 0.1.0\nentry: SKILL.md\nfiles:\n  - SKILL.md\nsignatures:\n  ed25519: abcd\n",
+    );
+    let mut installed = install_local_skill(
+        home.join(".agentenv"),
+        &bundle,
+        SkillInstallOptions {
+            allow_unsigned: true,
+            source_label: "local-dev".to_owned(),
+        },
+    )
+    .unwrap();
+    installed.signature_status = "signed".to_owned();
+    write_file(
+        &installed.path.join("installed.yaml"),
+        &serde_yaml::to_string(&installed).unwrap(),
+    );
+
+    let error = verify_installed_skill(
+        home.join(".agentenv"),
+        InstalledSkillSelector::Name("missing-public-key-demo".to_owned()),
+    )
+    .expect_err("signed records without public keys must fail verification");
+
+    assert!(matches!(error, SkillError::MissingSignature { .. }));
+}
+
+#[cfg(unix)]
+#[test]
+fn installed_verify_rejects_symlinked_cached_content_directory() {
+    let home = temp_dir("skill-verify-content-symlink-home");
+    let bundle = temp_dir("skill-verify-content-symlink-bundle");
+    let outside = temp_dir("skill-verify-content-symlink-outside");
+    write_file(&bundle.join("SKILL.md"), "# Demo\n");
+    write_file(
+        &bundle.join("skill.yaml"),
+        "name: verify-content-symlink-demo\nversion: 0.1.0\nentry: SKILL.md\nfiles:\n  - SKILL.md\n",
+    );
+    let installed = install_local_skill(
+        home.join(".agentenv"),
+        &bundle,
+        SkillInstallOptions {
+            allow_unsigned: true,
+            source_label: "local-dev".to_owned(),
+        },
+    )
+    .unwrap();
+    write_file(&outside.join("SKILL.md"), "# Demo\n");
+    fs::remove_dir_all(installed.path.join("content")).unwrap();
+    std::os::unix::fs::symlink(&outside, installed.path.join("content")).unwrap();
+
+    let error = verify_installed_skill(
+        home.join(".agentenv"),
+        InstalledSkillSelector::Name("verify-content-symlink-demo".to_owned()),
+    )
+    .expect_err("verify must reject symlinked cached content dirs");
+
+    assert!(matches!(error, SkillError::UnsafeBundlePath { .. }));
+}
+
+#[test]
+fn installed_verify_rejects_record_entry_tamper() {
+    let home = temp_dir("skill-verify-entry-tamper-home");
+    let bundle = temp_dir("skill-verify-entry-tamper-bundle");
+    write_file(&bundle.join("SKILL.md"), "# Demo\n");
+    write_file(
+        &bundle.join("skill.yaml"),
+        "name: entry-tamper-demo\nversion: 0.1.0\nentry: SKILL.md\nfiles:\n  - SKILL.md\n",
+    );
+    let mut installed = install_local_skill(
+        home.join(".agentenv"),
+        &bundle,
+        SkillInstallOptions {
+            allow_unsigned: true,
+            source_label: "local-dev".to_owned(),
+        },
+    )
+    .unwrap();
+    installed.entry = PathBuf::from("content/OTHER.md");
+    write_file(
+        &installed.path.join("installed.yaml"),
+        &serde_yaml::to_string(&installed).unwrap(),
+    );
+
+    let error = verify_installed_skill(
+        home.join(".agentenv"),
+        InstalledSkillSelector::Name("entry-tamper-demo".to_owned()),
+    )
+    .expect_err("verify must reject installed record entry tampering");
+
+    assert!(matches!(error, SkillError::UnsafeBundlePath { .. }));
+}
+
+#[test]
+fn installed_verify_rejects_signature_status_downgrade() {
+    let home = temp_dir("skill-verify-signature-downgrade-home");
+    let bundle = temp_dir("skill-verify-signature-downgrade-bundle");
+    write_file(&bundle.join("SKILL.md"), "# Demo\n");
+    write_file(
+        &bundle.join("skill.yaml"),
+        "name: signature-downgrade-demo\nversion: 0.1.0\nentry: SKILL.md\nfiles:\n  - SKILL.md\n",
+    );
+    let manifest = load_skill_manifest(&bundle).unwrap();
+    let digest = compute_bundle_digest(&bundle, &manifest).unwrap();
+    let signing_key = SigningKey::from_bytes(&[17_u8; 32]);
+    let payload = agentenv_core::skills::signature_payload(&manifest, &digest).unwrap();
+    let signature = hex::encode(signing_key.sign(&payload).to_bytes());
+    let public_key = hex::encode(signing_key.verifying_key().to_bytes());
+    write_file(
+        &bundle.join("skill.yaml"),
+        &format!(
+            "name: signature-downgrade-demo\nversion: 0.1.0\nentry: SKILL.md\nfiles:\n  - SKILL.md\nsignatures:\n  ed25519: {signature}\n  public_key_ed25519: {public_key}\n"
+        ),
+    );
+    let mut installed = install_local_skill(
+        home.join(".agentenv"),
+        &bundle,
+        SkillInstallOptions {
+            allow_unsigned: true,
+            source_label: "local-dev".to_owned(),
+        },
+    )
+    .unwrap();
+    installed.signature_status = "signed".to_owned();
+    installed.signature_public_key_ed25519 = Some(public_key);
+    write_file(
+        &installed.path.join("installed.yaml"),
+        &serde_yaml::to_string(&installed).unwrap(),
+    );
+    verify_installed_skill(
+        home.join(".agentenv"),
+        InstalledSkillSelector::Name("signature-downgrade-demo".to_owned()),
+    )
+    .expect("trusted signed record should verify");
+
+    installed.signature_status = "unsigned".to_owned();
+    installed.signature_public_key_ed25519 = None;
+    write_file(
+        &installed.path.join("installed.yaml"),
+        &serde_yaml::to_string(&installed).unwrap(),
+    );
+
+    let error = verify_installed_skill(
+        home.join(".agentenv"),
+        InstalledSkillSelector::Name("signature-downgrade-demo".to_owned()),
+    )
+    .expect_err("record edits must not downgrade signed manifests to unsigned");
+
+    assert!(matches!(error, SkillError::MissingSignature { .. }));
+}
+
+#[cfg(unix)]
+#[test]
+fn installed_index_rejects_symlinked_version_directory() {
+    let home = temp_dir("skill-index-symlink-home");
+    let outside = temp_dir("skill-index-symlink-outside");
+    let installed_yaml = r#"name: linked-demo
+version: 0.1.0
+source_type: local
+source_label: outside
+digest: sha256:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
+signature_status: unsigned
+entry: content/SKILL.md
+installed_at: "2026-05-08T00:00:00Z"
+path: ignored
+"#;
+    write_file(&outside.join("installed.yaml"), installed_yaml);
+    let version_parent = home.join(".agentenv/skills/linked-demo");
+    fs::create_dir_all(&version_parent).unwrap();
+    std::os::unix::fs::symlink(&outside, version_parent.join("0.1.0")).unwrap();
+
+    let error = list_installed_skills(home.join(".agentenv"))
+        .expect_err("store symlinked version directories must be rejected");
+
+    assert!(matches!(error, SkillError::UnsafeBundlePath { .. }));
+}
+
+#[test]
+fn installed_index_ignores_stale_staging_directories() {
+    let home = temp_dir("skill-index-stale-staging-home");
+    let bundle = temp_dir("skill-index-stale-staging-bundle");
+    write_file(&bundle.join("SKILL.md"), "# Demo\n");
+    write_file(
+        &bundle.join("skill.yaml"),
+        "name: stale-demo\nversion: 0.1.0\nentry: SKILL.md\nfiles:\n  - SKILL.md\n",
+    );
+    let installed = install_local_skill(
+        home.join(".agentenv"),
+        &bundle,
+        SkillInstallOptions {
+            allow_unsigned: true,
+            source_label: "local-dev".to_owned(),
+        },
+    )
+    .unwrap();
+    let stale_dir = installed.path.parent().unwrap().join(".0.1.0.backup-test");
+    fs::create_dir_all(&stale_dir).unwrap();
+    write_file(
+        &stale_dir.join("installed.yaml"),
+        &serde_yaml::to_string(&installed).unwrap(),
+    );
+
+    let installed = list_installed_skills(home.join(".agentenv")).unwrap();
+
+    assert_eq!(installed.len(), 1);
+    assert_eq!(installed[0].name, "stale-demo");
+}
+
+#[test]
+fn installed_verify_runs_self_test_command() {
+    let home = temp_dir("skill-self-test-home");
+    let bundle = temp_dir("skill-self-test-bundle");
+    write_file(&bundle.join("SKILL.md"), "# Demo\n");
+    write_file(
+        &bundle.join("skill.yaml"),
+        &format!(
+            "name: self-test-demo\nversion: 0.1.0\nentry: SKILL.md\nfiles:\n  - SKILL.md\nself_test:\n  command: {:?}\n",
+            self_test_file_exists_command()
+        ),
+    );
+    install_local_skill(
+        home.join(".agentenv"),
+        &bundle,
+        SkillInstallOptions {
+            allow_unsigned: true,
+            source_label: "local-dev".to_owned(),
+        },
+    )
+    .unwrap();
+
+    let verified = verify_installed_skill(
+        home.join(".agentenv"),
+        InstalledSkillSelector::Name("self-test-demo".to_owned()),
+    )
+    .expect("self-test command should pass");
+
+    assert_eq!(verified.name, "self-test-demo");
+}
+
+#[cfg(windows)]
+fn self_test_file_exists_command() -> &'static str {
+    "if exist SKILL.md (exit /B 0) else (exit /B 1)"
+}
+
+#[cfg(not(windows))]
+fn self_test_file_exists_command() -> &'static str {
+    "test -f SKILL.md"
 }
 
 fn temp_dir(prefix: &str) -> PathBuf {

--- a/crates/agentenv/src/main.rs
+++ b/crates/agentenv/src/main.rs
@@ -38,6 +38,7 @@ use tracing_subscriber::EnvFilter;
 
 mod builtin_factory;
 mod render;
+mod skills_cli;
 mod term_backend;
 
 const SELF_ENV_SENTINEL: &str = "__self__";
@@ -77,6 +78,7 @@ enum Commands {
     Blueprint(BlueprintArgs),
     Credentials(CredentialsArgs),
     Drivers(DriversArgs),
+    Skills(skills_cli::SkillsArgs),
     VerifyBlueprint {
         file: PathBuf,
     },
@@ -576,6 +578,7 @@ async fn run() -> Result<()> {
         Some(Commands::Blueprint(command)) => run_blueprint(command),
         Some(Commands::Credentials(command)) => run_credentials(command, &cli.events_sink).await,
         Some(Commands::Drivers(command)) => run_drivers(command),
+        Some(Commands::Skills(args)) => skills_cli::run_skills(args).await,
         Some(Commands::VerifyBlueprint { file }) => verify_blueprint(&file),
         Some(Commands::Verify { lockfile }) => verify_lockfile(&lockfile),
         Some(Commands::Freeze { name, output }) => freeze(&name, output.as_deref()),

--- a/crates/agentenv/src/main.rs
+++ b/crates/agentenv/src/main.rs
@@ -3857,6 +3857,7 @@ mod tests {
                 "blueprint".to_string(),
                 "credentials".to_string(),
                 "drivers".to_string(),
+                "skills".to_string(),
                 "verify-blueprint".to_string(),
                 "verify".to_string(),
                 "freeze".to_string(),

--- a/crates/agentenv/src/skills_cli.rs
+++ b/crates/agentenv/src/skills_cli.rs
@@ -1,0 +1,342 @@
+use std::{path::PathBuf, sync::Arc};
+
+use agentenv_core::skills::{
+    load_project_skills_config, load_user_skills_config, merge_skills_config, InstalledSkill,
+    InstalledSkillSelector, SkillAddRequest, SkillError, SkillPublishRequest, SkillSearchHit,
+    SkillService, SkillsConfig, SkillsConfigOverride,
+};
+use agentenv_credstore::{CredentialStore, CredentialStoreError};
+use agentenv_proto::{CredentialKind, CredentialRequirement};
+use anyhow::{bail, Context, Result};
+use clap::{Args, Subcommand};
+use serde::Serialize;
+
+#[derive(Debug, Args)]
+pub struct SkillsArgs {
+    #[command(subcommand)]
+    pub command: SkillsCommand,
+}
+
+#[derive(Debug, Subcommand)]
+pub enum SkillsCommand {
+    Search(SkillsSearchArgs),
+    Add(SkillsAddArgs),
+    Install(SkillsInstallArgs),
+    List(SkillsListArgs),
+    Info(SkillsInfoArgs),
+    Remove(SkillsRemoveArgs),
+    Publish(SkillsPublishArgs),
+    Verify(SkillsVerifyArgs),
+}
+
+#[derive(Debug, Args)]
+pub struct SkillsSearchArgs {
+    pub query: String,
+    #[arg(long)]
+    pub registry: Option<String>,
+    #[arg(long)]
+    pub json: bool,
+}
+
+#[derive(Debug, Args)]
+pub struct SkillsAddArgs {
+    pub handle: String,
+    #[arg(long)]
+    pub registry: Option<String>,
+    #[arg(long)]
+    pub allow_unsigned: bool,
+    #[arg(long)]
+    pub json: bool,
+}
+
+#[derive(Debug, Args)]
+pub struct SkillsInstallArgs {
+    #[arg(long = "from", value_name = "PATH")]
+    pub from: PathBuf,
+    #[arg(long)]
+    pub allow_unsigned: bool,
+    #[arg(long)]
+    pub json: bool,
+}
+
+#[derive(Debug, Args)]
+pub struct SkillsListArgs {
+    #[arg(long)]
+    pub json: bool,
+}
+
+#[derive(Debug, Args)]
+pub struct SkillsInfoArgs {
+    pub name: String,
+    #[arg(long)]
+    pub version: Option<String>,
+    #[arg(long)]
+    pub json: bool,
+}
+
+#[derive(Debug, Args)]
+pub struct SkillsRemoveArgs {
+    pub name: String,
+    #[arg(long)]
+    pub version: Option<String>,
+    #[arg(long)]
+    pub yes: bool,
+    #[arg(long)]
+    pub json: bool,
+}
+
+#[derive(Debug, Args)]
+pub struct SkillsPublishArgs {
+    pub path: PathBuf,
+    #[arg(long)]
+    pub registry: Option<String>,
+    #[arg(long)]
+    pub allow_unsigned: bool,
+    #[arg(long)]
+    pub json: bool,
+}
+
+#[derive(Debug, Args)]
+pub struct SkillsVerifyArgs {
+    pub name: String,
+    #[arg(long)]
+    pub version: Option<String>,
+    #[arg(long)]
+    pub json: bool,
+}
+
+#[derive(Debug, Serialize)]
+struct SkillsListJson {
+    skills: Vec<InstalledSkill>,
+}
+
+#[derive(Debug, Serialize)]
+struct SkillsSearchJson {
+    skills: Vec<SkillSearchHit>,
+}
+
+pub async fn run_skills(args: SkillsArgs) -> Result<()> {
+    let home = dirs::home_dir().context("home directory is unavailable")?;
+    let root = home.join(".agentenv");
+    let registry_override = registry_override_for_command(&args.command);
+    let config = load_effective_config(registry_override)?;
+    let service = SkillService::new(root, config)
+        .with_credential_resolver(Arc::new(resolve_skill_credential));
+    dispatch(args.command, service).await
+}
+
+async fn dispatch(command: SkillsCommand, service: SkillService) -> Result<()> {
+    match command {
+        SkillsCommand::Search(args) => {
+            let hits = service.search(&args.query).await?;
+            if args.json {
+                print_json(&SkillsSearchJson { skills: hits })
+            } else {
+                print_search_hits(&hits);
+                Ok(())
+            }
+        }
+        SkillsCommand::Add(args) => {
+            let installed = service
+                .add(SkillAddRequest {
+                    handle: args.handle,
+                    registry: args.registry,
+                    allow_unsigned: args.allow_unsigned,
+                })
+                .await?;
+            print_installed_result(&installed, args.json)
+        }
+        SkillsCommand::Install(args) => {
+            let installed = service.install_from_path(
+                &args.from,
+                args.allow_unsigned,
+                format!("local:{}", args.from.display()),
+            )?;
+            print_installed_result(&installed, args.json)
+        }
+        SkillsCommand::List(args) => {
+            let skills = service.list()?;
+            if args.json {
+                print_json(&SkillsListJson { skills })
+            } else {
+                print_installed_table(&skills);
+                Ok(())
+            }
+        }
+        SkillsCommand::Info(args) => {
+            let installed = service.info(selector(args.name, args.version))?;
+            if args.json {
+                print_json(&installed)
+            } else {
+                print_installed_info(&installed);
+                Ok(())
+            }
+        }
+        SkillsCommand::Remove(args) => {
+            if !args.yes {
+                bail!("refusing to remove a skill without --yes");
+            }
+            let removed = service.remove(selector(args.name, args.version))?;
+            print_installed_result(&removed, args.json)
+        }
+        SkillsCommand::Publish(args) => {
+            let hit = service
+                .publish(SkillPublishRequest {
+                    bundle_path: args.path,
+                    registry: args.registry,
+                    allow_unsigned: args.allow_unsigned,
+                })
+                .await?;
+            if args.json {
+                print_json(&hit)
+            } else {
+                println!(
+                    "{} {} {}",
+                    hit.name,
+                    hit.version,
+                    hit.digest.as_deref().unwrap_or("unknown")
+                );
+                Ok(())
+            }
+        }
+        SkillsCommand::Verify(args) => {
+            let installed = service.verify(selector(args.name, args.version))?;
+            print_installed_result(&installed, args.json)
+        }
+    }
+}
+
+fn registry_override_for_command(command: &SkillsCommand) -> Option<String> {
+    match command {
+        SkillsCommand::Search(args) => args.registry.clone(),
+        SkillsCommand::Add(args) => args.registry.clone(),
+        SkillsCommand::Publish(args) => args.registry.clone(),
+        SkillsCommand::Install(_)
+        | SkillsCommand::List(_)
+        | SkillsCommand::Info(_)
+        | SkillsCommand::Remove(_)
+        | SkillsCommand::Verify(_) => None,
+    }
+}
+
+fn load_effective_config(registry_override: Option<String>) -> Result<SkillsConfig> {
+    let user = match dirs::home_dir() {
+        Some(home) => {
+            let path = home.join(".config/agentenv/config.toml");
+            if path.is_file() {
+                load_user_skills_config(
+                    &std::fs::read_to_string(&path)
+                        .with_context(|| format!("read `{}`", path.display()))?,
+                )
+                .with_context(|| format!("load skills config `{}`", path.display()))?
+            } else {
+                SkillsConfig::default()
+            }
+        }
+        None => SkillsConfig::default(),
+    };
+
+    let project_path = std::env::current_dir()
+        .context("read current directory")?
+        .join("agentenv.yaml");
+    let project = if project_path.is_file() {
+        Some(
+            load_project_skills_config(
+                &std::fs::read_to_string(&project_path)
+                    .with_context(|| format!("read `{}`", project_path.display()))?,
+            )
+            .with_context(|| format!("load project skills config `{}`", project_path.display()))?,
+        )
+    } else {
+        None
+    };
+
+    merge_skills_config(
+        user,
+        project,
+        SkillsConfigOverride {
+            registry: registry_override,
+        },
+    )
+    .context("merge skills config")
+}
+
+fn resolve_skill_credential(name: &str) -> std::result::Result<Option<String>, SkillError> {
+    let store =
+        CredentialStore::from_default_paths().map_err(|error| SkillError::InvalidConfig {
+            message: format!("initialize credential store: {error}"),
+        })?;
+    let requirement = CredentialRequirement {
+        name: name.to_owned(),
+        kind: CredentialKind::ApiKey,
+        required: false,
+        description: "skill registry bearer token".to_owned(),
+        validator: None,
+    };
+    match store.resolve(name, &requirement) {
+        Ok(secret) => Ok(Some(secret.expose_secret().to_owned())),
+        Err(CredentialStoreError::MissingCredential { .. }) => Ok(None),
+        Err(error) => Err(SkillError::InvalidConfig {
+            message: format!("resolve credential `{name}`: {error}"),
+        }),
+    }
+}
+
+fn selector(name: String, version: Option<String>) -> InstalledSkillSelector {
+    match version {
+        Some(version) => InstalledSkillSelector::NameVersion { name, version },
+        None => InstalledSkillSelector::Name(name),
+    }
+}
+
+fn print_json<T: Serialize>(value: &T) -> Result<()> {
+    println!("{}", serde_json::to_string_pretty(value)?);
+    Ok(())
+}
+
+fn print_installed_result(installed: &InstalledSkill, json: bool) -> Result<()> {
+    if json {
+        print_json(installed)
+    } else {
+        println!(
+            "{} {} {}",
+            installed.name, installed.version, installed.digest
+        );
+        Ok(())
+    }
+}
+
+fn print_search_hits(hits: &[SkillSearchHit]) {
+    println!("NAME VERSION REGISTRY DIGEST");
+    for hit in hits {
+        println!(
+            "{} {} {} {}",
+            hit.name,
+            hit.version,
+            hit.registry,
+            hit.digest.as_deref().unwrap_or("unknown")
+        );
+    }
+}
+
+fn print_installed_table(skills: &[InstalledSkill]) {
+    println!("NAME VERSION SOURCE DIGEST");
+    for skill in skills {
+        println!(
+            "{} {} {} {}",
+            skill.name, skill.version, skill.source_type, skill.digest
+        );
+    }
+}
+
+fn print_installed_info(installed: &InstalledSkill) {
+    println!("name: {}", installed.name);
+    println!("version: {}", installed.version);
+    println!("source_type: {}", installed.source_type);
+    println!("source_label: {}", installed.source_label);
+    println!("digest: {}", installed.digest);
+    println!("signature_status: {}", installed.signature_status);
+    println!("entry: {}", installed.entry.display());
+    println!("installed_at: {}", installed.installed_at);
+    println!("path: {}", installed.path.display());
+}

--- a/crates/agentenv/src/skills_cli.rs
+++ b/crates/agentenv/src/skills_cli.rs
@@ -140,7 +140,7 @@ async fn dispatch(command: SkillsCommand, service: SkillService) -> Result<()> {
             let installed = service
                 .add(SkillAddRequest {
                     handle: args.handle,
-                    registry: args.registry,
+                    registry: None,
                     allow_unsigned: args.allow_unsigned,
                 })
                 .await?;
@@ -183,7 +183,7 @@ async fn dispatch(command: SkillsCommand, service: SkillService) -> Result<()> {
             let hit = service
                 .publish(SkillPublishRequest {
                     bundle_path: args.path,
-                    registry: args.registry,
+                    registry: None,
                     allow_unsigned: args.allow_unsigned,
                 })
                 .await?;

--- a/crates/agentenv/tests/cli_behavior.rs
+++ b/crates/agentenv/tests/cli_behavior.rs
@@ -583,6 +583,166 @@ fn skills_registry_config_precedence_is_user_project_then_cli() {
 }
 
 #[test]
+fn skills_cli_enforces_trust_self_tests_version_selectors_and_remove_confirmation() {
+    let temp_dir = make_temp_dir("skills-cli-lifecycle-matrix");
+    let old_bundle = temp_dir.join("matrix-0.1.0");
+    let new_bundle = temp_dir.join("matrix-0.2.0");
+    write_local_skill_bundle(
+        &old_bundle,
+        "matrix-skill",
+        "0.1.0",
+        "Old matrix skill",
+        Some("test -f SKILL.md"),
+    );
+    write_local_skill_bundle(
+        &new_bundle,
+        "matrix-skill",
+        "0.2.0",
+        "New matrix skill",
+        Some("test -f SKILL.md"),
+    );
+
+    let unsigned_default = Command::new(agentenv_bin())
+        .arg("skills")
+        .arg("install")
+        .arg("--from")
+        .arg(&old_bundle)
+        .env("HOME", &temp_dir)
+        .current_dir(&temp_dir)
+        .output()
+        .unwrap();
+    assert!(!unsigned_default.status.success());
+    assert!(
+        String::from_utf8_lossy(&unsigned_default.stderr).contains("missing Ed25519 signature"),
+        "{}",
+        output_summary(&unsigned_default)
+    );
+
+    for bundle in [&old_bundle, &new_bundle] {
+        let install = Command::new(agentenv_bin())
+            .arg("skills")
+            .arg("install")
+            .arg("--from")
+            .arg(bundle)
+            .arg("--allow-unsigned")
+            .arg("--json")
+            .env("HOME", &temp_dir)
+            .current_dir(&temp_dir)
+            .output()
+            .unwrap();
+        assert!(install.status.success(), "{}", output_summary(&install));
+        let installed: serde_json::Value = serde_json::from_slice(&install.stdout).unwrap();
+        assert_eq!(installed["name"], "matrix-skill");
+        assert_eq!(installed["signature_status"], "unsigned");
+    }
+
+    let ambiguous_info = Command::new(agentenv_bin())
+        .arg("skills")
+        .arg("info")
+        .arg("matrix-skill")
+        .env("HOME", &temp_dir)
+        .output()
+        .unwrap();
+    assert!(!ambiguous_info.status.success());
+    assert!(
+        String::from_utf8_lossy(&ambiguous_info.stderr).contains("multiple installed versions"),
+        "{}",
+        output_summary(&ambiguous_info)
+    );
+
+    let info_old = Command::new(agentenv_bin())
+        .arg("skills")
+        .arg("info")
+        .arg("matrix-skill")
+        .arg("--version")
+        .arg("0.1.0")
+        .arg("--json")
+        .env("HOME", &temp_dir)
+        .output()
+        .unwrap();
+    assert!(info_old.status.success(), "{}", output_summary(&info_old));
+    let info_old_json: serde_json::Value = serde_json::from_slice(&info_old.stdout).unwrap();
+    assert_eq!(info_old_json["version"], "0.1.0");
+
+    let verify_new = Command::new(agentenv_bin())
+        .arg("skills")
+        .arg("verify")
+        .arg("matrix-skill")
+        .arg("--version")
+        .arg("0.2.0")
+        .arg("--json")
+        .env("HOME", &temp_dir)
+        .output()
+        .unwrap();
+    assert!(
+        verify_new.status.success(),
+        "{}",
+        output_summary(&verify_new)
+    );
+    let verify_new_json: serde_json::Value = serde_json::from_slice(&verify_new.stdout).unwrap();
+    assert_eq!(verify_new_json["version"], "0.2.0");
+
+    let remove_without_yes = Command::new(agentenv_bin())
+        .arg("skills")
+        .arg("remove")
+        .arg("matrix-skill")
+        .arg("--version")
+        .arg("0.1.0")
+        .env("HOME", &temp_dir)
+        .output()
+        .unwrap();
+    assert!(!remove_without_yes.status.success());
+    assert!(
+        String::from_utf8_lossy(&remove_without_yes.stderr).contains("without --yes"),
+        "{}",
+        output_summary(&remove_without_yes)
+    );
+
+    let remove_old = Command::new(agentenv_bin())
+        .arg("skills")
+        .arg("remove")
+        .arg("matrix-skill")
+        .arg("--version")
+        .arg("0.1.0")
+        .arg("--yes")
+        .arg("--json")
+        .env("HOME", &temp_dir)
+        .output()
+        .unwrap();
+    assert!(
+        remove_old.status.success(),
+        "{}",
+        output_summary(&remove_old)
+    );
+    let remove_old_json: serde_json::Value = serde_json::from_slice(&remove_old.stdout).unwrap();
+    assert_eq!(remove_old_json["version"], "0.1.0");
+
+    let list_after_remove = Command::new(agentenv_bin())
+        .arg("skills")
+        .arg("list")
+        .arg("--json")
+        .env("HOME", &temp_dir)
+        .output()
+        .unwrap();
+    assert!(
+        list_after_remove.status.success(),
+        "{}",
+        output_summary(&list_after_remove)
+    );
+    let list_after_remove_json: serde_json::Value =
+        serde_json::from_slice(&list_after_remove.stdout).unwrap();
+    assert_eq!(
+        list_after_remove_json["skills"]
+            .as_array()
+            .unwrap()
+            .iter()
+            .map(|skill| skill["version"].as_str().unwrap())
+            .collect::<Vec<_>>(),
+        ["0.2.0"]
+    );
+}
+
+#[test]
 fn blueprint_lint_reports_json_diagnostics() {
     let temp_dir = make_temp_dir("blueprint-lint-json-diagnostics");
     let dockerfile = temp_dir.join("Dockerfile");
@@ -3438,6 +3598,27 @@ fn make_executable(path: &Path) {
         permissions.set_mode(0o755);
         fs::set_permissions(path, permissions).unwrap();
     }
+}
+
+fn write_local_skill_bundle(
+    bundle: &Path,
+    name: &str,
+    version: &str,
+    description: &str,
+    self_test: Option<&str>,
+) {
+    fs::create_dir_all(bundle).unwrap();
+    fs::write(bundle.join("SKILL.md"), format!("# {description}\n")).unwrap();
+    let self_test_yaml = self_test
+        .map(|command| format!("self_test:\n  command: {command}\n"))
+        .unwrap_or_default();
+    fs::write(
+        bundle.join("skill.yaml"),
+        format!(
+            "name: {name}\nversion: {version}\ndescription: {description}\nentry: SKILL.md\nfiles:\n  - SKILL.md\n{self_test_yaml}"
+        ),
+    )
+    .unwrap();
 }
 
 fn write_filesystem_registry_skill(registry: &Path, name: &str, version: &str, description: &str) {

--- a/crates/agentenv/tests/cli_behavior.rs
+++ b/crates/agentenv/tests/cli_behavior.rs
@@ -360,6 +360,63 @@ fn skills_install_list_info_verify_and_remove_local_bundle() {
 }
 
 #[test]
+fn skills_search_add_and_publish_use_filesystem_registry_config() {
+    let temp_dir = make_temp_dir("skills-cli-registry");
+    let registry = temp_dir.join("registry");
+    let bundle = temp_dir.join("bundle");
+    fs::create_dir_all(&bundle).unwrap();
+    fs::write(bundle.join("SKILL.md"), "# Registry Skill\n").unwrap();
+    fs::write(
+        bundle.join("skill.yaml"),
+        "name: registry-skill\nversion: 0.1.0\ndescription: Registry demo\nentry: SKILL.md\nfiles:\n  - SKILL.md\n",
+    )
+    .unwrap();
+    fs::write(
+        temp_dir.join("agentenv.yaml"),
+        format!(
+            "version: 0.1.0\nmin_agentenv_version: 0.0.1-alpha0\nsandbox: {{ driver: openshell }}\nagent: {{ driver: codex }}\ncontext: {{ driver: filesystem, mount: . }}\npolicy: {{ tier: balanced, presets: [] }}\nskills:\n  registries:\n    - name: local-dev\n      type: filesystem\n      path: {}\n",
+            registry.display()
+        ),
+    )
+    .unwrap();
+
+    let publish = Command::new(agentenv_bin())
+        .arg("skills")
+        .arg("publish")
+        .arg(&bundle)
+        .arg("--registry")
+        .arg("local-dev")
+        .arg("--allow-unsigned")
+        .env("HOME", &temp_dir)
+        .current_dir(&temp_dir)
+        .output()
+        .unwrap();
+    assert!(publish.status.success(), "{}", output_summary(&publish));
+
+    let search = Command::new(agentenv_bin())
+        .arg("skills")
+        .arg("search")
+        .arg("registry")
+        .env("HOME", &temp_dir)
+        .current_dir(&temp_dir)
+        .output()
+        .unwrap();
+    assert!(search.status.success(), "{}", output_summary(&search));
+    assert!(String::from_utf8_lossy(&search.stdout).contains("registry-skill"));
+
+    let add = Command::new(agentenv_bin())
+        .arg("skills")
+        .arg("add")
+        .arg("registry-skill@0.1.0")
+        .arg("--allow-unsigned")
+        .env("HOME", &temp_dir)
+        .current_dir(&temp_dir)
+        .output()
+        .unwrap();
+    assert!(add.status.success(), "{}", output_summary(&add));
+}
+
+#[test]
 fn blueprint_lint_reports_json_diagnostics() {
     let temp_dir = make_temp_dir("blueprint-lint-json-diagnostics");
     let dockerfile = temp_dir.join("Dockerfile");

--- a/crates/agentenv/tests/cli_behavior.rs
+++ b/crates/agentenv/tests/cli_behavior.rs
@@ -4,6 +4,7 @@ use std::{
     io::{Read, Write},
     path::{Path, PathBuf},
     process::{self, Command},
+    sync::{Mutex, MutexGuard},
     thread,
     time::{Duration, Instant, SystemTime, UNIX_EPOCH},
 };
@@ -191,6 +192,7 @@ policy:
         missing_stderr.contains("CUSTOM_OPENAI_KEY"),
         "stderr was: {missing_stderr}"
     );
+    write_failing_openshell_cli(&temp_dir);
 
     let present = Command::new(agentenv_bin())
         .arg("reproduce")
@@ -3274,6 +3276,29 @@ fn make_executable(path: &Path) {
     }
 }
 
+fn write_failing_openshell_cli(home: &Path) {
+    let bin_dir = home.join(".local").join("bin");
+    fs::create_dir_all(&bin_dir).unwrap();
+    let openshell = bin_dir.join("openshell");
+    fs::write(
+        &openshell,
+        r#"#!/bin/sh
+if [ "$1" = "--version" ]; then
+  printf 'openshell 0.0.30\n'
+  exit 0
+fi
+if [ "$1" = "status" ]; then
+  printf 'gateway down\n' >&2
+  exit 1
+fi
+printf 'unexpected openshell test command: %s\n' "$*" >&2
+exit 1
+"#,
+    )
+    .unwrap();
+    make_executable(&openshell);
+}
+
 fn agentenv_uninstall_temp_dirs(root: &Path) -> BTreeSet<PathBuf> {
     fs::read_dir(root)
         .unwrap()
@@ -3423,7 +3448,10 @@ fn reserve_tcp_port() -> u16 {
 
 struct ApprovalsServerChild {
     child: process::Child,
+    _guard: MutexGuard<'static, ()>,
 }
+
+static APPROVALS_SERVER_TEST_LOCK: Mutex<()> = Mutex::new(());
 
 impl Drop for ApprovalsServerChild {
     fn drop(&mut self) {
@@ -3433,12 +3461,16 @@ impl Drop for ApprovalsServerChild {
 }
 
 fn spawn_approvals_server(home: &Path, port: u16) -> ApprovalsServerChild {
+    let guard = APPROVALS_SERVER_TEST_LOCK.lock().unwrap();
     let child = Command::new(agentenv_bin())
         .env("HOME", home)
         .args(["approvals", "serve", "--addr", &format!("127.0.0.1:{port}")])
         .spawn()
         .unwrap();
-    ApprovalsServerChild { child }
+    ApprovalsServerChild {
+        child,
+        _guard: guard,
+    }
 }
 
 fn wait_for_http_ok(port: u16, path: &str) {

--- a/crates/agentenv/tests/cli_behavior.rs
+++ b/crates/agentenv/tests/cli_behavior.rs
@@ -419,6 +419,170 @@ fn skills_search_add_and_publish_use_filesystem_registry_config() {
 }
 
 #[test]
+fn skills_registry_cli_path_override_publishes_searches_and_adds() {
+    let temp_dir = make_temp_dir("skills-cli-registry-override");
+    let registry = temp_dir.join("registry");
+    let bundle = temp_dir.join("bundle");
+    fs::create_dir_all(&bundle).unwrap();
+    fs::write(bundle.join("SKILL.md"), "# Override Skill\n").unwrap();
+    fs::write(
+        bundle.join("skill.yaml"),
+        "name: override-skill\nversion: 0.1.0\ndescription: Override demo\nentry: SKILL.md\nfiles:\n  - SKILL.md\n",
+    )
+    .unwrap();
+
+    let publish = Command::new(agentenv_bin())
+        .arg("skills")
+        .arg("publish")
+        .arg(&bundle)
+        .arg("--registry")
+        .arg(&registry)
+        .arg("--allow-unsigned")
+        .arg("--json")
+        .env("HOME", &temp_dir)
+        .current_dir(&temp_dir)
+        .output()
+        .unwrap();
+    assert!(publish.status.success(), "{}", output_summary(&publish));
+    let publish_json: serde_json::Value = serde_json::from_slice(&publish.stdout).unwrap();
+    assert_eq!(publish_json["name"], "override-skill");
+    assert_eq!(publish_json["registry"], "cli");
+
+    let search = Command::new(agentenv_bin())
+        .arg("skills")
+        .arg("search")
+        .arg("override")
+        .arg("--registry")
+        .arg(&registry)
+        .arg("--json")
+        .env("HOME", &temp_dir)
+        .current_dir(&temp_dir)
+        .output()
+        .unwrap();
+    assert!(search.status.success(), "{}", output_summary(&search));
+    let search_json: serde_json::Value = serde_json::from_slice(&search.stdout).unwrap();
+    assert_eq!(search_json["skills"][0]["name"], "override-skill");
+    assert_eq!(search_json["skills"][0]["registry"], "cli");
+
+    let add = Command::new(agentenv_bin())
+        .arg("skills")
+        .arg("add")
+        .arg("override-skill@0.1.0")
+        .arg("--registry")
+        .arg(&registry)
+        .arg("--allow-unsigned")
+        .arg("--json")
+        .env("HOME", &temp_dir)
+        .current_dir(&temp_dir)
+        .output()
+        .unwrap();
+    assert!(add.status.success(), "{}", output_summary(&add));
+    let add_json: serde_json::Value = serde_json::from_slice(&add.stdout).unwrap();
+    assert_eq!(add_json["name"], "override-skill");
+    assert_eq!(add_json["source_type"], "filesystem");
+    assert_eq!(
+        add_json["source_label"],
+        "filesystem:cli:override-skill@0.1.0"
+    );
+}
+
+#[test]
+fn skills_registry_config_precedence_is_user_project_then_cli() {
+    let temp_dir = make_temp_dir("skills-cli-registry-precedence");
+    let user_registry = temp_dir.join("user-registry");
+    let project_registry = temp_dir.join("project-registry");
+    let cli_registry = temp_dir.join("cli-registry");
+    write_filesystem_registry_skill(
+        &user_registry,
+        "user-precedence-skill",
+        "0.1.0",
+        "Precedence demo",
+    );
+    write_filesystem_registry_skill(
+        &project_registry,
+        "project-precedence-skill",
+        "0.1.0",
+        "Precedence demo",
+    );
+    write_filesystem_registry_skill(
+        &cli_registry,
+        "cli-precedence-skill",
+        "0.1.0",
+        "Precedence demo",
+    );
+
+    fs::create_dir_all(temp_dir.join(".config/agentenv")).unwrap();
+    fs::write(
+        temp_dir.join(".config/agentenv/config.toml"),
+        format!(
+            "[skills]\nregistry_order = [\"shared\"]\n\n[[skills.registries]]\nname = \"shared\"\ntype = \"filesystem\"\npath = '{}'\n",
+            user_registry.display()
+        ),
+    )
+    .unwrap();
+    fs::write(
+        temp_dir.join("agentenv.yaml"),
+        format!(
+            "skills:\n  registry_order:\n    - shared\n  registries:\n    - name: shared\n      type: filesystem\n      path: {}\n",
+            project_registry.display()
+        ),
+    )
+    .unwrap();
+    let no_project_dir = temp_dir.join("no-project");
+    fs::create_dir_all(&no_project_dir).unwrap();
+
+    let user_search = Command::new(agentenv_bin())
+        .arg("skills")
+        .arg("search")
+        .arg("precedence")
+        .arg("--json")
+        .env("HOME", &temp_dir)
+        .current_dir(&no_project_dir)
+        .output()
+        .unwrap();
+    assert!(
+        user_search.status.success(),
+        "{}",
+        output_summary(&user_search)
+    );
+    assert_skill_search_names(&user_search.stdout, &["user-precedence-skill"]);
+
+    let project_search = Command::new(agentenv_bin())
+        .arg("skills")
+        .arg("search")
+        .arg("precedence")
+        .arg("--json")
+        .env("HOME", &temp_dir)
+        .current_dir(&temp_dir)
+        .output()
+        .unwrap();
+    assert!(
+        project_search.status.success(),
+        "{}",
+        output_summary(&project_search)
+    );
+    assert_skill_search_names(&project_search.stdout, &["project-precedence-skill"]);
+
+    let cli_search = Command::new(agentenv_bin())
+        .arg("skills")
+        .arg("search")
+        .arg("precedence")
+        .arg("--registry")
+        .arg(&cli_registry)
+        .arg("--json")
+        .env("HOME", &temp_dir)
+        .current_dir(&temp_dir)
+        .output()
+        .unwrap();
+    assert!(
+        cli_search.status.success(),
+        "{}",
+        output_summary(&cli_search)
+    );
+    assert_skill_search_names(&cli_search.stdout, &["cli-precedence-skill"]);
+}
+
+#[test]
 fn blueprint_lint_reports_json_diagnostics() {
     let temp_dir = make_temp_dir("blueprint-lint-json-diagnostics");
     let dockerfile = temp_dir.join("Dockerfile");
@@ -3274,6 +3438,46 @@ fn make_executable(path: &Path) {
         permissions.set_mode(0o755);
         fs::set_permissions(path, permissions).unwrap();
     }
+}
+
+fn write_filesystem_registry_skill(registry: &Path, name: &str, version: &str, description: &str) {
+    let bundle = registry.join("bundles").join(name).join(version);
+    fs::create_dir_all(&bundle).unwrap();
+    fs::write(
+        bundle.join("SKILL.md"),
+        format!("# {description}\n\n{name}\n"),
+    )
+    .unwrap();
+    fs::write(
+        bundle.join("skill.yaml"),
+        format!(
+            "name: {name}\nversion: {version}\ndescription: {description}\nentry: SKILL.md\nfiles:\n  - SKILL.md\n"
+        ),
+    )
+    .unwrap();
+    fs::write(
+        registry.join("index.yaml"),
+        format!(
+            "skills:\n  - name: {name}\n    version: {version}\n    description: {description}\n    registry: local\n"
+        ),
+    )
+    .unwrap();
+}
+
+fn assert_skill_search_names(stdout: &[u8], expected: &[&str]) {
+    let json: serde_json::Value = serde_json::from_slice(stdout).unwrap();
+    let names = json["skills"]
+        .as_array()
+        .unwrap()
+        .iter()
+        .map(|skill| skill["name"].as_str().unwrap())
+        .collect::<Vec<_>>();
+    assert_eq!(
+        names,
+        expected,
+        "stdout was: {}",
+        String::from_utf8_lossy(stdout)
+    );
 }
 
 fn write_failing_openshell_cli(home: &Path) {

--- a/crates/agentenv/tests/cli_behavior.rs
+++ b/crates/agentenv/tests/cli_behavior.rs
@@ -263,6 +263,103 @@ fn cli_includes_commands() {
 }
 
 #[test]
+fn cli_help_includes_skills_command() {
+    let output = Command::new(agentenv_bin()).arg("--help").output().unwrap();
+
+    assert!(output.status.success(), "{}", output_summary(&output));
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    assert!(stdout.contains("skills"), "stdout was: {stdout}");
+}
+
+#[test]
+fn skills_help_lists_lifecycle_subcommands() {
+    let output = Command::new(agentenv_bin())
+        .arg("skills")
+        .arg("--help")
+        .output()
+        .unwrap();
+
+    assert!(output.status.success(), "{}", output_summary(&output));
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    for command in [
+        "search", "add", "install", "list", "info", "remove", "publish", "verify",
+    ] {
+        assert!(
+            stdout.contains(command),
+            "missing {command}; stdout was: {stdout}"
+        );
+    }
+}
+
+#[test]
+fn skills_install_list_info_verify_and_remove_local_bundle() {
+    let temp_dir = make_temp_dir("skills-cli-local");
+    let bundle = temp_dir.join("bundle");
+    fs::create_dir_all(&bundle).unwrap();
+    fs::write(bundle.join("SKILL.md"), "# CLI Skill\n").unwrap();
+    fs::write(
+        bundle.join("skill.yaml"),
+        "name: cli-skill\nversion: 0.1.0\nentry: SKILL.md\nfiles:\n  - SKILL.md\n",
+    )
+    .unwrap();
+
+    let install = Command::new(agentenv_bin())
+        .arg("skills")
+        .arg("install")
+        .arg("--from")
+        .arg(&bundle)
+        .arg("--allow-unsigned")
+        .arg("--json")
+        .env("HOME", &temp_dir)
+        .current_dir(&temp_dir)
+        .output()
+        .unwrap();
+    assert!(install.status.success(), "{}", output_summary(&install));
+
+    let list = Command::new(agentenv_bin())
+        .arg("skills")
+        .arg("list")
+        .arg("--json")
+        .env("HOME", &temp_dir)
+        .output()
+        .unwrap();
+    assert!(list.status.success(), "{}", output_summary(&list));
+    let json: serde_json::Value = serde_json::from_slice(&list.stdout).unwrap();
+    assert_eq!(json["skills"][0]["name"], "cli-skill");
+
+    let info = Command::new(agentenv_bin())
+        .arg("skills")
+        .arg("info")
+        .arg("cli-skill")
+        .arg("--json")
+        .env("HOME", &temp_dir)
+        .output()
+        .unwrap();
+    assert!(info.status.success(), "{}", output_summary(&info));
+    let info_json: serde_json::Value = serde_json::from_slice(&info.stdout).unwrap();
+    assert_eq!(info_json["name"], "cli-skill");
+
+    let verify = Command::new(agentenv_bin())
+        .arg("skills")
+        .arg("verify")
+        .arg("cli-skill")
+        .env("HOME", &temp_dir)
+        .output()
+        .unwrap();
+    assert!(verify.status.success(), "{}", output_summary(&verify));
+
+    let remove = Command::new(agentenv_bin())
+        .arg("skills")
+        .arg("remove")
+        .arg("cli-skill")
+        .arg("--yes")
+        .env("HOME", &temp_dir)
+        .output()
+        .unwrap();
+    assert!(remove.status.success(), "{}", output_summary(&remove));
+}
+
+#[test]
 fn blueprint_lint_reports_json_diagnostics() {
     let temp_dir = make_temp_dir("blueprint-lint-json-diagnostics");
     let dockerfile = temp_dir.join("Dockerfile");

--- a/docs/superpowers/plans/2026-05-07-skills-cli.md
+++ b/docs/superpowers/plans/2026-05-07-skills-cli.md
@@ -1,0 +1,2034 @@
+# Skills Lifecycle CLI Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Implement the full `agentenv skills` lifecycle from issue #28 in one PR.
+
+**Architecture:** Add an async `agentenv-core::skills` service that owns manifests, verification, local cache state, registry adapters, and config precedence. Add a thin `agentenv` CLI module that parses `skills` subcommands, calls the service, and renders text or JSON. Keep skills as core-managed resources; do not add a driver kind or driver protocol method.
+
+**Tech Stack:** Rust 2021, `serde_yaml`, `serde_json`, `toml` for the issue-required user config file, `semver`, `sha2`, `ed25519-dalek`, `reqwest` with `rustls`, `tokio`, existing `agentenv-core::security::ssrf` validation, existing `agentenv-credstore` credential resolution.
+
+---
+
+## File Structure
+
+- Modify `Cargo.toml`
+  - Add workspace dependency `toml = "0.8"`.
+- Modify `crates/agentenv-core/Cargo.toml`
+  - Add `reqwest.workspace = true`.
+  - Add `toml.workspace = true`.
+- Modify `crates/agentenv/Cargo.toml`
+  - Add `toml.workspace = true` only if CLI config loading stays in the binary crate.
+- Modify `crates/agentenv-core/src/lib.rs`
+  - Export `pub mod skills;`.
+- Create `crates/agentenv-core/src/skills/mod.rs`
+  - Re-export the service, config, registry, manifest, installed record, and error types.
+- Create `crates/agentenv-core/src/skills/error.rs`
+  - Own `SkillError` with `thiserror`.
+- Create `crates/agentenv-core/src/skills/manifest.rs`
+  - Parse and validate `skill.yaml`; expand exact files and trailing `/**` directory patterns deterministically.
+- Create `crates/agentenv-core/src/skills/digest.rs`
+  - Compute canonical `sha256:<hex>` bundle digests over declared files.
+- Create `crates/agentenv-core/src/skills/signature.rs`
+  - Verify Ed25519 signatures over normalized manifest JSON and content digest.
+- Create `crates/agentenv-core/src/skills/index.rs`
+  - Read and write `~/.agentenv/skills/index.yaml`.
+- Create `crates/agentenv-core/src/skills/store.rs`
+  - Own cache layout, staging directories, atomic installs, remove, info, and verify.
+- Create `crates/agentenv-core/src/skills/config.rs`
+  - Deserialize skills config from project YAML and user TOML, merge with CLI registry overrides.
+- Create `crates/agentenv-core/src/skills/registry.rs`
+  - Define `RegistryAdapter`, `RegistryConfig`, `SkillSearchHit`, and `FetchedSkill`.
+- Create `crates/agentenv-core/src/skills/registry_filesystem.rs`
+  - Implement filesystem registry search/add/publish.
+- Create `crates/agentenv-core/src/skills/registry_http.rs`
+  - Implement HTTP registry search/add/publish with SSRF validation.
+- Create `crates/agentenv-core/src/skills/registry_oci.rs`
+  - Implement OCI Distribution API search/add/publish using `reqwest`.
+- Create `crates/agentenv-core/src/skills/service.rs`
+  - Compose config, store, and adapters into async operations.
+- Create `crates/agentenv-core/tests/skills.rs`
+  - Cover core behavior and registry adapters.
+- Modify `crates/agentenv/src/main.rs`
+  - Add `Skills(skills_cli::SkillsArgs)` to `Commands`, route to `skills_cli::run_skills`.
+- Create `crates/agentenv/src/skills_cli.rs`
+  - Define clap args and render text/JSON output.
+- Modify `crates/agentenv/src/render.rs`
+  - Add JSON wrappers only if `skills_cli.rs` cannot serialize response structs directly with `render::print_json`.
+- Modify `crates/agentenv/tests/cli_behavior.rs`
+  - Add CLI integration tests for all `skills` subcommands and config precedence.
+
+## Implementation Notes
+
+- Service methods that touch registries are async. The design doc's API block is illustrative; implement the real API as `async fn` for `search`, `add`, and `publish`, and regular `fn` for local index reads where no network is involved.
+- Do not use `.unwrap()` outside tests.
+- Do not add a new driver kind or modify `agentenv-proto`.
+- Use exact file patterns and trailing `/**` only. Do not add a glob dependency.
+- Use atomic writes by writing a temporary file in the same directory and renaming it into place.
+- Use temporary staging directories under `~/.agentenv/skills/.tmp/`.
+- The issue explicitly requires `~/.config/agentenv/config.toml`; keep TOML support confined to skills config loading.
+
+### Task 1: Core Skill Manifest and Digest
+
+**Files:**
+- Modify: `Cargo.toml`
+- Modify: `crates/agentenv-core/Cargo.toml`
+- Modify: `crates/agentenv-core/src/lib.rs`
+- Create: `crates/agentenv-core/src/skills/mod.rs`
+- Create: `crates/agentenv-core/src/skills/error.rs`
+- Create: `crates/agentenv-core/src/skills/manifest.rs`
+- Create: `crates/agentenv-core/src/skills/digest.rs`
+- Test: `crates/agentenv-core/tests/skills.rs`
+
+- [ ] **Step 1: Write failing manifest and digest tests**
+
+Add `crates/agentenv-core/tests/skills.rs` with these tests:
+
+```rust
+use std::{fs, path::{Path, PathBuf}};
+
+use agentenv_core::skills::{
+    compute_bundle_digest, load_skill_manifest, validate_skill_name, SkillError,
+};
+
+#[test]
+fn skill_manifest_accepts_minimal_bundle() {
+    let root = temp_dir("skill-manifest-minimal");
+    write_file(&root.join("SKILL.md"), "# Demo\n");
+    write_file(
+        &root.join("skill.yaml"),
+        "name: demo-skill\nversion: 0.1.0\nentry: SKILL.md\nfiles:\n  - SKILL.md\n",
+    );
+
+    let manifest = load_skill_manifest(&root).expect("manifest should load");
+
+    assert_eq!(manifest.name, "demo-skill");
+    assert_eq!(manifest.version.to_string(), "0.1.0");
+    assert_eq!(manifest.entry, PathBuf::from("SKILL.md"));
+    assert_eq!(manifest.declared_files, vec![PathBuf::from("SKILL.md")]);
+}
+
+#[test]
+fn skill_manifest_rejects_invalid_name() {
+    let root = temp_dir("skill-manifest-invalid-name");
+    write_file(&root.join("SKILL.md"), "# Demo\n");
+    write_file(
+        &root.join("skill.yaml"),
+        "name: ../demo\nversion: 0.1.0\nentry: SKILL.md\nfiles:\n  - SKILL.md\n",
+    );
+
+    let error = load_skill_manifest(&root).expect_err("name must be rejected");
+
+    assert!(matches!(error, SkillError::InvalidSkillName { .. }));
+}
+
+#[test]
+fn skill_manifest_rejects_parent_traversal() {
+    let root = temp_dir("skill-manifest-parent-traversal");
+    write_file(&root.join("SKILL.md"), "# Demo\n");
+    write_file(
+        &root.join("skill.yaml"),
+        "name: demo\nversion: 0.1.0\nentry: ../SKILL.md\nfiles:\n  - SKILL.md\n",
+    );
+
+    let error = load_skill_manifest(&root).expect_err("entry traversal must fail");
+
+    assert!(matches!(error, SkillError::UnsafeBundlePath { .. }));
+}
+
+#[test]
+fn skill_digest_is_stable_for_sorted_declared_files() {
+    let root = temp_dir("skill-digest-stable");
+    fs::create_dir_all(root.join("references")).unwrap();
+    write_file(&root.join("SKILL.md"), "# Demo\n");
+    write_file(&root.join("references/a.md"), "A\n");
+    write_file(&root.join("references/b.md"), "B\n");
+    write_file(
+        &root.join("skill.yaml"),
+        "name: demo\nversion: 0.1.0\nentry: SKILL.md\nfiles:\n  - references/**\n  - SKILL.md\n",
+    );
+    let manifest = load_skill_manifest(&root).unwrap();
+
+    let first = compute_bundle_digest(&root, &manifest).unwrap();
+    let second = compute_bundle_digest(&root, &manifest).unwrap();
+
+    assert_eq!(first, second);
+    assert!(first.starts_with("sha256:"));
+    assert_eq!(first.len(), "sha256:".len() + 64);
+}
+
+#[test]
+fn skill_digest_changes_when_content_changes() {
+    let root = temp_dir("skill-digest-changes");
+    write_file(&root.join("SKILL.md"), "# Demo\n");
+    write_file(
+        &root.join("skill.yaml"),
+        "name: demo\nversion: 0.1.0\nentry: SKILL.md\nfiles:\n  - SKILL.md\n",
+    );
+    let manifest = load_skill_manifest(&root).unwrap();
+    let before = compute_bundle_digest(&root, &manifest).unwrap();
+
+    write_file(&root.join("SKILL.md"), "# Changed\n");
+    let after = compute_bundle_digest(&root, &manifest).unwrap();
+
+    assert_ne!(before, after);
+}
+
+#[test]
+fn validate_skill_name_accepts_conservative_identifiers() {
+    for name in ["demo", "demo-skill", "demo_skill", "demo.skill", "a1"] {
+        validate_skill_name(name).expect(name);
+    }
+}
+
+fn temp_dir(prefix: &str) -> PathBuf {
+    let mut path = std::env::temp_dir();
+    path.push(format!("{prefix}-{}-{}", std::process::id(), unique_nanos()));
+    fs::create_dir_all(&path).unwrap();
+    path
+}
+
+fn write_file(path: &Path, content: &str) {
+    if let Some(parent) = path.parent() {
+        fs::create_dir_all(parent).unwrap();
+    }
+    fs::write(path, content).unwrap();
+}
+
+fn unique_nanos() -> u128 {
+    std::time::SystemTime::now()
+        .duration_since(std::time::UNIX_EPOCH)
+        .unwrap()
+        .as_nanos()
+}
+```
+
+- [ ] **Step 2: Run tests and verify RED**
+
+Run:
+
+```bash
+cargo test -p agentenv-core --test skills skill_manifest_accepts_minimal_bundle skill_digest_is_stable_for_sorted_declared_files
+```
+
+Expected: compile failure mentioning missing `agentenv_core::skills`.
+
+- [ ] **Step 3: Add module exports and dependencies**
+
+Edit root `Cargo.toml`:
+
+```toml
+toml = "0.8"
+```
+
+Edit `crates/agentenv-core/Cargo.toml`:
+
+```toml
+reqwest.workspace = true
+toml.workspace = true
+```
+
+Edit `crates/agentenv-core/src/lib.rs`:
+
+```rust
+pub mod skills;
+```
+
+Create `crates/agentenv-core/src/skills/mod.rs`:
+
+```rust
+pub mod digest;
+pub mod error;
+pub mod manifest;
+
+pub use digest::compute_bundle_digest;
+pub use error::SkillError;
+pub use manifest::{load_skill_manifest, validate_skill_name, SkillManifest};
+```
+
+- [ ] **Step 4: Implement `SkillError`**
+
+Create `crates/agentenv-core/src/skills/error.rs`:
+
+```rust
+use std::path::PathBuf;
+
+use thiserror::Error;
+
+#[derive(Debug, Error)]
+pub enum SkillError {
+    #[error("failed to read or write skill path `{path}`: {source}")]
+    Io { path: PathBuf, #[source] source: std::io::Error },
+    #[error("failed to parse skill YAML at `{path}`: {source}")]
+    Yaml { path: PathBuf, #[source] source: serde_yaml::Error },
+    #[error("invalid skill name `{name}`")]
+    InvalidSkillName { name: String },
+    #[error("invalid skill version `{version}`: {source}")]
+    InvalidVersion { version: String, #[source] source: semver::Error },
+    #[error("unsafe skill bundle path `{path}`")]
+    UnsafeBundlePath { path: PathBuf },
+    #[error("declared skill file `{path}` is missing")]
+    MissingDeclaredFile { path: PathBuf },
+    #[error("declared skill pattern `{pattern}` matched no files")]
+    EmptyFilePattern { pattern: String },
+    #[error("skill manifest `{path}` is missing required field `{field}`")]
+    MissingManifestField { path: PathBuf, field: &'static str },
+    #[error("skill digest mismatch: expected `{expected}`, found `{actual}`")]
+    DigestMismatch { expected: String, actual: String },
+}
+```
+
+- [ ] **Step 5: Implement manifest parsing**
+
+Create `crates/agentenv-core/src/skills/manifest.rs` with:
+
+```rust
+use std::{
+    collections::BTreeMap,
+    fs,
+    path::{Component, Path, PathBuf},
+};
+
+use semver::Version;
+use serde::{Deserialize, Serialize};
+use serde_yaml::Value;
+
+use super::SkillError;
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize)]
+pub struct SkillManifest {
+    pub name: String,
+    pub version: Version,
+    pub description: Option<String>,
+    pub entry: PathBuf,
+    pub declared_files: Vec<PathBuf>,
+    pub self_test_command: Option<String>,
+    pub signature_ed25519: Option<String>,
+    pub extra: BTreeMap<String, Value>,
+}
+
+#[derive(Debug, Deserialize)]
+struct RawManifest {
+    name: Option<String>,
+    version: Option<String>,
+    description: Option<String>,
+    entry: Option<PathBuf>,
+    #[serde(default)]
+    files: Vec<String>,
+    self_test: Option<RawSelfTest>,
+    signatures: Option<RawSignatures>,
+    #[serde(flatten)]
+    extra: BTreeMap<String, Value>,
+}
+
+#[derive(Debug, Deserialize)]
+struct RawSelfTest {
+    command: Option<String>,
+}
+
+#[derive(Debug, Deserialize)]
+struct RawSignatures {
+    ed25519: Option<String>,
+}
+
+pub fn load_skill_manifest(root: &Path) -> Result<SkillManifest, SkillError> {
+    let path = root.join("skill.yaml");
+    let yaml = fs::read_to_string(&path).map_err(|source| SkillError::Io {
+        path: path.clone(),
+        source,
+    })?;
+    let raw: RawManifest = serde_yaml::from_str(&yaml).map_err(|source| SkillError::Yaml {
+        path: path.clone(),
+        source,
+    })?;
+    normalize_manifest(root, &path, raw)
+}
+
+pub fn validate_skill_name(name: &str) -> Result<(), SkillError> {
+    let valid = !name.is_empty()
+        && !name.starts_with('.')
+        && name.bytes().all(|byte| {
+            byte.is_ascii_lowercase()
+                || byte.is_ascii_digit()
+                || matches!(byte, b'-' | b'_' | b'.')
+        })
+        && !name.contains('/')
+        && !name.contains('\\');
+    if valid {
+        Ok(())
+    } else {
+        Err(SkillError::InvalidSkillName {
+            name: name.to_owned(),
+        })
+    }
+}
+
+fn normalize_manifest(
+    root: &Path,
+    manifest_path: &Path,
+    raw: RawManifest,
+) -> Result<SkillManifest, SkillError> {
+    let name = raw.name.ok_or_else(|| SkillError::MissingManifestField {
+        path: manifest_path.to_path_buf(),
+        field: "name",
+    })?;
+    validate_skill_name(&name)?;
+    let version_text = raw.version.ok_or_else(|| SkillError::MissingManifestField {
+        path: manifest_path.to_path_buf(),
+        field: "version",
+    })?;
+    let version = Version::parse(&version_text).map_err(|source| SkillError::InvalidVersion {
+        version: version_text,
+        source,
+    })?;
+    let entry = normalize_relative_path(raw.entry.ok_or_else(|| SkillError::MissingManifestField {
+        path: manifest_path.to_path_buf(),
+        field: "entry",
+    })?)?;
+    let mut declared_files = expand_declared_files(root, &raw.files)?;
+    declared_files.sort();
+    declared_files.dedup();
+    if !declared_files.contains(&entry) {
+        return Err(SkillError::MissingDeclaredFile { path: entry });
+    }
+    Ok(SkillManifest {
+        name,
+        version,
+        description: raw.description,
+        entry,
+        declared_files,
+        self_test_command: raw.self_test.and_then(|value| value.command),
+        signature_ed25519: raw.signatures.and_then(|value| value.ed25519),
+        extra: raw.extra,
+    })
+}
+
+fn expand_declared_files(root: &Path, patterns: &[String]) -> Result<Vec<PathBuf>, SkillError> {
+    let mut files = Vec::new();
+    for pattern in patterns {
+        if let Some(prefix) = pattern.strip_suffix("/**") {
+            let dir = normalize_relative_path(PathBuf::from(prefix))?;
+            let before = files.len();
+            collect_files(root, &dir, &mut files)?;
+            if files.len() == before {
+                return Err(SkillError::EmptyFilePattern {
+                    pattern: pattern.clone(),
+                });
+            }
+        } else {
+            let path = normalize_relative_path(PathBuf::from(pattern))?;
+            if !root.join(&path).is_file() {
+                return Err(SkillError::MissingDeclaredFile { path });
+            }
+            files.push(path);
+        }
+    }
+    Ok(files)
+}
+
+fn collect_files(root: &Path, relative_dir: &Path, files: &mut Vec<PathBuf>) -> Result<(), SkillError> {
+    let absolute = root.join(relative_dir);
+    if !absolute.is_dir() {
+        return Ok(());
+    }
+    for entry in fs::read_dir(&absolute).map_err(|source| SkillError::Io {
+        path: absolute.clone(),
+        source,
+    })? {
+        let entry = entry.map_err(|source| SkillError::Io {
+            path: absolute.clone(),
+            source,
+        })?;
+        let child_relative = relative_dir.join(entry.file_name());
+        let kind = entry.file_type().map_err(|source| SkillError::Io {
+            path: entry.path(),
+            source,
+        })?;
+        if kind.is_dir() {
+            collect_files(root, &child_relative, files)?;
+        } else if kind.is_file() {
+            files.push(normalize_relative_path(child_relative)?);
+        }
+    }
+    Ok(())
+}
+
+pub fn normalize_relative_path(path: PathBuf) -> Result<PathBuf, SkillError> {
+    if path.is_absolute() {
+        return Err(SkillError::UnsafeBundlePath { path });
+    }
+    let mut normalized = PathBuf::new();
+    for component in path.components() {
+        match component {
+            Component::Normal(value) => normalized.push(value),
+            Component::CurDir => {}
+            Component::ParentDir | Component::RootDir | Component::Prefix(_) => {
+                return Err(SkillError::UnsafeBundlePath { path });
+            }
+        }
+    }
+    if normalized.as_os_str().is_empty() {
+        return Err(SkillError::UnsafeBundlePath { path: normalized });
+    }
+    Ok(normalized)
+}
+```
+
+- [ ] **Step 6: Implement digest computation**
+
+Create `crates/agentenv-core/src/skills/digest.rs`:
+
+```rust
+use std::{fs, path::Path};
+
+use sha2::{Digest, Sha256};
+
+use super::{manifest::SkillManifest, SkillError};
+
+pub fn compute_bundle_digest(root: &Path, manifest: &SkillManifest) -> Result<String, SkillError> {
+    let mut hasher = Sha256::new();
+    hasher.update(b"agentenv-skill-v1\n");
+    for relative in &manifest.declared_files {
+        let absolute = root.join(relative);
+        let bytes = fs::read(&absolute).map_err(|source| SkillError::Io {
+            path: absolute.clone(),
+            source,
+        })?;
+        let relative_text = relative.to_string_lossy().replace('\\', "/");
+        hasher.update(relative_text.as_bytes());
+        hasher.update(b"\0");
+        hasher.update(bytes.len().to_string().as_bytes());
+        hasher.update(b"\0");
+        hasher.update(&bytes);
+        hasher.update(b"\n");
+    }
+    Ok(format!("sha256:{}", hex::encode(hasher.finalize())))
+}
+```
+
+- [ ] **Step 7: Run tests and verify GREEN**
+
+Run:
+
+```bash
+cargo test -p agentenv-core --test skills skill_manifest skill_digest validate_skill_name
+```
+
+Expected: all tests in Task 1 pass.
+
+- [ ] **Step 8: Commit Task 1**
+
+Run:
+
+```bash
+git add Cargo.toml crates/agentenv-core/Cargo.toml crates/agentenv-core/src/lib.rs crates/agentenv-core/src/skills crates/agentenv-core/tests/skills.rs
+git commit -m "feat: add skill manifest validation"
+```
+
+### Task 2: Signatures, Installed Store, and Verification
+
+**Files:**
+- Modify: `crates/agentenv-core/src/skills/mod.rs`
+- Modify: `crates/agentenv-core/src/skills/error.rs`
+- Create: `crates/agentenv-core/src/skills/signature.rs`
+- Create: `crates/agentenv-core/src/skills/index.rs`
+- Create: `crates/agentenv-core/src/skills/store.rs`
+- Modify: `crates/agentenv-core/tests/skills.rs`
+
+- [ ] **Step 1: Write failing signature and store tests**
+
+Append these tests to `crates/agentenv-core/tests/skills.rs`:
+
+```rust
+use agentenv_core::skills::{
+    install_local_skill, verify_installed_skill, InstalledSkillSelector, SkillInstallOptions,
+};
+use ed25519_dalek::{Signer, SigningKey};
+
+#[test]
+fn signature_verification_accepts_signed_bundle() {
+    let root = temp_dir("skill-signature-valid");
+    write_file(&root.join("SKILL.md"), "# Demo\n");
+    write_file(
+        &root.join("skill.yaml"),
+        "name: signed-demo\nversion: 0.1.0\nentry: SKILL.md\nfiles:\n  - SKILL.md\n",
+    );
+    let manifest = load_skill_manifest(&root).unwrap();
+    let digest = compute_bundle_digest(&root, &manifest).unwrap();
+    let signing_key = SigningKey::from_bytes(&[7_u8; 32]);
+    let payload = agentenv_core::skills::signature_payload(&manifest, &digest).unwrap();
+    let signature = hex::encode(signing_key.sign(&payload).to_bytes());
+    let public_key = hex::encode(signing_key.verifying_key().to_bytes());
+
+    agentenv_core::skills::verify_ed25519_signature(&manifest, &digest, &signature, &public_key)
+        .expect("signature should verify");
+}
+
+#[test]
+fn signature_verification_rejects_tampered_digest() {
+    let root = temp_dir("skill-signature-tampered");
+    write_file(&root.join("SKILL.md"), "# Demo\n");
+    write_file(
+        &root.join("skill.yaml"),
+        "name: signed-demo\nversion: 0.1.0\nentry: SKILL.md\nfiles:\n  - SKILL.md\n",
+    );
+    let manifest = load_skill_manifest(&root).unwrap();
+    let digest = compute_bundle_digest(&root, &manifest).unwrap();
+    let signing_key = SigningKey::from_bytes(&[9_u8; 32]);
+    let payload = agentenv_core::skills::signature_payload(&manifest, &digest).unwrap();
+    let signature = hex::encode(signing_key.sign(&payload).to_bytes());
+    let public_key = hex::encode(signing_key.verifying_key().to_bytes());
+
+    let error = agentenv_core::skills::verify_ed25519_signature(
+        &manifest,
+        "sha256:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+        &signature,
+        &public_key,
+    )
+    .expect_err("tampered digest must fail");
+
+    assert!(matches!(error, SkillError::InvalidSignature { .. }));
+}
+
+#[test]
+fn local_install_writes_cache_and_index() {
+    let home = temp_dir("skill-install-home");
+    let bundle = temp_dir("skill-install-bundle");
+    write_file(&bundle.join("SKILL.md"), "# Demo\n");
+    write_file(
+        &bundle.join("skill.yaml"),
+        "name: local-demo\nversion: 0.1.0\nentry: SKILL.md\nfiles:\n  - SKILL.md\n",
+    );
+
+    let installed = install_local_skill(
+        &home.join(".agentenv"),
+        &bundle,
+        SkillInstallOptions {
+            allow_unsigned: true,
+            source_label: "local-dev".to_owned(),
+        },
+    )
+    .expect("install should succeed");
+
+    assert_eq!(installed.name, "local-demo");
+    assert_eq!(installed.version, "0.1.0");
+    assert!(installed.path.join("content/SKILL.md").is_file());
+    assert!(home.join(".agentenv/skills/index.yaml").is_file());
+}
+
+#[test]
+fn installed_verify_detects_content_tampering() {
+    let home = temp_dir("skill-verify-home");
+    let bundle = temp_dir("skill-verify-bundle");
+    write_file(&bundle.join("SKILL.md"), "# Demo\n");
+    write_file(
+        &bundle.join("skill.yaml"),
+        "name: verify-demo\nversion: 0.1.0\nentry: SKILL.md\nfiles:\n  - SKILL.md\n",
+    );
+    let installed = install_local_skill(
+        &home.join(".agentenv"),
+        &bundle,
+        SkillInstallOptions {
+            allow_unsigned: true,
+            source_label: "local-dev".to_owned(),
+        },
+    )
+    .unwrap();
+    write_file(&installed.path.join("content/SKILL.md"), "# Tampered\n");
+
+    let error = verify_installed_skill(
+        &home.join(".agentenv"),
+        InstalledSkillSelector::Name("verify-demo".to_owned()),
+    )
+    .expect_err("tampering must fail");
+
+    assert!(matches!(error, SkillError::DigestMismatch { .. }));
+}
+
+#[test]
+fn installed_verify_runs_self_test_command() {
+    let home = temp_dir("skill-self-test-home");
+    let bundle = temp_dir("skill-self-test-bundle");
+    write_file(&bundle.join("SKILL.md"), "# Demo\n");
+    write_file(
+        &bundle.join("skill.yaml"),
+        "name: self-test-demo\nversion: 0.1.0\nentry: SKILL.md\nfiles:\n  - SKILL.md\nself_test:\n  command: \"test -f SKILL.md\"\n",
+    );
+    install_local_skill(
+        &home.join(".agentenv"),
+        &bundle,
+        SkillInstallOptions {
+            allow_unsigned: true,
+            source_label: "local-dev".to_owned(),
+        },
+    )
+    .unwrap();
+
+    let verified = verify_installed_skill(
+        &home.join(".agentenv"),
+        InstalledSkillSelector::Name("self-test-demo".to_owned()),
+    )
+    .expect("self-test command should pass");
+
+    assert_eq!(verified.name, "self-test-demo");
+}
+```
+
+- [ ] **Step 2: Run tests and verify RED**
+
+Run:
+
+```bash
+cargo test -p agentenv-core --test skills signature_verification local_install installed_verify
+```
+
+Expected: compile failure for missing signature and store APIs.
+
+- [ ] **Step 3: Extend `SkillError`**
+
+Add these variants to `crates/agentenv-core/src/skills/error.rs`:
+
+```rust
+#[error("missing Ed25519 signature for skill `{name}` version `{version}`")]
+MissingSignature { name: String, version: String },
+#[error("invalid Ed25519 signature for skill `{name}` version `{version}`: {message}")]
+InvalidSignature { name: String, version: String, message: String },
+#[error("skill `{name}` is not installed")]
+SkillNotInstalled { name: String },
+#[error("skill `{name}` has multiple installed versions: {versions}")]
+AmbiguousInstalledVersion { name: String, versions: String },
+#[error("skill `{name}` version `{version}` is already installed with digest `{existing}`")]
+AlreadyInstalledDifferentDigest { name: String, version: String, existing: String },
+#[error("failed to parse or serialize installed skill JSON/YAML at `{path}`: {source}")]
+Serde { path: PathBuf, #[source] source: serde_yaml::Error },
+#[error("skill `{name}` version `{version}` self-test failed with status {status}")]
+SelfTestFailed { name: String, version: String, status: i32 },
+```
+
+- [ ] **Step 4: Implement signature helpers**
+
+Create `crates/agentenv-core/src/skills/signature.rs`:
+
+```rust
+use ed25519_dalek::{Signature, Verifier, VerifyingKey};
+use serde::Serialize;
+
+use super::{SkillError, SkillManifest};
+
+#[derive(Serialize)]
+struct SignedManifest<'a> {
+    name: &'a str,
+    version: String,
+    description: &'a Option<String>,
+    entry: String,
+    files: Vec<String>,
+    self_test_command: &'a Option<String>,
+}
+
+pub fn signature_payload(manifest: &SkillManifest, digest: &str) -> Result<Vec<u8>, SkillError> {
+    let normalized = SignedManifest {
+        name: &manifest.name,
+        version: manifest.version.to_string(),
+        description: &manifest.description,
+        entry: manifest.entry.to_string_lossy().replace('\\', "/"),
+        files: manifest
+            .declared_files
+            .iter()
+            .map(|path| path.to_string_lossy().replace('\\', "/"))
+            .collect(),
+        self_test_command: &manifest.self_test_command,
+    };
+    let mut payload = b"agentenv-skill-signature-v1\n".to_vec();
+    let json = serde_json::to_vec(&normalized).map_err(|source| SkillError::InvalidSignature {
+        name: manifest.name.clone(),
+        version: manifest.version.to_string(),
+        message: source.to_string(),
+    })?;
+    payload.extend(json);
+    payload.push(b'\n');
+    payload.extend(digest.as_bytes());
+    Ok(payload)
+}
+
+pub fn verify_ed25519_signature(
+    manifest: &SkillManifest,
+    digest: &str,
+    signature_hex: &str,
+    public_key_hex: &str,
+) -> Result<(), SkillError> {
+    let public_key_bytes = hex::decode(public_key_hex).map_err(|source| SkillError::InvalidSignature {
+        name: manifest.name.clone(),
+        version: manifest.version.to_string(),
+        message: source.to_string(),
+    })?;
+    let signature_bytes = hex::decode(signature_hex).map_err(|source| SkillError::InvalidSignature {
+        name: manifest.name.clone(),
+        version: manifest.version.to_string(),
+        message: source.to_string(),
+    })?;
+    let public_key_array: [u8; 32] = public_key_bytes.as_slice().try_into().map_err(|_| {
+        SkillError::InvalidSignature {
+            name: manifest.name.clone(),
+            version: manifest.version.to_string(),
+            message: "public key must be 32 bytes".to_owned(),
+        }
+    })?;
+    let signature = Signature::try_from(signature_bytes.as_slice()).map_err(|source| {
+        SkillError::InvalidSignature {
+            name: manifest.name.clone(),
+            version: manifest.version.to_string(),
+            message: source.to_string(),
+        }
+    })?;
+    let verifying_key = VerifyingKey::from_bytes(&public_key_array).map_err(|source| {
+        SkillError::InvalidSignature {
+            name: manifest.name.clone(),
+            version: manifest.version.to_string(),
+            message: source.to_string(),
+        }
+    })?;
+    let payload = signature_payload(manifest, digest)?;
+    verifying_key.verify(&payload, &signature).map_err(|source| {
+        SkillError::InvalidSignature {
+            name: manifest.name.clone(),
+            version: manifest.version.to_string(),
+            message: source.to_string(),
+        }
+    })
+}
+```
+
+- [ ] **Step 5: Implement installed record and store**
+
+Create `index.rs` and `store.rs` with these public types:
+
+```rust
+#[derive(Debug, Clone, serde::Serialize, serde::Deserialize, PartialEq, Eq)]
+pub struct InstalledSkill {
+    pub name: String,
+    pub version: String,
+    pub source_type: String,
+    pub source_label: String,
+    pub digest: String,
+    pub signature_status: String,
+    pub entry: std::path::PathBuf,
+    pub installed_at: String,
+    pub path: std::path::PathBuf,
+}
+
+#[derive(Debug, Clone)]
+pub struct SkillInstallOptions {
+    pub allow_unsigned: bool,
+    pub source_label: String,
+}
+
+#[derive(Debug, Clone)]
+pub enum InstalledSkillSelector {
+    Name(String),
+    NameVersion { name: String, version: String },
+}
+```
+
+Implement:
+
+```rust
+pub fn install_local_skill(
+    root: &Path,
+    bundle: &Path,
+    options: SkillInstallOptions,
+) -> Result<InstalledSkill, SkillError>
+
+pub fn list_installed_skills(root: &Path) -> Result<Vec<InstalledSkill>, SkillError>
+
+pub fn info_installed_skill(
+    root: &Path,
+    selector: InstalledSkillSelector,
+) -> Result<InstalledSkill, SkillError>
+
+pub fn remove_installed_skill(
+    root: &Path,
+    selector: InstalledSkillSelector,
+) -> Result<InstalledSkill, SkillError>
+
+pub fn verify_installed_skill(
+    root: &Path,
+    selector: InstalledSkillSelector,
+) -> Result<InstalledSkill, SkillError>
+```
+
+Store layout:
+
+```text
+<root>/skills/index.yaml
+<root>/skills/<name>/<version>/skill.yaml
+<root>/skills/<name>/<version>/content/<declared files>
+<root>/skills/<name>/<version>/installed.yaml
+```
+
+- [ ] **Step 6: Export new APIs**
+
+Update `crates/agentenv-core/src/skills/mod.rs`:
+
+```rust
+pub mod index;
+pub mod signature;
+pub mod store;
+
+pub use signature::{signature_payload, verify_ed25519_signature};
+pub use store::{
+    info_installed_skill, install_local_skill, list_installed_skills, remove_installed_skill,
+    verify_installed_skill, InstalledSkill, InstalledSkillSelector, SkillInstallOptions,
+};
+```
+
+- [ ] **Step 7: Run tests and verify GREEN**
+
+Run:
+
+```bash
+cargo test -p agentenv-core --test skills signature_verification local_install installed_verify
+```
+
+Expected: all Task 2 tests pass.
+
+- [ ] **Step 8: Commit Task 2**
+
+Run:
+
+```bash
+git add crates/agentenv-core/src/skills crates/agentenv-core/tests/skills.rs
+git commit -m "feat: verify and store installed skills"
+```
+
+### Task 3: Skills Config and Registry Resolution
+
+**Files:**
+- Modify: `crates/agentenv-core/src/skills/mod.rs`
+- Modify: `crates/agentenv-core/src/skills/error.rs`
+- Create: `crates/agentenv-core/src/skills/config.rs`
+- Create: `crates/agentenv-core/src/skills/registry.rs`
+- Modify: `crates/agentenv-core/tests/skills.rs`
+
+- [ ] **Step 1: Write failing config tests**
+
+Append tests:
+
+```rust
+use agentenv_core::skills::{
+    load_project_skills_config, load_user_skills_config, merge_skills_config, RegistryKind,
+    SkillsConfig, SkillsConfigOverride,
+};
+
+#[test]
+fn skills_config_loads_project_yaml_section() {
+    let yaml = r#"
+version: 0.1.0
+min_agentenv_version: 0.0.1-alpha0
+sandbox: { driver: openshell }
+agent: { driver: codex }
+context: { driver: filesystem, mount: . }
+policy: { tier: balanced, presets: [] }
+skills:
+  registries:
+    - name: local-dev
+      type: filesystem
+      path: /tmp/skills
+"#;
+
+    let config = load_project_skills_config(yaml).unwrap();
+
+    assert_eq!(config.registries.len(), 1);
+    assert_eq!(config.registries[0].name, "local-dev");
+    assert_eq!(config.registries[0].kind, RegistryKind::Filesystem);
+}
+
+#[test]
+fn skills_config_loads_user_toml() {
+    let toml = r#"
+[skills]
+registry_order = ["corp"]
+
+[[skills.registries]]
+name = "corp"
+type = "http"
+url = "https://skills.example.test"
+auth = "bearer-from-credstore:CORP_SKILLS_TOKEN"
+"#;
+
+    let config = load_user_skills_config(toml).unwrap();
+
+    assert_eq!(config.registry_order, vec!["corp"]);
+    assert_eq!(config.registries[0].auth.as_deref(), Some("bearer-from-credstore:CORP_SKILLS_TOKEN"));
+}
+
+#[test]
+fn cli_registry_override_wins_over_project_and_user_config() {
+    let user = SkillsConfig {
+        registries: vec![agentenv_core::skills::RegistryConfig::filesystem(
+            "user-local",
+            PathBuf::from("/user"),
+        )],
+        registry_order: vec!["user-local".to_owned()],
+    };
+    let project = SkillsConfig {
+        registries: vec![agentenv_core::skills::RegistryConfig::filesystem(
+            "project-local",
+            PathBuf::from("/project"),
+        )],
+        registry_order: vec!["project-local".to_owned()],
+    };
+
+    let merged = merge_skills_config(
+        user,
+        Some(project),
+        SkillsConfigOverride {
+            registry: Some("file:///override".to_owned()),
+        },
+    )
+    .unwrap();
+
+    assert_eq!(merged.registries.len(), 1);
+    assert_eq!(merged.registries[0].name, "cli");
+    assert_eq!(merged.registry_order, vec!["cli"]);
+}
+```
+
+- [ ] **Step 2: Run tests and verify RED**
+
+Run:
+
+```bash
+cargo test -p agentenv-core --test skills skills_config
+```
+
+Expected: compile failure for missing config APIs.
+
+- [ ] **Step 3: Implement config and registry types**
+
+Create `config.rs` and `registry.rs` with:
+
+```rust
+#[derive(Debug, Clone, Default, serde::Serialize, serde::Deserialize, PartialEq, Eq)]
+pub struct SkillsConfig {
+    #[serde(default)]
+    pub registries: Vec<RegistryConfig>,
+    #[serde(default)]
+    pub registry_order: Vec<String>,
+}
+
+#[derive(Debug, Clone, serde::Serialize, serde::Deserialize, PartialEq, Eq)]
+pub struct RegistryConfig {
+    pub name: String,
+    #[serde(rename = "type")]
+    pub kind: RegistryKind,
+    #[serde(default)]
+    pub url: Option<String>,
+    #[serde(default)]
+    pub path: Option<PathBuf>,
+    #[serde(default)]
+    pub auth: Option<String>,
+}
+
+#[derive(Debug, Clone, Copy, serde::Serialize, serde::Deserialize, PartialEq, Eq)]
+#[serde(rename_all = "kebab-case")]
+pub enum RegistryKind {
+    Filesystem,
+    Http,
+    Oci,
+}
+
+#[derive(Debug, Clone, Default, PartialEq, Eq)]
+pub struct SkillsConfigOverride {
+    pub registry: Option<String>,
+}
+```
+
+Implement:
+
+```rust
+pub fn load_project_skills_config(yaml: &str) -> Result<SkillsConfig, SkillError>
+pub fn load_user_skills_config(toml_text: &str) -> Result<SkillsConfig, SkillError>
+pub fn merge_skills_config(
+    user: SkillsConfig,
+    project: Option<SkillsConfig>,
+    override_config: SkillsConfigOverride,
+) -> Result<SkillsConfig, SkillError>
+```
+
+Resolution rules:
+
+- user config is the base
+- project config replaces base only when it has registries or order
+- CLI `--registry` replaces the list with one `cli` registry
+- `file://` and absolute paths become filesystem registries
+- `http://` and `https://` become HTTP registries
+- other strings without a URL scheme are treated as registry names to select from merged config
+
+- [ ] **Step 4: Extend errors and exports**
+
+Add errors:
+
+```rust
+#[error("registry `{name}` was not found")]
+RegistryNotFound { name: String },
+#[error("invalid skills config: {message}")]
+InvalidConfig { message: String },
+#[error("failed to parse skills config TOML: {source}")]
+Toml { #[source] source: toml::de::Error },
+```
+
+Update `mod.rs` exports:
+
+```rust
+pub mod config;
+pub mod registry;
+
+pub use config::{
+    load_project_skills_config, load_user_skills_config, merge_skills_config, RegistryConfig,
+    RegistryKind, SkillsConfig, SkillsConfigOverride,
+};
+```
+
+- [ ] **Step 5: Run tests and verify GREEN**
+
+Run:
+
+```bash
+cargo test -p agentenv-core --test skills skills_config
+```
+
+Expected: all Task 3 tests pass.
+
+- [ ] **Step 6: Commit Task 3**
+
+Run:
+
+```bash
+git add Cargo.toml crates/agentenv-core/Cargo.toml crates/agentenv-core/src/skills crates/agentenv-core/tests/skills.rs
+git commit -m "feat: load skills registry config"
+```
+
+### Task 4: Filesystem Registry and Skill Service
+
+**Files:**
+- Modify: `crates/agentenv-core/src/skills/mod.rs`
+- Modify: `crates/agentenv-core/src/skills/error.rs`
+- Create: `crates/agentenv-core/src/skills/registry_filesystem.rs`
+- Create: `crates/agentenv-core/src/skills/service.rs`
+- Modify: `crates/agentenv-core/tests/skills.rs`
+
+- [ ] **Step 1: Write failing filesystem registry tests**
+
+Append tests:
+
+```rust
+use agentenv_core::skills::{SkillAddRequest, SkillPublishRequest, SkillService};
+
+#[tokio::test]
+async fn filesystem_registry_search_add_and_publish_work() {
+    let home = temp_dir("skill-fs-home");
+    let registry = temp_dir("skill-fs-registry");
+    let bundle = temp_dir("skill-fs-bundle");
+    write_file(&bundle.join("SKILL.md"), "# Searchable Skill\n");
+    write_file(
+        &bundle.join("skill.yaml"),
+        "name: searchable-skill\nversion: 0.1.0\ndescription: Searchable demo\nentry: SKILL.md\nfiles:\n  - SKILL.md\n",
+    );
+    let service = SkillService::new(
+        home.join(".agentenv"),
+        SkillsConfig {
+            registries: vec![agentenv_core::skills::RegistryConfig::filesystem(
+                "local-dev",
+                registry.clone(),
+            )],
+            registry_order: vec!["local-dev".to_owned()],
+        },
+    );
+
+    service
+        .publish(SkillPublishRequest {
+            bundle_path: bundle,
+            registry: "local-dev".to_owned(),
+            allow_unsigned: true,
+        })
+        .await
+        .expect("publish should succeed");
+    let hits = service.search("searchable").await.expect("search should work");
+    assert_eq!(hits.len(), 1);
+    assert_eq!(hits[0].name, "searchable-skill");
+
+    let installed = service
+        .add(SkillAddRequest {
+            handle: "searchable-skill@0.1.0".to_owned(),
+            registry: None,
+            allow_unsigned: true,
+        })
+        .await
+        .expect("add should install");
+
+    assert_eq!(installed.name, "searchable-skill");
+}
+```
+
+- [ ] **Step 2: Run test and verify RED**
+
+Run:
+
+```bash
+cargo test -p agentenv-core --test skills filesystem_registry_search_add_and_publish_work
+```
+
+Expected: compile failure for missing service and filesystem registry.
+
+- [ ] **Step 3: Implement registry structs and trait**
+
+In `registry.rs`, add:
+
+```rust
+#[derive(Debug, Clone, serde::Serialize, serde::Deserialize, PartialEq, Eq)]
+pub struct SkillSearchHit {
+    pub name: String,
+    pub version: String,
+    pub description: Option<String>,
+    pub registry: String,
+    pub digest: Option<String>,
+    pub signature_ed25519: Option<String>,
+    pub public_key_ed25519: Option<String>,
+}
+
+#[derive(Debug, Clone)]
+pub struct FetchedSkill {
+    pub staging_path: PathBuf,
+    pub registry: String,
+    pub source_type: String,
+}
+
+#[async_trait::async_trait]
+pub trait RegistryAdapter {
+    async fn search(&self, query: &str) -> Result<Vec<SkillSearchHit>, SkillError>;
+    async fn fetch(&self, name: &str, version: Option<&str>) -> Result<FetchedSkill, SkillError>;
+    async fn publish(&self, bundle_path: &Path, allow_unsigned: bool) -> Result<SkillSearchHit, SkillError>;
+}
+```
+
+- [ ] **Step 4: Implement filesystem registry**
+
+Create `registry_filesystem.rs` with `FilesystemRegistryAdapter`. It should:
+
+- read and write `<registry>/index.yaml`
+- store bundles under `<registry>/bundles/<name>/<version>/`
+- use `install_local_skill` validation before publishing
+- refuse overwrite when same name/version has different digest
+- update index entries sorted by name then version
+
+- [ ] **Step 5: Implement `SkillService`**
+
+Create `service.rs` with:
+
+```rust
+#[derive(Debug, Clone)]
+pub struct SkillService {
+    root: PathBuf,
+    config: SkillsConfig,
+}
+
+#[derive(Debug, Clone)]
+pub struct SkillAddRequest {
+    pub handle: String,
+    pub registry: Option<String>,
+    pub allow_unsigned: bool,
+}
+
+#[derive(Debug, Clone)]
+pub struct SkillPublishRequest {
+    pub bundle_path: PathBuf,
+    pub registry: String,
+    pub allow_unsigned: bool,
+}
+```
+
+Implement:
+
+```rust
+impl SkillService {
+    pub fn new(root: PathBuf, config: SkillsConfig) -> Self
+    pub async fn search(&self, query: &str) -> Result<Vec<SkillSearchHit>, SkillError>
+    pub async fn add(&self, request: SkillAddRequest) -> Result<InstalledSkill, SkillError>
+    pub async fn publish(&self, request: SkillPublishRequest) -> Result<SkillSearchHit, SkillError>
+    pub fn list(&self) -> Result<Vec<InstalledSkill>, SkillError>
+    pub fn info(&self, selector: InstalledSkillSelector) -> Result<InstalledSkill, SkillError>
+    pub fn remove(&self, selector: InstalledSkillSelector) -> Result<InstalledSkill, SkillError>
+    pub fn verify(&self, selector: InstalledSkillSelector) -> Result<InstalledSkill, SkillError>
+}
+```
+
+Handle parsing rules:
+
+- `name@version` splits on the last `@`
+- missing version selects highest semantic version from search results
+- invalid name fails before registry access
+
+- [ ] **Step 6: Export service and adapter**
+
+Update `mod.rs`:
+
+```rust
+pub mod registry_filesystem;
+pub mod service;
+
+pub use registry::{FetchedSkill, RegistryAdapter, SkillSearchHit};
+pub use service::{SkillAddRequest, SkillPublishRequest, SkillService};
+```
+
+- [ ] **Step 7: Run test and verify GREEN**
+
+Run:
+
+```bash
+cargo test -p agentenv-core --test skills filesystem_registry_search_add_and_publish_work
+```
+
+Expected: test passes.
+
+- [ ] **Step 8: Commit Task 4**
+
+Run:
+
+```bash
+git add crates/agentenv-core/src/skills crates/agentenv-core/tests/skills.rs
+git commit -m "feat: add filesystem skill registry"
+```
+
+### Task 5: HTTP Registry with SSRF and Credentials
+
+**Files:**
+- Modify: `crates/agentenv-core/src/skills/mod.rs`
+- Modify: `crates/agentenv-core/src/skills/error.rs`
+- Create: `crates/agentenv-core/src/skills/registry_http.rs`
+- Modify: `crates/agentenv-core/src/skills/service.rs`
+- Modify: `crates/agentenv-core/tests/skills.rs`
+
+- [ ] **Step 1: Write failing HTTP registry tests**
+
+Append tests using a minimal Tokio TCP server:
+
+```rust
+#[tokio::test]
+async fn http_registry_rejects_unsafe_url_before_request() {
+    let home = temp_dir("skill-http-unsafe-home");
+    let service = SkillService::new(
+        home.join(".agentenv"),
+        SkillsConfig {
+            registries: vec![agentenv_core::skills::RegistryConfig::http(
+                "unsafe",
+                "http://127.0.0.1:9",
+                None,
+            )],
+            registry_order: vec!["unsafe".to_owned()],
+        },
+    );
+
+    let error = service.search("demo").await.expect_err("loopback URL must be blocked");
+
+    assert!(matches!(error, SkillError::RegistryUrlBlocked { .. }));
+}
+```
+
+Add a second test after the local HTTP fixture helper is available:
+
+```rust
+#[tokio::test]
+async fn http_registry_search_reads_static_index() {
+    let server = TestHttpRegistry::start().await;
+    server
+        .add_response(
+            "GET /index.yaml",
+            "entries:\n  - name: http-demo\n    version: 0.1.0\n    description: HTTP demo\n",
+        )
+        .await;
+    let home = temp_dir("skill-http-home");
+    let service = SkillService::new(
+        home.join(".agentenv"),
+        SkillsConfig {
+            registries: vec![agentenv_core::skills::RegistryConfig::http(
+                "http-dev",
+                &server.public_base_url(),
+                None,
+            )],
+            registry_order: vec!["http-dev".to_owned()],
+        },
+    );
+
+    let hits = service.search("http").await.expect("search should succeed");
+
+    assert_eq!(hits[0].name, "http-demo");
+}
+
+#[tokio::test]
+async fn http_registry_publish_and_add_round_trip() {
+    let server = TestHttpRegistry::start().await;
+    let home = temp_dir("skill-http-round-trip-home");
+    let bundle = temp_dir("skill-http-round-trip-bundle");
+    write_file(&bundle.join("SKILL.md"), "# HTTP Skill\n");
+    write_file(
+        &bundle.join("skill.yaml"),
+        "name: http-skill\nversion: 0.1.0\ndescription: HTTP skill\nentry: SKILL.md\nfiles:\n  - SKILL.md\n",
+    );
+    let service = SkillService::new(
+        home.join(".agentenv"),
+        SkillsConfig {
+            registries: vec![agentenv_core::skills::RegistryConfig::http(
+                "http-dev",
+                &server.public_base_url(),
+                None,
+            )],
+            registry_order: vec!["http-dev".to_owned()],
+        },
+    );
+
+    service
+        .publish(SkillPublishRequest {
+            bundle_path: bundle,
+            registry: "http-dev".to_owned(),
+            allow_unsigned: true,
+        })
+        .await
+        .expect("publish should upload files");
+
+    let installed = service
+        .add(SkillAddRequest {
+            handle: "http-skill@0.1.0".to_owned(),
+            registry: Some("http-dev".to_owned()),
+            allow_unsigned: true,
+        })
+        .await
+        .expect("add should download uploaded files");
+
+    assert_eq!(installed.name, "http-skill");
+}
+```
+
+- [ ] **Step 2: Run tests and verify RED**
+
+Run:
+
+```bash
+cargo test -p agentenv-core --test skills http_registry
+```
+
+Expected: compile failure for missing `registry_http` or failure because URL validation is not wired.
+
+- [ ] **Step 3: Extend errors**
+
+Add:
+
+```rust
+#[error("registry URL `{url}` was blocked by SSRF policy: {source}")]
+RegistryUrlBlocked {
+    url: String,
+    #[source]
+    source: crate::security::ssrf::SsrfBlocked,
+},
+#[error("HTTP registry request failed for `{url}`: {source}")]
+HttpRegistry {
+    url: String,
+    #[source]
+    source: reqwest::Error,
+},
+#[error("HTTP registry `{url}` returned status {status}")]
+HttpStatus {
+    url: String,
+    status: reqwest::StatusCode,
+},
+#[error("credential reference `{name}` is not available")]
+CredentialReferenceUnavailable { name: String },
+```
+
+- [ ] **Step 4: Implement HTTP adapter**
+
+Create `registry_http.rs`. Required behavior:
+
+- Validate base URL and each request URL with `validate_outbound(url, SsrfOptions::default())`.
+- `GET /index.yaml` for search.
+- `GET /bundles/<name>/<version>/skill.yaml` and content files for fetch.
+- `PUT` canonical files for publish.
+- Include `digest`, `signature_ed25519`, and `public_key_ed25519` in uploaded
+  and downloaded index entries.
+- Use bearer auth header when the service supplies a token.
+- Do not log bearer tokens.
+
+- [ ] **Step 5: Wire HTTP adapter into service**
+
+In `service.rs`, instantiate `HttpRegistryAdapter` for `RegistryKind::Http`. Add a credential resolver callback to `SkillService`:
+
+```rust
+pub type SkillCredentialResolver =
+    std::sync::Arc<dyn Fn(&str) -> Result<Option<String>, SkillError> + Send + Sync>;
+```
+
+Provide:
+
+```rust
+pub fn with_credential_resolver(self, resolver: SkillCredentialResolver) -> Self
+```
+
+Default resolver returns `Ok(None)`.
+
+- [ ] **Step 6: Run tests and verify GREEN**
+
+Run:
+
+```bash
+cargo test -p agentenv-core --test skills http_registry
+```
+
+Expected: HTTP registry tests pass.
+
+- [ ] **Step 7: Commit Task 5**
+
+Run:
+
+```bash
+git add crates/agentenv-core/src/skills crates/agentenv-core/tests/skills.rs
+git commit -m "feat: add http skill registry"
+```
+
+### Task 6: OCI Registry Adapter
+
+**Files:**
+- Modify: `crates/agentenv-core/src/skills/mod.rs`
+- Modify: `crates/agentenv-core/src/skills/error.rs`
+- Create: `crates/agentenv-core/src/skills/registry_oci.rs`
+- Modify: `crates/agentenv-core/src/skills/service.rs`
+- Modify: `crates/agentenv-core/tests/skills.rs`
+
+- [ ] **Step 1: Write failing OCI tests**
+
+Append:
+
+```rust
+#[tokio::test]
+async fn oci_registry_search_add_and_publish_use_distribution_api() {
+    let registry = TestOciRegistry::start().await;
+    let home = temp_dir("skill-oci-home");
+    let bundle = temp_dir("skill-oci-bundle");
+    write_file(&bundle.join("SKILL.md"), "# OCI Skill\n");
+    write_file(
+        &bundle.join("skill.yaml"),
+        "name: oci-skill\nversion: 0.1.0\ndescription: OCI demo\nentry: SKILL.md\nfiles:\n  - SKILL.md\n",
+    );
+    let service = SkillService::new(
+        home.join(".agentenv"),
+        SkillsConfig {
+            registries: vec![agentenv_core::skills::RegistryConfig::oci(
+                "oci-dev",
+                &registry.base_reference("agentenv-test"),
+                None,
+            )],
+            registry_order: vec!["oci-dev".to_owned()],
+        },
+    );
+
+    service
+        .publish(SkillPublishRequest {
+            bundle_path: bundle,
+            registry: "oci-dev".to_owned(),
+            allow_unsigned: true,
+        })
+        .await
+        .expect("OCI publish should work against fixture");
+
+    let hits = service.search("oci").await.expect("OCI search should work");
+    assert_eq!(hits[0].name, "oci-skill");
+
+    let installed = service
+        .add(SkillAddRequest {
+            handle: "oci-skill@0.1.0".to_owned(),
+            registry: Some("oci-dev".to_owned()),
+            allow_unsigned: true,
+        })
+        .await
+        .expect("OCI add should install");
+    assert_eq!(installed.name, "oci-skill");
+}
+```
+
+- [ ] **Step 2: Run test and verify RED**
+
+Run:
+
+```bash
+cargo test -p agentenv-core --test skills oci_registry_search_add_and_publish_use_distribution_api
+```
+
+Expected: compile failure for missing OCI registry adapter.
+
+- [ ] **Step 3: Implement minimal OCI client**
+
+Create `registry_oci.rs` with:
+
+```rust
+const OCI_IMAGE_MANIFEST: &str = "application/vnd.oci.image.manifest.v1+json";
+const AGENTENV_SKILL_CONFIG: &str = "application/vnd.agentenv.skill.config.v1+json";
+const AGENTENV_SKILL_MANIFEST: &str = "application/vnd.agentenv.skill.manifest.v1+yaml";
+const AGENTENV_SKILL_FILE: &str = "application/vnd.agentenv.skill.file.v1";
+const AGENTENV_SKILLS_INDEX: &str = "application/vnd.agentenv.skills.index.v1+yaml";
+```
+
+Implement the OCI Distribution API calls:
+
+- `GET /v2/<repo>/manifests/skills-index`
+- `GET /v2/<repo>/blobs/<digest>`
+- `POST /v2/<repo>/blobs/uploads/`
+- `PATCH <upload-location>`
+- `PUT <upload-location>&digest=<sha256>`
+- `PUT /v2/<repo>/manifests/<tag>`
+
+Use one layer per declared bundle file. Store each original relative path in the descriptor annotation `io.agentenv.skill.path`.
+
+- [ ] **Step 4: Add OCI auth errors**
+
+Add:
+
+```rust
+#[error("unsupported OCI authentication scheme `{scheme}`")]
+UnsupportedRegistryAuth { scheme: String },
+#[error("invalid OCI registry reference `{reference}`")]
+InvalidOciReference { reference: String },
+```
+
+- [ ] **Step 5: Wire OCI adapter into service**
+
+Instantiate `OciRegistryAdapter` for `RegistryKind::Oci`. Resolve bearer credentials through the same resolver used by HTTP.
+
+- [ ] **Step 6: Run test and verify GREEN**
+
+Run:
+
+```bash
+cargo test -p agentenv-core --test skills oci_registry_search_add_and_publish_use_distribution_api
+```
+
+Expected: test passes against fixture registry.
+
+- [ ] **Step 7: Commit Task 6**
+
+Run:
+
+```bash
+git add crates/agentenv-core/src/skills crates/agentenv-core/tests/skills.rs
+git commit -m "feat: add oci skill registry"
+```
+
+### Task 7: CLI Command Group
+
+**Files:**
+- Modify: `crates/agentenv/src/main.rs`
+- Create: `crates/agentenv/src/skills_cli.rs`
+- Modify: `crates/agentenv/tests/cli_behavior.rs`
+
+- [ ] **Step 1: Write failing CLI help and local lifecycle tests**
+
+Append tests to `crates/agentenv/tests/cli_behavior.rs`:
+
+```rust
+#[test]
+fn cli_help_includes_skills_command() {
+    let output = Command::new(agentenv_bin()).arg("--help").output().unwrap();
+    assert!(output.status.success(), "{}", output_summary(&output));
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    assert!(stdout.contains("skills"), "stdout was: {stdout}");
+}
+
+#[test]
+fn skills_help_lists_lifecycle_subcommands() {
+    let output = Command::new(agentenv_bin())
+        .arg("skills")
+        .arg("--help")
+        .output()
+        .unwrap();
+    assert!(output.status.success(), "{}", output_summary(&output));
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    for command in ["search", "add", "install", "list", "info", "remove", "publish", "verify"] {
+        assert!(stdout.contains(command), "missing {command}; stdout was: {stdout}");
+    }
+}
+
+#[test]
+fn skills_install_list_info_verify_and_remove_local_bundle() {
+    let temp_dir = make_temp_dir("skills-cli-local");
+    let bundle = temp_dir.join("bundle");
+    fs::create_dir_all(&bundle).unwrap();
+    fs::write(bundle.join("SKILL.md"), "# CLI Skill\n").unwrap();
+    fs::write(
+        bundle.join("skill.yaml"),
+        "name: cli-skill\nversion: 0.1.0\nentry: SKILL.md\nfiles:\n  - SKILL.md\n",
+    )
+    .unwrap();
+
+    let install = Command::new(agentenv_bin())
+        .arg("skills")
+        .arg("install")
+        .arg("--from")
+        .arg(&bundle)
+        .arg("--allow-unsigned")
+        .arg("--json")
+        .env("HOME", &temp_dir)
+        .current_dir(&temp_dir)
+        .output()
+        .unwrap();
+    assert!(install.status.success(), "{}", output_summary(&install));
+
+    let list = Command::new(agentenv_bin())
+        .arg("skills")
+        .arg("list")
+        .arg("--json")
+        .env("HOME", &temp_dir)
+        .output()
+        .unwrap();
+    assert!(list.status.success(), "{}", output_summary(&list));
+    let json: serde_json::Value = serde_json::from_slice(&list.stdout).unwrap();
+    assert_eq!(json["skills"][0]["name"], "cli-skill");
+
+    let info = Command::new(agentenv_bin())
+        .arg("skills")
+        .arg("info")
+        .arg("cli-skill")
+        .arg("--json")
+        .env("HOME", &temp_dir)
+        .output()
+        .unwrap();
+    assert!(info.status.success(), "{}", output_summary(&info));
+    let info_json: serde_json::Value = serde_json::from_slice(&info.stdout).unwrap();
+    assert_eq!(info_json["name"], "cli-skill");
+
+    let verify = Command::new(agentenv_bin())
+        .arg("skills")
+        .arg("verify")
+        .arg("cli-skill")
+        .env("HOME", &temp_dir)
+        .output()
+        .unwrap();
+    assert!(verify.status.success(), "{}", output_summary(&verify));
+
+    let remove = Command::new(agentenv_bin())
+        .arg("skills")
+        .arg("remove")
+        .arg("cli-skill")
+        .arg("--yes")
+        .env("HOME", &temp_dir)
+        .output()
+        .unwrap();
+    assert!(remove.status.success(), "{}", output_summary(&remove));
+}
+```
+
+- [ ] **Step 2: Run tests and verify RED**
+
+Run:
+
+```bash
+cargo test -p agentenv --test cli_behavior skills_help skills_install_list_info_verify_and_remove_local_bundle
+```
+
+Expected: failure because `skills` command does not exist.
+
+- [ ] **Step 3: Create `skills_cli.rs`**
+
+Implement clap structs:
+
+```rust
+use std::path::PathBuf;
+
+use anyhow::{Context, Result};
+use clap::{Args, Subcommand};
+use serde::Serialize;
+
+#[derive(Debug, Args)]
+pub struct SkillsArgs {
+    #[command(subcommand)]
+    pub command: SkillsCommand,
+}
+
+#[derive(Debug, Subcommand)]
+pub enum SkillsCommand {
+    Search(SkillsSearchArgs),
+    Add(SkillsAddArgs),
+    Install(SkillsInstallArgs),
+    List(SkillsListArgs),
+    Info(SkillsInfoArgs),
+    Remove(SkillsRemoveArgs),
+    Publish(SkillsPublishArgs),
+    Verify(SkillsVerifyArgs),
+}
+```
+
+Define one args struct per command with the flags from the design.
+
+- [ ] **Step 4: Add service construction and credential resolver**
+
+In `skills_cli.rs`, implement:
+
+```rust
+pub async fn run_skills(args: SkillsArgs) -> Result<()> {
+    let root = dirs::home_dir().context("home directory is unavailable")?.join(".agentenv");
+    let config = load_effective_config(None)?;
+    let service = agentenv_core::skills::SkillService::new(root, config)
+        .with_credential_resolver(std::sync::Arc::new(resolve_skill_credential));
+    dispatch(args, service).await
+}
+```
+
+`resolve_skill_credential` should use `CredentialStore::from_default_paths()` and return `Ok(None)` for missing optional registry credentials.
+
+- [ ] **Step 5: Route from main**
+
+Modify `main.rs`:
+
+```rust
+mod skills_cli;
+```
+
+Add:
+
+```rust
+Skills(skills_cli::SkillsArgs),
+```
+
+Route:
+
+```rust
+Some(Commands::Skills(args)) => skills_cli::run_skills(args).await,
+```
+
+- [ ] **Step 6: Render JSON and text**
+
+In `skills_cli.rs`, define:
+
+```rust
+#[derive(Debug, Serialize)]
+struct SkillsListJson {
+    skills: Vec<agentenv_core::skills::InstalledSkill>,
+}
+```
+
+Text output:
+
+- install/add/publish/verify: print `<name> <version> <digest>`
+- list: table headers `NAME VERSION SOURCE DIGEST`
+- info: one field per line
+- remove: print removed name and version
+
+- [ ] **Step 7: Run tests and verify GREEN**
+
+Run:
+
+```bash
+cargo test -p agentenv --test cli_behavior skills_help skills_install_list_info_verify_and_remove_local_bundle
+```
+
+Expected: tests pass.
+
+- [ ] **Step 8: Commit Task 7**
+
+Run:
+
+```bash
+git add crates/agentenv/src/main.rs crates/agentenv/src/skills_cli.rs crates/agentenv/tests/cli_behavior.rs
+git commit -m "feat: add skills cli commands"
+```
+
+### Task 8: CLI Registry Workflows and Config Precedence
+
+**Files:**
+- Modify: `crates/agentenv/src/skills_cli.rs`
+- Modify: `crates/agentenv/tests/cli_behavior.rs`
+
+- [ ] **Step 1: Write failing CLI registry tests**
+
+Append:
+
+```rust
+#[test]
+fn skills_search_add_and_publish_use_filesystem_registry_config() {
+    let temp_dir = make_temp_dir("skills-cli-registry");
+    let registry = temp_dir.join("registry");
+    let bundle = temp_dir.join("bundle");
+    fs::create_dir_all(&bundle).unwrap();
+    fs::write(bundle.join("SKILL.md"), "# Registry Skill\n").unwrap();
+    fs::write(
+        bundle.join("skill.yaml"),
+        "name: registry-skill\nversion: 0.1.0\ndescription: Registry demo\nentry: SKILL.md\nfiles:\n  - SKILL.md\n",
+    )
+    .unwrap();
+    fs::write(
+        temp_dir.join("agentenv.yaml"),
+        format!(
+            "version: 0.1.0\nmin_agentenv_version: 0.0.1-alpha0\nsandbox: {{ driver: openshell }}\nagent: {{ driver: codex }}\ncontext: {{ driver: filesystem, mount: . }}\npolicy: {{ tier: balanced, presets: [] }}\nskills:\n  registries:\n    - name: local-dev\n      type: filesystem\n      path: {}\n",
+            registry.display()
+        ),
+    )
+    .unwrap();
+
+    let publish = Command::new(agentenv_bin())
+        .arg("skills")
+        .arg("publish")
+        .arg(&bundle)
+        .arg("--registry")
+        .arg("local-dev")
+        .arg("--allow-unsigned")
+        .env("HOME", &temp_dir)
+        .current_dir(&temp_dir)
+        .output()
+        .unwrap();
+    assert!(publish.status.success(), "{}", output_summary(&publish));
+
+    let search = Command::new(agentenv_bin())
+        .arg("skills")
+        .arg("search")
+        .arg("registry")
+        .env("HOME", &temp_dir)
+        .current_dir(&temp_dir)
+        .output()
+        .unwrap();
+    assert!(search.status.success(), "{}", output_summary(&search));
+    assert!(String::from_utf8_lossy(&search.stdout).contains("registry-skill"));
+
+    let add = Command::new(agentenv_bin())
+        .arg("skills")
+        .arg("add")
+        .arg("registry-skill@0.1.0")
+        .arg("--allow-unsigned")
+        .env("HOME", &temp_dir)
+        .current_dir(&temp_dir)
+        .output()
+        .unwrap();
+    assert!(add.status.success(), "{}", output_summary(&add));
+}
+```
+
+- [ ] **Step 2: Run test and verify RED**
+
+Run:
+
+```bash
+cargo test -p agentenv --test cli_behavior skills_search_add_and_publish_use_filesystem_registry_config
+```
+
+Expected: failure because CLI config loading or registry routing is incomplete.
+
+- [ ] **Step 3: Implement effective config loading**
+
+In `skills_cli.rs`:
+
+- read `~/.config/agentenv/config.toml` if it exists
+- read `agentenv.yaml` from current working directory if it exists
+- call `merge_skills_config`
+- pass command `--registry` as `SkillsConfigOverride`
+
+Use `std::fs::read_to_string` and attach path context with `anyhow::Context`.
+
+- [ ] **Step 4: Finish command dispatch**
+
+Ensure every subcommand calls the matching service method:
+
+- `search` -> `service.search`
+- `add` -> `service.add`
+- `install --from` -> `service.install_from_path`
+- `list` -> `service.list`
+- `info` -> `service.info`
+- `remove` -> require `--yes` before deleting
+- `publish` -> `service.publish`
+- `verify` -> `service.verify`
+
+- [ ] **Step 5: Run test and verify GREEN**
+
+Run:
+
+```bash
+cargo test -p agentenv --test cli_behavior skills_search_add_and_publish_use_filesystem_registry_config
+```
+
+Expected: test passes.
+
+- [ ] **Step 6: Commit Task 8**
+
+Run:
+
+```bash
+git add crates/agentenv/src/skills_cli.rs crates/agentenv/tests/cli_behavior.rs
+git commit -m "feat: wire skills registry config in cli"
+```
+
+### Task 9: Final Verification and Issue Closure Prep
+
+**Files:**
+- Modify: `docs/superpowers/plans/2026-05-07-skills-cli.md` only if execution reveals a command correction.
+
+- [ ] **Step 1: Run formatting**
+
+Run:
+
+```bash
+cargo fmt
+```
+
+Expected: exits 0.
+
+- [ ] **Step 2: Run clippy**
+
+Run:
+
+```bash
+cargo clippy --workspace --all-targets -- -D warnings
+```
+
+Expected: exits 0 with no warnings.
+
+- [ ] **Step 3: Run full test suite**
+
+Run:
+
+```bash
+cargo test --workspace
+```
+
+Expected: exits 0 with all tests passing.
+
+- [ ] **Step 4: Inspect git status and summarize changed crates**
+
+Run:
+
+```bash
+git status --short
+git diff --stat HEAD
+```
+
+Expected: only intended files changed after the last task commit. PR summary should list `agentenv` and `agentenv-core` as affected crates.
+
+- [ ] **Step 5: Prepare PR notes**
+
+Include these points in the PR body:
+
+```markdown
+Closes #28.
+
+Affected crates:
+- `agentenv`
+- `agentenv-core`
+
+Summary:
+- Added `agentenv skills` lifecycle commands.
+- Added core-managed skill manifests, digest verification, Ed25519 signature checks, installed cache/index, and registry adapters.
+- Added filesystem, HTTP, and OCI registry support without adding a driver axis or changing the driver protocol.
+- Kept registry HTTP/OCI egress behind core SSRF URL validation.
+
+Validation:
+- `cargo fmt`
+- `cargo clippy --workspace --all-targets -- -D warnings`
+- `cargo test --workspace`
+
+Protocol notes:
+- No `agentenv-proto` schema-version bump.
+- No new driver kind.
+```

--- a/docs/superpowers/specs/2026-05-07-skills-cli-design.md
+++ b/docs/superpowers/specs/2026-05-07-skills-cli-design.md
@@ -1,0 +1,502 @@
+# M7-2 Design: `agentenv skills` Lifecycle CLI
+
+- Date: 2026-05-07
+- Issue: https://github.com/windoliver/agentenv/issues/28
+- Milestone: M7 Skills axis and registry
+- Depends on: https://github.com/windoliver/agentenv/issues/27
+- Affected crates: `agentenv`, `agentenv-core`
+
+## 1. Context and Goals
+
+Issue #28 adds first-class CLI support for the skill lifecycle:
+
+```text
+agentenv skills search <query>
+agentenv skills add <name>[@version]
+agentenv skills install --from <path>
+agentenv skills list
+agentenv skills info <name>
+agentenv skills remove <name>
+agentenv skills publish <path> --registry <url>
+agentenv skills verify <name>
+```
+
+Issue #27 chose the architectural lane: skills are core-managed resources, not
+`ContextDriver` sub-kinds and not a fifth pluggable axis. The implementation
+therefore belongs in core-owned lifecycle code and a thin CLI facade. Registry
+backends are package-registry adapters, not JSON-RPC drivers.
+
+The feature must provide one coherent PR for the full issue surface. The PR
+should make local, HTTP, and OCI skill workflows useful end to end without
+adding a runtime dependency, and preserve the narrow waist: MCP remains the
+agent-to-context protocol and JSON-RPC remains only the core-to-driver protocol.
+
+## 2. Scope and Non-Goals
+
+### In scope
+
+1. A new `agentenv-core::skills` module that owns skill manifests, registry
+   configuration, resolution, fetch, verification, install, remove, listing,
+   info, and publish behavior.
+2. The `agentenv skills` CLI group and all subcommands listed in issue #28.
+3. A deterministic skill cache under `~/.agentenv/skills/<name>/<version>/`.
+4. An installed-skill index used by `list`, `info`, `remove`, and `verify`.
+5. Skill bundle manifest parsing from `skill.yaml`.
+6. Deterministic SHA-256 bundle digests over declared files.
+7. Ed25519 signature verification for registry-installed bundles.
+8. Local development installs from `install --from <path>`.
+9. Filesystem registry search, add, verify, and publish.
+10. HTTP registry search, add, verify, and publish through SSRF-validated URLs.
+11. OCI registry search, add, verify, and publish through the OCI Distribution
+    API with `reqwest` and `rustls`.
+12. Config precedence: CLI flag, then project `agentenv.yaml`, then
+    `~/.config/agentenv/config.toml`.
+13. Tests for core behavior and CLI behavior.
+
+### Out of scope
+
+1. A new driver kind, new driver RPC method, or driver protocol schema bump.
+2. In-sandbox agent discovery and injection of selected skills during
+   `agentenv create`; that belongs to later M7 create/freeze integration.
+3. A network approval queue for registry fetches. This issue gates registry
+   URLs through the core SSRF validator; richer operator approval policy remains
+   a later policy/approvals integration.
+4. OpenPGP, x509, cosign, or alternate signature formats.
+5. Adding Python, Node, OpenSSL, ORAS, Docker, or another build-time/runtime
+   dependency to core.
+
+## 3. Architecture
+
+### 3.1 Core skill service
+
+Add `agentenv-core::skills` with focused submodules:
+
+1. `manifest` parses and validates `skill.yaml`.
+2. `digest` computes deterministic bundle digests.
+3. `signature` verifies Ed25519 signatures.
+4. `index` reads and writes the installed-skill index.
+5. `registry` defines registry config and adapter traits.
+6. `store` owns cache paths and atomic install/remove operations.
+7. `service` exposes high-level operations used by the CLI.
+
+The service API should make the CLI thin:
+
+```rust
+pub struct SkillService { /* root, config, registries */ }
+
+impl SkillService {
+    pub fn search(&self, query: &str) -> Result<Vec<SkillSearchHit>, SkillError>;
+    pub fn add(&self, request: SkillAddRequest) -> Result<InstalledSkill, SkillError>;
+    pub fn install_from_path(&self, request: SkillInstallRequest) -> Result<InstalledSkill, SkillError>;
+    pub fn list(&self) -> Result<Vec<InstalledSkill>, SkillError>;
+    pub fn info(&self, name: &str) -> Result<InstalledSkillInfo, SkillError>;
+    pub fn remove(&self, name: &str) -> Result<SkillRemoveReport, SkillError>;
+    pub fn publish(&self, request: SkillPublishRequest) -> Result<SkillPublishReport, SkillError>;
+    pub fn verify(&self, name: &str) -> Result<SkillVerifyReport, SkillError>;
+}
+```
+
+`thiserror` owns library errors. The CLI uses `anyhow` only to add command
+context and render human-readable failures.
+
+### 3.2 CLI facade
+
+Add `Skills(SkillsArgs)` to `crates/agentenv/src/main.rs` with these
+subcommands:
+
+```text
+skills search <query> [--registry <name-or-url>] [--json]
+skills add <name>[@version] [--registry <name-or-url>] [--allow-unsigned] [--json]
+skills install --from <path> [--allow-unsigned] [--json]
+skills list [--json]
+skills info <name> [--version <version>] [--json]
+skills remove <name> [--version <version>] [--yes] [--json]
+skills publish <path> --registry <name-or-url> [--allow-unsigned] [--json]
+skills verify <name> [--version <version>] [--json]
+```
+
+The issue surface does not require JSON output, but existing CLI tests already
+use stable JSON for machine paths. Adding `--json` for skills keeps this command
+usable in automation and makes tests precise.
+
+`info`, `remove`, and `verify` accept a name plus optional version. If a name is
+installed in exactly one version, the command resolves that version. If multiple
+versions are installed and no `--version` is provided, the command returns an
+ambiguous-name error listing available versions.
+
+### 3.3 Bundle manifest
+
+Each skill bundle has a `skill.yaml` at its root:
+
+```yaml
+name: example-skill
+version: 0.1.0
+description: Short description
+entry: SKILL.md
+files:
+  - SKILL.md
+  - references/**
+self_test:
+  command: agentenv-skill-test
+signatures:
+  ed25519: <hex signature>
+```
+
+Required fields:
+
+1. `name`
+2. `version`
+3. `entry`
+4. `files`
+
+Optional fields:
+
+1. `description`
+2. `self_test.command`
+3. `signatures.ed25519`
+4. additional metadata preserved as opaque YAML for future compatibility
+
+`name` is a conservative package identifier: ASCII lowercase letters, digits,
+dash, underscore, and dot, with no leading dot and no path separators.
+`version` must be valid semantic version syntax. `entry` and every expanded
+file path must stay under the bundle root, must be relative, and must not
+contain parent traversal.
+
+### 3.4 Installed index and cache layout
+
+Core stores immutable installed bundles under:
+
+```text
+~/.agentenv/skills/
+  index.yaml
+  <name>/
+    <version>/
+      skill.yaml
+      content/
+        ...
+      installed.yaml
+```
+
+`installed.yaml` records:
+
+1. name
+2. version
+3. source registry or local path
+4. source type: `local`, `filesystem`, `http`, or `oci`
+5. bundle digest
+6. signature status
+7. signature public key or trust record when available
+8. installed timestamp
+9. entry path
+
+The index is a derived lookup file optimized for CLI reads. The directory
+contents remain the source of truth for verification. Index writes should be
+atomic: write a temporary file next to `index.yaml`, then rename.
+
+## 4. Registry Behavior
+
+### 4.1 Registry config
+
+Support the issue's config shape:
+
+```yaml
+skills:
+  registries:
+    - name: community
+      type: oci
+      url: ghcr.io/agentenv-community
+    - name: corp
+      type: http
+      url: https://skills.acme.internal
+      auth: bearer-from-credstore
+    - name: local-dev
+      type: filesystem
+      path: /home/alice/dev/skills
+```
+
+The core config model also supports explicit resolution order:
+
+```yaml
+skills:
+  registry_order:
+    - corp
+    - community
+    - local-dev
+```
+
+If `registry_order` is omitted, the listed order of `registries` is used.
+
+### 4.2 Config precedence
+
+The CLI builds a final skills config from three sources:
+
+1. CLI flags, such as `--registry`.
+2. Project `agentenv.yaml`, using its top-level `skills` section when present.
+3. User config at `~/.config/agentenv/config.toml`.
+
+Project `agentenv.yaml` remains YAML. User config is TOML to match the issue.
+The same typed `SkillsConfig` should deserialize from both formats. CLI flags
+do not mutate config; they narrow the operation for the current command.
+
+### 4.3 Filesystem registry
+
+A filesystem registry is a directory tree with this layout:
+
+```text
+registry-root/
+  index.yaml
+  bundles/
+    <name>/
+      <version>/
+        skill.yaml
+        content/
+          ...
+```
+
+`search <query>` reads `index.yaml` and returns name/description/version hits.
+`add <name>[@version]` copies the selected bundle through the same verification
+and install path used by HTTP. `publish <path>` validates and verifies the local
+bundle, then writes it under `bundles/<name>/<version>/` and updates
+`index.yaml` atomically.
+
+### 4.4 HTTP registry
+
+HTTP registries expose a simple static layout:
+
+```text
+GET /index.yaml
+GET /bundles/<name>/<version>/skill.yaml
+GET /bundles/<name>/<version>/content/<path>
+PUT /bundles/<name>/<version>/...
+PUT /index.yaml
+```
+
+The first implementation uses static YAML index and bundle files instead of a
+custom API. Every HTTP URL goes through the core SSRF validator before fetch or
+publish. Redirects are handled only through a validator-aware fetch helper; the
+implementation must not follow unsafe redirects.
+
+`auth: bearer-from-credstore` means the CLI resolves a bearer token from the
+credential store and passes it into the HTTP adapter. The default credential
+name is `AGENTENV_SKILLS_<REGISTRY_NAME>_TOKEN`, where the registry name is
+uppercased and non-alphanumeric characters become underscores. Config may also
+use `auth: bearer-from-credstore:<credential-name>` to name the credential
+explicitly. Credential values are not written to the installed index or driver
+RPC payloads.
+
+### 4.5 OCI registry
+
+OCI registries use the OCI Distribution API directly through `reqwest` with the
+workspace's existing `rustls` TLS posture. No Docker, ORAS, Python, Node,
+OpenSSL, or external binary is introduced.
+
+The registry layout is agentenv-specific but OCI-native:
+
+```text
+<registry>/<namespace>/skills-index:latest
+<registry>/<namespace>/<skill-name>:<version>
+```
+
+`skills-index:latest` is an OCI artifact whose config blob contains the
+registry search index as YAML. Each skill artifact has:
+
+1. an OCI config blob containing normalized skill metadata
+2. one layer for canonical `skill.yaml`
+3. one layer per declared bundle file, each annotated with
+   `io.agentenv.skill.path`
+4. annotations for `org.opencontainers.image.title`,
+   `io.agentenv.skill.name`, `io.agentenv.skill.version`,
+   `io.agentenv.skill.digest`, and `io.agentenv.skill.signature.ed25519`
+
+`search <query>` pulls the `skills-index:latest` artifact and filters its
+entries locally. `add <name>[@version]` resolves through the index, pulls the
+selected skill artifact, verifies the manifest, digest, and signature, then
+installs it into the local cache. `publish <path>` pushes the skill artifact,
+then updates `skills-index:latest` with a compare-and-retry loop using the
+current index digest when the registry exposes one.
+
+The first implementation supports bearer tokens resolved from the credential
+store. Anonymous reads are allowed when the registry permits them. Challenge
+negotiation for every OCI auth variant is not required; unsupported auth
+schemes return typed registry-auth errors.
+
+## 5. Resolution Semantics
+
+`skills add <name>[@version]` resolves by:
+
+1. Parsing the handle into name plus optional exact version.
+2. Building the registry list from config and any `--registry` override.
+3. Searching registries in order.
+4. Selecting the exact version if specified.
+5. Selecting the highest semantic version if no version is specified.
+6. Fetching the bundle into a staging directory.
+7. Validating manifest, files, digest, and signature.
+8. Moving the verified bundle into the immutable cache path.
+9. Updating the installed index atomically.
+
+If multiple registries contain the same name/version, the first registry in
+resolution order wins. If a selected version is already installed with the same
+digest, the operation is idempotent. If the same name/version is installed with
+a different digest, the command fails and tells the user to remove the existing
+version first.
+
+## 6. Verification Semantics
+
+Verification has three layers.
+
+### 6.1 Manifest validation
+
+The manifest must have required fields, a valid package name, semantic version,
+a relative entry path, and declared files that stay under the bundle root.
+Glob-like file patterns are expanded deterministically and sorted
+lexicographically. Empty file expansions are errors because a manifest that
+claims a file but packages nothing is not reproducible.
+
+### 6.2 Content digest
+
+Core computes a SHA-256 digest over declared files using a canonical byte stream:
+
+```text
+agentenv-skill-v1
+<relative-path>\0
+<file-size-decimal>\0
+<file-bytes>
+...
+```
+
+Relative paths are normalized to `/` separators before hashing. The digest is
+rendered as `sha256:<64 lowercase hex>`, matching existing digest conventions in
+the repo.
+
+### 6.3 Signature verification
+
+The Ed25519 signature covers:
+
+```text
+agentenv-skill-signature-v1
+<canonical JSON bytes of normalized manifest without signatures>
+<content digest>
+```
+
+Registry-installed bundles must have a valid Ed25519 signature. Local
+`install --from` may install unsigned bundles only when `--allow-unsigned` is
+passed. Filesystem registry installs follow registry semantics and require
+signatures unless the command explicitly passes `--allow-unsigned`.
+
+`skills verify <name>` re-runs manifest validation, content digest computation,
+signature verification when applicable, and optional `self_test.command` if it
+is present. Self-tests execute with the bundle root as the current directory and
+must not receive credential environment variables from core.
+
+## 7. Publish Semantics
+
+`skills publish <path> --registry <name-or-url>`:
+
+1. Loads and validates the local bundle.
+2. Computes its content digest.
+3. Requires a valid signature before publishing to HTTP or OCI registries.
+4. Allows unsigned publish only to filesystem registries when the local command
+   passes `--allow-unsigned`.
+5. Refuses to overwrite an existing name/version with a different digest.
+6. Updates the target registry index atomically where the backend supports it.
+
+For HTTP registries, publish uses validator-checked `PUT` requests. For
+filesystem registries, publish writes to a temporary directory under the target
+registry root, then renames into place. For OCI registries, publish pushes the
+OCI artifact and updates the OCI index artifact in the same registry namespace.
+
+## 8. Error Model
+
+Use `thiserror` in `agentenv-core::skills`. Errors should distinguish:
+
+1. invalid manifest
+2. invalid skill name
+3. invalid semantic version
+4. unsafe bundle path
+5. missing declared file
+6. digest mismatch
+7. missing signature
+8. invalid signature
+9. unsupported registry authentication scheme
+10. registry not found
+11. skill not found
+12. ambiguous installed version
+13. already installed with different digest
+14. index read/write failure
+15. SSRF-blocked registry URL
+16. credential reference not available
+17. self-test failure
+
+CLI messages should be concise and actionable. JSON output should expose stable
+machine fields such as `kind`, `name`, `version`, `registry`, `digest`, and
+`verified`.
+
+## 9. Testing Strategy
+
+Follow TDD for each behavior.
+
+### 9.1 Core tests
+
+Add focused tests under `crates/agentenv-core/tests/skills.rs` or inline module
+tests:
+
+1. manifest parser accepts a minimal valid manifest
+2. manifest parser rejects invalid names
+3. manifest parser rejects invalid semantic versions
+4. path validation rejects absolute paths and parent traversal
+5. file expansion is deterministic
+6. digest is stable for sorted declared files
+7. digest changes when content changes
+8. signature verification accepts a valid Ed25519 signature
+9. signature verification rejects tampered content
+10. local install writes cache files and index entries
+11. repeated install with same digest is idempotent
+12. repeated install with different digest fails
+13. remove deletes the selected installed version
+14. info errors on ambiguous installed versions
+15. verify reruns digest and signature checks
+16. filesystem registry search/add/publish works
+17. HTTP registry search/add/publish uses validated URLs
+18. unsafe HTTP registry URLs are rejected before request
+19. OCI registry search reads the index artifact
+20. OCI registry add pulls and verifies a skill artifact
+21. OCI registry publish pushes a skill artifact and updates the index artifact
+22. config precedence merges user, project, and CLI registry selection
+
+### 9.2 CLI tests
+
+Add tests under `crates/agentenv/tests/cli_behavior.rs`:
+
+1. top-level help includes `skills`
+2. `skills --help` lists every subcommand from issue #28
+3. `skills install --from <path> --allow-unsigned` installs a local bundle
+4. `skills list --json` returns installed records
+5. `skills info <name> --json` reports manifest and digest
+6. `skills remove <name> --yes` removes the installed skill
+7. `skills verify <name>` succeeds for an untampered installed skill
+8. `skills verify <name>` fails after installed content is changed
+9. `skills search <query>` reads configured filesystem registries
+10. `skills add <name>@<version>` installs from a filesystem registry
+11. `skills publish <path> --registry <filesystem-name>` updates registry
+12. `--registry` overrides project and user registry order
+13. an OCI fixture registry can search, add, and publish through local HTTP
+
+### 9.3 Required verification commands
+
+Run at minimum:
+
+```bash
+cargo fmt
+cargo clippy --workspace --all-targets -- -D warnings
+cargo test --workspace
+```
+
+## 10. Rollout and PR Notes
+
+The PR description should list affected crates: `agentenv` and
+`agentenv-core`. It should call out that no driver protocol schema changes were
+made. It should also explicitly note that OCI support is implemented directly
+through the OCI Distribution API and does not add external runtime dependencies.
+
+The PR should reference issue #28 and mention that issue #27 is already
+completed by the architecture decision in `docs/ARCHITECTURE.md`.


### PR DESCRIPTION
Closes #28.

## Summary
- Add the `agentenv skills` lifecycle surface: search, add, install, list, info, remove, publish, and verify.
- Add core skill manifest validation, deterministic content digests, Ed25519 signature verification, installed cache/index handling, and self-test verification.
- Add configurable filesystem, HTTP, and OCI skill registries with CLI > project > user config precedence, credential lookup, and SSRF-gated network access.
- Stabilize CLI integration tests so the default workspace test command does not depend on host approval-server or Docker/OrbStack timing.

## Affected crates
- `agentenv`
- `agentenv-core`

## Validation
- `cargo fmt --check`
- `cargo clippy --workspace --all-targets -- -D warnings`
- `cargo test --workspace`
- `git diff --check`
