### PR TITLE
[codex] implement snapshot-fork primitive

### DIFF
--- a/crates/agentenv-core/src/driver.rs
+++ b/crates/agentenv-core/src/driver.rs
@@ -8,7 +8,8 @@ use agentenv_proto::{
     McpConfigPathParams, McpConfigPathResult, McpEndpoint, PreflightParams, PreflightResult,
     RenderEntrypointResult, RenderMcpConfigParams, RenderMcpConfigResult,
     RequiredNetworkRulesResult, SandboxHandle, SandboxSpec, SandboxStatus, SandboxStatusParams,
-    SchemaVersionError, SessionHandle, ShellHandle, ShutdownParams, StopParams,
+    SchemaVersionError, SessionHandle, ShellHandle, ShutdownParams, SnapshotId, SnapshotParams,
+    StopParams,
 };
 use async_trait::async_trait;
 use std::{fmt, time::Duration};
@@ -84,6 +85,18 @@ pub fn require_capability(capability: &str, supported: bool) -> DriverResult<()>
 pub fn persistent_sessions_missing() -> DriverError {
     DriverError::CapabilityMissing {
         capability: "supports_persistent_sessions".to_owned(),
+    }
+}
+
+pub fn snapshots_missing() -> DriverError {
+    DriverError::CapabilityMissing {
+        capability: "supports_snapshots".to_owned(),
+    }
+}
+
+pub fn fork_missing() -> DriverError {
+    DriverError::CapabilityMissing {
+        capability: "supports_fork".to_owned(),
     }
 }
 
@@ -195,6 +208,15 @@ pub trait SandboxDriver: Send + Sync {
     async fn initialize(&mut self, params: InitializeParams) -> DriverResult<InitializeResult>;
     async fn preflight(&self, params: PreflightParams) -> DriverResult<PreflightResult>;
     async fn create(&self, spec: SandboxSpec) -> DriverResult<SandboxHandle>;
+    async fn snapshot(&self, _params: SnapshotParams) -> DriverResult<SnapshotId> {
+        Err(snapshots_missing())
+    }
+    async fn fork_from_snapshot(
+        &self,
+        _params: agentenv_proto::ForkFromSnapshotParams,
+    ) -> DriverResult<SandboxHandle> {
+        Err(fork_missing())
+    }
     async fn connect(&self, params: ConnectParams) -> DriverResult<ShellHandle>;
     async fn create_session(&self, _params: CreateSessionParams) -> DriverResult<SessionHandle> {
         Err(persistent_sessions_missing())
@@ -404,6 +426,8 @@ mod tests {
                     supports_native_inference_routing: true,
                     supports_remote_host: false,
                     supports_persistent_sessions: false,
+                    supports_snapshots: false,
+                    supports_fork: false,
                 }),
             })
         }
@@ -502,6 +526,39 @@ mod tests {
         );
     }
 
+    #[tokio::test]
+    async fn sandbox_snapshot_methods_default_to_capability_missing() {
+        let driver = MinimalSandboxDriver;
+        let err = driver
+            .snapshot(agentenv_proto::SnapshotParams {
+                handle: "sb-1".to_owned(),
+                name: Some("before-risky-command".to_owned()),
+            })
+            .await
+            .expect_err("default snapshot implementation should reject");
+
+        assert!(
+            matches!(err, DriverError::CapabilityMissing { capability } if capability == "supports_snapshots")
+        );
+
+        let err = driver
+            .fork_from_snapshot(agentenv_proto::ForkFromSnapshotParams {
+                snapshot: agentenv_proto::SnapshotId {
+                    id: "snapshot://demo".to_owned(),
+                },
+                spec: agentenv_proto::ForkSpec {
+                    name: "experiment-1".to_owned(),
+                    metadata: Default::default(),
+                },
+            })
+            .await
+            .expect_err("default fork implementation should reject");
+
+        assert!(
+            matches!(err, DriverError::CapabilityMissing { capability } if capability == "supports_fork")
+        );
+    }
+
     #[test]
     fn compatibility_guard_rejects_mismatched_protocol_major() {
         let mismatched_protocol_version = format!(
@@ -522,6 +579,8 @@ mod tests {
                 supports_native_inference_routing: true,
                 supports_remote_host: false,
                 supports_persistent_sessions: false,
+                supports_snapshots: false,
+                supports_fork: false,
             }),
         };
 
@@ -545,6 +604,8 @@ mod tests {
                 supports_native_inference_routing: true,
                 supports_remote_host: false,
                 supports_persistent_sessions: false,
+                supports_snapshots: false,
+                supports_fork: false,
             }),
         };
 

--- a/crates/agentenv-core/src/runtime.rs
+++ b/crates/agentenv-core/src/runtime.rs
@@ -321,6 +321,8 @@ pub enum RuntimeError {
     MissingSelectedDriver { kind: &'static str, name: String },
     #[error("env `{name}` is missing required sandbox handle")]
     MissingSandboxHandle { name: String },
+    #[error("sandbox handle `{handle}` was not found in the env registry")]
+    SandboxHandleNotFound { handle: String },
     #[error("state name `{actual}` does not match env `{expected}`")]
     StateNameMismatch { expected: String, actual: String },
     #[error("frozen lockfile {role} driver pin `{actual_name}` version `{actual_version}` does not match persisted env state `{expected_name}` version `{expected_version}`")]
@@ -339,6 +341,15 @@ pub type RuntimeResult<T> = Result<T, RuntimeError>;
 pub struct CreateResult {
     pub admission: crate::admission::AdmissionReport,
     pub state: crate::env::EnvStateFile,
+    pub state_path: PathBuf,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct ForkEnvResult {
+    pub source: String,
+    pub name: String,
+    pub snapshot_id: String,
+    pub sandbox_handle: String,
     pub state_path: PathBuf,
 }
 
@@ -1518,6 +1529,95 @@ pub fn describe_env(options: &RuntimeOptions, name: &str) -> RuntimeResult<EnvDe
         blueprint_yaml,
         lock_yaml,
     })
+}
+
+fn describe_env_for_fork_source(
+    options: &RuntimeOptions,
+    source: &str,
+) -> RuntimeResult<EnvDescription> {
+    let mut valid_env_not_found = None;
+    if crate::env::validate_env_name(source).is_ok() {
+        match describe_env(options, source) {
+            Ok(description) => return Ok(description),
+            Err(RuntimeError::Env(crate::env::EnvError::NotFound { name })) => {
+                valid_env_not_found = Some(name);
+            }
+            Err(err) => return Err(err),
+        }
+    }
+
+    if let Some(description) = describe_env_by_sandbox_handle(options, source)? {
+        return Ok(description);
+    }
+
+    match valid_env_not_found {
+        Some(name) => Err(crate::env::EnvError::NotFound { name }.into()),
+        None => Err(RuntimeError::SandboxHandleNotFound {
+            handle: source.to_owned(),
+        }),
+    }
+}
+
+fn describe_env_by_sandbox_handle(
+    options: &RuntimeOptions,
+    handle: &str,
+) -> RuntimeResult<Option<EnvDescription>> {
+    let envs_dir = options.root.join("envs");
+    if !envs_dir.is_dir() {
+        return Ok(None);
+    }
+
+    for entry in fs::read_dir(&envs_dir).map_err(|source| crate::env::EnvError::Io {
+        path: envs_dir.clone(),
+        source,
+    })? {
+        let entry = entry.map_err(|source| crate::env::EnvError::Io {
+            path: envs_dir.clone(),
+            source,
+        })?;
+        let file_type = entry
+            .file_type()
+            .map_err(|source| crate::env::EnvError::Io {
+                path: entry.path(),
+                source,
+            })?;
+        if !file_type.is_dir() {
+            continue;
+        }
+        let Some(name) = entry.file_name().to_str().map(str::to_owned) else {
+            continue;
+        };
+        let Ok(env_name) = crate::env::validate_env_name(&name) else {
+            continue;
+        };
+        let paths = crate::env::EnvPaths::new(options.root.clone(), env_name);
+        let state = crate::env::read_state(&paths)?;
+        if state.name != name {
+            return Err(RuntimeError::StateNameMismatch {
+                expected: name,
+                actual: state.name,
+            });
+        }
+        if state.handles.sandbox.as_deref() == Some(handle) {
+            return describe_env(options, &name).map(Some);
+        }
+    }
+
+    Ok(None)
+}
+
+fn write_env_registry_file(content: &str, path: &Path) -> RuntimeResult<()> {
+    if let Some(parent) = path.parent() {
+        fs::create_dir_all(parent).map_err(|source| crate::env::EnvError::Io {
+            path: parent.to_path_buf(),
+            source,
+        })?;
+    }
+    fs::write(path, content).map_err(|source| crate::env::EnvError::Io {
+        path: path.to_path_buf(),
+        source,
+    })?;
+    Ok(())
 }
 
 pub fn freeze_env_lockfile(options: &RuntimeOptions, name: &str) -> RuntimeResult<String> {
@@ -3184,6 +3284,135 @@ pub async fn start_logs_stream_env(
     Ok(RunningLogStream { _set: set })
 }
 
+pub async fn fork_env(
+    options: &RuntimeOptions,
+    factory: &dyn DriverFactory,
+    source: &str,
+    name: &str,
+) -> RuntimeResult<ForkEnvResult> {
+    let target_env_name = crate::env::validate_env_name(name)?;
+    let target_paths = crate::env::EnvPaths::new(options.root.clone(), target_env_name.clone());
+    let target_env_dir = target_paths.env_dir();
+    if target_env_dir.exists() {
+        return Err(crate::env::EnvError::AlreadyExists {
+            name: name.to_owned(),
+        }
+        .into());
+    }
+
+    let source_description = describe_env_for_fork_source(options, source)?;
+    let source_env = source_description.state.name.clone();
+    let source_state = source_description.state;
+    let source_handle = required_sandbox_handle(&source_state, &source_env)?;
+    let selection = selection_from_state(&source_state);
+    let mut set = factory.build(&selection)?;
+    let init = initialize_sandbox_driver(options, set.sandbox.as_mut()).await?;
+    crate::driver::require_capability(
+        "supports_snapshots",
+        supports_snapshots(&init.capabilities),
+    )?;
+    crate::driver::require_capability("supports_fork", supports_fork(&init.capabilities))?;
+
+    let snapshot = set
+        .sandbox
+        .snapshot(agentenv_proto::SnapshotParams {
+            handle: source_handle,
+            name: Some(name.to_owned()),
+        })
+        .await?;
+    let forked = set
+        .sandbox
+        .fork_from_snapshot(agentenv_proto::ForkFromSnapshotParams {
+            snapshot: snapshot.clone(),
+            spec: agentenv_proto::ForkSpec {
+                name: name.to_owned(),
+                metadata: BTreeMap::new(),
+            },
+        })
+        .await?;
+    let forked_handle = forked.handle.clone();
+
+    let temp_workspace = create_temp_workspace(&options.root, target_env_name.as_str());
+    let temp_paths = crate::env::EnvPaths::new(temp_workspace.clone(), target_env_name);
+    let result = (|| -> RuntimeResult<ForkEnvResult> {
+        fs::create_dir_all(temp_paths.env_dir()).map_err(|source| crate::env::EnvError::Io {
+            path: temp_paths.env_dir(),
+            source,
+        })?;
+        write_env_registry_file(
+            &source_description.blueprint_yaml,
+            &temp_paths.blueprint_path(),
+        )?;
+        write_env_registry_file(&source_description.lock_yaml, &temp_paths.lock_path())?;
+
+        let now = now_utc_string();
+        let mut target_state = source_state;
+        target_state.name = name.to_owned();
+        target_state.phase = crate::env::EnvPhase::Running;
+        target_state.created_at = now.clone();
+        target_state.updated_at = now;
+        target_state.handles.sandbox = Some(forked_handle.clone());
+        target_state.handles.context = None;
+        target_state.handles.inference = None;
+        target_state.health.clear();
+        target_state.first_enter_hint_shown = false;
+        crate::env::write_state(&temp_paths, &target_state)?;
+        crate::env::append_event(
+            &temp_paths,
+            serde_json::json!({
+                "kind": "admission",
+                "status": "accepted",
+                "reason_code": crate::admission::ReasonCode::Created.as_str(),
+                "env": name,
+                "source_env": source_env.clone(),
+                "snapshot": snapshot.id.clone(),
+            }),
+        )?;
+
+        fs::create_dir_all(target_paths.envs_dir()).map_err(|source| crate::env::EnvError::Io {
+            path: target_paths.envs_dir(),
+            source,
+        })?;
+        if target_env_dir.exists() {
+            return Err(crate::env::EnvError::AlreadyExists {
+                name: name.to_owned(),
+            }
+            .into());
+        }
+        fs::rename(temp_paths.env_dir(), &target_env_dir).map_err(|source| {
+            if source.kind() == std::io::ErrorKind::AlreadyExists {
+                crate::env::EnvError::AlreadyExists {
+                    name: name.to_owned(),
+                }
+            } else {
+                crate::env::EnvError::Io {
+                    path: target_env_dir.clone(),
+                    source,
+                }
+            }
+        })?;
+
+        Ok(ForkEnvResult {
+            source: source_env,
+            name: name.to_owned(),
+            snapshot_id: snapshot.id,
+            sandbox_handle: forked_handle.clone(),
+            state_path: target_paths.state_path(),
+        })
+    })();
+
+    let _ = fs::remove_dir_all(&temp_workspace);
+    if result.is_err() {
+        let _ = set
+            .sandbox
+            .destroy(agentenv_proto::DestroyParams {
+                handle: forked_handle,
+            })
+            .await;
+    }
+    result
+}
+
 pub async fn destroy_env(
     options: &RuntimeOptions,
     factory: &dyn DriverFactory,
@@ -3371,6 +3600,26 @@ fn supports_hot_reload_policy(capabilities: &Capabilities) -> bool {
         capabilities,
         Capabilities::Sandbox(agentenv_proto::SandboxCapabilities {
             supports_hot_reload_policy: true,
+            ..
+        })
+    )
+}
+
+fn supports_snapshots(capabilities: &Capabilities) -> bool {
+    matches!(
+        capabilities,
+        Capabilities::Sandbox(agentenv_proto::SandboxCapabilities {
+            supports_snapshots: true,
+            ..
+        })
+    )
+}
+
+fn supports_fork(capabilities: &Capabilities) -> bool {
+    matches!(
+        capabilities,
+        Capabilities::Sandbox(agentenv_proto::SandboxCapabilities {
+            supports_fork: true,
             ..
         })
     )
@@ -4231,7 +4480,8 @@ fn runtime_error_reason_code(error: &RuntimeError) -> &'static str {
         RuntimeError::Env(EnvError::AlreadyExists { .. }) => {
             crate::admission::ReasonCode::EnvExists.as_str()
         }
-        RuntimeError::Env(EnvError::NotFound { .. }) => {
+        RuntimeError::Env(EnvError::NotFound { .. })
+        | RuntimeError::SandboxHandleNotFound { .. } => {
             crate::admission::ReasonCode::EnvNotFound.as_str()
         }
         RuntimeError::Env(EnvError::InvalidName { .. })
@@ -4634,6 +4884,94 @@ policy:
 state:
   persist_home: true
 "#
+    }
+
+    #[tokio::test]
+    async fn fork_env_persists_forked_sandbox_state() {
+        let root = unique_root("fork-env");
+        let options = RuntimeOptions {
+            root: root.clone(),
+            log_level: LogLevel::Info,
+            non_interactive: true,
+        };
+        let source_paths =
+            crate::env::EnvPaths::new(root.clone(), crate::env::validate_env_name("demo").unwrap());
+        fs::create_dir_all(source_paths.env_dir()).unwrap();
+        fs::write(
+            source_paths.blueprint_path(),
+            "sandbox:\n  driver: microvm\n",
+        )
+        .unwrap();
+        fs::write(source_paths.lock_path(), "drivers: {}\n").unwrap();
+        fs::write(source_paths.events_path(), "").unwrap();
+
+        let mut state = state_fixture("demo")
+            .with_sandbox_handle("microvm://firecracker/demo?workdir=/tmp/demo");
+        state.drivers.sandbox = crate::env::DriverRecord::new("microvm", "0.0.1-alpha0");
+        state.handles.context = Some("ctx-source".to_owned());
+        state.endpoints.context_mcp = Some(crate::env::PersistedMcpEndpoint {
+            url: "stdio://filesystem".to_owned(),
+            transport: agentenv_proto::McpTransport::Stdio,
+        });
+        write_state_json(&source_paths.env_dir(), state);
+
+        let calls = Arc::new(Mutex::new(ForkCalls::default()));
+        let factory = ForkingFactory {
+            calls: Arc::clone(&calls),
+            supports_snapshots: true,
+            supports_fork: true,
+        };
+
+        let result = super::fork_env(&options, &factory, "demo", "experiment")
+            .await
+            .expect("fork should succeed");
+
+        assert_eq!(result.source, "demo");
+        assert_eq!(result.name, "experiment");
+        assert!(result.state_path.ends_with("envs/experiment/state.json"));
+
+        let calls = calls.lock().unwrap();
+        assert_eq!(
+            calls.snapshot_handle.as_deref(),
+            Some("microvm://firecracker/demo?workdir=/tmp/demo")
+        );
+        assert_eq!(calls.snapshot_name.as_deref(), Some("experiment"));
+        assert_eq!(
+            calls.fork_snapshot_id.as_deref(),
+            Some("microvm-snapshot://demo/base")
+        );
+        assert_eq!(calls.fork_name.as_deref(), Some("experiment"));
+
+        let target_paths = crate::env::EnvPaths::new(
+            root.clone(),
+            crate::env::validate_env_name("experiment").unwrap(),
+        );
+        let target = crate::env::read_state(&target_paths).unwrap();
+        assert_eq!(target.name, "experiment");
+        assert_eq!(target.phase, crate::env::EnvPhase::Running);
+        assert_eq!(
+            target.handles.sandbox.as_deref(),
+            Some("microvm://firecracker/experiment")
+        );
+        assert_eq!(target.handles.context, None);
+        assert_eq!(target.handles.inference, None);
+        assert_eq!(
+            target
+                .endpoints
+                .context_mcp
+                .as_ref()
+                .map(|endpoint| &endpoint.url),
+            Some(&"stdio://filesystem".to_owned())
+        );
+        assert_eq!(
+            fs::read_to_string(target_paths.blueprint_path()).unwrap(),
+            "sandbox:\n  driver: microvm\n"
+        );
+        assert_eq!(
+            fs::read_to_string(target_paths.lock_path()).unwrap(),
+            "drivers: {}\n"
+        );
+        assert!(target_paths.events_path().is_file());
     }
 
     fn snapshot_credential_blueprint_yaml() -> &'static str {
@@ -5938,6 +6276,41 @@ policy:
         kill_called: Arc<AtomicBool>,
     }
 
+    #[derive(Default)]
+    struct ForkCalls {
+        snapshot_handle: Option<String>,
+        snapshot_name: Option<String>,
+        fork_snapshot_id: Option<String>,
+        fork_name: Option<String>,
+    }
+
+    struct ForkingSandboxDriver {
+        calls: Arc<Mutex<ForkCalls>>,
+        supports_snapshots: bool,
+        supports_fork: bool,
+    }
+
+    struct ForkingFactory {
+        calls: Arc<Mutex<ForkCalls>>,
+        supports_snapshots: bool,
+        supports_fork: bool,
+    }
+
+    impl DriverFactory for ForkingFactory {
+        fn build(&self, _selection: &super::DriverSelection) -> super::RuntimeResult<DriverSet> {
+            Ok(DriverSet {
+                sandbox: Box::new(ForkingSandboxDriver {
+                    calls: Arc::clone(&self.calls),
+                    supports_snapshots: self.supports_snapshots,
+                    supports_fork: self.supports_fork,
+                }),
+                agent: Box::new(super::tests_support::TinyAgentDriver),
+                context: Box::new(TinyContextDriver),
+                inference: None,
+            })
+        }
+    }
+
     #[async_trait]
     impl SandboxDriver for TinySandboxDriver {
         async fn initialize(&mut self, params: InitializeParams) -> DriverResult<InitializeResult> {
@@ -5956,6 +6329,8 @@ policy:
                     supports_native_inference_routing: true,
                     supports_remote_host: false,
                     supports_persistent_sessions: false,
+                    supports_snapshots: false,
+                    supports_fork: false,
                 }),
             })
         }
@@ -6049,6 +6424,149 @@ policy:
         ) -> DriverResult<EmptyResult> {
             Ok(EmptyResult {})
         }
+        async fn shutdown(
+            &mut self,
+            _params: agentenv_proto::ShutdownParams,
+        ) -> DriverResult<EmptyResult> {
+            Ok(EmptyResult {})
+        }
+    }
+
+    #[async_trait]
+    impl SandboxDriver for ForkingSandboxDriver {
+        async fn initialize(&mut self, params: InitializeParams) -> DriverResult<InitializeResult> {
+            assert_eq!(params.schema_version, SCHEMA_VERSION);
+            Ok(InitializeResult {
+                driver: DriverInfo {
+                    name: "microvm".to_owned(),
+                    kind: DriverKind::Sandbox,
+                    version: "0.0.1-alpha0".to_owned(),
+                    protocol_version: SCHEMA_VERSION.to_owned(),
+                },
+                capabilities: Capabilities::Sandbox(SandboxCapabilities {
+                    supports_hot_reload_policy: false,
+                    supports_filesystem_lockdown: true,
+                    supports_syscall_filter: true,
+                    supports_native_inference_routing: false,
+                    supports_remote_host: false,
+                    supports_persistent_sessions: false,
+                    supports_snapshots: self.supports_snapshots,
+                    supports_fork: self.supports_fork,
+                }),
+            })
+        }
+
+        async fn preflight(&self, _params: PreflightParams) -> DriverResult<PreflightResult> {
+            Ok(PreflightResult {
+                ok: true,
+                issues: Vec::new(),
+            })
+        }
+
+        async fn create(
+            &self,
+            _spec: agentenv_proto::SandboxSpec,
+        ) -> DriverResult<agentenv_proto::SandboxHandle> {
+            unreachable!("fork_env should not cold-create a sandbox")
+        }
+
+        async fn snapshot(
+            &self,
+            params: agentenv_proto::SnapshotParams,
+        ) -> DriverResult<agentenv_proto::SnapshotId> {
+            let mut calls = self.calls.lock().unwrap();
+            calls.snapshot_handle = Some(params.handle);
+            calls.snapshot_name = params.name;
+            Ok(agentenv_proto::SnapshotId {
+                id: "microvm-snapshot://demo/base".to_owned(),
+            })
+        }
+
+        async fn fork_from_snapshot(
+            &self,
+            params: agentenv_proto::ForkFromSnapshotParams,
+        ) -> DriverResult<agentenv_proto::SandboxHandle> {
+            let mut calls = self.calls.lock().unwrap();
+            calls.fork_snapshot_id = Some(params.snapshot.id);
+            calls.fork_name = Some(params.spec.name);
+            Ok(agentenv_proto::SandboxHandle {
+                handle: "microvm://firecracker/experiment".to_owned(),
+            })
+        }
+
+        async fn connect(
+            &self,
+            _params: agentenv_proto::ConnectParams,
+        ) -> DriverResult<agentenv_proto::ShellHandle> {
+            unreachable!("fork_env should not connect")
+        }
+
+        async fn exec(
+            &self,
+            _params: agentenv_proto::ExecParams,
+        ) -> DriverResult<agentenv_proto::ExecResult> {
+            unreachable!("fork_env should not exec")
+        }
+
+        async fn copy_in(
+            &self,
+            _params: agentenv_proto::CopyInParams,
+        ) -> DriverResult<EmptyResult> {
+            unreachable!("fork_env should not copy into the sandbox")
+        }
+
+        async fn copy_out(
+            &self,
+            _params: agentenv_proto::CopyOutParams,
+        ) -> DriverResult<EmptyResult> {
+            unreachable!("fork_env should not copy out of the sandbox")
+        }
+
+        async fn apply_policy(
+            &self,
+            _params: agentenv_proto::ApplyPolicyParams,
+        ) -> DriverResult<agentenv_proto::ApplyPolicyResult> {
+            unreachable!("fork_env should not apply policy")
+        }
+
+        async fn status(
+            &self,
+            _params: agentenv_proto::SandboxStatusParams,
+        ) -> DriverResult<agentenv_proto::SandboxStatus> {
+            Ok(agentenv_proto::SandboxStatus {
+                phase: agentenv_proto::SandboxPhase::Running,
+                healthy: true,
+                last_ping: None,
+            })
+        }
+
+        async fn logs(
+            &self,
+            _params: agentenv_proto::LogsParams,
+        ) -> DriverResult<agentenv_proto::LogsResult> {
+            Ok(agentenv_proto::LogsResult {
+                entries: Vec::new(),
+            })
+        }
+
+        async fn logs_stream(
+            &self,
+            _params: agentenv_proto::LogsStreamParams,
+        ) -> DriverResult<EmptyResult> {
+            Ok(EmptyResult {})
+        }
+
+        async fn stop(&self, _params: agentenv_proto::StopParams) -> DriverResult<EmptyResult> {
+            Ok(EmptyResult {})
+        }
+
+        async fn destroy(
+            &self,
+            _params: agentenv_proto::DestroyParams,
+        ) -> DriverResult<EmptyResult> {
+            Ok(EmptyResult {})
+        }
+
         async fn shutdown(
             &mut self,
             _params: agentenv_proto::ShutdownParams,
@@ -6363,6 +6881,8 @@ policy:
                     supports_native_inference_routing: true,
                     supports_remote_host: false,
                     supports_persistent_sessions: false,
+                    supports_snapshots: false,
+                    supports_fork: false,
                 }),
             })
         }
@@ -6827,6 +7347,8 @@ policy:
                     supports_native_inference_routing: true,
                     supports_remote_host: false,
                     supports_persistent_sessions: false,
+                    supports_snapshots: false,
+                    supports_fork: false,
                 }),
             })
         }
@@ -10325,6 +10847,8 @@ policy:
                     supports_native_inference_routing: true,
                     supports_remote_host: false,
                     supports_persistent_sessions: false,
+                    supports_snapshots: false,
+                    supports_fork: false,
                 }),
             ),
         };

--- a/crates/agentenv-proto/build.rs
+++ b/crates/agentenv-proto/build.rs
@@ -26,6 +26,10 @@ fn main() {
     write_schema::<types::McpEndpoint>(&schema_dir, "mcp-endpoint");
     write_schema::<types::SandboxSpec>(&schema_dir, "sandbox-spec");
     write_schema::<types::SandboxHandle>(&schema_dir, "sandbox-handle");
+    write_schema::<types::SnapshotParams>(&schema_dir, "snapshot-params");
+    write_schema::<types::SnapshotId>(&schema_dir, "snapshot-id");
+    write_schema::<types::ForkSpec>(&schema_dir, "fork-spec");
+    write_schema::<types::ForkFromSnapshotParams>(&schema_dir, "fork-from-snapshot-params");
     write_schema::<types::ConnectParams>(&schema_dir, "connect-params");
     write_schema::<types::ShellHandle>(&schema_dir, "shell-handle");
     write_schema::<types::CreateSessionParams>(&schema_dir, "create-session-params");

--- a/crates/agentenv-proto/schema/capabilities.json
+++ b/crates/agentenv-proto/schema/capabilities.json
@@ -90,6 +90,10 @@
         "supports_filesystem_lockdown": {
           "type": "boolean"
         },
+        "supports_fork": {
+          "default": false,
+          "type": "boolean"
+        },
         "supports_hot_reload_policy": {
           "type": "boolean"
         },
@@ -101,6 +105,10 @@
           "type": "boolean"
         },
         "supports_remote_host": {
+          "type": "boolean"
+        },
+        "supports_snapshots": {
+          "default": false,
           "type": "boolean"
         },
         "supports_syscall_filter": {

--- a/crates/agentenv-proto/schema/fork-from-snapshot-params.json
+++ b/crates/agentenv-proto/schema/fork-from-snapshot-params.json
@@ -1,0 +1,45 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "title": "ForkFromSnapshotParams",
+  "type": "object",
+  "required": [
+    "snapshot",
+    "spec"
+  ],
+  "properties": {
+    "snapshot": {
+      "$ref": "#/definitions/SnapshotId"
+    },
+    "spec": {
+      "$ref": "#/definitions/ForkSpec"
+    }
+  },
+  "definitions": {
+    "ForkSpec": {
+      "type": "object",
+      "required": [
+        "name"
+      ],
+      "properties": {
+        "metadata": {
+          "type": "object",
+          "additionalProperties": true
+        },
+        "name": {
+          "type": "string"
+        }
+      }
+    },
+    "SnapshotId": {
+      "type": "object",
+      "required": [
+        "id"
+      ],
+      "properties": {
+        "id": {
+          "type": "string"
+        }
+      }
+    }
+  }
+}

--- a/crates/agentenv-proto/schema/fork-spec.json
+++ b/crates/agentenv-proto/schema/fork-spec.json
@@ -1,0 +1,17 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "title": "ForkSpec",
+  "type": "object",
+  "required": [
+    "name"
+  ],
+  "properties": {
+    "metadata": {
+      "type": "object",
+      "additionalProperties": true
+    },
+    "name": {
+      "type": "string"
+    }
+  }
+}

--- a/crates/agentenv-proto/schema/initialize-result.json
+++ b/crates/agentenv-proto/schema/initialize-result.json
@@ -137,6 +137,10 @@
         "supports_filesystem_lockdown": {
           "type": "boolean"
         },
+        "supports_fork": {
+          "default": false,
+          "type": "boolean"
+        },
         "supports_hot_reload_policy": {
           "type": "boolean"
         },
@@ -148,6 +152,10 @@
           "type": "boolean"
         },
         "supports_remote_host": {
+          "type": "boolean"
+        },
+        "supports_snapshots": {
+          "default": false,
           "type": "boolean"
         },
         "supports_syscall_filter": {

--- a/crates/agentenv-proto/schema/snapshot-id.json
+++ b/crates/agentenv-proto/schema/snapshot-id.json
@@ -1,0 +1,13 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "title": "SnapshotId",
+  "type": "object",
+  "required": [
+    "id"
+  ],
+  "properties": {
+    "id": {
+      "type": "string"
+    }
+  }
+}

--- a/crates/agentenv-proto/schema/snapshot-params.json
+++ b/crates/agentenv-proto/schema/snapshot-params.json
@@ -1,0 +1,19 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "title": "SnapshotParams",
+  "type": "object",
+  "required": [
+    "handle"
+  ],
+  "properties": {
+    "handle": {
+      "type": "string"
+    },
+    "name": {
+      "type": [
+        "string",
+        "null"
+      ]
+    }
+  }
+}

--- a/crates/agentenv-proto/src/lib.rs
+++ b/crates/agentenv-proto/src/lib.rs
@@ -44,8 +44,8 @@ mod tests {
     }
 
     #[test]
-    fn schema_version_is_1_1() {
-        assert_eq!(SCHEMA_VERSION, "1.1");
+    fn schema_version_is_1_2() {
+        assert_eq!(SCHEMA_VERSION, "1.2");
     }
 
     #[test]
@@ -90,7 +90,7 @@ mod tests {
     }
 
     #[test]
-    fn sandbox_capabilities_default_missing_persistent_sessions_to_false() {
+    fn sandbox_capabilities_default_missing_optional_flags_to_false() {
         let capabilities: SandboxCapabilities = serde_json::from_value(serde_json::json!({
             "supports_hot_reload_policy": true,
             "supports_filesystem_lockdown": true,
@@ -101,6 +101,8 @@ mod tests {
         .expect("legacy sandbox capabilities should deserialize");
 
         assert!(!capabilities.supports_persistent_sessions);
+        assert!(!capabilities.supports_snapshots);
+        assert!(!capabilities.supports_fork);
     }
 
     #[test]

--- a/crates/agentenv-proto/src/schema_version.rs
+++ b/crates/agentenv-proto/src/schema_version.rs
@@ -2,7 +2,7 @@ use schemars::JsonSchema;
 use serde::{Deserialize, Serialize};
 use thiserror::Error;
 
-pub const SCHEMA_VERSION: &str = "1.1";
+pub const SCHEMA_VERSION: &str = "1.2";
 
 #[derive(Debug, Clone, Error, Serialize, Deserialize, JsonSchema, PartialEq, Eq)]
 #[serde(tag = "kind", rename_all = "snake_case")]

--- a/crates/agentenv-proto/src/types.rs
+++ b/crates/agentenv-proto/src/types.rs
@@ -152,6 +152,10 @@ pub struct SandboxCapabilities {
     pub supports_remote_host: bool,
     #[serde(default)]
     pub supports_persistent_sessions: bool,
+    #[serde(default)]
+    pub supports_snapshots: bool,
+    #[serde(default)]
+    pub supports_fork: bool,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize, JsonSchema, PartialEq, Eq)]
@@ -377,6 +381,31 @@ pub struct SandboxSpec {
 #[derive(Debug, Clone, Serialize, Deserialize, JsonSchema, PartialEq, Eq)]
 pub struct SandboxHandle {
     pub handle: String,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, JsonSchema, PartialEq, Eq)]
+pub struct SnapshotParams {
+    pub handle: String,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub name: Option<String>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, JsonSchema, PartialEq, Eq)]
+pub struct SnapshotId {
+    pub id: String,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, JsonSchema, PartialEq)]
+pub struct ForkSpec {
+    pub name: String,
+    #[serde(default, skip_serializing_if = "BTreeMap::is_empty")]
+    pub metadata: BTreeMap<String, Value>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, JsonSchema, PartialEq)]
+pub struct ForkFromSnapshotParams {
+    pub snapshot: SnapshotId,
+    pub spec: ForkSpec,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize, JsonSchema, PartialEq, Eq)]

--- a/crates/agentenv/src/main.rs
+++ b/crates/agentenv/src/main.rs
@@ -73,6 +73,7 @@ enum Commands {
     Approvals(ApprovalsArgs),
     Term(TermArgs),
     Snapshot(SnapshotArgs),
+    Fork(ForkArgs),
     Exec(ExecArgs),
     Blueprint(BlueprintArgs),
     Credentials(CredentialsArgs),
@@ -468,6 +469,14 @@ struct SnapshotRestoreCliArgs {
 }
 
 #[derive(Debug, Args)]
+struct ForkArgs {
+    #[arg(value_name = "SOURCE")]
+    source: String,
+    #[arg(long, value_name = "NEW_ENV")]
+    name: String,
+}
+
+#[derive(Debug, Args)]
 struct BlueprintArgs {
     #[command(subcommand)]
     command: BlueprintCommand,
@@ -571,6 +580,7 @@ async fn run() -> Result<()> {
         Some(Commands::Metrics(args)) => run_metrics(args).await,
         Some(Commands::Approvals(args)) => run_approvals(args, &cli.events_sink).await,
         Some(Commands::Snapshot(args)) => run_snapshot(args).await,
+        Some(Commands::Fork(args)) => run_fork(args).await,
         Some(Commands::Exec(args)) => run_exec(args, &cli.events_sink).await,
         Some(Commands::Term(args)) => run_term(args).await,
         Some(Commands::Blueprint(command)) => run_blueprint(command),
@@ -2431,6 +2441,25 @@ async fn run_snapshot_restore(args: SnapshotRestoreCliArgs) -> Result<()> {
     Ok(())
 }
 
+async fn run_fork(args: ForkArgs) -> Result<()> {
+    let options = runtime_options(true)?;
+    let result = agentenv_core::runtime::fork_env(
+        &options,
+        &builtin_factory::BuiltInDriverFactory,
+        &args.source,
+        &args.name,
+    )
+    .await?;
+
+    println!(
+        "Environment `{}` forked from `{}`",
+        result.name, result.source
+    );
+    println!("snapshot: {}", result.snapshot_id);
+    println!("sandbox: {}", result.sandbox_handle);
+    Ok(())
+}
+
 fn reject_snapshot_stdout_output(output: &Path) -> Result<()> {
     if output == Path::new("-") {
         bail!("--output - is not supported for snapshots; choose a directory path");
@@ -3850,6 +3879,7 @@ mod tests {
                 "approvals".to_string(),
                 "term".to_string(),
                 "snapshot".to_string(),
+                "fork".to_string(),
                 "exec".to_string(),
                 "blueprint".to_string(),
                 "credentials".to_string(),

--- a/crates/agentenv/src/render.rs
+++ b/crates/agentenv/src/render.rs
@@ -38,7 +38,8 @@ pub fn print_error_body_json(reason_code: ReasonCode, message: impl Into<String>
 
 pub fn reason_for_error(error: &RuntimeError) -> ReasonCode {
     match error {
-        RuntimeError::Env(EnvError::NotFound { .. }) => ReasonCode::EnvNotFound,
+        RuntimeError::Env(EnvError::NotFound { .. })
+        | RuntimeError::SandboxHandleNotFound { .. } => ReasonCode::EnvNotFound,
         RuntimeError::Env(EnvError::AlreadyExists { .. }) => ReasonCode::EnvExists,
         RuntimeError::Env(EnvError::InvalidName { .. }) => ReasonCode::InvalidBlueprint,
         RuntimeError::MissingCredential { .. } => ReasonCode::MissingCredential,

--- a/crates/agentenv/tests/cli_behavior.rs
+++ b/crates/agentenv/tests/cli_behavior.rs
@@ -58,6 +58,143 @@ fn freeze_persisted_env_writes_default_lockfile() {
 }
 
 #[test]
+fn fork_reports_capability_missing_for_openshell() {
+    let temp_dir = make_temp_dir("fork-openshell-unsupported");
+    let env_dir = write_minimal_env_state(&temp_dir, "demo");
+    let state_path = env_dir.join("state.json");
+    let mut state: serde_json::Value =
+        serde_json::from_str(&fs::read_to_string(&state_path).unwrap()).unwrap();
+    state["handles"]["sandbox"] = serde_json::Value::String("openshell://demo".to_owned());
+    fs::write(&state_path, serde_json::to_string_pretty(&state).unwrap()).unwrap();
+
+    let output = Command::new(agentenv_bin())
+        .arg("fork")
+        .arg("demo")
+        .arg("--name")
+        .arg("experiment")
+        .env("HOME", &temp_dir)
+        .current_dir(&temp_dir)
+        .output()
+        .unwrap();
+
+    assert!(!output.status.success());
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    assert!(
+        stderr.contains("supports_snapshots"),
+        "stderr was: {stderr}"
+    );
+}
+
+#[cfg(unix)]
+#[test]
+fn fork_microvm_cli_clones_env_with_fake_firecracker_api() {
+    use std::os::unix::fs::PermissionsExt;
+
+    let temp_dir = PathBuf::from(format!("/tmp/ae-fc-{}", unique_suffix()));
+    fs::create_dir_all(&temp_dir).unwrap();
+    let agentenv_root = temp_dir.join(".agentenv");
+    let source_workdir = agentenv_root.join("microvm").join("demo");
+    let child_workdir = agentenv_root.join("microvm").join("experiment");
+    fs::create_dir_all(&source_workdir).unwrap();
+    fs::create_dir_all(&child_workdir).unwrap();
+    let source_api_sock = source_workdir.join("api.sock");
+    let child_api_sock = child_workdir.join("api.sock");
+    let source_server = spawn_fake_firecracker_api(&source_api_sock, 3);
+    let child_server = spawn_fake_firecracker_api(&child_api_sock, 1);
+
+    let rootfs = temp_dir.join("rootfs.ext4");
+    fs::write(&rootfs, "rootfs").unwrap();
+    let env_dir = write_minimal_env_state(&temp_dir, "demo");
+    fs::write(
+        env_dir.join("blueprint.yaml"),
+        r#"
+version: 0.1.0
+min_agentenv_version: 0.0.1-alpha0
+sandbox:
+  driver: microvm
+  runtime: firecracker
+  kernel: /var/lib/agentenv/kernel/vmlinux
+  rootfs: /var/lib/agentenv/rootfs.ext4
+agent:
+  driver: codex
+context:
+  driver: filesystem
+  mount: .
+policy:
+  tier: restricted
+  presets: []
+"#,
+    )
+    .unwrap();
+    let state_path = env_dir.join("state.json");
+    let mut state: serde_json::Value =
+        serde_json::from_str(&fs::read_to_string(&state_path).unwrap()).unwrap();
+    state["drivers"]["sandbox"]["name"] = serde_json::Value::String("microvm".to_owned());
+    let source_handle = format!(
+        "microvm://firecracker/demo?workdir={}&api_sock={}&pid_file={}&rootfs={}&tap=tap-source",
+        source_workdir.display(),
+        source_api_sock.display(),
+        source_workdir.join("firecracker.pid").display(),
+        rootfs.display(),
+    );
+    state["handles"]["sandbox"] = serde_json::Value::String(source_handle.clone());
+    fs::write(&state_path, serde_json::to_string_pretty(&state).unwrap()).unwrap();
+
+    let fake_bin = temp_dir.join("bin");
+    fs::create_dir_all(&fake_bin).unwrap();
+    let firecracker = fake_bin.join("firecracker");
+    fs::write(&firecracker, "#!/bin/sh\nexit 0\n").unwrap();
+    let mut perms = fs::metadata(&firecracker).unwrap().permissions();
+    perms.set_mode(0o755);
+    fs::set_permissions(&firecracker, perms).unwrap();
+    let original_path = std::env::var_os("PATH").unwrap_or_default();
+    let test_path = format!("{}:{}", fake_bin.display(), original_path.to_string_lossy());
+
+    let output = Command::new(agentenv_bin())
+        .arg("fork")
+        .arg(&source_handle)
+        .arg("--name")
+        .arg("experiment")
+        .env("HOME", &temp_dir)
+        .env("PATH", test_path)
+        .current_dir(&temp_dir)
+        .output()
+        .unwrap();
+
+    assert!(
+        output.status.success(),
+        "stdout was: {}\nstderr was: {}",
+        String::from_utf8_lossy(&output.stdout),
+        String::from_utf8_lossy(&output.stderr)
+    );
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    assert!(stdout.contains("Environment `experiment` forked from `demo`"));
+    assert!(stdout.contains("snapshot: microvm-snapshot://firecracker/demo/experiment"));
+
+    let target_state_path = temp_dir
+        .join(".agentenv")
+        .join("envs")
+        .join("experiment")
+        .join("state.json");
+    let target: serde_json::Value =
+        serde_json::from_str(&fs::read_to_string(target_state_path).unwrap()).unwrap();
+    assert_eq!(target["name"], "experiment");
+    let handle = target["handles"]["sandbox"].as_str().unwrap();
+    assert!(handle.starts_with("microvm://firecracker/experiment?"));
+    assert!(handle.contains("tap=tap-source"));
+    assert!(child_workdir.join("rootfs.ext4").is_file());
+
+    let source_requests = source_server.join().unwrap();
+    let child_requests = child_server.join().unwrap();
+    assert_eq!(source_requests.len(), 3);
+    assert!(source_requests[0].starts_with("PATCH /vm "));
+    assert!(source_requests[1].starts_with("PUT /snapshot/create "));
+    assert!(source_requests[2].starts_with("PATCH /vm "));
+    assert_eq!(child_requests.len(), 1);
+    assert!(child_requests[0].starts_with("PUT /snapshot/load "));
+}
+
+#[test]
 fn reproduce_portable_lockfile_reports_missing_required_credential() {
     let temp_dir = make_temp_dir("reproduce-portable-missing-credential");
     let env_dir = write_minimal_env_state_with_credentials(&temp_dir, "demo", &["OPENAI_API_KEY"]);
@@ -3158,6 +3295,72 @@ fn unique_suffix() -> String {
 
 fn write_minimal_env_state(home: &Path, name: &str) -> PathBuf {
     write_minimal_env_state_with_credentials(home, name, &[])
+}
+
+#[cfg(unix)]
+fn spawn_fake_firecracker_api(
+    path: &Path,
+    expected_requests: usize,
+) -> thread::JoinHandle<Vec<String>> {
+    use std::os::unix::net::UnixListener;
+
+    if path.exists() {
+        fs::remove_file(path).unwrap();
+    }
+    fs::create_dir_all(path.parent().unwrap()).unwrap();
+    let listener = UnixListener::bind(path).unwrap();
+    listener.set_nonblocking(true).unwrap();
+    thread::spawn(move || {
+        let mut requests = Vec::new();
+        let deadline = Instant::now() + Duration::from_secs(10);
+        while requests.len() < expected_requests && Instant::now() < deadline {
+            match listener.accept() {
+                Ok((mut stream, _)) => {
+                    let request = read_fake_firecracker_request(&mut stream);
+                    requests.push(request);
+                    stream
+                        .write_all(b"HTTP/1.1 204 No Content\r\nContent-Length: 0\r\n\r\n")
+                        .unwrap();
+                }
+                Err(err) if err.kind() == std::io::ErrorKind::WouldBlock => {
+                    thread::sleep(Duration::from_millis(10));
+                }
+                Err(err) => panic!("fake Firecracker API accept failed: {err}"),
+            }
+        }
+        requests
+    })
+}
+
+#[cfg(unix)]
+fn read_fake_firecracker_request(stream: &mut std::os::unix::net::UnixStream) -> String {
+    let mut buffer = Vec::new();
+    let mut chunk = [0_u8; 1024];
+    loop {
+        let read = stream.read(&mut chunk).unwrap();
+        if read == 0 {
+            break;
+        }
+        buffer.extend_from_slice(&chunk[..read]);
+        if fake_http_request_complete(&buffer) {
+            break;
+        }
+    }
+    String::from_utf8(buffer).unwrap()
+}
+
+#[cfg(unix)]
+fn fake_http_request_complete(buffer: &[u8]) -> bool {
+    let Some(header_end) = buffer.windows(4).position(|window| window == b"\r\n\r\n") else {
+        return false;
+    };
+    let headers = String::from_utf8_lossy(&buffer[..header_end]);
+    let content_length = headers
+        .lines()
+        .find_map(|line| line.strip_prefix("Content-Length: "))
+        .and_then(|value| value.trim().parse::<usize>().ok())
+        .unwrap_or(0);
+    buffer.len() >= header_end + 4 + content_length
 }
 
 fn write_minimal_signed_snapshot(root: &Path, source_env: &str) -> PathBuf {

--- a/crates/drivers/sandbox-microvm/README.md
+++ b/crates/drivers/sandbox-microvm/README.md
@@ -49,6 +49,24 @@ sandbox:
   ssh_user: root
 ```
 
+## Snapshot and fork
+
+The Firecracker runtime implements the schema 1.2 sandbox snapshot/fork
+primitive used by:
+
+```bash
+agentenv fork <sandbox-handle> --name experiment
+```
+
+The driver pauses the source VM, calls Firecracker's snapshot API, resumes the
+source VM, clones the rootfs with a reflink/sparse copy when the host supports
+it, starts a child Firecracker process, and loads the snapshot into the child VM.
+The fork inherits the source SSH metadata and tap name unless the caller uses
+`ForkSpec.metadata` to override them.
+
+Apple Container and Kata runtimes return explicit capability errors for
+snapshot/fork until their host-specific implementations are designed.
+
 Run live integration tests with:
 
 ```bash

--- a/crates/drivers/sandbox-microvm/src/lib.rs
+++ b/crates/drivers/sandbox-microvm/src/lib.rs
@@ -3,10 +3,11 @@
 use std::{
     collections::BTreeMap,
     fs,
-    io::{self, Write},
+    io::{self, Read, Write},
     path::{Path, PathBuf},
     process::{Command, Stdio},
     sync::{Arc, Mutex},
+    time::Duration,
 };
 
 use agentenv_core::driver::{
@@ -15,12 +16,12 @@ use agentenv_core::driver::{
 use agentenv_proto::{
     assert_compatible_schema_version, ApplyPolicyParams, ApplyPolicyResult, AttachSessionParams,
     Capabilities, ConnectParams, CopyInParams, CopyOutParams, CreateSessionParams, DestroyParams,
-    DriverInfo, DriverKind, EmptyResult, ExecParams, ExecResult, InitializeParams,
-    InitializeResult, IssueSeverity, KillSessionParams, ListSessionsParams, ListSessionsResult,
-    LogEntry, LogLevel, LogsParams, LogsResult, LogsStreamParams, NetworkPolicy, PreflightIssue,
-    PreflightParams, PreflightResult, SandboxCapabilities, SandboxHandle, SandboxPhase,
-    SandboxSpec, SandboxStatus, SandboxStatusParams, SessionHandle, ShellHandle, ShutdownParams,
-    StopParams, SCHEMA_VERSION,
+    DriverInfo, DriverKind, EmptyResult, ExecParams, ExecResult, ForkFromSnapshotParams,
+    InitializeParams, InitializeResult, IssueSeverity, KillSessionParams, ListSessionsParams,
+    ListSessionsResult, LogEntry, LogLevel, LogsParams, LogsResult, LogsStreamParams,
+    NetworkPolicy, PreflightIssue, PreflightParams, PreflightResult, SandboxCapabilities,
+    SandboxHandle, SandboxPhase, SandboxSpec, SandboxStatus, SandboxStatusParams, SessionHandle,
+    ShellHandle, ShutdownParams, SnapshotId, SnapshotParams, StopParams, SCHEMA_VERSION,
 };
 use serde::{Deserialize, Serialize};
 use serde_json::Value;
@@ -62,6 +63,81 @@ trait CommandRunner: Send + Sync {
     }
 
     fn spawn(&self, program: &str, request: &CommandRequest) -> io::Result<u32>;
+}
+
+trait FirecrackerApi: Send + Sync {
+    fn set_vm_state(&self, api_sock: &Path, state: &str) -> DriverResult<()>;
+
+    fn create_snapshot(
+        &self,
+        api_sock: &Path,
+        snapshot_path: &Path,
+        mem_file_path: &Path,
+    ) -> DriverResult<()>;
+
+    fn load_snapshot(
+        &self,
+        api_sock: &Path,
+        snapshot_path: &Path,
+        mem_file_path: &Path,
+        network_overrides: &BTreeMap<String, String>,
+        resume_vm: bool,
+    ) -> DriverResult<()>;
+}
+
+#[derive(Debug, Default)]
+struct UnixFirecrackerApi;
+
+impl FirecrackerApi for UnixFirecrackerApi {
+    fn set_vm_state(&self, api_sock: &Path, state: &str) -> DriverResult<()> {
+        firecracker_api_json(
+            api_sock,
+            "PATCH",
+            "/vm",
+            &serde_json::json!({ "state": state }),
+        )
+    }
+
+    fn create_snapshot(
+        &self,
+        api_sock: &Path,
+        snapshot_path: &Path,
+        mem_file_path: &Path,
+    ) -> DriverResult<()> {
+        firecracker_api_json(
+            api_sock,
+            "PUT",
+            "/snapshot/create",
+            &serde_json::json!({
+                "snapshot_type": "Full",
+                "snapshot_path": snapshot_path.display().to_string(),
+                "mem_file_path": mem_file_path.display().to_string(),
+            }),
+        )
+    }
+
+    fn load_snapshot(
+        &self,
+        api_sock: &Path,
+        snapshot_path: &Path,
+        mem_file_path: &Path,
+        network_overrides: &BTreeMap<String, String>,
+        resume_vm: bool,
+    ) -> DriverResult<()> {
+        let mut body = serde_json::json!({
+            "snapshot_path": snapshot_path.display().to_string(),
+            "mem_file_path": mem_file_path.display().to_string(),
+            "resume_vm": resume_vm,
+        });
+        if !network_overrides.is_empty() {
+            body["network_overrides"] = serde_json::to_value(network_overrides).map_err(|err| {
+                DriverError::InvalidInput {
+                    message: format!("failed to encode network overrides: {err}"),
+                }
+            })?;
+        }
+        firecracker_api_json(api_sock, "PUT", "/snapshot/load", &body)
+    }
 }
 
 #[derive(Debug, Default)]
@@ -142,6 +218,135 @@ fn command_failed(program: &str, request: &CommandRequest, output: CommandOutput
     }
 }
 
+fn firecracker_api_json(
+    api_sock: &Path,
+    method: &str,
+    path: &str,
+    body: &Value,
+) -> DriverResult<()> {
+    let body = serde_json::to_string(body).map_err(|source| DriverError::InvalidInput {
+        message: format!("failed to encode Firecracker API body: {source}"),
+    })?;
+    firecracker_api_request(api_sock, method, path, &body)
+}
+
+#[cfg(unix)]
+fn firecracker_api_request(
+    api_sock: &Path,
+    method: &str,
+    path: &str,
+    body: &str,
+) -> DriverResult<()> {
+    use std::os::unix::net::UnixStream;
+    use std::thread;
+
+    let mut last_error = None;
+    let mut stream = None;
+    for _ in 0..50 {
+        match UnixStream::connect(api_sock) {
+            Ok(value) => {
+                stream = Some(value);
+                break;
+            }
+            Err(source)
+                if matches!(
+                    source.kind(),
+                    io::ErrorKind::NotFound | io::ErrorKind::ConnectionRefused
+                ) =>
+            {
+                last_error = Some(source);
+                thread::sleep(Duration::from_millis(20));
+            }
+            Err(source) => {
+                return Err(DriverError::CommandSpawn {
+                    command: firecracker_api_command(method, path, api_sock),
+                    source,
+                });
+            }
+        }
+    }
+    let mut stream = stream.ok_or_else(|| DriverError::CommandSpawn {
+        command: firecracker_api_command(method, path, api_sock),
+        source: last_error.unwrap_or_else(|| {
+            io::Error::new(
+                io::ErrorKind::TimedOut,
+                "Firecracker API socket unavailable",
+            )
+        }),
+    })?;
+    stream
+        .set_read_timeout(Some(Duration::from_secs(5)))
+        .map_err(|source| DriverError::CommandSpawn {
+            command: firecracker_api_command(method, path, api_sock),
+            source,
+        })?;
+    stream
+        .set_write_timeout(Some(Duration::from_secs(5)))
+        .map_err(|source| DriverError::CommandSpawn {
+            command: firecracker_api_command(method, path, api_sock),
+            source,
+        })?;
+    let request = format!(
+        "{method} {path} HTTP/1.1\r\nHost: localhost\r\nAccept: application/json\r\nContent-Type: application/json\r\nContent-Length: {}\r\nConnection: close\r\n\r\n{body}",
+        body.len()
+    );
+    stream
+        .write_all(request.as_bytes())
+        .map_err(|source| DriverError::CommandSpawn {
+            command: firecracker_api_command(method, path, api_sock),
+            source,
+        })?;
+    let mut response = String::new();
+    stream
+        .read_to_string(&mut response)
+        .map_err(|source| DriverError::CommandSpawn {
+            command: firecracker_api_command(method, path, api_sock),
+            source,
+        })?;
+    let status = parse_http_status(&response);
+    if matches!(status, Some(200..=299)) {
+        return Ok(());
+    }
+    Err(DriverError::CommandFailed {
+        command: firecracker_api_command(method, path, api_sock),
+        status,
+        stdout: String::new(),
+        stderr: response,
+    })
+}
+
+#[cfg(not(unix))]
+fn firecracker_api_request(
+    api_sock: &Path,
+    method: &str,
+    path: &str,
+    _body: &str,
+) -> DriverResult<()> {
+    Err(DriverError::InvalidInput {
+        message: format!(
+            "Firecracker API sockets require a Unix host: {}",
+            firecracker_api_command(method, path, api_sock)
+        ),
+    })
+}
+
+fn firecracker_api_command(method: &str, path: &str, api_sock: &Path) -> String {
+    format!(
+        "firecracker-api {method} {path} --api-sock {}",
+        api_sock.display()
+    )
+}
+
+fn parse_http_status(response: &str) -> Option<i32> {
+    response
+        .lines()
+        .next()?
+        .split_whitespace()
+        .nth(1)?
+        .parse::<i32>()
+        .ok()
+}
+
 fn preflight_issue(
     severity: IssueSeverity,
     code: &str,
@@ -168,6 +373,7 @@ pub struct MicroVmDriver {
     ssh_binary: String,
     scp_binary: String,
     runner: Arc<dyn CommandRunner>,
+    api: Arc<dyn FirecrackerApi>,
     host: HostChecks,
     workdir: Mutex<Option<PathBuf>>,
 }
@@ -180,6 +386,7 @@ impl Default for MicroVmDriver {
             ssh_binary: SSH_BINARY.to_owned(),
             scp_binary: SCP_BINARY.to_owned(),
             runner: Arc::new(ProcessCommandRunner),
+            api: Arc::new(UnixFirecrackerApi),
             host: HostChecks::detect(),
             workdir: Mutex::new(None),
         }
@@ -213,7 +420,30 @@ impl MicroVmDriver {
             ssh_binary: SSH_BINARY.to_owned(),
             scp_binary: SCP_BINARY.to_owned(),
             runner,
+            api: Arc::new(UnixFirecrackerApi),
             host,
+            workdir: Mutex::new(None),
+        }
+    }
+
+    fn for_tests_with_api<T, A>(runner: Arc<T>, api: Arc<A>, is_linux: bool, has_kvm: bool) -> Self
+    where
+        T: CommandRunner + 'static,
+        A: FirecrackerApi + 'static,
+    {
+        Self {
+            firecracker_binary: FIRECRACKER_BINARY.to_owned(),
+            apple_container_binary: APPLE_CONTAINER_BINARY.to_owned(),
+            ssh_binary: SSH_BINARY.to_owned(),
+            scp_binary: SCP_BINARY.to_owned(),
+            runner,
+            api,
+            host: HostChecks {
+                is_linux,
+                is_macos: false,
+                is_apple_silicon: false,
+                has_kvm,
+            },
             workdir: Mutex::new(None),
         }
     }
@@ -393,6 +623,38 @@ impl MicroVmDriver {
         Ok(SandboxHandle {
             handle: handle.to_handle()?,
         })
+    }
+
+    fn clone_rootfs_for_fork(&self, source_rootfs: &str, child_rootfs: &Path) -> DriverResult<()> {
+        if let Some(parent) = child_rootfs.parent() {
+            fs::create_dir_all(parent).map_err(|source| DriverError::InvalidInput {
+                message: format!("failed to create `{}`: {source}", parent.display()),
+            })?;
+        }
+        let request = CommandRequest {
+            args: vec![
+                "--reflink=auto".to_owned(),
+                "--sparse=always".to_owned(),
+                source_rootfs.to_owned(),
+                child_rootfs.to_string_lossy().into_owned(),
+            ],
+            env: BTreeMap::new(),
+            stdin: None,
+        };
+        match self.runner.run("cp", &request) {
+            Ok(output) if output.status == Some(0) => Ok(()),
+            Ok(_) | Err(_) => {
+                fs::copy(source_rootfs, child_rootfs).map_err(|source| {
+                    DriverError::InvalidInput {
+                        message: format!(
+                            "failed to copy rootfs `{source_rootfs}` to `{}`: {source}",
+                            child_rootfs.display()
+                        ),
+                    }
+                })?;
+                Ok(())
+            }
+        }
     }
 }
 
@@ -732,6 +994,8 @@ struct MicroVmHandle {
     pid_file: PathBuf,
     ssh: Option<SshTarget>,
     env_file: Option<String>,
+    rootfs: Option<String>,
+    tap: Option<String>,
 }
 
 impl MicroVmHandle {
@@ -744,6 +1008,8 @@ impl MicroVmHandle {
             workdir,
             ssh: spec.ssh.clone(),
             env_file: None,
+            rootfs: Some(spec.rootfs.clone()),
+            tap: spec.tap.clone(),
         }
     }
 
@@ -756,6 +1022,8 @@ impl MicroVmHandle {
             workdir,
             ssh: None,
             env_file: spec.guest_env_file.clone(),
+            rootfs: None,
+            tap: None,
         }
     }
 
@@ -775,6 +1043,12 @@ impl MicroVmHandle {
         }
         if let Some(env_file) = self.env_file.as_deref() {
             url.query_pairs_mut().append_pair("env_file", env_file);
+        }
+        if let Some(rootfs) = self.rootfs.as_deref() {
+            url.query_pairs_mut().append_pair("rootfs", rootfs);
+        }
+        if let Some(tap) = self.tap.as_deref() {
+            url.query_pairs_mut().append_pair("tap", tap);
         }
         Ok(url.to_string())
     }
@@ -816,6 +1090,11 @@ impl MicroVmHandle {
             validate_guest_env_file_path(env_file)
                 .map_err(|err| invalid_handle(handle, err.to_string()))?;
         }
+        let rootfs = query.get("rootfs").cloned();
+        let tap = query.get("tap").cloned();
+        if let Some(tap) = tap.as_deref() {
+            validate_tap(tap).map_err(|err| invalid_handle(handle, err.to_string()))?;
+        }
         Ok(Self {
             runtime,
             name,
@@ -824,6 +1103,8 @@ impl MicroVmHandle {
             pid_file,
             ssh,
             env_file,
+            rootfs,
+            tap,
         })
     }
 
@@ -831,6 +1112,108 @@ impl MicroVmHandle {
         self.ssh
             .as_ref()
             .ok_or_else(|| capability_missing(MICROVM_SSH_CAPABILITY))
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+struct FirecrackerSnapshotId {
+    source_name: String,
+    snapshot_name: String,
+    snapshot_path: PathBuf,
+    mem_file_path: PathBuf,
+    rootfs: String,
+    tap: Option<String>,
+    ssh: Option<SshTarget>,
+}
+
+impl FirecrackerSnapshotId {
+    fn new(handle: &MicroVmHandle, snapshot_name: &str) -> DriverResult<Self> {
+        let rootfs = handle
+            .rootfs
+            .clone()
+            .ok_or_else(|| DriverError::InvalidInput {
+                message: "firecracker snapshot requires a rootfs path in the sandbox handle"
+                    .to_owned(),
+            })?;
+        let snapshot_dir = handle.workdir.join("snapshots").join(snapshot_name);
+        Ok(Self {
+            source_name: handle.name.clone(),
+            snapshot_name: snapshot_name.to_owned(),
+            snapshot_path: snapshot_dir.join("vmstate"),
+            mem_file_path: snapshot_dir.join("memory"),
+            rootfs,
+            tap: handle.tap.clone(),
+            ssh: handle.ssh.clone(),
+        })
+    }
+
+    fn to_id(&self) -> DriverResult<String> {
+        let base = format!(
+            "microvm-snapshot://firecracker/{}/{}",
+            self.source_name, self.snapshot_name
+        );
+        let mut url = Url::parse(&base).map_err(|source| DriverError::InvalidInput {
+            message: format!("failed to build microvm snapshot id: {source}"),
+        })?;
+        {
+            let mut pairs = url.query_pairs_mut();
+            pairs.append_pair("snapshot_path", &self.snapshot_path.to_string_lossy());
+            pairs.append_pair("mem_file_path", &self.mem_file_path.to_string_lossy());
+            pairs.append_pair("rootfs", &self.rootfs);
+            if let Some(tap) = self.tap.as_deref() {
+                pairs.append_pair("tap", tap);
+            }
+        }
+        if let Some(ssh) = self.ssh.as_ref() {
+            ssh.to_query(&mut url);
+        }
+        Ok(url.to_string())
+    }
+
+    fn from_id(id: &str) -> DriverResult<Self> {
+        let url = Url::parse(id).map_err(|source| DriverError::InvalidHandle {
+            handle: id.to_owned(),
+            message: source.to_string(),
+        })?;
+        if url.scheme() != "microvm-snapshot" || url.host_str() != Some("firecracker") {
+            return Err(DriverError::InvalidHandle {
+                handle: id.to_owned(),
+                message: "expected firecracker microvm snapshot id".to_owned(),
+            });
+        }
+        let mut segments = url
+            .path_segments()
+            .ok_or_else(|| DriverError::InvalidHandle {
+                handle: id.to_owned(),
+                message: "snapshot id path is invalid".to_owned(),
+            })?;
+        let source_name = segments.next().unwrap_or_default().to_owned();
+        let snapshot_name = segments.next().unwrap_or_default().to_owned();
+        validate_name(&source_name, "snapshot source name")
+            .map_err(|err| invalid_handle(id, err.to_string()))?;
+        validate_name(&snapshot_name, "snapshot name")
+            .map_err(|err| invalid_handle(id, err.to_string()))?;
+        let query = query_map(&url);
+        let snapshot_path = required_query_path(&query, id, "snapshot_path")?;
+        let mem_file_path = required_query_path(&query, id, "mem_file_path")?;
+        let rootfs = query
+            .get("rootfs")
+            .cloned()
+            .ok_or_else(|| invalid_handle(id, "missing rootfs query parameter"))?;
+        let tap = query.get("tap").cloned();
+        if let Some(tap) = tap.as_deref() {
+            validate_tap(tap).map_err(|err| invalid_handle(id, err.to_string()))?;
+        }
+        let ssh = SshTarget::from_query(&url, id)?;
+        Ok(Self {
+            source_name,
+            snapshot_name,
+            snapshot_path,
+            mem_file_path,
+            rootfs,
+            tap,
+            ssh,
+        })
     }
 }
 
@@ -1312,6 +1695,8 @@ impl SandboxDriver for MicroVmDriver {
                 supports_native_inference_routing: false,
                 supports_remote_host: false,
                 supports_persistent_sessions: false,
+                supports_snapshots: true,
+                supports_fork: true,
             }),
         })
     }
@@ -1341,6 +1726,115 @@ impl SandboxDriver for MicroVmDriver {
                 "{UNSUPPORTED_RUNTIME_CAPABILITY}:kata"
             ))),
         }
+    }
+
+    async fn snapshot(&self, params: SnapshotParams) -> DriverResult<SnapshotId> {
+        let handle = MicroVmHandle::from_handle(&params.handle)?;
+        if handle.runtime != MicroVmRuntime::Firecracker {
+            return Err(capability_missing(&format!(
+                "supports_snapshots:{}",
+                handle.runtime.label()
+            )));
+        }
+        let snapshot_name = params
+            .name
+            .unwrap_or_else(|| format!("snapshot-{}", uuid_like_suffix()));
+        validate_name(&snapshot_name, "snapshot name")?;
+        let snapshot = FirecrackerSnapshotId::new(&handle, &snapshot_name)?;
+        if let Some(parent) = snapshot.snapshot_path.parent() {
+            fs::create_dir_all(parent).map_err(|source| DriverError::InvalidInput {
+                message: format!(
+                    "failed to create snapshot directory `{}`: {source}",
+                    parent.display()
+                ),
+            })?;
+        }
+
+        self.api.set_vm_state(&handle.api_sock, "Paused")?;
+        let create_result = self.api.create_snapshot(
+            &handle.api_sock,
+            &snapshot.snapshot_path,
+            &snapshot.mem_file_path,
+        );
+        let resume_result = self.api.set_vm_state(&handle.api_sock, "Resumed");
+        create_result?;
+        resume_result?;
+
+        Ok(SnapshotId {
+            id: snapshot.to_id()?,
+        })
+    }
+
+    async fn fork_from_snapshot(
+        &self,
+        params: ForkFromSnapshotParams,
+    ) -> DriverResult<SandboxHandle> {
+        let snapshot = FirecrackerSnapshotId::from_id(&params.snapshot.id)?;
+        let name = params.spec.name;
+        validate_name(&name, "fork name")?;
+        let child_tap =
+            optional_metadata_string(&params.spec.metadata, "tap")?.or(snapshot.tap.clone());
+        if let Some(tap) = child_tap.as_deref() {
+            validate_tap(tap)?;
+        }
+        let child_ssh = SshTarget::from_metadata(&params.spec.metadata)?.or(snapshot.ssh.clone());
+        let parent = self.workdir_parent()?;
+        let workdir = ensure_workdir(&parent, &name)?;
+        let child_rootfs = workdir.join("rootfs.ext4");
+        self.clone_rootfs_for_fork(&snapshot.rootfs, &child_rootfs)?;
+        let handle = MicroVmHandle {
+            runtime: MicroVmRuntime::Firecracker,
+            name,
+            api_sock: workdir.join("api.sock"),
+            pid_file: workdir.join("firecracker.pid"),
+            workdir,
+            ssh: child_ssh,
+            env_file: None,
+            rootfs: Some(child_rootfs.to_string_lossy().into_owned()),
+            tap: child_tap,
+        };
+        let request = CommandRequest {
+            args: vec![
+                "--api-sock".to_owned(),
+                handle.api_sock.to_string_lossy().into_owned(),
+            ],
+            env: BTreeMap::new(),
+            stdin: None,
+        };
+        let pid = self
+            .runner
+            .spawn(&self.firecracker_binary, &request)
+            .map_err(|source| DriverError::CommandSpawn {
+                command: command_string(&self.firecracker_binary, &request.args),
+                source,
+            })?;
+        write_pid(&handle.pid_file, pid)?;
+        let mut network_overrides = BTreeMap::new();
+        if let Some(tap) = handle.tap.as_deref() {
+            network_overrides.insert("eth0".to_owned(), tap.to_owned());
+        }
+        if let Err(err) = self.api.load_snapshot(
+            &handle.api_sock,
+            &snapshot.snapshot_path,
+            &snapshot.mem_file_path,
+            &network_overrides,
+            true,
+        ) {
+            let _ = self.runner.run(
+                "kill",
+                &CommandRequest {
+                    args: vec![pid.to_string()],
+                    env: BTreeMap::new(),
+                    stdin: None,
+                },
+            );
+            let _ = fs::remove_file(&handle.pid_file);
+            return Err(err);
+        }
+
+        Ok(SandboxHandle {
+            handle: handle.to_handle()?,
+        })
     }
 
     async fn connect(&self, params: ConnectParams) -> DriverResult<ShellHandle> {
@@ -1762,16 +2256,90 @@ mod tests {
         sync::{Arc, Mutex},
     };
 
-    use agentenv_core::driver::{DriverError, SandboxDriver};
+    use agentenv_core::driver::{DriverError, DriverResult, SandboxDriver};
     use agentenv_proto::{
         Capabilities, ConnectParams, CopyInParams, CopyOutParams, DriverKind, ExecParams,
-        FilesystemPolicy, InferencePolicy, InitializeParams, LogLevel, NetworkAccessPolicy,
-        NetworkPolicy, NetworkRule, NetworkTarget, PolicyReloadability, PreflightParams,
-        ProcessPolicy, SandboxSpec, SCHEMA_VERSION,
+        FilesystemPolicy, ForkFromSnapshotParams, ForkSpec, InferencePolicy, InitializeParams,
+        LogLevel, NetworkAccessPolicy, NetworkPolicy, NetworkRule, NetworkTarget,
+        PolicyReloadability, PreflightParams, ProcessPolicy, SandboxSpec, SnapshotParams,
+        SCHEMA_VERSION,
     };
     use serde_json::json;
 
     use super::{CommandOutput, CommandRequest, FirecrackerConfig, HostChecks, MicroVmDriver};
+
+    #[derive(Debug, Clone, PartialEq, Eq)]
+    enum ApiCall {
+        VmState {
+            api_sock: String,
+            state: String,
+        },
+        CreateSnapshot {
+            api_sock: String,
+            snapshot_path: String,
+            mem_file_path: String,
+        },
+        LoadSnapshot {
+            api_sock: String,
+            snapshot_path: String,
+            mem_file_path: String,
+            network_overrides: BTreeMap<String, String>,
+            resume_vm: bool,
+        },
+    }
+
+    #[derive(Debug, Default)]
+    struct RecordingFirecrackerApi {
+        calls: Mutex<Vec<ApiCall>>,
+    }
+
+    impl RecordingFirecrackerApi {
+        fn calls(&self) -> Vec<ApiCall> {
+            self.calls.lock().unwrap().clone()
+        }
+    }
+
+    impl super::FirecrackerApi for RecordingFirecrackerApi {
+        fn set_vm_state(&self, api_sock: &Path, state: &str) -> DriverResult<()> {
+            self.calls.lock().unwrap().push(ApiCall::VmState {
+                api_sock: api_sock.display().to_string(),
+                state: state.to_owned(),
+            });
+            Ok(())
+        }
+
+        fn create_snapshot(
+            &self,
+            api_sock: &Path,
+            snapshot_path: &Path,
+            mem_file_path: &Path,
+        ) -> DriverResult<()> {
+            self.calls.lock().unwrap().push(ApiCall::CreateSnapshot {
+                api_sock: api_sock.display().to_string(),
+                snapshot_path: snapshot_path.display().to_string(),
+                mem_file_path: mem_file_path.display().to_string(),
+            });
+            Ok(())
+        }
+
+        fn load_snapshot(
+            &self,
+            api_sock: &Path,
+            snapshot_path: &Path,
+            mem_file_path: &Path,
+            network_overrides: &BTreeMap<String, String>,
+            resume_vm: bool,
+        ) -> DriverResult<()> {
+            self.calls.lock().unwrap().push(ApiCall::LoadSnapshot {
+                api_sock: api_sock.display().to_string(),
+                snapshot_path: snapshot_path.display().to_string(),
+                mem_file_path: mem_file_path.display().to_string(),
+                network_overrides: network_overrides.clone(),
+                resume_vm,
+            });
+            Ok(())
+        }
+    }
 
     #[derive(Debug, Default)]
     struct RecordingRunner {
@@ -1887,9 +2455,141 @@ mod tests {
                 assert!(!capabilities.supports_native_inference_routing);
                 assert!(!capabilities.supports_remote_host);
                 assert!(!capabilities.supports_persistent_sessions);
+                assert!(capabilities.supports_snapshots);
+                assert!(capabilities.supports_fork);
             }
             other => panic!("expected sandbox capabilities, got {other:?}"),
         }
+    }
+
+    #[tokio::test]
+    async fn firecracker_snapshot_pauses_creates_snapshot_and_resumes() {
+        let temp = tempfile::tempdir().unwrap();
+        let runner = Arc::new(RecordingRunner::default());
+        let api = Arc::new(RecordingFirecrackerApi::default());
+        let mut driver =
+            MicroVmDriver::for_tests_with_api(Arc::clone(&runner), Arc::clone(&api), true, true);
+        driver.initialize(init_params(temp.path())).await.unwrap();
+        let rootfs = temp.path().join("rootfs.ext4");
+        std::fs::write(&rootfs, "rootfs").unwrap();
+        let handle = driver
+            .create(SandboxSpec {
+                image: None,
+                env: BTreeMap::new(),
+                policy: None,
+                metadata: BTreeMap::from([
+                    ("name".to_owned(), json!("fc-test")),
+                    ("runtime".to_owned(), json!("firecracker")),
+                    (
+                        "kernel".to_owned(),
+                        json!("/var/lib/agentenv/kernel/vmlinux"),
+                    ),
+                    ("rootfs".to_owned(), json!(rootfs.display().to_string())),
+                    ("tap".to_owned(), json!("tap-source")),
+                ]),
+            })
+            .await
+            .unwrap();
+
+        let snapshot = driver
+            .snapshot(SnapshotParams {
+                handle: handle.handle,
+                name: Some("experiment".to_owned()),
+            })
+            .await
+            .unwrap();
+
+        assert!(snapshot.id.starts_with("microvm-snapshot://firecracker/"));
+        let calls = api.calls();
+        assert_eq!(calls.len(), 3);
+        assert!(matches!(
+            &calls[0],
+            ApiCall::VmState { state, .. } if state == "Paused"
+        ));
+        assert!(matches!(
+            &calls[1],
+            ApiCall::CreateSnapshot {
+                snapshot_path,
+                mem_file_path,
+                ..
+            } if snapshot_path.ends_with("/snapshots/experiment/vmstate")
+                && mem_file_path.ends_with("/snapshots/experiment/memory")
+        ));
+        assert!(matches!(
+            &calls[2],
+            ApiCall::VmState { state, .. } if state == "Resumed"
+        ));
+        assert!(snapshot.id.contains("rootfs="));
+        assert!(snapshot.id.contains("tap=tap-source"));
+    }
+
+    #[tokio::test]
+    async fn firecracker_fork_clones_rootfs_loads_snapshot_and_returns_child_handle() {
+        let temp = tempfile::tempdir().unwrap();
+        let runner = Arc::new(RecordingRunner::default());
+        let api = Arc::new(RecordingFirecrackerApi::default());
+        let mut driver =
+            MicroVmDriver::for_tests_with_api(Arc::clone(&runner), Arc::clone(&api), true, true);
+        driver.initialize(init_params(temp.path())).await.unwrap();
+        let rootfs = temp.path().join("rootfs.ext4");
+        std::fs::write(&rootfs, "rootfs").unwrap();
+        let handle = driver
+            .create(SandboxSpec {
+                image: None,
+                env: BTreeMap::new(),
+                policy: None,
+                metadata: BTreeMap::from([
+                    ("name".to_owned(), json!("fc-test")),
+                    ("runtime".to_owned(), json!("firecracker")),
+                    (
+                        "kernel".to_owned(),
+                        json!("/var/lib/agentenv/kernel/vmlinux"),
+                    ),
+                    ("rootfs".to_owned(), json!(rootfs.display().to_string())),
+                    ("tap".to_owned(), json!("tap-source")),
+                ]),
+            })
+            .await
+            .unwrap();
+        let snapshot = driver
+            .snapshot(SnapshotParams {
+                handle: handle.handle,
+                name: Some("experiment".to_owned()),
+            })
+            .await
+            .unwrap();
+
+        let forked = driver
+            .fork_from_snapshot(ForkFromSnapshotParams {
+                snapshot,
+                spec: ForkSpec {
+                    name: "experiment".to_owned(),
+                    metadata: BTreeMap::from([("tap".to_owned(), json!("tap-child"))]),
+                },
+            })
+            .await
+            .unwrap();
+
+        assert!(forked
+            .handle
+            .starts_with("microvm://firecracker/experiment?"));
+        assert!(forked.handle.contains("tap=tap-child"));
+        assert!(forked.handle.contains("rootfs="));
+        let spawned = runner.spawned();
+        assert_eq!(spawned.len(), 2);
+        assert_eq!(spawned[1].args[0], "--api-sock");
+        assert!(!spawned[1].args.contains(&"--config-file".to_owned()));
+        let calls = api.calls();
+        assert!(matches!(
+            calls.last(),
+            Some(ApiCall::LoadSnapshot {
+                network_overrides,
+                resume_vm: true,
+                ..
+            }) if network_overrides.get("eth0").map(String::as_str) == Some("tap-child")
+        ));
+        assert_eq!(runner.call_programs()[1], "cp");
+        assert_eq!(runner.calls()[1].args[0], "--reflink=auto");
     }
 
     #[tokio::test]

--- a/crates/drivers/sandbox-openshell/src/lib.rs
+++ b/crates/drivers/sandbox-openshell/src/lib.rs
@@ -554,6 +554,8 @@ impl SandboxDriver for OpenShellDriver {
                 supports_native_inference_routing: true,
                 supports_remote_host: true,
                 supports_persistent_sessions: true,
+                supports_snapshots: false,
+                supports_fork: false,
             }),
         })
     }

--- a/crates/drivers/sandbox-remote-ssh/src/lib.rs
+++ b/crates/drivers/sandbox-remote-ssh/src/lib.rs
@@ -674,6 +674,8 @@ impl SandboxDriver for RemoteSshDriver {
                 supports_native_inference_routing: false,
                 supports_remote_host: true,
                 supports_persistent_sessions: false,
+                supports_snapshots: false,
+                supports_fork: false,
             }),
         })
     }

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -62,11 +62,12 @@ Concrete: OpenShell (first-class), microVM/Firecracker on Linux/KVM and Apple Co
 Responsibilities:
 - Preflight checks (runtime installed, versions compatible)
 - `create` / `connect` / `exec` / `copy_in/out` / `status` / `stop` / `destroy`
+- Optionally `snapshot` a running sandbox and `fork_from_snapshot` into a new env
 - Translate a generic `NetworkPolicy` into its native policy format
 - Apply, update, and optionally hot-reload policy
 - Surface egress denials into the approvals queue
 
-Capability flags: `supports_hot_reload_policy`, `supports_filesystem_lockdown`, `supports_syscall_filter`, `supports_native_inference_routing`, `supports_remote_host`.
+Capability flags: `supports_hot_reload_policy`, `supports_filesystem_lockdown`, `supports_syscall_filter`, `supports_native_inference_routing`, `supports_remote_host`, `supports_persistent_sessions`, `supports_snapshots`, `supports_fork`.
 
 ### `AgentDriver` — what runs inside the sandbox?
 

--- a/docs/DRIVER_PROTOCOL.md
+++ b/docs/DRIVER_PROTOCOL.md
@@ -1,4 +1,4 @@
-# agentenv Driver Protocol (v1.1 draft)
+# agentenv Driver Protocol (v1.2 draft)
 
 > JSON-RPC 2.0 over stdio. LSP-style framing. One contract for built-in Rust drivers and subprocess drivers in any language.
 
@@ -34,19 +34,23 @@ Every subprocess driver ships with a `manifest.json` at the root of its install 
 
 ```json
 {
-  "schema_version": "1.1",
-  "name": "nexus",
-  "kind": "context",
+  "schema_version": "1.2",
+  "name": "microvm",
+  "kind": "sandbox",
   "version": "0.1.0",
-  "description": "Nexus context backend driver",
-  "binary": "./bin/agentenv-driver-nexus",
+  "description": "MicroVM sandbox backend driver",
+  "binary": "./bin/agentenv-driver-microvm",
   "args": [],
   "env": {},
   "capabilities_preview": {
-    "is_remote": true,
-    "is_shared": true,
-    "supports_zones": true,
-    "supports_snapshots": true
+    "supports_hot_reload_policy": false,
+    "supports_filesystem_lockdown": true,
+    "supports_syscall_filter": true,
+    "supports_native_inference_routing": false,
+    "supports_remote_host": false,
+    "supports_persistent_sessions": false,
+    "supports_snapshots": true,
+    "supports_fork": true
   }
 }
 ```
@@ -63,7 +67,7 @@ Installed to `~/.agentenv/drivers/<name>/manifest.json`. The core discovers it a
   "id": 1,
   "method": "initialize",
   "params": {
-    "schema_version": "1.1",
+    "schema_version": "1.2",
     "core_version": "0.1.0",
     "workdir": "/home/alice/.agentenv/runs/myapp-01HXY",
     "log_level": "info"
@@ -82,7 +86,7 @@ Response:
       "name": "openshell",
       "kind": "sandbox",
       "version": "0.1.0",
-      "protocol_version": "1.1"
+      "protocol_version": "1.2"
     },
     "capabilities": {
       "supports_hot_reload_policy": true,
@@ -90,7 +94,9 @@ Response:
       "supports_syscall_filter": true,
       "supports_native_inference_routing": true,
       "supports_remote_host": true,
-      "supports_persistent_sessions": true
+      "supports_persistent_sessions": true,
+      "supports_snapshots": false,
+      "supports_fork": false
     }
   }
 }
@@ -133,8 +139,18 @@ Each driver kind (`sandbox` / `agent` / `context` / `inference`) has its own set
 | `status` | `{handle}` | `SandboxStatus` |
 | `logs` | `{handle, since, follow: false}` | `[LogEntry]` |
 | `logs_stream` | `{handle, since}` | streamed via notifications |
+| `snapshot` | `SnapshotParams {handle, name?}` | `SnapshotId` |
+| `fork_from_snapshot` | `ForkFromSnapshotParams {snapshot, spec}` | `SandboxHandle` |
 | `stop` | `{handle}` | `{}` |
 | `destroy` | `{handle}` | `{}` |
+
+Snapshot and fork are optional sandbox capabilities in schema 1.2. Core checks
+`supports_snapshots` before `snapshot` and `supports_fork` before
+`fork_from_snapshot`; drivers that cannot support them return
+`CapabilityMissing`. `SnapshotId.id` is an opaque driver-owned string. `ForkSpec`
+carries the target env name plus driver-specific metadata overrides such as a
+Firecracker tap or SSH target; credentials still never flow over generic driver
+RPC.
 
 Image hardening profiles are create-time sandbox configuration in schema 1.1.
 Core resolves `sandbox.hardening`, merges supported filesystem settings into

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -26,6 +26,7 @@ First-class Rust drivers for the critical path.
 
 - **M2-1** — `sandbox-openshell` (built-in)
 - **H-2** — `sandbox-microvm` (built-in, Firecracker on Linux/KVM; Apple Container on macOS; Kata reserved)
+- **H-3** — Snapshot/fork primitive for fast Firecracker env branching
 - **M2-2** — Built-in agent drivers: Claude, Codex, OpenClaw
 - **M2-3** — Built-in context drivers: filesystem, mcp-generic, none
 - **M2-4** — Built-in inference drivers: openai, anthropic, ollama, passthrough

--- a/tests/driver-conformance/src/bin/mock-driver.rs
+++ b/tests/driver-conformance/src/bin/mock-driver.rs
@@ -96,6 +96,8 @@ fn handle_request(request: RpcRequestEnvelope) -> Result<RpcResponseEnvelope> {
                             supports_native_inference_routing: false,
                             supports_remote_host: false,
                             supports_persistent_sessions: false,
+                            supports_snapshots: false,
+                            supports_fork: false,
                         }),
                     },
                 )?,

--- a/tests/driver-conformance/src/lib.rs
+++ b/tests/driver-conformance/src/lib.rs
@@ -1247,6 +1247,8 @@ mod tests {
                 supports_native_inference_routing: false,
                 supports_remote_host: false,
                 supports_persistent_sessions: false,
+                supports_snapshots: false,
+                supports_fork: false,
             })),
             ..FakeAgentDriver::default()
         };
@@ -1371,6 +1373,8 @@ mod tests {
                         supports_native_inference_routing: true,
                         supports_remote_host: false,
                         supports_persistent_sessions: false,
+                        supports_snapshots: false,
+                        supports_fork: false,
                     })
                 }),
             })
@@ -1536,6 +1540,8 @@ mod tests {
                 supports_native_inference_routing: true,
                 supports_remote_host: false,
                 supports_persistent_sessions: false,
+                supports_snapshots: false,
+                supports_fork: false,
             })),
             ..FakeSandboxDriver::default()
         };


### PR DESCRIPTION
## Summary

Closes #39.

- Bump the driver protocol to v1.2 with sandbox snapshot/fork capability flags and generated schemas.
- Add `agentenv fork SOURCE --name NEW_ENV`, accepting either a persisted env name or sandbox handle.
- Implement Firecracker snapshot/fork in `sandbox-microvm`: pause, create snapshot, resume, clone rootfs, spawn child VM, and load the snapshot.
- Gate unsupported drivers cleanly and document the protocol, architecture, roadmap, and microvm behavior.
- Add CLI e2e coverage with fake Firecracker API sockets plus focused runtime and driver tests.

## Validation

- `cargo fmt --check`
- `cargo clippy --workspace --all-targets -- -D warnings`
- `cargo test --workspace`
- `cargo test -p agentenv --test cli_behavior fork_`
- `cargo test -p agentenv-core fork_env_persists_forked_sandbox_state`
- `cargo test -p sandbox-microvm`
- `cargo test -p agentenv-proto`
- `cargo test -p driver-conformance`

Live Firecracker and Apple Container integration tests remain opt-in/ignored because they require host-specific KVM or Apple Container setup.