### PR TITLE
[codex] Bundle environments as skill bundles

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -141,6 +141,7 @@ dependencies = [
  "libc",
  "rand_core",
  "reqwest",
+ "rustix 1.1.4",
  "schemars",
  "semver",
  "serde",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -95,6 +95,7 @@ dependencies = [
  "tempfile",
  "time",
  "tokio",
+ "toml",
  "tracing",
  "tracing-subscriber",
  "tui",

--- a/crates/agentenv-core/Cargo.toml
+++ b/crates/agentenv-core/Cargo.toml
@@ -25,6 +25,7 @@ thiserror.workspace = true
 ipnet.workspace = true
 url.workspace = true
 reqwest.workspace = true
+rustix = { version = "1.1", features = ["fs"] }
 sha2.workspace = true
 ed25519-dalek.workspace = true
 hex.workspace = true

--- a/crates/agentenv-core/src/bundle/mod.rs
+++ b/crates/agentenv-core/src/bundle/mod.rs
@@ -1,0 +1,10 @@
+mod model;
+mod render;
+mod writer;
+
+pub use model::{
+    BundleManifest, BundleManifestAgentenv, BundleManifestFile, BundleManifestSkill,
+    BundleProvenance, BundleProvenanceDigests, BundleProvenanceSource, BundleSource, BundleWarning,
+    ReferenceDocument, SkillBundleInput, SkillBundleMetadata, SkillBundleOutput,
+};
+pub use writer::{emit_skill_bundle, BundleError};

--- a/crates/agentenv-core/src/bundle/model.rs
+++ b/crates/agentenv-core/src/bundle/model.rs
@@ -1,0 +1,116 @@
+use std::path::PathBuf;
+
+use semver::Version;
+use serde::{Deserialize, Serialize};
+
+use crate::driver_artifact::DriverArtifact;
+
+#[derive(Debug, Clone)]
+pub struct SkillBundleInput {
+    pub source: BundleSource,
+    pub metadata: SkillBundleMetadata,
+    pub blueprint_yaml: String,
+    pub lockfile_yaml: String,
+    pub reference_document: Option<ReferenceDocument>,
+    pub output_dir: PathBuf,
+    pub agentenv_version: String,
+    pub created_at: String,
+    pub driver_artifacts: Vec<DriverArtifact>,
+}
+
+#[derive(Debug, Clone)]
+pub struct BundleSource {
+    pub env_name: String,
+    pub project_path: Option<PathBuf>,
+    pub git_commit: Option<String>,
+    pub git_dirty: Option<bool>,
+}
+
+#[derive(Debug, Clone)]
+pub struct SkillBundleMetadata {
+    pub name: String,
+    pub version: Version,
+    pub description: String,
+    pub author: Option<String>,
+    pub license: Option<String>,
+    pub tags: Vec<String>,
+}
+
+#[derive(Debug, Clone)]
+pub struct ReferenceDocument {
+    pub source_relative_path: String,
+    pub content: String,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub struct SkillBundleOutput {
+    pub output_dir: PathBuf,
+    pub skill_name: String,
+    pub version: String,
+    pub bundle_digest: String,
+    pub blueprint_digest: String,
+    pub lockfile_digest: String,
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub warnings: Vec<BundleWarning>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub struct BundleWarning {
+    pub message: String,
+}
+
+#[derive(Debug, Clone, Serialize)]
+pub struct BundleManifest {
+    pub version: String,
+    pub kind: String,
+    pub skill: BundleManifestSkill,
+    pub agentenv: BundleManifestAgentenv,
+    pub files: Vec<BundleManifestFile>,
+}
+
+#[derive(Debug, Clone, Serialize)]
+pub struct BundleManifestSkill {
+    pub name: String,
+    pub version: String,
+    pub entry: String,
+}
+
+#[derive(Debug, Clone, Serialize)]
+pub struct BundleManifestAgentenv {
+    pub schema: String,
+    pub bundle: bool,
+}
+
+#[derive(Debug, Clone, Serialize)]
+pub struct BundleManifestFile {
+    pub path: String,
+    pub sha256: String,
+}
+
+#[derive(Debug, Clone, Serialize)]
+pub struct BundleProvenance {
+    pub version: String,
+    pub created_at: String,
+    pub agentenv_version: String,
+    pub source: BundleProvenanceSource,
+    pub digests: BundleProvenanceDigests,
+}
+
+#[derive(Debug, Clone, Serialize)]
+pub struct BundleProvenanceSource {
+    pub kind: String,
+    pub env_name: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub project_path: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub project_git_commit: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub project_git_dirty: Option<bool>,
+}
+
+#[derive(Debug, Clone, Serialize)]
+pub struct BundleProvenanceDigests {
+    pub blueprint: String,
+    pub lockfile: String,
+    pub manifest: String,
+}

--- a/crates/agentenv-core/src/bundle/render.rs
+++ b/crates/agentenv-core/src/bundle/render.rs
@@ -1,0 +1,156 @@
+use super::model::{ReferenceDocument, SkillBundleMetadata};
+
+pub(crate) const AGENTENV_BUNDLE_SCHEMA: &str = "0.1";
+
+pub(crate) fn render_skill_md(
+    metadata: &SkillBundleMetadata,
+    env_name: &str,
+    has_reference: bool,
+) -> String {
+    let mut frontmatter = Vec::new();
+    frontmatter.push("---".to_owned());
+    frontmatter.push(format!("name: {}", metadata.name));
+    frontmatter.push(format!(
+        "description: {}",
+        yaml_string(&metadata.description)
+    ));
+    frontmatter.push(format!("version: {}", metadata.version));
+    if let Some(author) = metadata.author.as_deref() {
+        frontmatter.push(format!("author: {}", yaml_string(author)));
+    }
+    if let Some(license) = metadata.license.as_deref() {
+        frontmatter.push(format!("license: {}", yaml_string(license)));
+    }
+    if !metadata.tags.is_empty() {
+        frontmatter.push(format!("tags: [{}]", metadata.tags.join(", ")));
+    }
+    frontmatter.push("agentenv-bundle: true".to_owned());
+    frontmatter.push(format!("agentenv-schema: \"{}\"", AGENTENV_BUNDLE_SCHEMA));
+    frontmatter.push("---".to_owned());
+
+    let mut body = vec![
+        format!("# {}", metadata.name),
+        String::new(),
+        format!(
+            "This skill reconstructs the `{env_name}` development environment with `agentenv`."
+        ),
+        String::new(),
+        "## Bootstrap".to_owned(),
+        String::new(),
+        "Run this from the skill directory:".to_owned(),
+        String::new(),
+        "```bash".to_owned(),
+        "scripts/bootstrap.sh".to_owned(),
+        "```".to_owned(),
+        String::new(),
+        "The script verifies `agentenv.lock` and reproduces the environment with:".to_owned(),
+        String::new(),
+        "```bash".to_owned(),
+        "agentenv verify agentenv.lock".to_owned(),
+        format!("agentenv reproduce agentenv.lock --name {env_name}"),
+        "```".to_owned(),
+        String::new(),
+        "## Included Files".to_owned(),
+        String::new(),
+        "- `blueprint.yaml` is the frozen blueprint used to create the environment.".to_owned(),
+        "- `agentenv.lock` pins drivers, artifacts, policy, and credential references.".to_owned(),
+    ];
+    if has_reference {
+        body.push("- `references/architecture.md` contains copied project architecture notes when available.".to_owned());
+    }
+
+    format!("{}\n\n{}\n", frontmatter.join("\n"), body.join("\n"))
+}
+
+pub(crate) fn render_skill_yaml(metadata: &SkillBundleMetadata, has_reference: bool) -> String {
+    let mut files = vec![
+        "  - SKILL.md".to_owned(),
+        "  - blueprint.yaml".to_owned(),
+        "  - agentenv.lock".to_owned(),
+        "  - scripts/**".to_owned(),
+        "  - .agentenv/**".to_owned(),
+    ];
+    if has_reference {
+        files.push("  - references/**".to_owned());
+    }
+
+    let mut yaml = vec![
+        format!("name: {}", metadata.name),
+        format!("version: {}", metadata.version),
+        format!("description: {}", yaml_string(&metadata.description)),
+        "entry: SKILL.md".to_owned(),
+        "files:".to_owned(),
+    ];
+    yaml.extend(files);
+    if !metadata.tags.is_empty() {
+        yaml.push("tags:".to_owned());
+        yaml.extend(metadata.tags.iter().map(|tag| format!("  - {tag}")));
+    }
+    yaml.push("agentenv_bundle: true".to_owned());
+    yaml.push(format!("agentenv_schema: \"{}\"", AGENTENV_BUNDLE_SCHEMA));
+    yaml.push(String::new());
+    yaml.join("\n")
+}
+
+pub(crate) fn render_bootstrap(env_name: &str) -> String {
+    format!(
+        r#"#!/usr/bin/env bash
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${{BASH_SOURCE[0]}}")" && pwd)"
+BUNDLE_DIR="$(cd "${{SCRIPT_DIR}}/.." && pwd)"
+ENV_NAME="${{AGENTENV_ENV_NAME:-{env_name}}}"
+
+cd "${{BUNDLE_DIR}}"
+agentenv verify agentenv.lock
+agentenv reproduce agentenv.lock --name "${{ENV_NAME}}"
+"#
+    )
+}
+
+pub(crate) fn render_reference(document: &ReferenceDocument) -> String {
+    format!(
+        "# Project Architecture\n\nSource: `{}`\n\n{}",
+        document.source_relative_path,
+        ensure_trailing_newline(&document.content)
+    )
+}
+
+pub(crate) fn ensure_trailing_newline(input: &str) -> String {
+    if input.ends_with('\n') {
+        input.to_owned()
+    } else {
+        format!("{input}\n")
+    }
+}
+
+fn yaml_string(value: &str) -> String {
+    if is_plain_yaml_scalar(value) {
+        value.to_owned()
+    } else {
+        serde_yaml::to_string(value)
+            .map(|serialized| {
+                serialized
+                    .trim()
+                    .trim_start_matches("---")
+                    .trim()
+                    .trim_end_matches("...")
+                    .trim()
+                    .to_owned()
+            })
+            .unwrap_or_else(|_| format!("{value:?}"))
+    }
+}
+
+fn is_plain_yaml_scalar(value: &str) -> bool {
+    !value.is_empty()
+        && !value.starts_with([
+            '-', '?', ':', '@', '`', '&', '*', '#', '!', '|', '>', '{', '[',
+        ])
+        && !value.contains('\n')
+        && !value.contains(": ")
+        && !matches!(
+            value,
+            "true" | "false" | "null" | "~" | "True" | "False" | "NULL"
+        )
+}

--- a/crates/agentenv-core/src/bundle/render.rs
+++ b/crates/agentenv-core/src/bundle/render.rs
@@ -92,11 +92,12 @@ pub(crate) fn render_skill_yaml(
         "SKILL.md",
         "blueprint.yaml",
         "agentenv.lock",
-        "scripts/**",
-        ".agentenv/**",
+        "scripts/bootstrap.sh",
+        ".agentenv/manifest.json",
+        ".agentenv/provenance.json",
     ];
     if has_reference {
-        files.push("references/**");
+        files.push("references/architecture.md");
     }
 
     let skill_yaml = SkillYaml {

--- a/crates/agentenv-core/src/bundle/render.rs
+++ b/crates/agentenv-core/src/bundle/render.rs
@@ -1,32 +1,54 @@
 use super::model::{ReferenceDocument, SkillBundleMetadata};
+use serde::Serialize;
 
 pub(crate) const AGENTENV_BUNDLE_SCHEMA: &str = "0.1";
+
+#[derive(Debug, Serialize)]
+struct SkillFrontmatter<'a> {
+    name: &'a str,
+    description: &'a str,
+    version: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    author: Option<&'a str>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    license: Option<&'a str>,
+    #[serde(skip_serializing_if = "Vec::is_empty")]
+    tags: Vec<&'a str>,
+    #[serde(rename = "agentenv-bundle")]
+    agentenv_bundle: bool,
+    #[serde(rename = "agentenv-schema")]
+    agentenv_schema: &'static str,
+}
+
+#[derive(Debug, Serialize)]
+struct SkillYaml<'a> {
+    name: &'a str,
+    version: String,
+    description: &'a str,
+    entry: &'static str,
+    files: Vec<&'static str>,
+    #[serde(skip_serializing_if = "Vec::is_empty")]
+    tags: Vec<&'a str>,
+    agentenv_bundle: bool,
+    agentenv_schema: &'static str,
+}
 
 pub(crate) fn render_skill_md(
     metadata: &SkillBundleMetadata,
     env_name: &str,
     has_reference: bool,
-) -> String {
-    let mut frontmatter = Vec::new();
-    frontmatter.push("---".to_owned());
-    frontmatter.push(format!("name: {}", metadata.name));
-    frontmatter.push(format!(
-        "description: {}",
-        yaml_string(&metadata.description)
-    ));
-    frontmatter.push(format!("version: {}", metadata.version));
-    if let Some(author) = metadata.author.as_deref() {
-        frontmatter.push(format!("author: {}", yaml_string(author)));
-    }
-    if let Some(license) = metadata.license.as_deref() {
-        frontmatter.push(format!("license: {}", yaml_string(license)));
-    }
-    if !metadata.tags.is_empty() {
-        frontmatter.push(format!("tags: [{}]", metadata.tags.join(", ")));
-    }
-    frontmatter.push("agentenv-bundle: true".to_owned());
-    frontmatter.push(format!("agentenv-schema: \"{}\"", AGENTENV_BUNDLE_SCHEMA));
-    frontmatter.push("---".to_owned());
+) -> Result<String, serde_yaml::Error> {
+    let frontmatter = SkillFrontmatter {
+        name: &metadata.name,
+        description: &metadata.description,
+        version: metadata.version.to_string(),
+        author: metadata.author.as_deref(),
+        license: metadata.license.as_deref(),
+        tags: metadata.tags.iter().map(String::as_str).collect(),
+        agentenv_bundle: true,
+        agentenv_schema: AGENTENV_BUNDLE_SCHEMA,
+    };
+    let frontmatter = serde_yaml::to_string(&frontmatter)?;
 
     let mut body = vec![
         format!("# {}", metadata.name),
@@ -59,37 +81,35 @@ pub(crate) fn render_skill_md(
         body.push("- `references/architecture.md` contains copied project architecture notes when available.".to_owned());
     }
 
-    format!("{}\n\n{}\n", frontmatter.join("\n"), body.join("\n"))
+    Ok(format!("---\n{}---\n\n{}\n", frontmatter, body.join("\n")))
 }
 
-pub(crate) fn render_skill_yaml(metadata: &SkillBundleMetadata, has_reference: bool) -> String {
+pub(crate) fn render_skill_yaml(
+    metadata: &SkillBundleMetadata,
+    has_reference: bool,
+) -> Result<String, serde_yaml::Error> {
     let mut files = vec![
-        "  - SKILL.md".to_owned(),
-        "  - blueprint.yaml".to_owned(),
-        "  - agentenv.lock".to_owned(),
-        "  - scripts/**".to_owned(),
-        "  - .agentenv/**".to_owned(),
+        "SKILL.md",
+        "blueprint.yaml",
+        "agentenv.lock",
+        "scripts/**",
+        ".agentenv/**",
     ];
     if has_reference {
-        files.push("  - references/**".to_owned());
+        files.push("references/**");
     }
 
-    let mut yaml = vec![
-        format!("name: {}", metadata.name),
-        format!("version: {}", metadata.version),
-        format!("description: {}", yaml_string(&metadata.description)),
-        "entry: SKILL.md".to_owned(),
-        "files:".to_owned(),
-    ];
-    yaml.extend(files);
-    if !metadata.tags.is_empty() {
-        yaml.push("tags:".to_owned());
-        yaml.extend(metadata.tags.iter().map(|tag| format!("  - {tag}")));
-    }
-    yaml.push("agentenv_bundle: true".to_owned());
-    yaml.push(format!("agentenv_schema: \"{}\"", AGENTENV_BUNDLE_SCHEMA));
-    yaml.push(String::new());
-    yaml.join("\n")
+    let skill_yaml = SkillYaml {
+        name: &metadata.name,
+        version: metadata.version.to_string(),
+        description: &metadata.description,
+        entry: "SKILL.md",
+        files,
+        tags: metadata.tags.iter().map(String::as_str).collect(),
+        agentenv_bundle: true,
+        agentenv_schema: AGENTENV_BUNDLE_SCHEMA,
+    };
+    serde_yaml::to_string(&skill_yaml)
 }
 
 pub(crate) fn render_bootstrap(env_name: &str) -> String {
@@ -122,35 +142,4 @@ pub(crate) fn ensure_trailing_newline(input: &str) -> String {
     } else {
         format!("{input}\n")
     }
-}
-
-fn yaml_string(value: &str) -> String {
-    if is_plain_yaml_scalar(value) {
-        value.to_owned()
-    } else {
-        serde_yaml::to_string(value)
-            .map(|serialized| {
-                serialized
-                    .trim()
-                    .trim_start_matches("---")
-                    .trim()
-                    .trim_end_matches("...")
-                    .trim()
-                    .to_owned()
-            })
-            .unwrap_or_else(|_| format!("{value:?}"))
-    }
-}
-
-fn is_plain_yaml_scalar(value: &str) -> bool {
-    !value.is_empty()
-        && !value.starts_with([
-            '-', '?', ':', '@', '`', '&', '*', '#', '!', '|', '>', '{', '[',
-        ])
-        && !value.contains('\n')
-        && !value.contains(": ")
-        && !matches!(
-            value,
-            "true" | "false" | "null" | "~" | "True" | "False" | "NULL"
-        )
 }

--- a/crates/agentenv-core/src/bundle/writer.rs
+++ b/crates/agentenv-core/src/bundle/writer.rs
@@ -1,0 +1,471 @@
+use std::{
+    fs,
+    path::{Path, PathBuf},
+    time::{SystemTime, UNIX_EPOCH},
+};
+
+use thiserror::Error;
+
+use super::{
+    model::{
+        BundleManifest, BundleManifestAgentenv, BundleManifestFile, BundleManifestSkill,
+        BundleProvenance, BundleProvenanceDigests, BundleProvenanceSource, BundleWarning,
+        SkillBundleInput, SkillBundleOutput,
+    },
+    render::{
+        ensure_trailing_newline, render_bootstrap, render_reference, render_skill_md,
+        render_skill_yaml, AGENTENV_BUNDLE_SCHEMA,
+    },
+};
+use crate::{
+    digest::sha256_hex,
+    portable_lockfile::{verify_portable_lockfile_yaml, PortableLockfileError},
+    skills::{compute_bundle_digest, load_skill_manifest, validate_skill_name, SkillError},
+};
+
+#[derive(Debug, Error)]
+pub enum BundleError {
+    #[error("output path already exists: `{path}`")]
+    OutputExists { path: PathBuf },
+    #[error("output path ancestry contains symlink `{path}`")]
+    SymlinkAncestor { path: PathBuf },
+    #[error("failed to read or write bundle path `{path}`: {source}")]
+    Io {
+        path: PathBuf,
+        #[source]
+        source: std::io::Error,
+    },
+    #[error("failed to serialize bundle JSON at `{path}`: {source}")]
+    Json {
+        path: PathBuf,
+        #[source]
+        source: serde_json::Error,
+    },
+    #[error(transparent)]
+    Skill(#[from] SkillError),
+    #[error(transparent)]
+    Lockfile(#[from] PortableLockfileError),
+    #[error("portable lockfile verification failed: {messages}")]
+    LockfileVerification { messages: String },
+    #[error("bundle manifest inventory mismatch for `{path}`")]
+    ManifestDigestMismatch { path: String },
+    #[error("bundle validation failed: {message}")]
+    Validation { message: String },
+}
+
+struct WrittenBundle {
+    blueprint_digest: String,
+    lockfile_digest: String,
+    warnings: Vec<BundleWarning>,
+}
+
+pub fn emit_skill_bundle(input: SkillBundleInput) -> Result<SkillBundleOutput, BundleError> {
+    if input.output_dir.exists() {
+        return Err(BundleError::OutputExists {
+            path: input.output_dir,
+        });
+    }
+    validate_output_ancestry(&input.output_dir)?;
+    validate_skill_name(&input.metadata.name)?;
+
+    let staging_dir = staging_dir_for(&input.output_dir)?;
+    if staging_dir.exists() {
+        remove_dir_all(&staging_dir)?;
+    }
+    create_dir_all(&staging_dir)?;
+
+    let result = write_and_validate_staging(&input, &staging_dir);
+    match result {
+        Ok(written) => {
+            rename(&staging_dir, &input.output_dir)?;
+            let manifest = load_skill_manifest(&input.output_dir)?;
+            let bundle_digest = compute_bundle_digest(&input.output_dir, &manifest)?;
+            Ok(SkillBundleOutput {
+                output_dir: input.output_dir,
+                skill_name: input.metadata.name,
+                version: input.metadata.version.to_string(),
+                bundle_digest,
+                blueprint_digest: written.blueprint_digest,
+                lockfile_digest: written.lockfile_digest,
+                warnings: written.warnings,
+            })
+        }
+        Err(error) => {
+            let cleanup = remove_dir_all(&staging_dir);
+            if cleanup.is_err() {
+                return Err(error);
+            }
+            Err(error)
+        }
+    }
+}
+
+fn write_and_validate_staging(
+    input: &SkillBundleInput,
+    staging_dir: &Path,
+) -> Result<WrittenBundle, BundleError> {
+    let has_reference = input.reference_document.is_some();
+    let blueprint_yaml = ensure_trailing_newline(&input.blueprint_yaml);
+    let lockfile_yaml = ensure_trailing_newline(&input.lockfile_yaml);
+    let blueprint_digest = sha256_digest(blueprint_yaml.as_bytes());
+    let lockfile_digest = sha256_digest(lockfile_yaml.as_bytes());
+
+    let verify_report = verify_portable_lockfile_yaml(&lockfile_yaml, &input.driver_artifacts)?;
+    if !verify_report.errors.is_empty() {
+        return Err(BundleError::LockfileVerification {
+            messages: verify_report
+                .errors
+                .iter()
+                .map(|issue| issue.message.as_str())
+                .collect::<Vec<_>>()
+                .join("; "),
+        });
+    }
+    let warnings = verify_report
+        .warnings
+        .iter()
+        .map(|issue| BundleWarning {
+            message: issue.message.clone(),
+        })
+        .collect::<Vec<_>>();
+
+    write_file(
+        staging_dir,
+        "SKILL.md",
+        render_skill_md(&input.metadata, &input.source.env_name, has_reference).as_bytes(),
+    )?;
+    write_file(
+        staging_dir,
+        "skill.yaml",
+        render_skill_yaml(&input.metadata, has_reference).as_bytes(),
+    )?;
+    write_file(staging_dir, "blueprint.yaml", blueprint_yaml.as_bytes())?;
+    write_file(staging_dir, "agentenv.lock", lockfile_yaml.as_bytes())?;
+    write_file(
+        staging_dir,
+        "scripts/bootstrap.sh",
+        render_bootstrap(&input.source.env_name).as_bytes(),
+    )?;
+    set_executable(staging_dir.join("scripts/bootstrap.sh"))?;
+
+    if let Some(document) = input.reference_document.as_ref() {
+        write_file(
+            staging_dir,
+            "references/architecture.md",
+            render_reference(document).as_bytes(),
+        )?;
+    }
+
+    let manifest = bundle_manifest(staging_dir, &input.metadata)?;
+    let manifest_json =
+        serde_json::to_string_pretty(&manifest).map_err(|source| BundleError::Json {
+            path: staging_dir.join(".agentenv/manifest.json"),
+            source,
+        })?;
+    write_file(
+        staging_dir,
+        ".agentenv/manifest.json",
+        ensure_trailing_newline(&manifest_json).as_bytes(),
+    )?;
+    let manifest_digest = sha256_file(staging_dir.join(".agentenv/manifest.json"))?;
+
+    let provenance = BundleProvenance {
+        version: AGENTENV_BUNDLE_SCHEMA.to_owned(),
+        created_at: input.created_at.clone(),
+        agentenv_version: input.agentenv_version.clone(),
+        source: BundleProvenanceSource {
+            kind: "environment".to_owned(),
+            env_name: input.source.env_name.clone(),
+            project_path: input
+                .source
+                .project_path
+                .as_ref()
+                .map(|path| path.display().to_string()),
+            project_git_commit: input.source.git_commit.clone(),
+            project_git_dirty: input.source.git_dirty,
+        },
+        digests: BundleProvenanceDigests {
+            blueprint: blueprint_digest.clone(),
+            lockfile: lockfile_digest.clone(),
+            manifest: manifest_digest,
+        },
+    };
+    let provenance_json =
+        serde_json::to_string_pretty(&provenance).map_err(|source| BundleError::Json {
+            path: staging_dir.join(".agentenv/provenance.json"),
+            source,
+        })?;
+    write_file(
+        staging_dir,
+        ".agentenv/provenance.json",
+        ensure_trailing_newline(&provenance_json).as_bytes(),
+    )?;
+
+    validate_staging(staging_dir, &manifest, &input.metadata, has_reference)?;
+
+    Ok(WrittenBundle {
+        blueprint_digest,
+        lockfile_digest,
+        warnings,
+    })
+}
+
+fn bundle_manifest(
+    staging_dir: &Path,
+    metadata: &super::model::SkillBundleMetadata,
+) -> Result<BundleManifest, BundleError> {
+    let mut files = generated_inventory_paths(staging_dir)?;
+    files.retain(|path| path != ".agentenv/manifest.json" && path != ".agentenv/provenance.json");
+    let mut manifest_files = Vec::with_capacity(files.len());
+    for path in files {
+        let digest = sha256_file(staging_dir.join(&path))?;
+        manifest_files.push(BundleManifestFile {
+            path,
+            sha256: digest,
+        });
+    }
+
+    Ok(BundleManifest {
+        version: AGENTENV_BUNDLE_SCHEMA.to_owned(),
+        kind: "agentenv.skill_bundle".to_owned(),
+        skill: BundleManifestSkill {
+            name: metadata.name.clone(),
+            version: metadata.version.to_string(),
+            entry: "SKILL.md".to_owned(),
+        },
+        agentenv: BundleManifestAgentenv {
+            schema: AGENTENV_BUNDLE_SCHEMA.to_owned(),
+            bundle: true,
+        },
+        files: manifest_files,
+    })
+}
+
+fn validate_staging(
+    staging_dir: &Path,
+    manifest: &BundleManifest,
+    metadata: &super::model::SkillBundleMetadata,
+    has_reference: bool,
+) -> Result<(), BundleError> {
+    let skill_manifest = load_skill_manifest(staging_dir)?;
+    if skill_manifest.name != metadata.name || skill_manifest.version != metadata.version {
+        return Err(BundleError::Validation {
+            message: "skill.yaml metadata does not match bundle metadata".to_owned(),
+        });
+    }
+    if !has_reference
+        && skill_manifest
+            .declared_files
+            .iter()
+            .any(|path| path.starts_with("references"))
+    {
+        return Err(BundleError::Validation {
+            message: "skill.yaml declares references without a reference document".to_owned(),
+        });
+    }
+
+    let skill_md = read_to_string(staging_dir.join("SKILL.md"))?;
+    if !skill_md.contains("agentenv-bundle: true")
+        || !skill_md.contains("agentenv-schema: \"0.1\"")
+        || !skill_md.contains("agentenv verify agentenv.lock")
+        || !skill_md.contains("agentenv reproduce agentenv.lock")
+    {
+        return Err(BundleError::Validation {
+            message: "SKILL.md is missing required agentenv bundle instructions".to_owned(),
+        });
+    }
+
+    let bootstrap = read_to_string(staging_dir.join("scripts/bootstrap.sh"))?;
+    if !bootstrap.contains("agentenv verify agentenv.lock")
+        || !bootstrap.contains("agentenv reproduce agentenv.lock --name \"${ENV_NAME}\"")
+    {
+        return Err(BundleError::Validation {
+            message: "bootstrap script is missing required agentenv commands".to_owned(),
+        });
+    }
+
+    for file in &manifest.files {
+        let actual = sha256_file(staging_dir.join(&file.path))?;
+        if actual != file.sha256 {
+            return Err(BundleError::ManifestDigestMismatch {
+                path: file.path.clone(),
+            });
+        }
+    }
+
+    compute_bundle_digest(staging_dir, &skill_manifest)?;
+    Ok(())
+}
+
+fn generated_inventory_paths(root: &Path) -> Result<Vec<String>, BundleError> {
+    let mut paths = Vec::new();
+    collect_file_paths(root, root, &mut paths)?;
+    paths.sort();
+    Ok(paths)
+}
+
+fn collect_file_paths(
+    root: &Path,
+    current: &Path,
+    paths: &mut Vec<String>,
+) -> Result<(), BundleError> {
+    let entries = fs::read_dir(current).map_err(|source| BundleError::Io {
+        path: current.to_path_buf(),
+        source,
+    })?;
+    for entry in entries {
+        let entry = entry.map_err(|source| BundleError::Io {
+            path: current.to_path_buf(),
+            source,
+        })?;
+        let path = entry.path();
+        let metadata = fs::symlink_metadata(&path).map_err(|source| BundleError::Io {
+            path: path.clone(),
+            source,
+        })?;
+        if metadata.file_type().is_symlink() {
+            return Err(BundleError::Validation {
+                message: format!("generated bundle path `{}` is a symlink", path.display()),
+            });
+        }
+        if metadata.is_dir() {
+            collect_file_paths(root, &path, paths)?;
+        } else if metadata.is_file() {
+            paths.push(relative_slash_path(root, &path)?);
+        }
+    }
+    Ok(())
+}
+
+fn relative_slash_path(root: &Path, path: &Path) -> Result<String, BundleError> {
+    let relative = path
+        .strip_prefix(root)
+        .map_err(|_| BundleError::Validation {
+            message: format!(
+                "generated path `{}` escaped bundle root `{}`",
+                path.display(),
+                root.display()
+            ),
+        })?;
+    let mut parts = Vec::new();
+    for component in relative.components() {
+        let std::path::Component::Normal(part) = component else {
+            return Err(BundleError::Validation {
+                message: format!("generated path `{}` is not relative", path.display()),
+            });
+        };
+        let Some(part) = part.to_str() else {
+            return Err(BundleError::Validation {
+                message: format!("generated path `{}` is not UTF-8", path.display()),
+            });
+        };
+        parts.push(part);
+    }
+    Ok(parts.join("/"))
+}
+
+fn validate_output_ancestry(output_dir: &Path) -> Result<(), BundleError> {
+    let parent = output_dir.parent().unwrap_or_else(|| Path::new("."));
+    let mut current = PathBuf::new();
+    for component in parent.components() {
+        current.push(component.as_os_str());
+        match fs::symlink_metadata(&current) {
+            Ok(metadata) if metadata.file_type().is_symlink() => {
+                return Err(BundleError::SymlinkAncestor { path: current });
+            }
+            Ok(_) => {}
+            Err(source) if source.kind() == std::io::ErrorKind::NotFound => {
+                create_dir_all(&current)?;
+            }
+            Err(source) => {
+                return Err(BundleError::Io {
+                    path: current,
+                    source,
+                });
+            }
+        }
+    }
+    Ok(())
+}
+
+fn staging_dir_for(output_dir: &Path) -> Result<PathBuf, BundleError> {
+    let parent = output_dir.parent().unwrap_or_else(|| Path::new("."));
+    let name = output_dir
+        .file_name()
+        .and_then(|name| name.to_str())
+        .unwrap_or("bundle");
+    let nanos = SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .map_err(|source| BundleError::Validation {
+            message: format!("system clock is before UNIX epoch: {source}"),
+        })?
+        .as_nanos();
+    Ok(parent.join(format!(
+        ".{name}.agentenv-staging-{}-{nanos}",
+        std::process::id()
+    )))
+}
+
+fn write_file(root: &Path, relative: &str, bytes: &[u8]) -> Result<(), BundleError> {
+    let path = root.join(relative);
+    if let Some(parent) = path.parent() {
+        create_dir_all(parent)?;
+    }
+    fs::write(&path, bytes).map_err(|source| BundleError::Io { path, source })
+}
+
+fn read_to_string(path: PathBuf) -> Result<String, BundleError> {
+    fs::read_to_string(&path).map_err(|source| BundleError::Io { path, source })
+}
+
+fn create_dir_all(path: &Path) -> Result<(), BundleError> {
+    fs::create_dir_all(path).map_err(|source| BundleError::Io {
+        path: path.to_path_buf(),
+        source,
+    })
+}
+
+fn remove_dir_all(path: &Path) -> Result<(), BundleError> {
+    if !path.exists() {
+        return Ok(());
+    }
+    fs::remove_dir_all(path).map_err(|source| BundleError::Io {
+        path: path.to_path_buf(),
+        source,
+    })
+}
+
+fn rename(from: &Path, to: &Path) -> Result<(), BundleError> {
+    fs::rename(from, to).map_err(|source| BundleError::Io {
+        path: to.to_path_buf(),
+        source,
+    })
+}
+
+fn sha256_file(path: PathBuf) -> Result<String, BundleError> {
+    let bytes = fs::read(&path).map_err(|source| BundleError::Io { path, source })?;
+    Ok(sha256_digest(&bytes))
+}
+
+fn sha256_digest(bytes: &[u8]) -> String {
+    format!("sha256:{}", sha256_hex(bytes))
+}
+
+#[cfg(unix)]
+fn set_executable(path: PathBuf) -> Result<(), BundleError> {
+    use std::os::unix::fs::PermissionsExt;
+
+    let mut permissions = fs::metadata(&path)
+        .map_err(|source| BundleError::Io {
+            path: path.clone(),
+            source,
+        })?
+        .permissions();
+    permissions.set_mode(0o755);
+    fs::set_permissions(&path, permissions).map_err(|source| BundleError::Io { path, source })
+}
+
+#[cfg(not(unix))]
+fn set_executable(_path: PathBuf) -> Result<(), BundleError> {
+    Ok(())
+}

--- a/crates/agentenv-core/src/bundle/writer.rs
+++ b/crates/agentenv-core/src/bundle/writer.rs
@@ -31,8 +31,6 @@ use crate::{
 pub enum BundleError {
     #[error("output path already exists: `{path}`")]
     OutputExists { path: PathBuf },
-    #[error("output path ancestry contains symlink `{path}`")]
-    SymlinkAncestor { path: PathBuf },
     #[error("failed to read or write bundle path `{path}`: {source}")]
     Io {
         path: PathBuf,
@@ -86,7 +84,7 @@ pub fn emit_skill_bundle(input: SkillBundleInput) -> Result<SkillBundleOutput, B
             });
         }
     }
-    validate_output_ancestry(&input.output_dir)?;
+    ensure_output_parent_exists(&input.output_dir)?;
     validate_skill_name(&input.metadata.name)?;
     validate_env_name(&input.source.env_name)?;
 
@@ -577,28 +575,9 @@ fn relative_slash_path(root: &Path, path: &Path) -> Result<String, BundleError> 
     Ok(parts.join("/"))
 }
 
-fn validate_output_ancestry(output_dir: &Path) -> Result<(), BundleError> {
+fn ensure_output_parent_exists(output_dir: &Path) -> Result<(), BundleError> {
     let parent = output_dir.parent().unwrap_or_else(|| Path::new("."));
-    let mut current = PathBuf::new();
-    for component in parent.components() {
-        current.push(component.as_os_str());
-        match fs::symlink_metadata(&current) {
-            Ok(metadata) if metadata.file_type().is_symlink() => {
-                return Err(BundleError::SymlinkAncestor { path: current });
-            }
-            Ok(_) => {}
-            Err(source) if source.kind() == std::io::ErrorKind::NotFound => {
-                create_dir_all(&current)?;
-            }
-            Err(source) => {
-                return Err(BundleError::Io {
-                    path: current,
-                    source,
-                });
-            }
-        }
-    }
-    Ok(())
+    create_dir_all(parent)
 }
 
 fn create_unique_staging_dir(output_dir: &Path) -> Result<PathBuf, BundleError> {

--- a/crates/agentenv-core/src/bundle/writer.rs
+++ b/crates/agentenv-core/src/bundle/writer.rs
@@ -60,10 +60,19 @@ struct WrittenBundle {
 }
 
 pub fn emit_skill_bundle(input: SkillBundleInput) -> Result<SkillBundleOutput, BundleError> {
-    if input.output_dir.exists() {
-        return Err(BundleError::OutputExists {
-            path: input.output_dir,
-        });
+    match fs::symlink_metadata(&input.output_dir) {
+        Ok(_) => {
+            return Err(BundleError::OutputExists {
+                path: input.output_dir,
+            });
+        }
+        Err(source) if source.kind() == std::io::ErrorKind::NotFound => {}
+        Err(source) => {
+            return Err(BundleError::Io {
+                path: input.output_dir,
+                source,
+            });
+        }
     }
     validate_output_ancestry(&input.output_dir)?;
     validate_skill_name(&input.metadata.name)?;

--- a/crates/agentenv-core/src/bundle/writer.rs
+++ b/crates/agentenv-core/src/bundle/writer.rs
@@ -1,4 +1,5 @@
 use std::{
+    collections::BTreeMap,
     fs,
     path::{Path, PathBuf},
     time::{SystemTime, UNIX_EPOCH},
@@ -10,7 +11,7 @@ use super::{
     model::{
         BundleManifest, BundleManifestAgentenv, BundleManifestFile, BundleManifestSkill,
         BundleProvenance, BundleProvenanceDigests, BundleProvenanceSource, BundleWarning,
-        SkillBundleInput, SkillBundleOutput,
+        SkillBundleInput, SkillBundleMetadata, SkillBundleOutput,
     },
     render::{
         ensure_trailing_newline, render_bootstrap, render_reference, render_skill_md,
@@ -20,7 +21,9 @@ use super::{
 use crate::{
     digest::sha256_hex,
     portable_lockfile::{verify_portable_lockfile_yaml, PortableLockfileError},
-    skills::{compute_bundle_digest, load_skill_manifest, validate_skill_name, SkillError},
+    skills::{
+        compute_bundle_digest, load_skill_manifest, validate_skill_name, SkillError, SkillManifest,
+    },
 };
 
 #[derive(Debug, Error)]
@@ -274,6 +277,7 @@ fn validate_staging(
     }
 
     let skill_md = read_to_string(staging_dir.join("SKILL.md"))?;
+    validate_metadata_parity(&skill_manifest, &skill_md, metadata)?;
     if !skill_md.contains("agentenv-bundle: true")
         || !skill_md.contains("agentenv-schema: \"0.1\"")
         || !skill_md.contains("agentenv verify agentenv.lock")
@@ -304,6 +308,185 @@ fn validate_staging(
 
     compute_bundle_digest(staging_dir, &skill_manifest)?;
     Ok(())
+}
+
+fn validate_metadata_parity(
+    skill_manifest: &SkillManifest,
+    skill_md: &str,
+    metadata: &SkillBundleMetadata,
+) -> Result<(), BundleError> {
+    let frontmatter = parse_skill_md_frontmatter(skill_md)?;
+
+    let frontmatter_name = required_string(&frontmatter, "name", "SKILL.md frontmatter")?;
+    validate_equal("name", &frontmatter_name, &metadata.name)?;
+    validate_equal("name", &skill_manifest.name, &metadata.name)?;
+
+    let expected_version = metadata.version.to_string();
+    let frontmatter_version = required_string(&frontmatter, "version", "SKILL.md frontmatter")?;
+    validate_equal("version", &frontmatter_version, &expected_version)?;
+    validate_equal(
+        "version",
+        &skill_manifest.version.to_string(),
+        &expected_version,
+    )?;
+
+    let frontmatter_description =
+        required_string(&frontmatter, "description", "SKILL.md frontmatter")?;
+    validate_equal(
+        "description",
+        &frontmatter_description,
+        &metadata.description,
+    )?;
+    let manifest_description =
+        skill_manifest
+            .description
+            .as_deref()
+            .ok_or_else(|| BundleError::Validation {
+                message: "skill.yaml is missing description".to_owned(),
+            })?;
+    validate_equal(
+        "description",
+        manifest_description,
+        metadata.description.as_str(),
+    )?;
+
+    let frontmatter_tags = optional_string_sequence(&frontmatter, "tags", "SKILL.md frontmatter")?;
+    let manifest_tags =
+        optional_string_sequence(&skill_manifest.extra, "tags", "skill.yaml extra metadata")?;
+    validate_equal("tags", &frontmatter_tags, &metadata.tags)?;
+    validate_equal("tags", &manifest_tags, &metadata.tags)?;
+
+    let frontmatter_schema =
+        required_string(&frontmatter, "agentenv-schema", "SKILL.md frontmatter")?;
+    let manifest_schema = required_string(
+        &skill_manifest.extra,
+        "agentenv_schema",
+        "skill.yaml extra metadata",
+    )?;
+    validate_equal(
+        "agentenv schema",
+        frontmatter_schema.as_str(),
+        AGENTENV_BUNDLE_SCHEMA,
+    )?;
+    validate_equal(
+        "agentenv schema",
+        manifest_schema.as_str(),
+        AGENTENV_BUNDLE_SCHEMA,
+    )?;
+
+    let frontmatter_bundle =
+        required_bool(&frontmatter, "agentenv-bundle", "SKILL.md frontmatter")?;
+    let manifest_bundle = required_bool(
+        &skill_manifest.extra,
+        "agentenv_bundle",
+        "skill.yaml extra metadata",
+    )?;
+    if !frontmatter_bundle || !manifest_bundle {
+        return Err(BundleError::Validation {
+            message: "agentenv bundle marker must be true in SKILL.md and skill.yaml".to_owned(),
+        });
+    }
+
+    Ok(())
+}
+
+fn parse_skill_md_frontmatter(
+    skill_md: &str,
+) -> Result<BTreeMap<String, serde_yaml::Value>, BundleError> {
+    let mut lines = skill_md.lines();
+    if lines.next() != Some("---") {
+        return Err(BundleError::Validation {
+            message: "SKILL.md is missing frontmatter".to_owned(),
+        });
+    }
+
+    let mut frontmatter = Vec::new();
+    for line in lines {
+        if line == "---" {
+            return serde_yaml::from_str(&frontmatter.join("\n")).map_err(|source| {
+                BundleError::Validation {
+                    message: format!("failed to parse SKILL.md frontmatter: {source}"),
+                }
+            });
+        }
+        frontmatter.push(line);
+    }
+
+    Err(BundleError::Validation {
+        message: "SKILL.md frontmatter is not closed".to_owned(),
+    })
+}
+
+fn required_string(
+    map: &BTreeMap<String, serde_yaml::Value>,
+    key: &str,
+    source: &str,
+) -> Result<String, BundleError> {
+    match map.get(key) {
+        Some(serde_yaml::Value::String(value)) => Ok(value.clone()),
+        Some(value) => Err(BundleError::Validation {
+            message: format!("{source} field `{key}` must be a string, found `{value:?}`"),
+        }),
+        None => Err(BundleError::Validation {
+            message: format!("{source} is missing `{key}`"),
+        }),
+    }
+}
+
+fn required_bool(
+    map: &BTreeMap<String, serde_yaml::Value>,
+    key: &str,
+    source: &str,
+) -> Result<bool, BundleError> {
+    match map.get(key) {
+        Some(serde_yaml::Value::Bool(value)) => Ok(*value),
+        Some(value) => Err(BundleError::Validation {
+            message: format!("{source} field `{key}` must be a boolean, found `{value:?}`"),
+        }),
+        None => Err(BundleError::Validation {
+            message: format!("{source} is missing `{key}`"),
+        }),
+    }
+}
+
+fn optional_string_sequence(
+    map: &BTreeMap<String, serde_yaml::Value>,
+    key: &str,
+    source: &str,
+) -> Result<Vec<String>, BundleError> {
+    let Some(value) = map.get(key) else {
+        return Ok(Vec::new());
+    };
+    let serde_yaml::Value::Sequence(items) = value else {
+        return Err(BundleError::Validation {
+            message: format!("{source} field `{key}` must be a string sequence"),
+        });
+    };
+
+    items
+        .iter()
+        .map(|item| match item {
+            serde_yaml::Value::String(value) => Ok(value.clone()),
+            other => Err(BundleError::Validation {
+                message: format!("{source} field `{key}` contains non-string item `{other:?}`"),
+            }),
+        })
+        .collect()
+}
+
+fn validate_equal<T>(field: &str, actual: &T, expected: &T) -> Result<(), BundleError>
+where
+    T: std::fmt::Debug + PartialEq + ?Sized,
+{
+    if actual == expected {
+        return Ok(());
+    }
+
+    Err(BundleError::Validation {
+        message: format!(
+            "skill metadata `{field}` mismatch: expected `{expected:?}`, found `{actual:?}`"
+        ),
+    })
 }
 
 fn generated_inventory_paths(root: &Path) -> Result<Vec<String>, BundleError> {
@@ -477,4 +660,84 @@ fn set_executable(path: PathBuf) -> Result<(), BundleError> {
 #[cfg(not(unix))]
 fn set_executable(_path: PathBuf) -> Result<(), BundleError> {
     Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use std::{collections::BTreeMap, path::PathBuf};
+
+    use semver::Version;
+    use serde_yaml::Value;
+
+    use super::*;
+    use crate::skills::SkillManifest;
+
+    #[test]
+    fn metadata_parity_rejects_frontmatter_description_tags_and_schema_drift() {
+        let metadata = SkillBundleMetadata {
+            name: "demo".to_owned(),
+            version: Version::parse("1.0.0").unwrap(),
+            description: "Reproducible dev env for demo".to_owned(),
+            author: None,
+            license: None,
+            tags: vec!["openshell".to_owned(), "dev-env".to_owned()],
+        };
+        let manifest = skill_manifest_for(&metadata);
+        let skill_md = r#"---
+name: demo
+description: Reproducible dev env for demo
+version: 1.0.0
+tags: [openshell, dev-env]
+agentenv-bundle: true
+agentenv-schema: "0.1"
+---
+
+# demo
+"#;
+
+        validate_metadata_parity(&manifest, skill_md, &metadata).unwrap();
+
+        let description_drift = skill_md.replace(
+            "description: Reproducible dev env for demo",
+            "description: drift",
+        );
+        assert!(validate_metadata_parity(&manifest, &description_drift, &metadata).is_err());
+
+        let tag_drift = skill_md.replace("tags: [openshell, dev-env]", "tags: [other]");
+        assert!(validate_metadata_parity(&manifest, &tag_drift, &metadata).is_err());
+
+        let schema_drift = skill_md.replace("agentenv-schema: \"0.1\"", "agentenv-schema: \"9.9\"");
+        assert!(validate_metadata_parity(&manifest, &schema_drift, &metadata).is_err());
+    }
+
+    fn skill_manifest_for(metadata: &SkillBundleMetadata) -> SkillManifest {
+        let mut extra = BTreeMap::new();
+        extra.insert(
+            "tags".to_owned(),
+            Value::Sequence(
+                metadata
+                    .tags
+                    .iter()
+                    .map(|tag| Value::String(tag.clone()))
+                    .collect(),
+            ),
+        );
+        extra.insert("agentenv_bundle".to_owned(), Value::Bool(true));
+        extra.insert(
+            "agentenv_schema".to_owned(),
+            Value::String(AGENTENV_BUNDLE_SCHEMA.to_owned()),
+        );
+
+        SkillManifest {
+            name: metadata.name.clone(),
+            version: metadata.version.clone(),
+            description: Some(metadata.description.clone()),
+            entry: PathBuf::from("SKILL.md"),
+            declared_files: vec![PathBuf::from("SKILL.md")],
+            self_test_command: None,
+            signature_ed25519: None,
+            signature_public_key_ed25519: None,
+            extra,
+        }
+    }
 }

--- a/crates/agentenv-core/src/bundle/writer.rs
+++ b/crates/agentenv-core/src/bundle/writer.rs
@@ -2,10 +2,10 @@ use std::{
     collections::BTreeMap,
     fs,
     path::{Path, PathBuf},
-    time::{SystemTime, UNIX_EPOCH},
 };
 
 use thiserror::Error;
+use uuid::Uuid;
 
 use super::{
     model::{
@@ -20,6 +20,7 @@ use super::{
 };
 use crate::{
     digest::sha256_hex,
+    env::{validate_env_name, EnvError},
     portable_lockfile::{verify_portable_lockfile_yaml, PortableLockfileError},
     skills::{
         compute_bundle_digest, load_skill_manifest, validate_skill_name, SkillError, SkillManifest,
@@ -44,6 +45,14 @@ pub enum BundleError {
         #[source]
         source: serde_json::Error,
     },
+    #[error("failed to serialize bundle YAML at `{path}`: {source}")]
+    Yaml {
+        path: PathBuf,
+        #[source]
+        source: serde_yaml::Error,
+    },
+    #[error(transparent)]
+    Env(#[from] EnvError),
     #[error(transparent)]
     Skill(#[from] SkillError),
     #[error(transparent)]
@@ -79,29 +88,13 @@ pub fn emit_skill_bundle(input: SkillBundleInput) -> Result<SkillBundleOutput, B
     }
     validate_output_ancestry(&input.output_dir)?;
     validate_skill_name(&input.metadata.name)?;
+    validate_env_name(&input.source.env_name)?;
 
-    let staging_dir = staging_dir_for(&input.output_dir)?;
-    if staging_dir.exists() {
-        remove_dir_all(&staging_dir)?;
-    }
-    create_dir_all(&staging_dir)?;
+    let staging_dir = create_unique_staging_dir(&input.output_dir)?;
 
-    let result = write_and_validate_staging(&input, &staging_dir);
+    let result = publish_validated_bundle(&input, &staging_dir);
     match result {
-        Ok(written) => {
-            rename(&staging_dir, &input.output_dir)?;
-            let manifest = load_skill_manifest(&input.output_dir)?;
-            let bundle_digest = compute_bundle_digest(&input.output_dir, &manifest)?;
-            Ok(SkillBundleOutput {
-                output_dir: input.output_dir,
-                skill_name: input.metadata.name,
-                version: input.metadata.version.to_string(),
-                bundle_digest,
-                blueprint_digest: written.blueprint_digest,
-                lockfile_digest: written.lockfile_digest,
-                warnings: written.warnings,
-            })
-        }
+        Ok(output) => Ok(output),
         Err(error) => {
             let cleanup = remove_dir_all(&staging_dir);
             if cleanup.is_err() {
@@ -110,6 +103,25 @@ pub fn emit_skill_bundle(input: SkillBundleInput) -> Result<SkillBundleOutput, B
             Err(error)
         }
     }
+}
+
+fn publish_validated_bundle(
+    input: &SkillBundleInput,
+    staging_dir: &Path,
+) -> Result<SkillBundleOutput, BundleError> {
+    let written = write_and_validate_staging(input, staging_dir)?;
+    publish_staging(staging_dir, &input.output_dir)?;
+    let manifest = load_skill_manifest(&input.output_dir)?;
+    let bundle_digest = compute_bundle_digest(&input.output_dir, &manifest)?;
+    Ok(SkillBundleOutput {
+        output_dir: input.output_dir.clone(),
+        skill_name: input.metadata.name.clone(),
+        version: input.metadata.version.to_string(),
+        bundle_digest,
+        blueprint_digest: written.blueprint_digest,
+        lockfile_digest: written.lockfile_digest,
+        warnings: written.warnings,
+    })
 }
 
 fn write_and_validate_staging(
@@ -144,12 +156,22 @@ fn write_and_validate_staging(
     write_file(
         staging_dir,
         "SKILL.md",
-        render_skill_md(&input.metadata, &input.source.env_name, has_reference).as_bytes(),
+        render_skill_md(&input.metadata, &input.source.env_name, has_reference)
+            .map_err(|source| BundleError::Yaml {
+                path: staging_dir.join("SKILL.md"),
+                source,
+            })?
+            .as_bytes(),
     )?;
     write_file(
         staging_dir,
         "skill.yaml",
-        render_skill_yaml(&input.metadata, has_reference).as_bytes(),
+        render_skill_yaml(&input.metadata, has_reference)
+            .map_err(|source| BundleError::Yaml {
+                path: staging_dir.join("skill.yaml"),
+                source,
+            })?
+            .as_bytes(),
     )?;
     write_file(staging_dir, "blueprint.yaml", blueprint_yaml.as_bytes())?;
     write_file(staging_dir, "agentenv.lock", lockfile_yaml.as_bytes())?;
@@ -279,7 +301,6 @@ fn validate_staging(
     let skill_md = read_to_string(staging_dir.join("SKILL.md"))?;
     validate_metadata_parity(&skill_manifest, &skill_md, metadata)?;
     if !skill_md.contains("agentenv-bundle: true")
-        || !skill_md.contains("agentenv-schema: \"0.1\"")
         || !skill_md.contains("agentenv verify agentenv.lock")
         || !skill_md.contains("agentenv reproduce agentenv.lock")
     {
@@ -580,22 +601,38 @@ fn validate_output_ancestry(output_dir: &Path) -> Result<(), BundleError> {
     Ok(())
 }
 
-fn staging_dir_for(output_dir: &Path) -> Result<PathBuf, BundleError> {
+fn create_unique_staging_dir(output_dir: &Path) -> Result<PathBuf, BundleError> {
+    create_unique_staging_dir_with_candidates(
+        output_dir,
+        std::iter::repeat_with(|| staging_dir_name(output_dir)),
+    )
+}
+
+fn create_unique_staging_dir_with_candidates(
+    output_dir: &Path,
+    candidates: impl IntoIterator<Item = String>,
+) -> Result<PathBuf, BundleError> {
     let parent = output_dir.parent().unwrap_or_else(|| Path::new("."));
+    for candidate in candidates.into_iter().take(16) {
+        let path = parent.join(candidate);
+        match fs::create_dir(&path) {
+            Ok(()) => return Ok(path),
+            Err(source) if source.kind() == std::io::ErrorKind::AlreadyExists => continue,
+            Err(source) => return Err(BundleError::Io { path, source }),
+        }
+    }
+
+    Err(BundleError::Validation {
+        message: "failed to allocate unique staging directory".to_owned(),
+    })
+}
+
+fn staging_dir_name(output_dir: &Path) -> String {
     let name = output_dir
         .file_name()
         .and_then(|name| name.to_str())
         .unwrap_or("bundle");
-    let nanos = SystemTime::now()
-        .duration_since(UNIX_EPOCH)
-        .map_err(|source| BundleError::Validation {
-            message: format!("system clock is before UNIX epoch: {source}"),
-        })?
-        .as_nanos();
-    Ok(parent.join(format!(
-        ".{name}.agentenv-staging-{}-{nanos}",
-        std::process::id()
-    )))
+    format!(".{name}.agentenv-staging-{}", Uuid::new_v4())
 }
 
 fn write_file(root: &Path, relative: &str, bytes: &[u8]) -> Result<(), BundleError> {
@@ -627,10 +664,49 @@ fn remove_dir_all(path: &Path) -> Result<(), BundleError> {
     })
 }
 
-fn rename(from: &Path, to: &Path) -> Result<(), BundleError> {
-    fs::rename(from, to).map_err(|source| BundleError::Io {
-        path: to.to_path_buf(),
-        source,
+fn publish_staging(from: &Path, to: &Path) -> Result<(), BundleError> {
+    publish_staging_no_replace(from, to)
+}
+
+#[cfg(any(
+    target_vendor = "apple",
+    target_os = "linux",
+    target_os = "android",
+    target_os = "redox"
+))]
+fn publish_staging_no_replace(from: &Path, to: &Path) -> Result<(), BundleError> {
+    use rustix::fs::{renameat_with, RenameFlags, CWD};
+
+    match renameat_with(CWD, from, CWD, to, RenameFlags::NOREPLACE) {
+        Ok(()) => Ok(()),
+        Err(rustix::io::Errno::EXIST) => Err(BundleError::OutputExists {
+            path: to.to_path_buf(),
+        }),
+        Err(source) => Err(BundleError::Io {
+            path: to.to_path_buf(),
+            source: std::io::Error::from_raw_os_error(source.raw_os_error()),
+        }),
+    }
+}
+
+#[cfg(not(any(
+    target_vendor = "apple",
+    target_os = "linux",
+    target_os = "android",
+    target_os = "redox"
+)))]
+fn publish_staging_no_replace(from: &Path, to: &Path) -> Result<(), BundleError> {
+    fs::rename(from, to).map_err(|source| {
+        if source.kind() == std::io::ErrorKind::AlreadyExists {
+            BundleError::OutputExists {
+                path: to.to_path_buf(),
+            }
+        } else {
+            BundleError::Io {
+                path: to.to_path_buf(),
+                source,
+            }
+        }
     })
 }
 
@@ -671,6 +747,43 @@ mod tests {
 
     use super::*;
     use crate::skills::SkillManifest;
+
+    #[test]
+    fn publish_staging_rejects_existing_output_path() {
+        let root = temp_test_dir("publish-existing");
+        let staging = root.join("staging");
+        let output = root.join("output");
+        fs::create_dir(&staging).unwrap();
+        fs::create_dir(&output).unwrap();
+
+        let error = publish_staging(&staging, &output).unwrap_err();
+
+        assert!(matches!(error, BundleError::OutputExists { .. }));
+        assert!(staging.is_dir());
+        assert!(output.is_dir());
+    }
+
+    #[test]
+    fn unique_staging_dir_does_not_remove_existing_collision() {
+        let root = temp_test_dir("staging-collision");
+        let output = root.join("bundle");
+        let collision = root.join(".bundle.agentenv-staging-test-collision");
+        fs::create_dir(&collision).unwrap();
+        fs::write(collision.join("sentinel"), b"keep").unwrap();
+
+        let created = create_unique_staging_dir_with_candidates(
+            &output,
+            [
+                ".bundle.agentenv-staging-test-collision".to_owned(),
+                ".bundle.agentenv-staging-test-created".to_owned(),
+            ],
+        )
+        .unwrap();
+
+        assert_eq!(created, root.join(".bundle.agentenv-staging-test-created"));
+        assert!(collision.join("sentinel").is_file());
+        assert!(created.is_dir());
+    }
 
     #[test]
     fn metadata_parity_rejects_frontmatter_description_tags_and_schema_drift() {
@@ -739,5 +852,23 @@ agentenv-schema: "0.1"
             signature_public_key_ed25519: None,
             extra,
         }
+    }
+
+    fn temp_test_dir(prefix: &str) -> PathBuf {
+        let workspace_root = PathBuf::from(env!("CARGO_MANIFEST_DIR"))
+            .parent()
+            .and_then(|path| path.parent())
+            .unwrap()
+            .to_path_buf();
+        let root = workspace_root.join("target").join(format!(
+            "{prefix}-{}-{}",
+            std::process::id(),
+            std::time::SystemTime::now()
+                .duration_since(std::time::UNIX_EPOCH)
+                .unwrap()
+                .as_nanos()
+        ));
+        fs::create_dir_all(&root).unwrap();
+        root
     }
 }

--- a/crates/agentenv-core/src/lib.rs
+++ b/crates/agentenv-core/src/lib.rs
@@ -3,6 +3,7 @@
 pub mod admission;
 pub mod agent_common;
 pub mod blueprint;
+pub mod bundle;
 pub mod context_common;
 pub mod digest;
 pub mod driver;

--- a/crates/agentenv-core/src/runtime.rs
+++ b/crates/agentenv-core/src/runtime.rs
@@ -414,6 +414,13 @@ pub struct EnvDescription {
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct FrozenEnvBundleSource {
+    pub env_name: String,
+    pub blueprint_yaml: String,
+    pub lockfile_yaml: String,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 pub struct DriverHealthSummary {
     pub healthy: bool,
     #[serde(default, skip_serializing_if = "Option::is_none")]
@@ -1687,6 +1694,19 @@ pub fn freeze_env_lockfile(options: &RuntimeOptions, name: &str) -> RuntimeResul
     }
 
     Ok(lockfile.to_yaml_deterministic()?)
+}
+
+pub fn freeze_env_for_bundle(
+    options: &RuntimeOptions,
+    name: &str,
+) -> RuntimeResult<FrozenEnvBundleSource> {
+    let description = describe_env(options, name)?;
+    let lockfile_yaml = freeze_env_lockfile(options, name)?;
+    Ok(FrozenEnvBundleSource {
+        env_name: description.state.name,
+        blueprint_yaml: description.blueprint_yaml,
+        lockfile_yaml,
+    })
 }
 
 fn portable_lockfile_matches_env_blueprint(
@@ -4798,9 +4818,9 @@ mod tests {
 
     use super::{
         approval_coordinator_for_env, component_spec, env_approval_overlay_path,
-        env_approval_proposals_path, env_events_db_path, initialize_context_driver,
-        initialize_sandbox_driver, DriverFactory, DriverSet, RuntimeError, RuntimeOptions,
-        RuntimeSecret,
+        env_approval_proposals_path, env_events_db_path, freeze_env_for_bundle,
+        initialize_context_driver, initialize_sandbox_driver, DriverFactory, DriverSet,
+        RuntimeError, RuntimeOptions, RuntimeSecret,
     };
 
     fn unique_root(prefix: &str) -> std::path::PathBuf {
@@ -4831,6 +4851,65 @@ mod tests {
             health: BTreeMap::new(),
             first_enter_hint_shown: false,
         }
+    }
+
+    #[test]
+    fn freeze_env_for_bundle_returns_persisted_blueprint_and_portable_lockfile() {
+        let root = unique_root("agentenv-runtime-freeze-bundle-source");
+        let options = RuntimeOptions {
+            root: root.clone(),
+            log_level: LogLevel::Info,
+            non_interactive: true,
+        };
+        let env_dir = root.join("envs").join("demo");
+        fs::create_dir_all(&env_dir).unwrap();
+        let driver_version = env!("CARGO_PKG_VERSION");
+        fs::write(
+            env_dir.join("state.json"),
+            serde_json::json!({
+                "version": "0.1.0",
+                "name": "demo",
+                "phase": "running",
+                "created_at": "2026-05-09T00:00:00Z",
+                "updated_at": "2026-05-09T00:00:00Z",
+                "drivers": {
+                    "sandbox": {"name": "openshell", "version": driver_version},
+                    "agent": {"name": "codex", "version": driver_version},
+                    "context": {"name": "filesystem", "version": driver_version},
+                    "inference": {"name": "passthrough", "version": driver_version}
+                },
+                "handles": {},
+                "endpoints": {},
+                "first_enter_hint_shown": false
+            })
+            .to_string(),
+        )
+        .unwrap();
+        let blueprint_yaml = r#"version: 0.1.0
+min_agentenv_version: 0.0.1-alpha0
+sandbox:
+  driver: openshell
+agent:
+  driver: codex
+context:
+  driver: filesystem
+  mount: .
+inference:
+  driver: passthrough
+policy:
+  tier: balanced
+  presets: []
+"#;
+        fs::write(env_dir.join("blueprint.yaml"), blueprint_yaml).unwrap();
+        let lock_yaml = crate::lifecycle::freeze_from_blueprint_yaml(blueprint_yaml).unwrap();
+        fs::write(env_dir.join("lock.yaml"), lock_yaml).unwrap();
+
+        let frozen = freeze_env_for_bundle(&options, "demo").unwrap();
+
+        assert_eq!(frozen.env_name, "demo");
+        assert_eq!(frozen.blueprint_yaml, blueprint_yaml);
+        assert!(frozen.lockfile_yaml.contains("version: 0.2.0"));
+        assert!(frozen.lockfile_yaml.contains("name: demo"));
     }
 
     fn write_state_json(env_dir: &std::path::Path, state: crate::env::EnvStateFile) {

--- a/crates/agentenv-core/src/runtime.rs
+++ b/crates/agentenv-core/src/runtime.rs
@@ -1629,6 +1629,13 @@ fn write_env_registry_file(content: &str, path: &Path) -> RuntimeResult<()> {
 
 pub fn freeze_env_lockfile(options: &RuntimeOptions, name: &str) -> RuntimeResult<String> {
     let description = describe_env(options, name)?;
+    freeze_env_lockfile_from_description(options, description)
+}
+
+fn freeze_env_lockfile_from_description(
+    options: &RuntimeOptions,
+    description: EnvDescription,
+) -> RuntimeResult<String> {
     let mut discovery_config = crate::driver_catalog::DriverDiscoveryConfig::from_env();
     discovery_config.installed_root = options.root.join("drivers");
     let driver_artifacts =
@@ -1701,10 +1708,12 @@ pub fn freeze_env_for_bundle(
     name: &str,
 ) -> RuntimeResult<FrozenEnvBundleSource> {
     let description = describe_env(options, name)?;
-    let lockfile_yaml = freeze_env_lockfile(options, name)?;
+    let env_name = description.state.name.clone();
+    let blueprint_yaml = description.blueprint_yaml.clone();
+    let lockfile_yaml = freeze_env_lockfile_from_description(options, description)?;
     Ok(FrozenEnvBundleSource {
-        env_name: description.state.name,
-        blueprint_yaml: description.blueprint_yaml,
+        env_name,
+        blueprint_yaml,
         lockfile_yaml,
     })
 }
@@ -4908,8 +4917,28 @@ policy:
 
         assert_eq!(frozen.env_name, "demo");
         assert_eq!(frozen.blueprint_yaml, blueprint_yaml);
-        assert!(frozen.lockfile_yaml.contains("version: 0.2.0"));
-        assert!(frozen.lockfile_yaml.contains("name: demo"));
+        let crate::lockfile::LockfileDocument::Portable(lockfile) =
+            crate::lockfile::LockfileDocument::from_yaml(&frozen.lockfile_yaml).unwrap()
+        else {
+            panic!("bundle source should include a portable lockfile");
+        };
+        let mut discovery_config = crate::driver_catalog::DriverDiscoveryConfig::from_env();
+        discovery_config.installed_root = root.join("drivers");
+        let driver_artifacts =
+            crate::driver_artifact::discover_driver_artifacts(discovery_config, None).unwrap();
+        let expected = crate::portable_lockfile::build_portable_lockfile(
+            crate::portable_lockfile::PortableLockfileInput {
+                name: "demo".to_owned(),
+                blueprint_yaml: frozen.blueprint_yaml.clone(),
+                driver_artifacts,
+            },
+        )
+        .unwrap();
+
+        assert_eq!(lockfile.name, "demo");
+        assert_eq!(lockfile.version, crate::lockfile::PORTABLE_LOCKFILE_VERSION);
+        assert_eq!(lockfile.composition, expected.composition);
+        assert_eq!(lockfile.blueprint_hash, expected.blueprint_hash);
     }
 
     fn write_state_json(env_dir: &std::path::Path, state: crate::env::EnvStateFile) {

--- a/crates/agentenv-core/tests/bundle.rs
+++ b/crates/agentenv-core/tests/bundle.rs
@@ -1,4 +1,4 @@
-use std::{fs, path::PathBuf};
+use std::{collections::BTreeSet, fs, path::PathBuf};
 
 use agentenv_core::{
     bundle::{
@@ -157,6 +157,69 @@ fn emit_skill_bundle_writes_reference_document_when_provided() {
     assert_eq!(
         yaml_string_sequence(&frontmatter, "tags"),
         vec!["openshell", "codex", "filesystem", "dev-env"]
+    );
+}
+
+#[test]
+fn emit_skill_bundle_declares_explicit_files_for_remote_registry_fetch() {
+    let root = temp_dir("bundle-explicit-files");
+    let out = root.join("demo-skill");
+    let blueprint_yaml = minimal_blueprint();
+    let driver_artifacts = test_driver_artifacts();
+    let lockfile_yaml = portable_lock_yaml("demo", &blueprint_yaml, &driver_artifacts);
+
+    emit_skill_bundle(SkillBundleInput {
+        source: BundleSource {
+            env_name: "demo".to_owned(),
+            project_path: Some(root.join("project")),
+            git_commit: None,
+            git_dirty: None,
+        },
+        metadata: SkillBundleMetadata {
+            name: "demo".to_owned(),
+            version: Version::parse("1.0.0").unwrap(),
+            description: "Reproducible dev env for demo".to_owned(),
+            author: None,
+            license: None,
+            tags: vec!["dev-env".to_owned()],
+        },
+        blueprint_yaml,
+        lockfile_yaml,
+        reference_document: Some(ReferenceDocument {
+            source_relative_path: "README.md".to_owned(),
+            content: "# Demo\n".to_owned(),
+        }),
+        output_dir: out.clone(),
+        agentenv_version: "0.0.1-alpha0".to_owned(),
+        created_at: "2026-05-09T00:00:00Z".to_owned(),
+        driver_artifacts,
+    })
+    .unwrap();
+
+    let skill_yaml: serde_yaml::Value =
+        serde_yaml::from_str(&fs::read_to_string(out.join("skill.yaml")).unwrap()).unwrap();
+    let files = yaml_string_sequence(&skill_yaml, "files")
+        .into_iter()
+        .collect::<BTreeSet<_>>();
+
+    assert_eq!(
+        files,
+        [
+            ".agentenv/manifest.json",
+            ".agentenv/provenance.json",
+            "SKILL.md",
+            "agentenv.lock",
+            "blueprint.yaml",
+            "references/architecture.md",
+            "scripts/bootstrap.sh",
+        ]
+        .into_iter()
+        .map(str::to_owned)
+        .collect::<BTreeSet<_>>()
+    );
+    assert!(
+        files.iter().all(|path| !path.ends_with("/**")),
+        "remote registry fetch requires explicit file entries, got {files:?}"
     );
 }
 

--- a/crates/agentenv-core/tests/bundle.rs
+++ b/crates/agentenv-core/tests/bundle.rs
@@ -1,0 +1,330 @@
+use std::{fs, path::PathBuf};
+
+use agentenv_core::{
+    bundle::{
+        emit_skill_bundle, BundleSource, ReferenceDocument, SkillBundleInput, SkillBundleMetadata,
+        SkillBundleOutput,
+    },
+    driver_artifact::DriverArtifact,
+    driver_catalog::DriverSource,
+    portable_lockfile::{build_portable_lockfile, PortableLockfileInput},
+    registry::DriverKind,
+    skills::{compute_bundle_digest, load_skill_manifest},
+};
+use semver::Version;
+
+#[test]
+fn emit_skill_bundle_writes_expected_layout() {
+    let root = temp_dir("bundle-layout");
+    let out = root.join("demo-skill");
+    let blueprint_yaml = minimal_blueprint();
+    let driver_artifacts = test_driver_artifacts();
+    let lockfile_yaml = portable_lock_yaml("demo", &blueprint_yaml, &driver_artifacts);
+
+    let output: SkillBundleOutput = emit_skill_bundle(SkillBundleInput {
+        source: BundleSource {
+            env_name: "demo".to_owned(),
+            project_path: None,
+            git_commit: None,
+            git_dirty: None,
+        },
+        metadata: SkillBundleMetadata {
+            name: "demo".to_owned(),
+            version: Version::parse("1.0.0").unwrap(),
+            description: "Reproducible dev env for demo".to_owned(),
+            author: None,
+            license: None,
+            tags: vec![
+                "openshell".to_owned(),
+                "codex".to_owned(),
+                "filesystem".to_owned(),
+                "dev-env".to_owned(),
+            ],
+        },
+        blueprint_yaml: blueprint_yaml.clone(),
+        lockfile_yaml: lockfile_yaml.clone(),
+        reference_document: None,
+        output_dir: out.clone(),
+        agentenv_version: "0.0.1-alpha0".to_owned(),
+        created_at: "2026-05-09T00:00:00Z".to_owned(),
+        driver_artifacts,
+    })
+    .unwrap();
+
+    assert_eq!(output.output_dir, out);
+    assert_eq!(output.skill_name, "demo");
+    assert_eq!(output.version, "1.0.0");
+    assert!(output.warnings.is_empty());
+    assert!(out.join("SKILL.md").is_file());
+    assert!(out.join("skill.yaml").is_file());
+    assert!(out.join("blueprint.yaml").is_file());
+    assert!(out.join("agentenv.lock").is_file());
+    assert!(out.join("scripts/bootstrap.sh").is_file());
+    assert!(out.join(".agentenv/manifest.json").is_file());
+    assert!(out.join(".agentenv/provenance.json").is_file());
+    assert!(!out.join("references").exists());
+
+    let skill = fs::read_to_string(out.join("SKILL.md")).unwrap();
+    assert!(skill.contains("agentenv-bundle: true"));
+    assert!(skill.contains("agentenv-schema: \"0.1\""));
+    assert!(skill.contains("agentenv reproduce agentenv.lock --name demo"));
+
+    let bootstrap = fs::read_to_string(out.join("scripts/bootstrap.sh")).unwrap();
+    assert!(bootstrap.contains("agentenv verify agentenv.lock"));
+    assert!(bootstrap.contains("agentenv reproduce agentenv.lock --name \"${ENV_NAME}\""));
+
+    let manifest = load_skill_manifest(&out).unwrap();
+    assert_eq!(manifest.name, "demo");
+    assert_eq!(manifest.version.to_string(), "1.0.0");
+    assert_eq!(manifest.entry, PathBuf::from("SKILL.md"));
+    assert!(manifest
+        .declared_files
+        .contains(&PathBuf::from("agentenv.lock")));
+    assert!(!manifest
+        .declared_files
+        .iter()
+        .any(|path| path.starts_with("references")));
+
+    let digest = compute_bundle_digest(&out, &manifest).unwrap();
+    assert_eq!(output.bundle_digest, digest);
+    assert_eq!(output.blueprint_digest, sha256_digest(&blueprint_yaml));
+    assert_eq!(output.lockfile_digest, sha256_digest(&lockfile_yaml));
+    assert_eq!(
+        fs::read_to_string(out.join("blueprint.yaml")).unwrap(),
+        ensure_trailing_newline(&blueprint_yaml)
+    );
+    assert_eq!(
+        fs::read_to_string(out.join("agentenv.lock")).unwrap(),
+        ensure_trailing_newline(&lockfile_yaml)
+    );
+}
+
+#[test]
+fn emit_skill_bundle_writes_reference_document_when_provided() {
+    let root = temp_dir("bundle-reference");
+    let out = root.join("demo-skill");
+    let blueprint_yaml = minimal_blueprint();
+    let driver_artifacts = test_driver_artifacts();
+    let lockfile_yaml = portable_lock_yaml("demo", &blueprint_yaml, &driver_artifacts);
+
+    emit_skill_bundle(SkillBundleInput {
+        source: BundleSource {
+            env_name: "demo".to_owned(),
+            project_path: Some(root.join("project")),
+            git_commit: Some("abc123".to_owned()),
+            git_dirty: Some(false),
+        },
+        metadata: SkillBundleMetadata {
+            name: "demo".to_owned(),
+            version: Version::parse("1.0.0").unwrap(),
+            description: "Reproducible dev env for demo".to_owned(),
+            author: Some("Alice Example".to_owned()),
+            license: Some("MIT".to_owned()),
+            tags: vec![
+                "openshell".to_owned(),
+                "codex".to_owned(),
+                "filesystem".to_owned(),
+                "dev-env".to_owned(),
+            ],
+        },
+        blueprint_yaml,
+        lockfile_yaml,
+        reference_document: Some(ReferenceDocument {
+            source_relative_path: "docs/ARCHITECTURE.md".to_owned(),
+            content: "# Architecture\n\nDetails\n".to_owned(),
+        }),
+        output_dir: out.clone(),
+        agentenv_version: "0.0.1-alpha0".to_owned(),
+        created_at: "2026-05-09T00:00:00Z".to_owned(),
+        driver_artifacts,
+    })
+    .unwrap();
+
+    let reference = fs::read_to_string(out.join("references/architecture.md")).unwrap();
+    assert!(reference.starts_with("# Project Architecture\n\nSource: `docs/ARCHITECTURE.md`\n\n"));
+    assert!(reference.contains("# Architecture"));
+
+    let manifest = load_skill_manifest(&out).unwrap();
+    assert!(manifest
+        .declared_files
+        .contains(&PathBuf::from("references/architecture.md")));
+
+    let skill = fs::read_to_string(out.join("SKILL.md")).unwrap();
+    assert!(skill.contains("author: Alice Example"));
+    assert!(skill.contains("license: MIT"));
+    assert!(skill.contains("tags: [openshell, codex, filesystem, dev-env]"));
+}
+
+#[test]
+fn emit_skill_bundle_records_blueprint_lockfile_and_manifest_digests() {
+    let root = temp_dir("bundle-digests");
+    let out = root.join("demo-skill");
+    let blueprint_yaml = minimal_blueprint();
+    let driver_artifacts = test_driver_artifacts();
+    let lockfile_yaml = portable_lock_yaml("demo", &blueprint_yaml, &driver_artifacts);
+
+    let output = emit_skill_bundle(SkillBundleInput {
+        source: BundleSource {
+            env_name: "demo".to_owned(),
+            project_path: None,
+            git_commit: None,
+            git_dirty: None,
+        },
+        metadata: SkillBundleMetadata {
+            name: "demo".to_owned(),
+            version: Version::parse("1.0.0").unwrap(),
+            description: "Reproducible dev env for demo".to_owned(),
+            author: None,
+            license: None,
+            tags: vec!["dev-env".to_owned()],
+        },
+        blueprint_yaml: blueprint_yaml.clone(),
+        lockfile_yaml: lockfile_yaml.clone(),
+        reference_document: None,
+        output_dir: out.clone(),
+        agentenv_version: "0.0.1-alpha0".to_owned(),
+        created_at: "2026-05-09T00:00:00Z".to_owned(),
+        driver_artifacts,
+    })
+    .unwrap();
+
+    let manifest_json = fs::read_to_string(out.join(".agentenv/manifest.json")).unwrap();
+    assert!(manifest_json.contains("\"path\": \"SKILL.md\""));
+    assert!(manifest_json.contains("\"path\": \"skill.yaml\""));
+    assert!(manifest_json.contains("\"path\": \"blueprint.yaml\""));
+    assert!(manifest_json.contains("\"path\": \"agentenv.lock\""));
+    assert!(manifest_json.contains("\"path\": \"scripts/bootstrap.sh\""));
+    assert!(!manifest_json.contains("provenance.json"));
+
+    let provenance_json = fs::read_to_string(out.join(".agentenv/provenance.json")).unwrap();
+    assert!(provenance_json.contains("\"created_at\": \"2026-05-09T00:00:00Z\""));
+    assert!(provenance_json.contains(&format!("\"blueprint\": \"{}\"", output.blueprint_digest)));
+    assert!(provenance_json.contains(&format!("\"lockfile\": \"{}\"", output.lockfile_digest)));
+    assert!(provenance_json.contains("\"manifest\": \"sha256:"));
+}
+
+#[test]
+fn emit_skill_bundle_rejects_existing_output_path() {
+    let root = temp_dir("bundle-existing");
+    let out = root.join("demo-skill");
+    fs::create_dir_all(&out).unwrap();
+    let blueprint_yaml = minimal_blueprint();
+    let driver_artifacts = test_driver_artifacts();
+    let lockfile_yaml = portable_lock_yaml("demo", &blueprint_yaml, &driver_artifacts);
+
+    let error = emit_skill_bundle(SkillBundleInput {
+        source: BundleSource {
+            env_name: "demo".to_owned(),
+            project_path: None,
+            git_commit: None,
+            git_dirty: None,
+        },
+        metadata: SkillBundleMetadata {
+            name: "demo".to_owned(),
+            version: Version::parse("1.0.0").unwrap(),
+            description: "Reproducible dev env for demo".to_owned(),
+            author: None,
+            license: None,
+            tags: vec!["dev-env".to_owned()],
+        },
+        blueprint_yaml,
+        lockfile_yaml,
+        reference_document: None,
+        output_dir: out,
+        agentenv_version: "0.0.1-alpha0".to_owned(),
+        created_at: "2026-05-09T00:00:00Z".to_owned(),
+        driver_artifacts,
+    })
+    .unwrap_err();
+
+    assert!(error.to_string().contains("output path already exists"));
+}
+
+fn minimal_blueprint() -> String {
+    r#"version: 0.1.0
+min_agentenv_version: 0.0.1-alpha0
+sandbox:
+  driver: openshell
+agent:
+  driver: codex
+context:
+  driver: filesystem
+  mount: .
+inference:
+  driver: passthrough
+policy:
+  tier: balanced
+  presets: []
+"#
+    .to_owned()
+}
+
+fn portable_lock_yaml(
+    name: &str,
+    blueprint_yaml: &str,
+    driver_artifacts: &[DriverArtifact],
+) -> String {
+    build_portable_lockfile(PortableLockfileInput {
+        name: name.to_owned(),
+        blueprint_yaml: blueprint_yaml.to_owned(),
+        driver_artifacts: driver_artifacts.to_vec(),
+    })
+    .unwrap()
+    .to_yaml_deterministic()
+    .unwrap()
+}
+
+fn test_driver_artifacts() -> Vec<DriverArtifact> {
+    let version = Version::parse(env!("CARGO_PKG_VERSION")).unwrap();
+    [
+        (DriverKind::Sandbox, "openshell"),
+        (DriverKind::Agent, "codex"),
+        (DriverKind::Context, "filesystem"),
+        (DriverKind::Inference, "passthrough"),
+    ]
+    .into_iter()
+    .map(|(kind, name)| DriverArtifact {
+        kind,
+        name: name.to_owned(),
+        version: version.clone(),
+        source: DriverSource::BuiltIn,
+        digest: "sha256:1111111111111111111111111111111111111111111111111111111111111111"
+            .to_owned(),
+        install_hint: None,
+        entry: None,
+    })
+    .collect()
+}
+
+fn ensure_trailing_newline(input: &str) -> String {
+    if input.ends_with('\n') {
+        input.to_owned()
+    } else {
+        format!("{input}\n")
+    }
+}
+
+fn sha256_digest(input: &str) -> String {
+    format!(
+        "sha256:{}",
+        agentenv_core::digest::sha256_hex(ensure_trailing_newline(input).as_bytes())
+    )
+}
+
+fn temp_dir(prefix: &str) -> PathBuf {
+    let workspace_root = PathBuf::from(env!("CARGO_MANIFEST_DIR"))
+        .parent()
+        .and_then(|path| path.parent())
+        .unwrap()
+        .to_path_buf();
+    let path = workspace_root.join("target").join(format!(
+        "{prefix}-{}-{}",
+        std::process::id(),
+        std::time::SystemTime::now()
+            .duration_since(std::time::UNIX_EPOCH)
+            .unwrap()
+            .as_nanos()
+    ));
+    fs::create_dir_all(&path).unwrap();
+    path
+}

--- a/crates/agentenv-core/tests/bundle.rs
+++ b/crates/agentenv-core/tests/bundle.rs
@@ -240,6 +240,44 @@ fn emit_skill_bundle_rejects_existing_output_path() {
     assert!(error.to_string().contains("output path already exists"));
 }
 
+#[cfg(unix)]
+#[test]
+fn emit_skill_bundle_rejects_dangling_symlink_output_path() {
+    let root = temp_dir("bundle-existing-symlink");
+    let out = root.join("demo-skill");
+    std::os::unix::fs::symlink(root.join("missing-target"), &out).unwrap();
+    let blueprint_yaml = minimal_blueprint();
+    let driver_artifacts = test_driver_artifacts();
+    let lockfile_yaml = portable_lock_yaml("demo", &blueprint_yaml, &driver_artifacts);
+
+    let error = emit_skill_bundle(SkillBundleInput {
+        source: BundleSource {
+            env_name: "demo".to_owned(),
+            project_path: None,
+            git_commit: None,
+            git_dirty: None,
+        },
+        metadata: SkillBundleMetadata {
+            name: "demo".to_owned(),
+            version: Version::parse("1.0.0").unwrap(),
+            description: "Reproducible dev env for demo".to_owned(),
+            author: None,
+            license: None,
+            tags: vec!["dev-env".to_owned()],
+        },
+        blueprint_yaml,
+        lockfile_yaml,
+        reference_document: None,
+        output_dir: out,
+        agentenv_version: "0.0.1-alpha0".to_owned(),
+        created_at: "2026-05-09T00:00:00Z".to_owned(),
+        driver_artifacts,
+    })
+    .unwrap_err();
+
+    assert!(error.to_string().contains("output path already exists"));
+}
+
 fn minimal_blueprint() -> String {
     r#"version: 0.1.0
 min_agentenv_version: 0.0.1-alpha0

--- a/crates/agentenv-core/tests/bundle.rs
+++ b/crates/agentenv-core/tests/bundle.rs
@@ -156,6 +156,74 @@ fn emit_skill_bundle_writes_reference_document_when_provided() {
 }
 
 #[test]
+fn emit_skill_bundle_keeps_skill_yaml_and_frontmatter_in_sync() {
+    let root = temp_dir("bundle-parity");
+    let out = root.join("demo-skill");
+    let blueprint_yaml = minimal_blueprint();
+    let driver_artifacts = test_driver_artifacts();
+    let lockfile_yaml = portable_lock_yaml("demo", &blueprint_yaml, &driver_artifacts);
+
+    emit_skill_bundle(SkillBundleInput {
+        source: BundleSource {
+            env_name: "demo".to_owned(),
+            project_path: None,
+            git_commit: None,
+            git_dirty: None,
+        },
+        metadata: SkillBundleMetadata {
+            name: "demo".to_owned(),
+            version: Version::parse("1.0.0").unwrap(),
+            description: "Reproducible dev env for demo".to_owned(),
+            author: None,
+            license: None,
+            tags: vec![
+                "openshell".to_owned(),
+                "codex".to_owned(),
+                "dev-env".to_owned(),
+            ],
+        },
+        blueprint_yaml,
+        lockfile_yaml,
+        reference_document: None,
+        output_dir: out.clone(),
+        agentenv_version: "0.0.1-alpha0".to_owned(),
+        created_at: "2026-05-09T00:00:00Z".to_owned(),
+        driver_artifacts,
+    })
+    .unwrap();
+
+    let skill_yaml: serde_yaml::Value =
+        serde_yaml::from_str(&fs::read_to_string(out.join("skill.yaml")).unwrap()).unwrap();
+    let skill_md = fs::read_to_string(out.join("SKILL.md")).unwrap();
+    let frontmatter = parse_skill_frontmatter(&skill_md);
+
+    assert_eq!(
+        yaml_string_field(&frontmatter, "name"),
+        yaml_string_field(&skill_yaml, "name")
+    );
+    assert_eq!(
+        yaml_string_field(&frontmatter, "version"),
+        yaml_string_field(&skill_yaml, "version")
+    );
+    assert_eq!(
+        yaml_string_field(&frontmatter, "description"),
+        yaml_string_field(&skill_yaml, "description")
+    );
+    assert_eq!(
+        yaml_string_sequence(&frontmatter, "tags"),
+        yaml_string_sequence(&skill_yaml, "tags")
+    );
+    assert_eq!(
+        yaml_string_field(&frontmatter, "agentenv-schema"),
+        yaml_string_field(&skill_yaml, "agentenv_schema")
+    );
+    assert_eq!(
+        frontmatter["agentenv-bundle"].as_bool(),
+        skill_yaml["agentenv_bundle"].as_bool()
+    );
+}
+
+#[test]
 fn emit_skill_bundle_records_blueprint_lockfile_and_manifest_digests() {
     let root = temp_dir("bundle-digests");
     let out = root.join("demo-skill");
@@ -347,6 +415,32 @@ fn sha256_digest(input: &str) -> String {
         "sha256:{}",
         agentenv_core::digest::sha256_hex(ensure_trailing_newline(input).as_bytes())
     )
+}
+
+fn parse_skill_frontmatter(skill_md: &str) -> serde_yaml::Value {
+    let mut lines = skill_md.lines();
+    assert_eq!(lines.next(), Some("---"));
+    let mut frontmatter = Vec::new();
+    for line in lines {
+        if line == "---" {
+            return serde_yaml::from_str(&frontmatter.join("\n")).unwrap();
+        }
+        frontmatter.push(line);
+    }
+    panic!("SKILL.md frontmatter was not closed");
+}
+
+fn yaml_string_field(value: &serde_yaml::Value, key: &str) -> String {
+    value[key].as_str().unwrap().to_owned()
+}
+
+fn yaml_string_sequence(value: &serde_yaml::Value, key: &str) -> Vec<String> {
+    value[key]
+        .as_sequence()
+        .unwrap()
+        .iter()
+        .map(|item| item.as_str().unwrap().to_owned())
+        .collect()
 }
 
 fn temp_dir(prefix: &str) -> PathBuf {

--- a/crates/agentenv-core/tests/bundle.rs
+++ b/crates/agentenv-core/tests/bundle.rs
@@ -439,6 +439,48 @@ fn emit_skill_bundle_rejects_dangling_symlink_output_path() {
     assert!(error.to_string().contains("output path already exists"));
 }
 
+#[cfg(unix)]
+#[test]
+fn emit_skill_bundle_allows_symlinked_output_parent() {
+    let root = temp_dir("bundle-symlink-parent");
+    let target = root.join("target");
+    fs::create_dir_all(&target).unwrap();
+    let link = root.join("link");
+    std::os::unix::fs::symlink(&target, &link).unwrap();
+    let out = link.join("demo-skill");
+    let blueprint_yaml = minimal_blueprint();
+    let driver_artifacts = test_driver_artifacts();
+    let lockfile_yaml = portable_lock_yaml("demo", &blueprint_yaml, &driver_artifacts);
+
+    let output = emit_skill_bundle(SkillBundleInput {
+        source: BundleSource {
+            env_name: "demo".to_owned(),
+            project_path: None,
+            git_commit: None,
+            git_dirty: None,
+        },
+        metadata: SkillBundleMetadata {
+            name: "demo".to_owned(),
+            version: Version::parse("1.0.0").unwrap(),
+            description: "Reproducible dev env for demo".to_owned(),
+            author: None,
+            license: None,
+            tags: vec!["dev-env".to_owned()],
+        },
+        blueprint_yaml,
+        lockfile_yaml,
+        reference_document: None,
+        output_dir: out.clone(),
+        agentenv_version: "0.0.1-alpha0".to_owned(),
+        created_at: "2026-05-09T00:00:00Z".to_owned(),
+        driver_artifacts,
+    })
+    .unwrap();
+
+    assert_eq!(output.output_dir, out);
+    assert!(target.join("demo-skill/SKILL.md").is_file());
+}
+
 fn minimal_blueprint() -> String {
     r#"version: 0.1.0
 min_agentenv_version: 0.0.1-alpha0

--- a/crates/agentenv-core/tests/bundle.rs
+++ b/crates/agentenv-core/tests/bundle.rs
@@ -65,8 +65,9 @@ fn emit_skill_bundle_writes_expected_layout() {
     assert!(!out.join("references").exists());
 
     let skill = fs::read_to_string(out.join("SKILL.md")).unwrap();
-    assert!(skill.contains("agentenv-bundle: true"));
-    assert!(skill.contains("agentenv-schema: \"0.1\""));
+    let frontmatter = parse_skill_frontmatter(&skill);
+    assert_eq!(frontmatter["agentenv-bundle"].as_bool(), Some(true));
+    assert_eq!(yaml_string_field(&frontmatter, "agentenv-schema"), "0.1");
     assert!(skill.contains("agentenv reproduce agentenv.lock --name demo"));
 
     let bootstrap = fs::read_to_string(out.join("scripts/bootstrap.sh")).unwrap();
@@ -150,9 +151,13 @@ fn emit_skill_bundle_writes_reference_document_when_provided() {
         .contains(&PathBuf::from("references/architecture.md")));
 
     let skill = fs::read_to_string(out.join("SKILL.md")).unwrap();
-    assert!(skill.contains("author: Alice Example"));
-    assert!(skill.contains("license: MIT"));
-    assert!(skill.contains("tags: [openshell, codex, filesystem, dev-env]"));
+    let frontmatter = parse_skill_frontmatter(&skill);
+    assert_eq!(yaml_string_field(&frontmatter, "author"), "Alice Example");
+    assert_eq!(yaml_string_field(&frontmatter, "license"), "MIT");
+    assert_eq!(
+        yaml_string_sequence(&frontmatter, "tags"),
+        vec!["openshell", "codex", "filesystem", "dev-env"]
+    );
 }
 
 #[test]
@@ -221,6 +226,94 @@ fn emit_skill_bundle_keeps_skill_yaml_and_frontmatter_in_sync() {
         frontmatter["agentenv-bundle"].as_bool(),
         skill_yaml["agentenv_bundle"].as_bool()
     );
+}
+
+#[test]
+fn emit_skill_bundle_quotes_yaml_like_descriptions_and_special_tags() {
+    let root = temp_dir("bundle-yaml-safety");
+    let out = root.join("demo-skill");
+    let blueprint_yaml = minimal_blueprint();
+    let driver_artifacts = test_driver_artifacts();
+    let lockfile_yaml = portable_lock_yaml("demo", &blueprint_yaml, &driver_artifacts);
+    let description = "true".to_owned();
+    let tags = vec![
+        "port:5432".to_owned(),
+        "hash # tag".to_owned(),
+        "comma,tag".to_owned(),
+        "line\nbreak".to_owned(),
+    ];
+
+    emit_skill_bundle(SkillBundleInput {
+        source: BundleSource {
+            env_name: "demo".to_owned(),
+            project_path: None,
+            git_commit: None,
+            git_dirty: None,
+        },
+        metadata: SkillBundleMetadata {
+            name: "demo".to_owned(),
+            version: Version::parse("1.0.0").unwrap(),
+            description: description.clone(),
+            author: None,
+            license: None,
+            tags: tags.clone(),
+        },
+        blueprint_yaml,
+        lockfile_yaml,
+        reference_document: None,
+        output_dir: out.clone(),
+        agentenv_version: "0.0.1-alpha0".to_owned(),
+        created_at: "2026-05-09T00:00:00Z".to_owned(),
+        driver_artifacts,
+    })
+    .unwrap();
+
+    let skill_yaml: serde_yaml::Value =
+        serde_yaml::from_str(&fs::read_to_string(out.join("skill.yaml")).unwrap()).unwrap();
+    let skill_md = fs::read_to_string(out.join("SKILL.md")).unwrap();
+    let frontmatter = parse_skill_frontmatter(&skill_md);
+
+    assert_eq!(yaml_string_field(&frontmatter, "description"), description);
+    assert_eq!(yaml_string_field(&skill_yaml, "description"), description);
+    assert_eq!(yaml_string_sequence(&frontmatter, "tags"), tags);
+    assert_eq!(yaml_string_sequence(&skill_yaml, "tags"), tags);
+}
+
+#[test]
+fn emit_skill_bundle_rejects_invalid_env_name_before_final_output() {
+    let root = temp_dir("bundle-invalid-env");
+    let out = root.join("demo-skill");
+    let blueprint_yaml = minimal_blueprint();
+    let driver_artifacts = test_driver_artifacts();
+    let lockfile_yaml = portable_lock_yaml("demo", &blueprint_yaml, &driver_artifacts);
+
+    let error = emit_skill_bundle(SkillBundleInput {
+        source: BundleSource {
+            env_name: "demo;rm-rf".to_owned(),
+            project_path: None,
+            git_commit: None,
+            git_dirty: None,
+        },
+        metadata: SkillBundleMetadata {
+            name: "demo".to_owned(),
+            version: Version::parse("1.0.0").unwrap(),
+            description: "Reproducible dev env for demo".to_owned(),
+            author: None,
+            license: None,
+            tags: vec!["dev-env".to_owned()],
+        },
+        blueprint_yaml,
+        lockfile_yaml,
+        reference_document: None,
+        output_dir: out.clone(),
+        agentenv_version: "0.0.1-alpha0".to_owned(),
+        created_at: "2026-05-09T00:00:00Z".to_owned(),
+        driver_artifacts,
+    })
+    .unwrap_err();
+
+    assert!(error.to_string().contains("invalid env name"));
+    assert!(!out.exists());
 }
 
 #[test]

--- a/crates/agentenv/Cargo.toml
+++ b/crates/agentenv/Cargo.toml
@@ -48,6 +48,7 @@ serde_yaml.workspace = true
 sha2.workspace = true
 time = { workspace = true, features = ["formatting"] }
 tokio.workspace = true
+toml.workspace = true
 tracing.workspace = true
 tracing-subscriber.workspace = true
 url.workspace = true

--- a/crates/agentenv/src/bundle_cli.rs
+++ b/crates/agentenv/src/bundle_cli.rs
@@ -1,0 +1,127 @@
+use std::path::PathBuf;
+
+use agentenv_core::bundle::{
+    emit_skill_bundle, BundleSource, SkillBundleInput, SkillBundleMetadata,
+};
+use agentenv_core::skills::validate_skill_name;
+use anyhow::{bail, Context, Result};
+use clap::Args;
+use time::{format_description::well_known::Rfc3339, OffsetDateTime};
+
+#[derive(Debug, Args)]
+pub(crate) struct BundleArgs {
+    pub(crate) source: String,
+    #[arg(long = "as-skill")]
+    pub(crate) as_skill: bool,
+    #[arg(long, value_name = "DIR")]
+    pub(crate) out: PathBuf,
+    #[arg(long)]
+    pub(crate) env: Option<String>,
+    #[arg(long)]
+    pub(crate) name: Option<String>,
+    #[arg(long)]
+    pub(crate) version: Option<String>,
+    #[arg(long)]
+    pub(crate) description: Option<String>,
+    #[arg(long)]
+    pub(crate) author: Option<String>,
+    #[arg(long)]
+    pub(crate) license: Option<String>,
+    #[arg(long = "tag")]
+    pub(crate) tags: Vec<String>,
+    #[arg(long)]
+    pub(crate) json: bool,
+}
+
+pub(crate) fn run_bundle(args: BundleArgs) -> Result<()> {
+    if !args.as_skill {
+        bail!("only `agentenv bundle <source> --as-skill --out <dir>` is supported");
+    }
+
+    let source = resolve_source(&args)?;
+    let options = crate::runtime_options(true)?;
+    let frozen = agentenv_core::runtime::freeze_env_for_bundle(&options, &source.env_name)
+        .with_context(|| format!("failed to freeze environment `{}`", source.env_name))?;
+    let driver_artifacts = crate::discover_runtime_driver_artifacts(&options)?;
+
+    let skill_name = args.name.clone().unwrap_or_else(|| frozen.env_name.clone());
+    validate_skill_name(&skill_name)
+        .with_context(|| format!("invalid skill name `{skill_name}`"))?;
+
+    let version = args.version.as_deref().unwrap_or("1.0.0");
+    let metadata = SkillBundleMetadata {
+        name: skill_name.clone(),
+        version: version
+            .parse()
+            .with_context(|| format!("invalid skill version `{version}`"))?,
+        description: args
+            .description
+            .clone()
+            .unwrap_or_else(|| format!("Reproducible dev env for {skill_name}")),
+        author: args.author.clone(),
+        license: args.license.clone(),
+        tags: if args.tags.is_empty() {
+            vec!["dev-env".to_owned()]
+        } else {
+            args.tags.clone()
+        },
+    };
+    let created_at = OffsetDateTime::now_utc()
+        .format(&Rfc3339)
+        .context("failed to format bundle creation timestamp")?;
+
+    let output = emit_skill_bundle(SkillBundleInput {
+        source,
+        metadata,
+        blueprint_yaml: frozen.blueprint_yaml,
+        lockfile_yaml: frozen.lockfile_yaml,
+        reference_document: None,
+        output_dir: args.out.clone(),
+        agentenv_version: env!("CARGO_PKG_VERSION").to_owned(),
+        created_at,
+        driver_artifacts,
+    })
+    .context("failed to emit skill bundle")?;
+
+    if args.json {
+        println!("{}", serde_json::to_string_pretty(&output)?);
+    } else {
+        println!("Skill bundle written: {}", output.output_dir.display());
+        println!("bundle digest: {}", output.bundle_digest);
+        println!("blueprint digest: {}", output.blueprint_digest);
+        println!("lockfile digest: {}", output.lockfile_digest);
+    }
+
+    Ok(())
+}
+
+fn resolve_source(args: &BundleArgs) -> Result<BundleSource> {
+    let source_path = PathBuf::from(&args.source);
+    let project_path = if source_path.is_dir() {
+        Some(source_path)
+    } else {
+        None
+    };
+    let env_name = match (&args.env, &project_path) {
+        (Some(env), _) => env.clone(),
+        (None, Some(path)) => path
+            .file_name()
+            .and_then(|name| name.to_str())
+            .filter(|name| !name.is_empty())
+            .map(str::to_owned)
+            .with_context(|| {
+                format!(
+                    "failed to derive environment name from project path `{}`",
+                    path.display()
+                )
+            })?,
+        (None, None) => args.source.clone(),
+    };
+
+    Ok(BundleSource {
+        env_name,
+        project_path,
+        git_commit: None,
+        git_dirty: None,
+    })
+}

--- a/crates/agentenv/src/bundle_cli.rs
+++ b/crates/agentenv/src/bundle_cli.rs
@@ -1,7 +1,10 @@
-use std::path::PathBuf;
+use std::{
+    fs,
+    path::{Path, PathBuf},
+};
 
 use agentenv_core::bundle::{
-    emit_skill_bundle, BundleSource, SkillBundleInput, SkillBundleMetadata,
+    emit_skill_bundle, BundleSource, ReferenceDocument, SkillBundleInput, SkillBundleMetadata,
 };
 use agentenv_core::skills::validate_skill_name;
 use anyhow::{bail, Context, Result};
@@ -14,7 +17,7 @@ pub(crate) struct BundleArgs {
     #[arg(long = "as-skill")]
     pub(crate) as_skill: bool,
     #[arg(long, value_name = "DIR")]
-    pub(crate) out: PathBuf,
+    pub(crate) out: Option<PathBuf>,
     #[arg(long)]
     pub(crate) env: Option<String>,
     #[arg(long)]
@@ -35,10 +38,15 @@ pub(crate) struct BundleArgs {
 
 pub(crate) fn run_bundle(args: BundleArgs) -> Result<()> {
     if !args.as_skill {
-        bail!("only `agentenv bundle <source> --as-skill --out <dir>` is supported");
+        bail!("bundle currently supports only --as-skill");
     }
+    let output_dir = args
+        .out
+        .clone()
+        .context("bundle --as-skill requires --out <dir>")?;
 
     let source = resolve_source(&args)?;
+    let reference_document = load_reference_document(source.project_path.as_deref())?;
     let options = crate::runtime_options(true)?;
     let frozen = agentenv_core::runtime::freeze_env_for_bundle(&options, &source.env_name)
         .with_context(|| format!("failed to freeze environment `{}`", source.env_name))?;
@@ -75,8 +83,8 @@ pub(crate) fn run_bundle(args: BundleArgs) -> Result<()> {
         metadata,
         blueprint_yaml: frozen.blueprint_yaml,
         lockfile_yaml: frozen.lockfile_yaml,
-        reference_document: None,
-        output_dir: args.out.clone(),
+        reference_document,
+        output_dir,
         agentenv_version: env!("CARGO_PKG_VERSION").to_owned(),
         created_at,
         driver_artifacts,
@@ -124,4 +132,25 @@ fn resolve_source(args: &BundleArgs) -> Result<BundleSource> {
         git_commit: None,
         git_dirty: None,
     })
+}
+
+fn load_reference_document(project_path: Option<&Path>) -> Result<Option<ReferenceDocument>> {
+    let Some(project_path) = project_path else {
+        return Ok(None);
+    };
+
+    for relative in ["docs/ARCHITECTURE.md", "ARCHITECTURE.md", "README.md"] {
+        let path = project_path.join(relative);
+        if path.is_file() {
+            let content = fs::read_to_string(&path).with_context(|| {
+                format!("failed to read reference document `{}`", path.display())
+            })?;
+            return Ok(Some(ReferenceDocument {
+                source_relative_path: relative.to_owned(),
+                content,
+            }));
+        }
+    }
+
+    Ok(None)
 }

--- a/crates/agentenv/src/bundle_cli.rs
+++ b/crates/agentenv/src/bundle_cli.rs
@@ -1,6 +1,7 @@
 use std::{
     fs,
     path::{Path, PathBuf},
+    process::Command,
 };
 
 use agentenv_core::bundle::{
@@ -56,24 +57,7 @@ pub(crate) fn run_bundle(args: BundleArgs) -> Result<()> {
     validate_skill_name(&skill_name)
         .with_context(|| format!("invalid skill name `{skill_name}`"))?;
 
-    let version = args.version.as_deref().unwrap_or("1.0.0");
-    let metadata = SkillBundleMetadata {
-        name: skill_name.clone(),
-        version: version
-            .parse()
-            .with_context(|| format!("invalid skill version `{version}`"))?,
-        description: args
-            .description
-            .clone()
-            .unwrap_or_else(|| format!("Reproducible dev env for {skill_name}")),
-        author: args.author.clone(),
-        license: args.license.clone(),
-        tags: if args.tags.is_empty() {
-            vec!["dev-env".to_owned()]
-        } else {
-            args.tags.clone()
-        },
-    };
+    let metadata = build_metadata(&args, source.project_path.as_deref(), &skill_name)?;
     let created_at = OffsetDateTime::now_utc()
         .format(&Rfc3339)
         .context("failed to format bundle creation timestamp")?;
@@ -128,11 +112,47 @@ fn resolve_source(args: &BundleArgs) -> Result<BundleSource> {
         (None, None) => args.source.clone(),
     };
 
+    let (git_commit, git_dirty) = project_path
+        .as_deref()
+        .map(|path| (detect_git_commit(path), detect_git_dirty(path)))
+        .unwrap_or((None, None));
+
     Ok(BundleSource {
         env_name,
         project_path,
-        git_commit: None,
-        git_dirty: None,
+        git_commit,
+        git_dirty,
+    })
+}
+
+fn build_metadata(
+    args: &BundleArgs,
+    project_path: Option<&Path>,
+    skill_name: &str,
+) -> Result<SkillBundleMetadata> {
+    let version = args.version.as_deref().unwrap_or("1.0.0");
+    Ok(SkillBundleMetadata {
+        name: skill_name.to_owned(),
+        version: version
+            .parse()
+            .with_context(|| format!("invalid skill version `{version}`"))?,
+        description: args
+            .description
+            .clone()
+            .unwrap_or_else(|| format!("Reproducible dev env for {skill_name}")),
+        author: args
+            .author
+            .clone()
+            .or_else(|| project_path.and_then(detect_git_author)),
+        license: args
+            .license
+            .clone()
+            .or_else(|| project_path.and_then(detect_license)),
+        tags: if args.tags.is_empty() {
+            vec!["dev-env".to_owned()]
+        } else {
+            args.tags.clone()
+        },
     })
 }
 
@@ -163,5 +183,139 @@ fn is_regular_file_without_following_symlinks(path: &Path) -> Result<bool> {
         Err(error) if error.kind() == std::io::ErrorKind::NotFound => Ok(false),
         Err(source) => Err(source)
             .with_context(|| format!("failed to inspect reference document `{}`", path.display())),
+    }
+}
+
+fn detect_git_author(project_path: &Path) -> Option<String> {
+    git_stdout(project_path, ["config", "user.name"])
+}
+
+fn detect_git_commit(project_path: &Path) -> Option<String> {
+    git_stdout(project_path, ["rev-parse", "HEAD"])
+}
+
+fn detect_git_dirty(project_path: &Path) -> Option<bool> {
+    let output = Command::new("git")
+        .args(["status", "--porcelain"])
+        .current_dir(project_path)
+        .output()
+        .ok()?;
+    if !output.status.success() {
+        return None;
+    }
+
+    Some(!output.stdout.is_empty())
+}
+
+fn git_stdout<const N: usize>(project_path: &Path, args: [&str; N]) -> Option<String> {
+    let output = Command::new("git")
+        .args(args)
+        .current_dir(project_path)
+        .output()
+        .ok()?;
+    if !output.status.success() {
+        return None;
+    }
+
+    let value = String::from_utf8(output.stdout).ok()?.trim().to_owned();
+    if value.is_empty() {
+        None
+    } else {
+        Some(value)
+    }
+}
+
+fn detect_license(project_path: &Path) -> Option<String> {
+    detect_cargo_license(project_path).or_else(|| detect_license_file(project_path))
+}
+
+fn detect_cargo_license(project_path: &Path) -> Option<String> {
+    let cargo_toml = fs::read_to_string(project_path.join("Cargo.toml")).ok()?;
+    license_in_cargo_section(&cargo_toml, "package")
+        .or_else(|| license_in_cargo_section(&cargo_toml, "workspace.package"))
+}
+
+fn license_in_cargo_section(contents: &str, target_section: &str) -> Option<String> {
+    let mut current_section = None;
+    for line in contents.lines() {
+        let line = line.split('#').next().unwrap_or("").trim();
+        if line.starts_with('[') && line.ends_with(']') {
+            current_section = Some(line.trim_matches(['[', ']']));
+            continue;
+        }
+        if current_section != Some(target_section) {
+            continue;
+        }
+        let Some((key, value)) = line.split_once('=') else {
+            continue;
+        };
+        if key.trim() != "license" {
+            continue;
+        }
+        return parse_toml_string(value.trim());
+    }
+    None
+}
+
+fn parse_toml_string(value: &str) -> Option<String> {
+    let value = value.trim();
+    if value.starts_with('"') && value.ends_with('"') && value.len() >= 2 {
+        Some(value[1..value.len() - 1].to_owned())
+    } else {
+        None
+    }
+}
+
+fn detect_license_file(project_path: &Path) -> Option<String> {
+    for file_name in [
+        "LICENSE-MIT",
+        "LICENSE-APACHE",
+        "LICENSE-APACHE-2.0",
+        "LICENSE",
+        "LICENSE.md",
+        "LICENSE.txt",
+        "COPYING",
+        "COPYING.md",
+        "COPYING.txt",
+    ] {
+        let path = project_path.join(file_name);
+        if !path.is_file() {
+            continue;
+        }
+        if let Some(license) = license_from_file_name(file_name) {
+            return Some(license.to_owned());
+        }
+        if let Ok(contents) = fs::read_to_string(path) {
+            if let Some(license) = license_from_contents(&contents) {
+                return Some(license.to_owned());
+            }
+        }
+    }
+    None
+}
+
+fn license_from_file_name(file_name: &str) -> Option<&'static str> {
+    match file_name {
+        "LICENSE-MIT" => Some("MIT"),
+        "LICENSE-APACHE" | "LICENSE-APACHE-2.0" => Some("Apache-2.0"),
+        _ => None,
+    }
+}
+
+fn license_from_contents(contents: &str) -> Option<&'static str> {
+    if contents.contains("MIT License") {
+        Some("MIT")
+    } else if contents.contains("Apache License") && contents.contains("Version 2.0") {
+        Some("Apache-2.0")
+    } else if contents.contains("Mozilla Public License") && contents.contains("Version 2.0") {
+        Some("MPL-2.0")
+    } else if contents.contains("GNU GENERAL PUBLIC LICENSE") && contents.contains("Version 3") {
+        Some("GPL-3.0")
+    } else if contents.contains("BSD 3-Clause License") {
+        Some("BSD-3-Clause")
+    } else if contents.contains("BSD 2-Clause License") {
+        Some("BSD-2-Clause")
+    } else {
+        None
     }
 }

--- a/crates/agentenv/src/bundle_cli.rs
+++ b/crates/agentenv/src/bundle_cli.rs
@@ -10,6 +10,7 @@ use agentenv_core::bundle::{
 use agentenv_core::skills::validate_skill_name;
 use anyhow::{bail, Context, Result};
 use clap::Args;
+use serde::Serialize;
 use time::{format_description::well_known::Rfc3339, OffsetDateTime};
 
 #[derive(Debug, Args)]
@@ -76,7 +77,8 @@ pub(crate) fn run_bundle(args: BundleArgs) -> Result<()> {
     .context("failed to emit skill bundle")?;
 
     if args.json {
-        println!("{}", serde_json::to_string_pretty(&output)?);
+        let rendered = serde_json::to_string_pretty(&BundleJson::from(output))?;
+        println!("{rendered}");
     } else {
         println!("Skill bundle written: {}", output.output_dir.display());
         println!("bundle digest: {}", output.bundle_digest);
@@ -85,6 +87,29 @@ pub(crate) fn run_bundle(args: BundleArgs) -> Result<()> {
     }
 
     Ok(())
+}
+
+#[derive(Debug, Serialize)]
+struct BundleJson {
+    output_dir: PathBuf,
+    skill_name: String,
+    version: String,
+    bundle_digest: String,
+    blueprint_digest: String,
+    lockfile_digest: String,
+}
+
+impl From<agentenv_core::bundle::SkillBundleOutput> for BundleJson {
+    fn from(output: agentenv_core::bundle::SkillBundleOutput) -> Self {
+        Self {
+            output_dir: output.output_dir,
+            skill_name: output.skill_name,
+            version: output.version,
+            bundle_digest: output.bundle_digest,
+            blueprint_digest: output.blueprint_digest,
+            lockfile_digest: output.lockfile_digest,
+        }
+    }
 }
 
 fn resolve_source(args: &BundleArgs) -> Result<BundleSource> {

--- a/crates/agentenv/src/bundle_cli.rs
+++ b/crates/agentenv/src/bundle_cli.rs
@@ -187,7 +187,7 @@ fn is_regular_file_without_following_symlinks(path: &Path) -> Result<bool> {
 }
 
 fn detect_git_author(project_path: &Path) -> Option<String> {
-    git_stdout(project_path, ["config", "user.name"])
+    git_stdout(project_path, ["config", "--local", "user.name"])
 }
 
 fn detect_git_commit(project_path: &Path) -> Option<String> {
@@ -231,39 +231,19 @@ fn detect_license(project_path: &Path) -> Option<String> {
 
 fn detect_cargo_license(project_path: &Path) -> Option<String> {
     let cargo_toml = fs::read_to_string(project_path.join("Cargo.toml")).ok()?;
-    license_in_cargo_section(&cargo_toml, "package")
-        .or_else(|| license_in_cargo_section(&cargo_toml, "workspace.package"))
-}
-
-fn license_in_cargo_section(contents: &str, target_section: &str) -> Option<String> {
-    let mut current_section = None;
-    for line in contents.lines() {
-        let line = line.split('#').next().unwrap_or("").trim();
-        if line.starts_with('[') && line.ends_with(']') {
-            current_section = Some(line.trim_matches(['[', ']']));
-            continue;
-        }
-        if current_section != Some(target_section) {
-            continue;
-        }
-        let Some((key, value)) = line.split_once('=') else {
-            continue;
-        };
-        if key.trim() != "license" {
-            continue;
-        }
-        return parse_toml_string(value.trim());
-    }
-    None
-}
-
-fn parse_toml_string(value: &str) -> Option<String> {
-    let value = value.trim();
-    if value.starts_with('"') && value.ends_with('"') && value.len() >= 2 {
-        Some(value[1..value.len() - 1].to_owned())
-    } else {
-        None
-    }
+    let value: toml::Value = toml::from_str(&cargo_toml).ok()?;
+    value
+        .get("package")
+        .and_then(|package| package.get("license"))
+        .and_then(toml::Value::as_str)
+        .or_else(|| {
+            value
+                .get("workspace")
+                .and_then(|workspace| workspace.get("package"))
+                .and_then(|package| package.get("license"))
+                .and_then(toml::Value::as_str)
+        })
+        .map(str::to_owned)
 }
 
 fn detect_license_file(project_path: &Path) -> Option<String> {

--- a/crates/agentenv/src/bundle_cli.rs
+++ b/crates/agentenv/src/bundle_cli.rs
@@ -106,7 +106,9 @@ pub(crate) fn run_bundle(args: BundleArgs) -> Result<()> {
 fn resolve_source(args: &BundleArgs) -> Result<BundleSource> {
     let source_path = PathBuf::from(&args.source);
     let project_path = if source_path.is_dir() {
-        Some(source_path)
+        Some(source_path.canonicalize().with_context(|| {
+            format!("failed to resolve project path `{}`", source_path.display())
+        })?)
     } else {
         None
     };
@@ -141,7 +143,7 @@ fn load_reference_document(project_path: Option<&Path>) -> Result<Option<Referen
 
     for relative in ["docs/ARCHITECTURE.md", "ARCHITECTURE.md", "README.md"] {
         let path = project_path.join(relative);
-        if path.is_file() {
+        if is_regular_file_without_following_symlinks(&path)? {
             let content = fs::read_to_string(&path).with_context(|| {
                 format!("failed to read reference document `{}`", path.display())
             })?;
@@ -153,4 +155,13 @@ fn load_reference_document(project_path: Option<&Path>) -> Result<Option<Referen
     }
 
     Ok(None)
+}
+
+fn is_regular_file_without_following_symlinks(path: &Path) -> Result<bool> {
+    match fs::symlink_metadata(path) {
+        Ok(metadata) => Ok(metadata.file_type().is_file()),
+        Err(error) if error.kind() == std::io::ErrorKind::NotFound => Ok(false),
+        Err(source) => Err(source)
+            .with_context(|| format!("failed to inspect reference document `{}`", path.display())),
+    }
 }

--- a/crates/agentenv/src/main.rs
+++ b/crates/agentenv/src/main.rs
@@ -3891,6 +3891,7 @@ mod tests {
                 "credentials".to_string(),
                 "drivers".to_string(),
                 "skills".to_string(),
+                "bundle".to_string(),
                 "verify-blueprint".to_string(),
                 "verify".to_string(),
                 "freeze".to_string(),

--- a/crates/agentenv/src/main.rs
+++ b/crates/agentenv/src/main.rs
@@ -37,6 +37,7 @@ use tokio::io::{AsyncReadExt, AsyncWriteExt};
 use tracing_subscriber::EnvFilter;
 
 mod builtin_factory;
+mod bundle_cli;
 mod render;
 mod skills_cli;
 mod term_backend;
@@ -80,6 +81,7 @@ enum Commands {
     Credentials(CredentialsArgs),
     Drivers(DriversArgs),
     Skills(skills_cli::SkillsArgs),
+    Bundle(bundle_cli::BundleArgs),
     VerifyBlueprint {
         file: PathBuf,
     },
@@ -589,6 +591,7 @@ async fn run() -> Result<()> {
         Some(Commands::Credentials(command)) => run_credentials(command, &cli.events_sink).await,
         Some(Commands::Drivers(command)) => run_drivers(command),
         Some(Commands::Skills(args)) => skills_cli::run_skills(args).await,
+        Some(Commands::Bundle(args)) => bundle_cli::run_bundle(args),
         Some(Commands::VerifyBlueprint { file }) => verify_blueprint(&file),
         Some(Commands::Verify { lockfile }) => verify_lockfile(&lockfile),
         Some(Commands::Freeze { name, output }) => freeze(&name, output.as_deref()),

--- a/crates/agentenv/tests/cli_behavior.rs
+++ b/crates/agentenv/tests/cli_behavior.rs
@@ -59,6 +59,49 @@ fn freeze_persisted_env_writes_default_lockfile() {
 }
 
 #[test]
+fn bundle_help_lists_as_skill_and_out_flags() {
+    let temp_dir = make_temp_dir("bundle-help");
+
+    let output = Command::new(agentenv_bin())
+        .arg("bundle")
+        .arg("--help")
+        .env("HOME", &temp_dir)
+        .current_dir(&temp_dir)
+        .output()
+        .unwrap();
+
+    assert!(
+        output.status.success(),
+        "stderr was: {}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    assert!(stdout.contains("--as-skill"), "stdout was: {stdout}");
+    assert!(stdout.contains("--out"), "stdout was: {stdout}");
+}
+
+#[test]
+fn bundle_as_skill_rejects_missing_env() {
+    let temp_dir = make_temp_dir("bundle-missing-env");
+    let out_dir = temp_dir.join("bundle-out");
+
+    let output = Command::new(agentenv_bin())
+        .arg("bundle")
+        .arg("missing-env")
+        .arg("--as-skill")
+        .arg("--out")
+        .arg(&out_dir)
+        .env("HOME", &temp_dir)
+        .current_dir(&temp_dir)
+        .output()
+        .unwrap();
+
+    assert!(!output.status.success());
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    assert!(stderr.contains("missing-env"), "stderr was: {stderr}");
+}
+
+#[test]
 fn fork_reports_capability_missing_for_openshell() {
     let temp_dir = make_temp_dir("fork-openshell-unsupported");
     let env_dir = write_minimal_env_state(&temp_dir, "demo");

--- a/crates/agentenv/tests/cli_behavior.rs
+++ b/crates/agentenv/tests/cli_behavior.rs
@@ -181,6 +181,110 @@ fn bundle_directory_source_loads_architecture_reference() {
 }
 
 #[test]
+fn bundle_dot_source_derives_env_from_current_directory() {
+    let temp_dir = make_temp_dir("bundle-dot-source");
+    write_minimal_env_state(&temp_dir, "demo");
+    let project_dir = temp_dir.join("demo");
+    fs::create_dir_all(&project_dir).unwrap();
+    let out_dir = fs::canonicalize(&temp_dir).unwrap().join("demo-dot-skill");
+
+    let output = Command::new(agentenv_bin())
+        .arg("bundle")
+        .arg(".")
+        .arg("--as-skill")
+        .arg("--out")
+        .arg(&out_dir)
+        .env("HOME", &temp_dir)
+        .current_dir(&project_dir)
+        .output()
+        .unwrap();
+
+    assert!(
+        output.status.success(),
+        "stdout was: {}\nstderr was: {}",
+        String::from_utf8_lossy(&output.stdout),
+        String::from_utf8_lossy(&output.stderr)
+    );
+    assert!(out_dir.join("SKILL.md").is_file());
+}
+
+#[cfg(unix)]
+#[test]
+fn bundle_directory_source_skips_symlinked_reference_document() {
+    use std::os::unix::fs::symlink;
+
+    let temp_dir = make_temp_dir("bundle-symlink-reference");
+    write_minimal_env_state(&temp_dir, "demo");
+    let project_dir = temp_dir.join("demo");
+    fs::create_dir_all(project_dir.join("docs")).unwrap();
+    let outside_reference = temp_dir.join("outside-architecture.md");
+    fs::write(&outside_reference, "# Outside\n\nDo not copy\n").unwrap();
+    symlink(
+        &outside_reference,
+        project_dir.join("docs").join("ARCHITECTURE.md"),
+    )
+    .unwrap();
+    let out_dir = fs::canonicalize(&temp_dir)
+        .unwrap()
+        .join("demo-symlink-skill");
+
+    let output = Command::new(agentenv_bin())
+        .arg("bundle")
+        .arg(&project_dir)
+        .arg("--as-skill")
+        .arg("--out")
+        .arg(&out_dir)
+        .env("HOME", &temp_dir)
+        .current_dir(&temp_dir)
+        .output()
+        .unwrap();
+
+    assert!(
+        output.status.success(),
+        "stdout was: {}\nstderr was: {}",
+        String::from_utf8_lossy(&output.stdout),
+        String::from_utf8_lossy(&output.stderr)
+    );
+    assert!(!out_dir.join("references/architecture.md").exists());
+}
+
+#[test]
+fn bundle_json_outputs_digest_summary() {
+    let temp_dir = make_temp_dir("bundle-json-summary");
+    write_minimal_env_state(&temp_dir, "demo");
+    let out_dir = fs::canonicalize(&temp_dir).unwrap().join("demo-json-skill");
+
+    let output = Command::new(agentenv_bin())
+        .arg("bundle")
+        .arg("demo")
+        .arg("--as-skill")
+        .arg("--out")
+        .arg(&out_dir)
+        .arg("--json")
+        .env("HOME", &temp_dir)
+        .current_dir(&temp_dir)
+        .output()
+        .unwrap();
+
+    assert!(
+        output.status.success(),
+        "stdout was: {}\nstderr was: {}",
+        String::from_utf8_lossy(&output.stdout),
+        String::from_utf8_lossy(&output.stderr)
+    );
+    let summary: serde_json::Value = serde_json::from_slice(&output.stdout).unwrap();
+    assert_eq!(
+        summary["output_dir"].as_str(),
+        Some(out_dir.to_str().unwrap())
+    );
+    assert_eq!(summary["skill_name"].as_str(), Some("demo"));
+    assert_eq!(summary["version"].as_str(), Some("1.0.0"));
+    assert!(summary["bundle_digest"].as_str().is_some());
+    assert!(summary["blueprint_digest"].as_str().is_some());
+    assert!(summary["lockfile_digest"].as_str().is_some());
+}
+
+#[test]
 fn fork_reports_capability_missing_for_openshell() {
     let temp_dir = make_temp_dir("fork-openshell-unsupported");
     let env_dir = write_minimal_env_state(&temp_dir, "demo");

--- a/crates/agentenv/tests/cli_behavior.rs
+++ b/crates/agentenv/tests/cli_behavior.rs
@@ -231,6 +231,7 @@ fn bundle_as_skill_exports_existing_env_with_project_reference() {
         String::from_utf8_lossy(&output.stderr)
     );
     assert!(out_dir.join("SKILL.md").is_file());
+    assert!(out_dir.join("skill.yaml").is_file());
     let skill = fs::read_to_string(out_dir.join("SKILL.md")).unwrap();
     assert!(
         skill.contains("author: Alice Example"),

--- a/crates/agentenv/tests/cli_behavior.rs
+++ b/crates/agentenv/tests/cli_behavior.rs
@@ -78,6 +78,50 @@ fn bundle_help_lists_as_skill_and_out_flags() {
     let stdout = String::from_utf8_lossy(&output.stdout);
     assert!(stdout.contains("--as-skill"), "stdout was: {stdout}");
     assert!(stdout.contains("--out"), "stdout was: {stdout}");
+    assert!(stdout.contains("--env"), "stdout was: {stdout}");
+}
+
+#[test]
+fn bundle_as_skill_requires_out_flag() {
+    let temp_dir = make_temp_dir("bundle-missing-out");
+
+    let output = Command::new(agentenv_bin())
+        .arg("bundle")
+        .arg("demo")
+        .arg("--as-skill")
+        .env("HOME", &temp_dir)
+        .current_dir(&temp_dir)
+        .output()
+        .unwrap();
+
+    assert!(!output.status.success());
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    assert!(
+        stderr.contains("bundle --as-skill requires --out <dir>"),
+        "stderr was: {stderr}"
+    );
+}
+
+#[test]
+fn bundle_rejects_missing_as_skill_flag() {
+    let temp_dir = make_temp_dir("bundle-missing-as-skill");
+
+    let output = Command::new(agentenv_bin())
+        .arg("bundle")
+        .arg("demo")
+        .arg("--out")
+        .arg(temp_dir.join("bundle-out"))
+        .env("HOME", &temp_dir)
+        .current_dir(&temp_dir)
+        .output()
+        .unwrap();
+
+    assert!(!output.status.success());
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    assert!(
+        stderr.contains("bundle currently supports only --as-skill"),
+        "stderr was: {stderr}"
+    );
 }
 
 #[test]
@@ -99,6 +143,41 @@ fn bundle_as_skill_rejects_missing_env() {
     assert!(!output.status.success());
     let stderr = String::from_utf8_lossy(&output.stderr);
     assert!(stderr.contains("missing-env"), "stderr was: {stderr}");
+}
+
+#[test]
+fn bundle_directory_source_loads_architecture_reference() {
+    let temp_dir = make_temp_dir("bundle-reference-doc");
+    write_minimal_env_state(&temp_dir, "demo");
+    let project_dir = temp_dir.join("demo");
+    fs::create_dir_all(project_dir.join("docs")).unwrap();
+    fs::write(
+        project_dir.join("docs").join("ARCHITECTURE.md"),
+        "# Architecture\n\nReference details\n",
+    )
+    .unwrap();
+    let out_dir = fs::canonicalize(&temp_dir).unwrap().join("demo-skill");
+
+    let output = Command::new(agentenv_bin())
+        .arg("bundle")
+        .arg(&project_dir)
+        .arg("--as-skill")
+        .arg("--out")
+        .arg(&out_dir)
+        .env("HOME", &temp_dir)
+        .current_dir(&temp_dir)
+        .output()
+        .unwrap();
+
+    assert!(
+        output.status.success(),
+        "stdout was: {}\nstderr was: {}",
+        String::from_utf8_lossy(&output.stdout),
+        String::from_utf8_lossy(&output.stderr)
+    );
+    let reference = fs::read_to_string(out_dir.join("references/architecture.md")).unwrap();
+    assert!(reference.contains("Source: `docs/ARCHITECTURE.md`"));
+    assert!(reference.contains("Reference details"));
 }
 
 #[test]

--- a/crates/agentenv/tests/cli_behavior.rs
+++ b/crates/agentenv/tests/cli_behavior.rs
@@ -257,6 +257,96 @@ fn bundle_as_skill_exports_existing_env_with_project_reference() {
 }
 
 #[test]
+fn bundle_metadata_detection_uses_local_git_author_and_cargo_license() {
+    let temp_dir = make_temp_dir("bundle-detected-metadata");
+    write_minimal_env_state(&temp_dir, "demo");
+    let project_dir = temp_dir.join("demo");
+    fs::create_dir_all(&project_dir).unwrap();
+    fs::write(
+        project_dir.join("Cargo.toml"),
+        "[package]\nname = 'demo'\nversion = '0.1.0'\nlicense = 'Apache-2.0'\n",
+    )
+    .unwrap();
+    run_git(&project_dir, &["init"]);
+    run_git(&project_dir, &["config", "user.name", "Detected Author"]);
+    let out_dir = fs::canonicalize(&temp_dir)
+        .unwrap()
+        .join("demo-detected-metadata-skill");
+
+    let output = Command::new(agentenv_bin())
+        .arg("bundle")
+        .arg(&project_dir)
+        .arg("--as-skill")
+        .arg("--out")
+        .arg(&out_dir)
+        .env("HOME", &temp_dir)
+        .current_dir(&temp_dir)
+        .output()
+        .unwrap();
+
+    assert!(
+        output.status.success(),
+        "stdout was: {}\nstderr was: {}",
+        String::from_utf8_lossy(&output.stdout),
+        String::from_utf8_lossy(&output.stderr)
+    );
+    let skill = fs::read_to_string(out_dir.join("SKILL.md")).unwrap();
+    assert!(
+        skill.contains("author: Detected Author"),
+        "SKILL.md was: {skill}"
+    );
+    assert!(
+        skill.contains("license: Apache-2.0"),
+        "SKILL.md was: {skill}"
+    );
+}
+
+#[test]
+fn bundle_metadata_detection_ignores_global_git_author_for_non_git_project() {
+    let temp_dir = make_temp_dir("bundle-ignore-global-git-author");
+    write_minimal_env_state(&temp_dir, "demo");
+    let project_dir = temp_dir.join("demo");
+    fs::create_dir_all(&project_dir).unwrap();
+    fs::write(project_dir.join("LICENSE-MIT"), "MIT License\n").unwrap();
+    let git_config = Command::new("git")
+        .args(["config", "--global", "user.name", "Global Author"])
+        .env("HOME", &temp_dir)
+        .current_dir(&temp_dir)
+        .output()
+        .unwrap();
+    assert!(
+        git_config.status.success(),
+        "git config --global failed\nstdout: {}\nstderr: {}",
+        String::from_utf8_lossy(&git_config.stdout),
+        String::from_utf8_lossy(&git_config.stderr)
+    );
+    let out_dir = fs::canonicalize(&temp_dir)
+        .unwrap()
+        .join("demo-license-file-skill");
+
+    let output = Command::new(agentenv_bin())
+        .arg("bundle")
+        .arg(&project_dir)
+        .arg("--as-skill")
+        .arg("--out")
+        .arg(&out_dir)
+        .env("HOME", &temp_dir)
+        .current_dir(&temp_dir)
+        .output()
+        .unwrap();
+
+    assert!(
+        output.status.success(),
+        "stdout was: {}\nstderr was: {}",
+        String::from_utf8_lossy(&output.stdout),
+        String::from_utf8_lossy(&output.stderr)
+    );
+    let skill = fs::read_to_string(out_dir.join("SKILL.md")).unwrap();
+    assert!(!skill.contains("Global Author"), "SKILL.md was: {skill}");
+    assert!(skill.contains("license: MIT"), "SKILL.md was: {skill}");
+}
+
+#[test]
 fn bundle_dot_source_derives_env_from_current_directory() {
     let temp_dir = make_temp_dir("bundle-dot-source");
     write_minimal_env_state(&temp_dir, "demo");

--- a/crates/agentenv/tests/cli_behavior.rs
+++ b/crates/agentenv/tests/cli_behavior.rs
@@ -451,6 +451,106 @@ fn bundle_json_outputs_digest_summary() {
 }
 
 #[test]
+fn bundle_as_skill_json_output_installs_as_local_skill() {
+    let temp_dir = make_temp_dir("bundle-json-install");
+    write_minimal_env_state(&temp_dir, "demo");
+    let output_dir = fs::canonicalize(&temp_dir).unwrap().join("demo-skill");
+
+    let output = Command::new(agentenv_bin())
+        .arg("bundle")
+        .arg("demo")
+        .arg("--as-skill")
+        .arg("--out")
+        .arg(&output_dir)
+        .arg("--json")
+        .env("HOME", &temp_dir)
+        .current_dir(&temp_dir)
+        .output()
+        .unwrap();
+
+    assert!(
+        output.status.success(),
+        "stdout was: {}\nstderr was: {}",
+        String::from_utf8_lossy(&output.stdout),
+        String::from_utf8_lossy(&output.stderr)
+    );
+    let json: serde_json::Value = serde_json::from_slice(&output.stdout).unwrap();
+    assert!(
+        output.stdout.ends_with(b"\n"),
+        "stdout was: {}",
+        String::from_utf8_lossy(&output.stdout)
+    );
+    let keys = json
+        .as_object()
+        .unwrap()
+        .keys()
+        .map(String::as_str)
+        .collect::<BTreeSet<_>>();
+    assert_eq!(
+        keys,
+        [
+            "blueprint_digest",
+            "bundle_digest",
+            "lockfile_digest",
+            "output_dir",
+            "skill_name",
+            "version",
+        ]
+        .into_iter()
+        .collect()
+    );
+    assert_eq!(json["output_dir"], output_dir.to_str().unwrap());
+    assert_eq!(json["skill_name"], "demo");
+    assert_eq!(json["version"], "1.0.0");
+    assert!(json["bundle_digest"]
+        .as_str()
+        .unwrap()
+        .starts_with("sha256:"));
+    assert!(json["blueprint_digest"]
+        .as_str()
+        .unwrap()
+        .starts_with("sha256:"));
+    assert!(json["lockfile_digest"]
+        .as_str()
+        .unwrap()
+        .starts_with("sha256:"));
+
+    let install = Command::new(agentenv_bin())
+        .arg("skills")
+        .arg("install")
+        .arg("--from")
+        .arg(&output_dir)
+        .arg("--allow-unsigned")
+        .arg("--json")
+        .env("HOME", &temp_dir)
+        .current_dir(&temp_dir)
+        .output()
+        .unwrap();
+    assert!(
+        install.status.success(),
+        "stdout was: {}\nstderr was: {}",
+        String::from_utf8_lossy(&install.stdout),
+        String::from_utf8_lossy(&install.stderr)
+    );
+
+    let verify = Command::new(agentenv_bin())
+        .arg("skills")
+        .arg("verify")
+        .arg("demo")
+        .arg("--json")
+        .env("HOME", &temp_dir)
+        .current_dir(&temp_dir)
+        .output()
+        .unwrap();
+    assert!(
+        verify.status.success(),
+        "stdout was: {}\nstderr was: {}",
+        String::from_utf8_lossy(&verify.stdout),
+        String::from_utf8_lossy(&verify.stderr)
+    );
+}
+
+#[test]
 fn fork_reports_capability_missing_for_openshell() {
     let temp_dir = make_temp_dir("fork-openshell-unsupported");
     let env_dir = write_minimal_env_state(&temp_dir, "demo");

--- a/crates/agentenv/tests/cli_behavior.rs
+++ b/crates/agentenv/tests/cli_behavior.rs
@@ -428,6 +428,7 @@ fn bundle_json_outputs_digest_summary() {
         .arg(&out_dir)
         .arg("--json")
         .env("HOME", &temp_dir)
+        .env_remove("AGENTENV_DRIVER_PATH")
         .current_dir(&temp_dir)
         .output()
         .unwrap();
@@ -464,6 +465,7 @@ fn bundle_as_skill_json_output_installs_as_local_skill() {
         .arg(&output_dir)
         .arg("--json")
         .env("HOME", &temp_dir)
+        .env_remove("AGENTENV_DRIVER_PATH")
         .current_dir(&temp_dir)
         .output()
         .unwrap();
@@ -523,6 +525,7 @@ fn bundle_as_skill_json_output_installs_as_local_skill() {
         .arg("--allow-unsigned")
         .arg("--json")
         .env("HOME", &temp_dir)
+        .env_remove("AGENTENV_DRIVER_PATH")
         .current_dir(&temp_dir)
         .output()
         .unwrap();

--- a/crates/agentenv/tests/cli_behavior.rs
+++ b/crates/agentenv/tests/cli_behavior.rs
@@ -181,6 +181,81 @@ fn bundle_directory_source_loads_architecture_reference() {
 }
 
 #[test]
+fn bundle_as_skill_exports_existing_env_with_project_reference() {
+    let temp_dir = make_temp_dir("bundle-project-reference");
+    write_minimal_env_state(&temp_dir, "demo");
+    let project_dir = temp_dir.join("demo");
+    fs::create_dir_all(project_dir.join("docs")).unwrap();
+    fs::write(
+        project_dir.join("docs").join("ARCHITECTURE.md"),
+        "# Architecture\n\nProject reference details\n",
+    )
+    .unwrap();
+    run_git(&project_dir, &["init"]);
+    run_git(&project_dir, &["config", "user.name", "Detected Author"]);
+    run_git(
+        &project_dir,
+        &["config", "user.email", "detected@example.com"],
+    );
+    run_git(&project_dir, &["add", "docs/ARCHITECTURE.md"]);
+    run_git(
+        &project_dir,
+        &["commit", "-m", "Add architecture reference"],
+    );
+    let expected_commit = git_stdout(&project_dir, &["rev-parse", "HEAD"]);
+    let out_dir = fs::canonicalize(&temp_dir)
+        .unwrap()
+        .join("demo-project-skill");
+
+    let output = Command::new(agentenv_bin())
+        .arg("bundle")
+        .arg(&project_dir)
+        .arg("--as-skill")
+        .arg("--out")
+        .arg(&out_dir)
+        .arg("--author")
+        .arg("Alice Example")
+        .arg("--license")
+        .arg("MIT")
+        .arg("--tag")
+        .arg("rust")
+        .env("HOME", &temp_dir)
+        .current_dir(&temp_dir)
+        .output()
+        .unwrap();
+
+    assert!(
+        output.status.success(),
+        "stdout was: {}\nstderr was: {}",
+        String::from_utf8_lossy(&output.stdout),
+        String::from_utf8_lossy(&output.stderr)
+    );
+    assert!(out_dir.join("SKILL.md").is_file());
+    let skill = fs::read_to_string(out_dir.join("SKILL.md")).unwrap();
+    assert!(
+        skill.contains("author: Alice Example"),
+        "SKILL.md was: {skill}"
+    );
+    assert!(skill.contains("license: MIT"), "SKILL.md was: {skill}");
+    assert!(skill.contains("- rust"), "SKILL.md was: {skill}");
+    let reference = fs::read_to_string(out_dir.join("references/architecture.md")).unwrap();
+    assert!(reference.contains("Source: `docs/ARCHITECTURE.md`"));
+    assert!(reference.contains("Project reference details"));
+    let provenance: serde_json::Value = serde_json::from_str(
+        &fs::read_to_string(out_dir.join(".agentenv/provenance.json")).unwrap(),
+    )
+    .unwrap();
+    assert_eq!(
+        provenance["source"]["project_git_commit"].as_str(),
+        Some(expected_commit.as_str())
+    );
+    assert_eq!(
+        provenance["source"]["project_git_dirty"].as_bool(),
+        Some(false)
+    );
+}
+
+#[test]
 fn bundle_dot_source_derives_env_from_current_directory() {
     let temp_dir = make_temp_dir("bundle-dot-source");
     write_minimal_env_state(&temp_dir, "demo");
@@ -4081,6 +4156,35 @@ fn unique_suffix() -> String {
             .unwrap()
             .as_nanos()
     )
+}
+
+fn run_git(current_dir: &Path, args: &[&str]) {
+    let output = Command::new("git")
+        .args(args)
+        .current_dir(current_dir)
+        .output()
+        .unwrap();
+    assert!(
+        output.status.success(),
+        "git {args:?} failed\nstdout: {}\nstderr: {}",
+        String::from_utf8_lossy(&output.stdout),
+        String::from_utf8_lossy(&output.stderr)
+    );
+}
+
+fn git_stdout(current_dir: &Path, args: &[&str]) -> String {
+    let output = Command::new("git")
+        .args(args)
+        .current_dir(current_dir)
+        .output()
+        .unwrap();
+    assert!(
+        output.status.success(),
+        "git {args:?} failed\nstdout: {}\nstderr: {}",
+        String::from_utf8_lossy(&output.stdout),
+        String::from_utf8_lossy(&output.stderr)
+    );
+    String::from_utf8(output.stdout).unwrap().trim().to_owned()
 }
 
 fn write_minimal_env_state(home: &Path, name: &str) -> PathBuf {

--- a/docs/superpowers/plans/2026-05-09-m7-5-bundle-as-skill.md
+++ b/docs/superpowers/plans/2026-05-09-m7-5-bundle-as-skill.md
@@ -1,0 +1,1617 @@
+# M7-5 Bundle As Skill Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Add `agentenv bundle <source> --as-skill --out <dir>` so a frozen agentenv environment can be emitted as an installable skill bundle with both `skill.yaml` and `SKILL.md` metadata.
+
+**Architecture:** Keep the CLI thin and put deterministic bundle rendering in `agentenv-core::bundle`. Runtime source material comes from the existing environment registry and `freeze_env_lockfile`, while the generated bundle remains compatible with the existing `agentenv skills install --from` path.
+
+**Tech Stack:** Rust 2021, `clap`, `serde`, `serde_json`, `serde_yaml`, `sha2`, `semver`, `time`, existing `agentenv-core` runtime and skills APIs.
+
+---
+
+## File Structure
+
+- Create: `crates/agentenv-core/src/bundle/mod.rs`
+- Create: `crates/agentenv-core/src/bundle/model.rs`
+- Create: `crates/agentenv-core/src/bundle/render.rs`
+- Create: `crates/agentenv-core/src/bundle/writer.rs`
+- Create: `crates/agentenv-core/tests/bundle.rs`
+- Modify: `crates/agentenv-core/src/lib.rs`
+- Modify: `crates/agentenv-core/src/runtime.rs`
+- Create: `crates/agentenv/src/bundle_cli.rs`
+- Modify: `crates/agentenv/src/main.rs`
+- Modify: `crates/agentenv/tests/cli_behavior.rs`
+- Reference: `docs/superpowers/specs/2026-05-09-m7-5-bundle-as-skill-design.md`
+
+## Task 1: Core Bundle Writer
+
+**Files:**
+- Create: `crates/agentenv-core/tests/bundle.rs`
+- Create: `crates/agentenv-core/src/bundle/mod.rs`
+- Create: `crates/agentenv-core/src/bundle/model.rs`
+- Create: `crates/agentenv-core/src/bundle/render.rs`
+- Create: `crates/agentenv-core/src/bundle/writer.rs`
+- Modify: `crates/agentenv-core/src/lib.rs`
+
+- [ ] **Step 1: Write failing core layout tests**
+
+Create `crates/agentenv-core/tests/bundle.rs` with tests that exercise the public API before it exists:
+
+```rust
+use std::{
+    fs,
+    path::{Path, PathBuf},
+};
+
+use agentenv_core::{
+    bundle::{
+        emit_skill_bundle, BundleSource, ReferenceDocument, SkillBundleInput,
+        SkillBundleMetadata,
+    },
+    driver_artifact::DriverArtifact,
+    driver_catalog::DriverSource,
+    portable_lockfile::{build_portable_lockfile, PortableLockfileInput},
+    registry::DriverKind,
+    skills::{compute_bundle_digest, load_skill_manifest},
+};
+use semver::Version;
+
+#[test]
+fn emit_skill_bundle_writes_expected_layout() {
+    let root = temp_dir("bundle-layout");
+    let out = root.join("demo-skill");
+    let blueprint_yaml = minimal_blueprint();
+    let driver_artifacts = test_driver_artifacts();
+    let lockfile_yaml = portable_lock_yaml("demo", &blueprint_yaml, &driver_artifacts);
+
+    let output = emit_skill_bundle(SkillBundleInput {
+        source: BundleSource {
+            env_name: "demo".to_owned(),
+            project_path: None,
+            git_commit: None,
+            git_dirty: None,
+        },
+        metadata: SkillBundleMetadata {
+            name: "demo".to_owned(),
+            version: Version::parse("1.0.0").unwrap(),
+            description: "Reproducible dev env for demo".to_owned(),
+            author: None,
+            license: None,
+            tags: vec!["openshell".to_owned(), "codex".to_owned(), "filesystem".to_owned(), "dev-env".to_owned()],
+        },
+        blueprint_yaml: blueprint_yaml.clone(),
+        lockfile_yaml: lockfile_yaml.clone(),
+        reference_document: None,
+        output_dir: out.clone(),
+        agentenv_version: "0.0.1-alpha0".to_owned(),
+        created_at: "2026-05-09T00:00:00Z".to_owned(),
+        driver_artifacts,
+    })
+    .unwrap();
+
+    assert_eq!(output.output_dir, out);
+    assert_eq!(output.skill_name, "demo");
+    assert_eq!(output.version, "1.0.0");
+    assert!(out.join("SKILL.md").is_file());
+    assert!(out.join("skill.yaml").is_file());
+    assert!(out.join("blueprint.yaml").is_file());
+    assert!(out.join("agentenv.lock").is_file());
+    assert!(out.join("scripts/bootstrap.sh").is_file());
+    assert!(out.join(".agentenv/manifest.json").is_file());
+    assert!(out.join(".agentenv/provenance.json").is_file());
+    assert!(!out.join("references").exists());
+
+    let skill = fs::read_to_string(out.join("SKILL.md")).unwrap();
+    assert!(skill.contains("agentenv-bundle: true"));
+    assert!(skill.contains("agentenv-schema: \"0.1\""));
+    assert!(skill.contains("agentenv reproduce agentenv.lock --name demo"));
+
+    let bootstrap = fs::read_to_string(out.join("scripts/bootstrap.sh")).unwrap();
+    assert!(bootstrap.contains("agentenv verify agentenv.lock"));
+    assert!(bootstrap.contains("agentenv reproduce agentenv.lock --name \"${ENV_NAME}\""));
+
+    let manifest = load_skill_manifest(&out).unwrap();
+    assert_eq!(manifest.name, "demo");
+    assert_eq!(manifest.version.to_string(), "1.0.0");
+    assert_eq!(manifest.entry, PathBuf::from("SKILL.md"));
+    assert!(manifest.declared_files.contains(&PathBuf::from("agentenv.lock")));
+    assert!(!manifest.declared_files.iter().any(|path| path.starts_with("references")));
+
+    let digest = compute_bundle_digest(&out, &manifest).unwrap();
+    assert_eq!(output.bundle_digest, digest);
+    assert_eq!(fs::read_to_string(out.join("blueprint.yaml")).unwrap(), ensure_trailing_newline(&blueprint_yaml));
+    assert_eq!(fs::read_to_string(out.join("agentenv.lock")).unwrap(), ensure_trailing_newline(&lockfile_yaml));
+}
+
+#[test]
+fn emit_skill_bundle_writes_reference_document_when_provided() {
+    let root = temp_dir("bundle-reference");
+    let out = root.join("demo-skill");
+    let blueprint_yaml = minimal_blueprint();
+    let driver_artifacts = test_driver_artifacts();
+    let lockfile_yaml = portable_lock_yaml("demo", &blueprint_yaml, &driver_artifacts);
+
+    emit_skill_bundle(SkillBundleInput {
+        source: BundleSource {
+            env_name: "demo".to_owned(),
+            project_path: Some(root.join("project")),
+            git_commit: Some("abc123".to_owned()),
+            git_dirty: Some(false),
+        },
+        metadata: SkillBundleMetadata {
+            name: "demo".to_owned(),
+            version: Version::parse("1.0.0").unwrap(),
+            description: "Reproducible dev env for demo".to_owned(),
+            author: Some("Alice Example".to_owned()),
+            license: Some("MIT".to_owned()),
+            tags: vec!["openshell".to_owned(), "codex".to_owned(), "filesystem".to_owned(), "dev-env".to_owned()],
+        },
+        blueprint_yaml,
+        lockfile_yaml,
+        reference_document: Some(ReferenceDocument {
+            source_relative_path: "docs/ARCHITECTURE.md".to_owned(),
+            content: "# Architecture\n\nDetails\n".to_owned(),
+        }),
+        output_dir: out.clone(),
+        agentenv_version: "0.0.1-alpha0".to_owned(),
+        created_at: "2026-05-09T00:00:00Z".to_owned(),
+        driver_artifacts,
+    })
+    .unwrap();
+
+    let reference = fs::read_to_string(out.join("references/architecture.md")).unwrap();
+    assert!(reference.starts_with("# Project Architecture\n\nSource: `docs/ARCHITECTURE.md`\n\n"));
+    assert!(reference.contains("# Architecture"));
+
+    let manifest = load_skill_manifest(&out).unwrap();
+    assert!(manifest.declared_files.contains(&PathBuf::from("references/architecture.md")));
+
+    let skill = fs::read_to_string(out.join("SKILL.md")).unwrap();
+    assert!(skill.contains("author: Alice Example"));
+    assert!(skill.contains("license: MIT"));
+    assert!(skill.contains("tags: [openshell, codex, filesystem, dev-env]"));
+}
+
+#[test]
+fn emit_skill_bundle_rejects_existing_output_path() {
+    let root = temp_dir("bundle-existing");
+    let out = root.join("demo-skill");
+    fs::create_dir_all(&out).unwrap();
+    let blueprint_yaml = minimal_blueprint();
+    let driver_artifacts = test_driver_artifacts();
+    let lockfile_yaml = portable_lock_yaml("demo", &blueprint_yaml, &driver_artifacts);
+
+    let error = emit_skill_bundle(SkillBundleInput {
+        source: BundleSource {
+            env_name: "demo".to_owned(),
+            project_path: None,
+            git_commit: None,
+            git_dirty: None,
+        },
+        metadata: SkillBundleMetadata {
+            name: "demo".to_owned(),
+            version: Version::parse("1.0.0").unwrap(),
+            description: "Reproducible dev env for demo".to_owned(),
+            author: None,
+            license: None,
+            tags: vec!["dev-env".to_owned()],
+        },
+        blueprint_yaml,
+        lockfile_yaml,
+        reference_document: None,
+        output_dir: out,
+        agentenv_version: "0.0.1-alpha0".to_owned(),
+        created_at: "2026-05-09T00:00:00Z".to_owned(),
+        driver_artifacts,
+    })
+    .unwrap_err();
+
+    assert!(error.to_string().contains("output path already exists"));
+}
+
+fn minimal_blueprint() -> String {
+    r#"version: 0.1.0
+min_agentenv_version: 0.0.1-alpha0
+sandbox:
+  driver: openshell
+agent:
+  driver: codex
+context:
+  driver: filesystem
+  mount: .
+inference:
+  driver: passthrough
+policy:
+  tier: balanced
+  presets: []
+"#
+    .to_owned()
+}
+
+fn portable_lock_yaml(name: &str, blueprint_yaml: &str, driver_artifacts: &[DriverArtifact]) -> String {
+    build_portable_lockfile(PortableLockfileInput {
+        name: name.to_owned(),
+        blueprint_yaml: blueprint_yaml.to_owned(),
+        driver_artifacts: driver_artifacts.to_vec(),
+    })
+    .unwrap()
+    .to_yaml_deterministic()
+    .unwrap()
+}
+
+fn test_driver_artifacts() -> Vec<DriverArtifact> {
+    let version = Version::parse(env!("CARGO_PKG_VERSION")).unwrap();
+    [
+        (DriverKind::Sandbox, "openshell"),
+        (DriverKind::Agent, "codex"),
+        (DriverKind::Context, "filesystem"),
+        (DriverKind::Inference, "passthrough"),
+    ]
+    .into_iter()
+    .map(|(kind, name)| DriverArtifact {
+        kind,
+        name: name.to_owned(),
+        version: version.clone(),
+        source: DriverSource::BuiltIn,
+        digest: "sha256:1111111111111111111111111111111111111111111111111111111111111111".to_owned(),
+        install_hint: None,
+        entry: None,
+    })
+    .collect()
+}
+
+fn ensure_trailing_newline(input: &str) -> String {
+    if input.ends_with('\n') {
+        input.to_owned()
+    } else {
+        format!("{input}\n")
+    }
+}
+
+fn temp_dir(prefix: &str) -> PathBuf {
+    let path = std::env::temp_dir().join(format!(
+        "{prefix}-{}-{}",
+        std::process::id(),
+        std::time::SystemTime::now()
+            .duration_since(std::time::UNIX_EPOCH)
+            .unwrap()
+            .as_nanos()
+    ));
+    fs::create_dir_all(&path).unwrap();
+    path
+}
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run:
+
+```bash
+cargo test -p agentenv-core --test bundle
+```
+
+Expected: FAIL with unresolved import `agentenv_core::bundle`.
+
+- [ ] **Step 3: Add core module exports and models**
+
+Modify `crates/agentenv-core/src/lib.rs`:
+
+```rust
+pub mod bundle;
+```
+
+Create `crates/agentenv-core/src/bundle/mod.rs`:
+
+```rust
+mod model;
+mod render;
+mod writer;
+
+pub use model::{
+    BundleManifest, BundleManifestFile, BundleSource, BundleWarning, ReferenceDocument,
+    SkillBundleInput, SkillBundleMetadata, SkillBundleOutput,
+};
+pub use writer::{emit_skill_bundle, BundleError};
+```
+
+Create `crates/agentenv-core/src/bundle/model.rs`:
+
+```rust
+use std::path::PathBuf;
+
+use semver::Version;
+use serde::{Deserialize, Serialize};
+
+use crate::driver_artifact::DriverArtifact;
+
+#[derive(Debug, Clone)]
+pub struct SkillBundleInput {
+    pub source: BundleSource,
+    pub metadata: SkillBundleMetadata,
+    pub blueprint_yaml: String,
+    pub lockfile_yaml: String,
+    pub reference_document: Option<ReferenceDocument>,
+    pub output_dir: PathBuf,
+    pub agentenv_version: String,
+    pub created_at: String,
+    pub driver_artifacts: Vec<DriverArtifact>,
+}
+
+#[derive(Debug, Clone)]
+pub struct BundleSource {
+    pub env_name: String,
+    pub project_path: Option<PathBuf>,
+    pub git_commit: Option<String>,
+    pub git_dirty: Option<bool>,
+}
+
+#[derive(Debug, Clone)]
+pub struct SkillBundleMetadata {
+    pub name: String,
+    pub version: Version,
+    pub description: String,
+    pub author: Option<String>,
+    pub license: Option<String>,
+    pub tags: Vec<String>,
+}
+
+#[derive(Debug, Clone)]
+pub struct ReferenceDocument {
+    pub source_relative_path: String,
+    pub content: String,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub struct SkillBundleOutput {
+    pub output_dir: PathBuf,
+    pub skill_name: String,
+    pub version: String,
+    pub bundle_digest: String,
+    pub blueprint_digest: String,
+    pub lockfile_digest: String,
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub warnings: Vec<BundleWarning>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub struct BundleWarning {
+    pub message: String,
+}
+
+#[derive(Debug, Clone, Serialize)]
+pub struct BundleManifest {
+    pub version: String,
+    pub kind: String,
+    pub skill: BundleManifestSkill,
+    pub agentenv: BundleManifestAgentenv,
+    pub files: Vec<BundleManifestFile>,
+}
+
+#[derive(Debug, Clone, Serialize)]
+pub struct BundleManifestSkill {
+    pub name: String,
+    pub version: String,
+    pub entry: String,
+}
+
+#[derive(Debug, Clone, Serialize)]
+pub struct BundleManifestAgentenv {
+    pub schema: String,
+    pub bundle: bool,
+}
+
+#[derive(Debug, Clone, Serialize)]
+pub struct BundleManifestFile {
+    pub path: String,
+    pub sha256: String,
+}
+
+#[derive(Debug, Clone, Serialize)]
+pub struct BundleProvenance {
+    pub version: String,
+    pub created_at: String,
+    pub agentenv_version: String,
+    pub source: BundleProvenanceSource,
+    pub digests: BundleProvenanceDigests,
+}
+
+#[derive(Debug, Clone, Serialize)]
+pub struct BundleProvenanceSource {
+    pub kind: String,
+    pub env_name: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub project_path: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub project_git_commit: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub project_git_dirty: Option<bool>,
+}
+
+#[derive(Debug, Clone, Serialize)]
+pub struct BundleProvenanceDigests {
+    pub blueprint: String,
+    pub lockfile: String,
+    pub manifest: String,
+}
+```
+
+- [ ] **Step 4: Add render helpers**
+
+Create `crates/agentenv-core/src/bundle/render.rs`:
+
+```rust
+use super::model::{ReferenceDocument, SkillBundleMetadata};
+
+pub(crate) const AGENTENV_BUNDLE_SCHEMA: &str = "0.1";
+
+pub(crate) fn render_skill_md(metadata: &SkillBundleMetadata, env_name: &str, has_reference: bool) -> String {
+    let mut frontmatter = Vec::new();
+    frontmatter.push("---".to_owned());
+    frontmatter.push(format!("name: {}", metadata.name));
+    frontmatter.push(format!("description: {}", yaml_string(&metadata.description)));
+    frontmatter.push(format!("version: {}", metadata.version));
+    if let Some(author) = metadata.author.as_deref() {
+        frontmatter.push(format!("author: {}", yaml_string(author)));
+    }
+    if let Some(license) = metadata.license.as_deref() {
+        frontmatter.push(format!("license: {}", yaml_string(license)));
+    }
+    if !metadata.tags.is_empty() {
+        frontmatter.push(format!("tags: [{}]", metadata.tags.join(", ")));
+    }
+    frontmatter.push("agentenv-bundle: true".to_owned());
+    frontmatter.push(format!("agentenv-schema: \"{}\"", AGENTENV_BUNDLE_SCHEMA));
+    frontmatter.push("---".to_owned());
+
+    let mut body = vec![
+        format!("# {}", metadata.name),
+        String::new(),
+        format!("This skill reconstructs the `{env_name}` development environment with `agentenv`."),
+        String::new(),
+        "## Bootstrap".to_owned(),
+        String::new(),
+        "Run this from the skill directory:".to_owned(),
+        String::new(),
+        "```bash".to_owned(),
+        "scripts/bootstrap.sh".to_owned(),
+        "```".to_owned(),
+        String::new(),
+        "The script verifies `agentenv.lock` and reproduces the environment with:".to_owned(),
+        String::new(),
+        "```bash".to_owned(),
+        "agentenv verify agentenv.lock".to_owned(),
+        format!("agentenv reproduce agentenv.lock --name {env_name}"),
+        "```".to_owned(),
+        String::new(),
+        "## Included Files".to_owned(),
+        String::new(),
+        "- `blueprint.yaml` is the frozen blueprint used to create the environment.".to_owned(),
+        "- `agentenv.lock` pins drivers, artifacts, policy, and credential references.".to_owned(),
+    ];
+    if has_reference {
+        body.push("- `references/architecture.md` contains copied project architecture notes when available.".to_owned());
+    }
+
+    format!("{}\n\n{}\n", frontmatter.join("\n"), body.join("\n"))
+}
+
+pub(crate) fn render_skill_yaml(metadata: &SkillBundleMetadata, has_reference: bool) -> String {
+    let mut files = vec![
+        "  - SKILL.md".to_owned(),
+        "  - blueprint.yaml".to_owned(),
+        "  - agentenv.lock".to_owned(),
+        "  - scripts/**".to_owned(),
+        "  - .agentenv/**".to_owned(),
+    ];
+    if has_reference {
+        files.push("  - references/**".to_owned());
+    }
+
+    let mut yaml = vec![
+        format!("name: {}", metadata.name),
+        format!("version: {}", metadata.version),
+        format!("description: {}", yaml_string(&metadata.description)),
+        "entry: SKILL.md".to_owned(),
+        "files:".to_owned(),
+    ];
+    yaml.extend(files);
+    if !metadata.tags.is_empty() {
+        yaml.push("tags:".to_owned());
+        yaml.extend(metadata.tags.iter().map(|tag| format!("  - {tag}")));
+    }
+    yaml.push("agentenv_bundle: true".to_owned());
+    yaml.push(format!("agentenv_schema: \"{}\"", AGENTENV_BUNDLE_SCHEMA));
+    format!("{}\n", yaml.join("\n"))
+}
+
+pub(crate) fn render_bootstrap(env_name: &str) -> String {
+    format!(
+        "#!/usr/bin/env bash\nset -euo pipefail\n\nSCRIPT_DIR=\"$(cd \"$(dirname \"${{BASH_SOURCE[0]}}\")\" && pwd)\"\nBUNDLE_DIR=\"$(cd \"${{SCRIPT_DIR}}/..\" && pwd)\"\nENV_NAME=\"${{AGENTENV_ENV_NAME:-{env_name}}}\"\n\ncd \"${{BUNDLE_DIR}}\"\nagentenv verify agentenv.lock\nagentenv reproduce agentenv.lock --name \"${{ENV_NAME}}\"\n"
+    )
+}
+
+pub(crate) fn render_reference(document: &ReferenceDocument) -> String {
+    format!(
+        "# Project Architecture\n\nSource: `{}`\n\n{}",
+        document.source_relative_path,
+        ensure_trailing_newline(&document.content)
+    )
+}
+
+pub(crate) fn ensure_trailing_newline(input: &str) -> String {
+    if input.ends_with('\n') {
+        input.to_owned()
+    } else {
+        format!("{input}\n")
+    }
+}
+
+fn yaml_string(input: &str) -> String {
+    if input.bytes().all(|byte| byte.is_ascii_alphanumeric() || matches!(byte, b' ' | b'-' | b'_' | b'.' | b':' | b'/')) {
+        input.to_owned()
+    } else {
+        serde_yaml::to_string(input)
+            .expect("string serialization cannot fail")
+            .trim()
+            .to_owned()
+    }
+}
+```
+
+- [ ] **Step 5: Add writer implementation**
+
+Create `crates/agentenv-core/src/bundle/writer.rs` with this structure:
+
+```rust
+use std::{
+    fs,
+    path::{Path, PathBuf},
+    time::{SystemTime, UNIX_EPOCH},
+};
+
+use sha2::{Digest, Sha256};
+use thiserror::Error;
+
+use super::{
+    model::{
+        BundleManifest, BundleManifestAgentenv, BundleManifestFile, BundleManifestSkill,
+        BundleProvenance, BundleProvenanceDigests, BundleProvenanceSource,
+        SkillBundleInput, SkillBundleOutput,
+    },
+    render::{
+        ensure_trailing_newline, render_bootstrap, render_reference, render_skill_md,
+        render_skill_yaml, AGENTENV_BUNDLE_SCHEMA,
+    },
+};
+
+#[derive(Debug, Error)]
+pub enum BundleError {
+    #[error("output path already exists: `{path}`")]
+    OutputExists { path: PathBuf },
+    #[error("failed to read or write bundle path `{path}`: {source}")]
+    Io { path: PathBuf, #[source] source: std::io::Error },
+    #[error("failed to serialize bundle data at `{path}`: {source}")]
+    Serde { path: PathBuf, #[source] source: serde_json::Error },
+    #[error(transparent)]
+    Skill(#[from] crate::skills::SkillError),
+    #[error(transparent)]
+    Lockfile(#[from] crate::portable_lockfile::PortableLockfileError),
+    #[error("generated lockfile did not verify: {details}")]
+    LockfileVerification { details: String },
+}
+
+pub fn emit_skill_bundle(input: SkillBundleInput) -> Result<SkillBundleOutput, BundleError> {
+    if input.output_dir.exists() {
+        return Err(BundleError::OutputExists { path: input.output_dir });
+    }
+
+    let staging = staging_path(&input.output_dir)?;
+    if staging.exists() {
+        fs::remove_dir_all(&staging).map_err(|source| BundleError::Io { path: staging.clone(), source })?;
+    }
+    fs::create_dir_all(&staging).map_err(|source| BundleError::Io { path: staging.clone(), source })?;
+
+    let result = write_bundle(&input, &staging).and_then(|mut output| {
+        validate_bundle(&input, &staging)?;
+        fs::rename(&staging, &input.output_dir).map_err(|source| BundleError::Io {
+            path: input.output_dir.clone(),
+            source,
+        })?;
+        output.output_dir = input.output_dir.clone();
+        Ok(output)
+    });
+
+    if result.is_err() {
+        let _ = fs::remove_dir_all(&staging);
+    }
+
+    result
+}
+
+fn write_bundle(input: &SkillBundleInput, staging: &Path) -> Result<SkillBundleOutput, BundleError> {
+    let has_reference = input.reference_document.is_some();
+    write_file(&staging.join("SKILL.md"), &render_skill_md(&input.metadata, &input.source.env_name, has_reference))?;
+    write_file(&staging.join("skill.yaml"), &render_skill_yaml(&input.metadata, has_reference))?;
+    write_file(&staging.join("blueprint.yaml"), &ensure_trailing_newline(&input.blueprint_yaml))?;
+    write_file(&staging.join("agentenv.lock"), &ensure_trailing_newline(&input.lockfile_yaml))?;
+    write_file(&staging.join("scripts/bootstrap.sh"), &render_bootstrap(&input.source.env_name))?;
+
+    #[cfg(unix)]
+    {
+        use std::os::unix::fs::PermissionsExt;
+        let path = staging.join("scripts/bootstrap.sh");
+        let mut permissions = fs::metadata(&path).map_err(|source| BundleError::Io { path: path.clone(), source })?.permissions();
+        permissions.set_mode(0o755);
+        fs::set_permissions(&path, permissions).map_err(|source| BundleError::Io { path, source })?;
+    }
+
+    if let Some(reference) = input.reference_document.as_ref() {
+        write_file(&staging.join("references/architecture.md"), &render_reference(reference))?;
+    }
+
+    let blueprint_digest = digest_file(&staging.join("blueprint.yaml"))?;
+    let lockfile_digest = digest_file(&staging.join("agentenv.lock"))?;
+    let mut manifest = manifest_for(input, staging)?;
+    write_json(&staging.join(".agentenv/manifest.json"), &manifest)?;
+    let manifest_digest = digest_file(&staging.join(".agentenv/manifest.json"))?;
+    let provenance = BundleProvenance {
+        version: AGENTENV_BUNDLE_SCHEMA.to_owned(),
+        created_at: input.created_at.clone(),
+        agentenv_version: input.agentenv_version.clone(),
+        source: BundleProvenanceSource {
+            kind: "environment".to_owned(),
+            env_name: input.source.env_name.clone(),
+            project_path: input.source.project_path.as_ref().map(|path| path.display().to_string()),
+            project_git_commit: input.source.git_commit.clone(),
+            project_git_dirty: input.source.git_dirty,
+        },
+        digests: BundleProvenanceDigests {
+            blueprint: blueprint_digest.clone(),
+            lockfile: lockfile_digest.clone(),
+            manifest: manifest_digest,
+        },
+    };
+    write_json(&staging.join(".agentenv/provenance.json"), &provenance)?;
+
+    manifest.files = manifest_files(staging)?;
+    write_json(&staging.join(".agentenv/manifest.json"), &manifest)?;
+
+    let skill_manifest = crate::skills::load_skill_manifest(staging)?;
+    let bundle_digest = crate::skills::compute_bundle_digest(staging, &skill_manifest)?;
+
+    Ok(SkillBundleOutput {
+        output_dir: staging.to_path_buf(),
+        skill_name: input.metadata.name.clone(),
+        version: input.metadata.version.to_string(),
+        bundle_digest,
+        blueprint_digest,
+        lockfile_digest,
+        warnings: Vec::new(),
+    })
+}
+```
+
+Continue the same file with these private helpers:
+
+```rust
+fn validate_bundle(input: &SkillBundleInput, staging: &Path) -> Result<(), BundleError> {
+    let manifest = crate::skills::load_skill_manifest(staging)?;
+    crate::skills::compute_bundle_digest(staging, &manifest)?;
+    let report = crate::portable_lockfile::verify_portable_lockfile_yaml(
+        &fs::read_to_string(staging.join("agentenv.lock")).map_err(|source| BundleError::Io {
+            path: staging.join("agentenv.lock"),
+            source,
+        })?,
+        &input.driver_artifacts,
+    )?;
+    if !report.errors.is_empty() {
+        let details = report.errors.iter().map(|issue| issue.message.as_str()).collect::<Vec<_>>().join("; ");
+        return Err(BundleError::LockfileVerification { details });
+    }
+    Ok(())
+}
+
+fn manifest_for(input: &SkillBundleInput, staging: &Path) -> Result<BundleManifest, BundleError> {
+    Ok(BundleManifest {
+        version: AGENTENV_BUNDLE_SCHEMA.to_owned(),
+        kind: "agentenv.skill_bundle".to_owned(),
+        skill: BundleManifestSkill {
+            name: input.metadata.name.clone(),
+            version: input.metadata.version.to_string(),
+            entry: "SKILL.md".to_owned(),
+        },
+        agentenv: BundleManifestAgentenv {
+            schema: AGENTENV_BUNDLE_SCHEMA.to_owned(),
+            bundle: true,
+        },
+        files: manifest_files(staging)?,
+    })
+}
+
+fn manifest_files(root: &Path) -> Result<Vec<BundleManifestFile>, BundleError> {
+    let mut paths = Vec::new();
+    collect_manifest_paths(root, root, &mut paths)?;
+    paths.sort();
+    paths.into_iter().map(|path| {
+        let absolute = root.join(&path);
+        Ok(BundleManifestFile {
+            path: path.to_string_lossy().replace('\\', "/"),
+            sha256: digest_file(&absolute)?,
+        })
+    }).collect()
+}
+
+fn collect_manifest_paths(root: &Path, dir: &Path, paths: &mut Vec<PathBuf>) -> Result<(), BundleError> {
+    for entry in fs::read_dir(dir).map_err(|source| BundleError::Io { path: dir.to_path_buf(), source })? {
+        let entry = entry.map_err(|source| BundleError::Io { path: dir.to_path_buf(), source })?;
+        let path = entry.path();
+        let relative = path.strip_prefix(root).expect("path collected from root").to_path_buf();
+        if relative == Path::new(".agentenv/provenance.json") {
+            continue;
+        }
+        let file_type = entry.file_type().map_err(|source| BundleError::Io { path: path.clone(), source })?;
+        if file_type.is_dir() {
+            collect_manifest_paths(root, &path, paths)?;
+        } else if file_type.is_file() {
+            paths.push(relative);
+        }
+    }
+    Ok(())
+}
+
+fn digest_file(path: &Path) -> Result<String, BundleError> {
+    let bytes = fs::read(path).map_err(|source| BundleError::Io { path: path.to_path_buf(), source })?;
+    let mut hasher = Sha256::new();
+    hasher.update(bytes);
+    Ok(format!("sha256:{:x}", hasher.finalize()))
+}
+
+fn write_file(path: &Path, content: &str) -> Result<(), BundleError> {
+    if let Some(parent) = path.parent() {
+        fs::create_dir_all(parent).map_err(|source| BundleError::Io { path: parent.to_path_buf(), source })?;
+    }
+    fs::write(path, content).map_err(|source| BundleError::Io { path: path.to_path_buf(), source })
+}
+
+fn write_json<T: serde::Serialize>(path: &Path, value: &T) -> Result<(), BundleError> {
+    if let Some(parent) = path.parent() {
+        fs::create_dir_all(parent).map_err(|source| BundleError::Io { path: parent.to_path_buf(), source })?;
+    }
+    let rendered = serde_json::to_string_pretty(value)
+        .map_err(|source| BundleError::Serde { path: path.to_path_buf(), source })?;
+    fs::write(path, format!("{rendered}\n")).map_err(|source| BundleError::Io { path: path.to_path_buf(), source })
+}
+
+fn staging_path(output: &Path) -> Result<PathBuf, BundleError> {
+    let parent = output.parent().unwrap_or_else(|| Path::new("."));
+    let name = output.file_name().and_then(|name| name.to_str()).unwrap_or("bundle");
+    let nonce = SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .map_err(|source| BundleError::Io {
+            path: parent.to_path_buf(),
+            source: std::io::Error::other(source),
+        })?
+        .as_nanos();
+    Ok(parent.join(format!(".{name}.{}.{}.tmp", std::process::id(), nonce)))
+}
+```
+
+- [ ] **Step 6: Run core bundle tests**
+
+Run:
+
+```bash
+cargo test -p agentenv-core --test bundle
+```
+
+Expected: PASS.
+
+- [ ] **Step 7: Commit core writer**
+
+```bash
+git add crates/agentenv-core/src/lib.rs crates/agentenv-core/src/bundle crates/agentenv-core/tests/bundle.rs
+git commit -m "feat: add skill bundle writer"
+```
+
+## Task 2: Runtime Freeze Source Helper
+
+**Files:**
+- Modify: `crates/agentenv-core/src/runtime.rs`
+
+- [ ] **Step 1: Add failing runtime unit test**
+
+In the `#[cfg(test)]` module in `crates/agentenv-core/src/runtime.rs`, add:
+
+```rust
+#[test]
+fn freeze_env_for_bundle_returns_persisted_blueprint_and_portable_lockfile() {
+    let root = unique_root("agentenv-runtime-freeze-bundle-source");
+    let options = RuntimeOptions {
+        root: root.clone(),
+        log_level: LogLevel::Info,
+        non_interactive: true,
+    };
+    let env_dir = root.join("envs").join("demo");
+    fs::create_dir_all(&env_dir).unwrap();
+    let driver_version = env!("CARGO_PKG_VERSION");
+    fs::write(
+        env_dir.join("state.json"),
+        serde_json::json!({
+            "version": "0.1.0",
+            "name": "demo",
+            "phase": "running",
+            "created_at": "2026-05-09T00:00:00Z",
+            "updated_at": "2026-05-09T00:00:00Z",
+            "drivers": {
+                "sandbox": {"name": "openshell", "version": driver_version},
+                "agent": {"name": "codex", "version": driver_version},
+                "context": {"name": "filesystem", "version": driver_version},
+                "inference": {"name": "passthrough", "version": driver_version}
+            },
+            "handles": {},
+            "endpoints": {},
+            "first_enter_hint_shown": false
+        })
+        .to_string(),
+    )
+    .unwrap();
+    let blueprint_yaml = r#"version: 0.1.0
+min_agentenv_version: 0.0.1-alpha0
+sandbox:
+  driver: openshell
+agent:
+  driver: codex
+context:
+  driver: filesystem
+  mount: .
+inference:
+  driver: passthrough
+policy:
+  tier: balanced
+  presets: []
+"#;
+    fs::write(env_dir.join("blueprint.yaml"), blueprint_yaml).unwrap();
+    let lock_yaml = crate::lifecycle::freeze_from_blueprint_yaml(blueprint_yaml).unwrap();
+    fs::write(env_dir.join("lock.yaml"), lock_yaml).unwrap();
+
+    let frozen = freeze_env_for_bundle(&options, "demo").unwrap();
+
+    assert_eq!(frozen.env_name, "demo");
+    assert_eq!(frozen.blueprint_yaml, blueprint_yaml);
+    assert!(frozen.lockfile_yaml.contains("version: 0.2.0"));
+    assert!(frozen.lockfile_yaml.contains("name: demo"));
+}
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run:
+
+```bash
+cargo test -p agentenv-core runtime::tests::freeze_env_for_bundle_returns_persisted_blueprint_and_portable_lockfile
+```
+
+Expected: FAIL with missing `freeze_env_for_bundle`.
+
+- [ ] **Step 3: Add runtime helper**
+
+Near `EnvDescription` in `crates/agentenv-core/src/runtime.rs`, add:
+
+```rust
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct FrozenEnvBundleSource {
+    pub env_name: String,
+    pub blueprint_yaml: String,
+    pub lockfile_yaml: String,
+}
+```
+
+Near `freeze_env_lockfile`, add:
+
+```rust
+pub fn freeze_env_for_bundle(
+    options: &RuntimeOptions,
+    name: &str,
+) -> RuntimeResult<FrozenEnvBundleSource> {
+    let description = describe_env(options, name)?;
+    let lockfile_yaml = freeze_env_lockfile(options, name)?;
+    Ok(FrozenEnvBundleSource {
+        env_name: description.state.name,
+        blueprint_yaml: description.blueprint_yaml,
+        lockfile_yaml,
+    })
+}
+```
+
+- [ ] **Step 4: Run runtime test**
+
+Run:
+
+```bash
+cargo test -p agentenv-core runtime::tests::freeze_env_for_bundle_returns_persisted_blueprint_and_portable_lockfile
+```
+
+Expected: PASS.
+
+- [ ] **Step 5: Commit runtime helper**
+
+```bash
+git add crates/agentenv-core/src/runtime.rs
+git commit -m "feat: expose frozen env source for bundles"
+```
+
+## Task 3: CLI Command Skeleton
+
+**Files:**
+- Create: `crates/agentenv/src/bundle_cli.rs`
+- Modify: `crates/agentenv/src/main.rs`
+- Modify: `crates/agentenv/tests/cli_behavior.rs`
+
+- [ ] **Step 1: Add failing CLI help and missing-env tests**
+
+In `crates/agentenv/tests/cli_behavior.rs`, add near existing CLI command tests:
+
+```rust
+#[test]
+fn bundle_help_lists_as_skill_and_out_flags() {
+    let output = Command::new(agentenv_bin())
+        .arg("bundle")
+        .arg("--help")
+        .output()
+        .unwrap();
+
+    assert!(output.status.success());
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    assert!(stdout.contains("--as-skill"), "stdout was: {stdout}");
+    assert!(stdout.contains("--out"), "stdout was: {stdout}");
+    assert!(stdout.contains("--env"), "stdout was: {stdout}");
+}
+
+#[test]
+fn bundle_as_skill_rejects_missing_env() {
+    let temp_dir = make_temp_dir("bundle-missing-env");
+    let output = Command::new(agentenv_bin())
+        .arg("bundle")
+        .arg("missing")
+        .arg("--as-skill")
+        .arg("--out")
+        .arg(temp_dir.join("missing-skill"))
+        .env("HOME", &temp_dir)
+        .current_dir(&temp_dir)
+        .output()
+        .unwrap();
+
+    assert!(!output.status.success());
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    assert!(stderr.contains("env `missing` not found") || stderr.contains("environment `missing` does not exist"), "stderr was: {stderr}");
+}
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run:
+
+```bash
+cargo test -p agentenv --test cli_behavior bundle_help_lists_as_skill_and_out_flags bundle_as_skill_rejects_missing_env
+```
+
+Expected: FAIL because `bundle` is not a recognized command.
+
+- [ ] **Step 3: Add CLI module and command enum entry**
+
+Create `crates/agentenv/src/bundle_cli.rs`:
+
+```rust
+use std::path::PathBuf;
+
+use agentenv_core::bundle::{
+    emit_skill_bundle, BundleSource, ReferenceDocument, SkillBundleInput,
+    SkillBundleMetadata, SkillBundleOutput,
+};
+use anyhow::{bail, Context, Result};
+use clap::Args;
+use semver::Version;
+use serde::Serialize;
+
+#[derive(Debug, Args)]
+pub struct BundleArgs {
+    pub source: String,
+    #[arg(long)]
+    pub as_skill: bool,
+    #[arg(long, value_name = "DIR")]
+    pub out: Option<PathBuf>,
+    #[arg(long)]
+    pub env: Option<String>,
+    #[arg(long)]
+    pub name: Option<String>,
+    #[arg(long)]
+    pub version: Option<String>,
+    #[arg(long)]
+    pub description: Option<String>,
+    #[arg(long)]
+    pub author: Option<String>,
+    #[arg(long)]
+    pub license: Option<String>,
+    #[arg(long = "tag")]
+    pub tags: Vec<String>,
+    #[arg(long)]
+    pub json: bool,
+}
+
+#[derive(Debug, Serialize)]
+struct BundleJson {
+    output_dir: PathBuf,
+    skill_name: String,
+    version: String,
+    bundle_digest: String,
+    blueprint_digest: String,
+    lockfile_digest: String,
+}
+
+pub fn run_bundle(args: BundleArgs) -> Result<()> {
+    if !args.as_skill {
+        bail!("bundle currently supports only --as-skill");
+    }
+    let out = args
+        .out
+        .clone()
+        .context("bundle --as-skill requires --out <dir>")?;
+
+    let source_path = PathBuf::from(&args.source);
+    let project_path = source_path.is_dir().then_some(source_path.clone());
+    let env_name = match args.env.as_deref() {
+        Some(env) => env.to_owned(),
+        None if project_path.is_some() => source_path
+            .file_name()
+            .and_then(|name| name.to_str())
+            .context("project directory must have a UTF-8 basename")?
+            .to_owned(),
+        None => args.source.clone(),
+    };
+
+    let options = crate::runtime_options(true)?;
+    let frozen = agentenv_core::runtime::freeze_env_for_bundle(&options, &env_name)
+        .with_context(|| format!("environment `{env_name}` does not exist or cannot be frozen"))?;
+    let driver_artifacts = crate::discover_runtime_driver_artifacts(&options)?;
+    let metadata = build_metadata(&args, &frozen, project_path.as_ref())?;
+    let reference_document = load_reference_document(project_path.as_ref())?;
+
+    let output = emit_skill_bundle(SkillBundleInput {
+        source: BundleSource {
+            env_name: frozen.env_name.clone(),
+            project_path,
+            git_commit: None,
+            git_dirty: None,
+        },
+        metadata,
+        blueprint_yaml: frozen.blueprint_yaml,
+        lockfile_yaml: frozen.lockfile_yaml,
+        reference_document,
+        output_dir: out,
+        agentenv_version: env!("CARGO_PKG_VERSION").to_owned(),
+        created_at: created_at_now(),
+        driver_artifacts,
+    })?;
+
+    print_output(output, args.json)
+}
+```
+
+Continue `bundle_cli.rs` with:
+
+```rust
+fn build_metadata(
+    args: &BundleArgs,
+    frozen: &agentenv_core::runtime::FrozenEnvBundleSource,
+    _project_path: Option<&PathBuf>,
+) -> Result<SkillBundleMetadata> {
+    let name = args.name.clone().unwrap_or_else(|| frozen.env_name.clone());
+    agentenv_core::skills::validate_skill_name(&name)
+        .with_context(|| format!("derived skill name `{name}` is invalid; pass --name"))?;
+    let version = args
+        .version
+        .as_deref()
+        .unwrap_or("1.0.0")
+        .parse::<Version>()
+        .with_context(|| format!("invalid skill version `{}`", args.version.as_deref().unwrap_or("1.0.0")))?;
+    let description = args
+        .description
+        .clone()
+        .unwrap_or_else(|| format!("Reproducible dev env for {name}"));
+    let mut tags = args.tags.clone();
+    if tags.is_empty() {
+        tags.push("dev-env".to_owned());
+    }
+    Ok(SkillBundleMetadata {
+        name,
+        version,
+        description,
+        author: args.author.clone(),
+        license: args.license.clone(),
+        tags,
+    })
+}
+
+fn load_reference_document(project_path: Option<&PathBuf>) -> Result<Option<ReferenceDocument>> {
+    let Some(project_path) = project_path else {
+        return Ok(None);
+    };
+    for relative in ["docs/ARCHITECTURE.md", "ARCHITECTURE.md", "README.md"] {
+        let path = project_path.join(relative);
+        if path.is_file() {
+            let content = std::fs::read_to_string(&path)
+                .with_context(|| format!("failed to read reference document `{}`", path.display()))?;
+            return Ok(Some(ReferenceDocument {
+                source_relative_path: relative.to_owned(),
+                content,
+            }));
+        }
+    }
+    Ok(None)
+}
+
+fn created_at_now() -> String {
+    time::OffsetDateTime::now_utc()
+        .format(&time::format_description::well_known::Rfc3339)
+        .expect("RFC3339 formatting cannot fail")
+}
+
+fn print_output(output: SkillBundleOutput, json: bool) -> Result<()> {
+    if json {
+        let rendered = serde_json::to_string_pretty(&BundleJson {
+            output_dir: output.output_dir,
+            skill_name: output.skill_name,
+            version: output.version,
+            bundle_digest: output.bundle_digest,
+            blueprint_digest: output.blueprint_digest,
+            lockfile_digest: output.lockfile_digest,
+        })?;
+        println!("{rendered}");
+    } else {
+        println!(
+            "Skill bundle written: {} ({})",
+            output.output_dir.display(),
+            output.bundle_digest
+        );
+    }
+    Ok(())
+}
+```
+
+Modify `crates/agentenv/src/main.rs`:
+
+```rust
+mod bundle_cli;
+```
+
+Add to `Commands`:
+
+```rust
+Bundle(bundle_cli::BundleArgs),
+```
+
+Add to `run()` match:
+
+```rust
+Some(Commands::Bundle(args)) => bundle_cli::run_bundle(args),
+```
+
+- [ ] **Step 4: Run CLI skeleton tests**
+
+Run:
+
+```bash
+cargo test -p agentenv --test cli_behavior bundle_help_lists_as_skill_and_out_flags bundle_as_skill_rejects_missing_env
+```
+
+Expected: PASS.
+
+- [ ] **Step 5: Commit CLI skeleton**
+
+```bash
+git add crates/agentenv/src/main.rs crates/agentenv/src/bundle_cli.rs crates/agentenv/tests/cli_behavior.rs
+git commit -m "feat: add bundle as skill cli skeleton"
+```
+
+## Task 4: Metadata And Reference Detection
+
+**Files:**
+- Modify: `crates/agentenv/src/bundle_cli.rs`
+- Modify: `crates/agentenv/tests/cli_behavior.rs`
+
+- [ ] **Step 1: Add failing CLI export test with project metadata**
+
+In `crates/agentenv/tests/cli_behavior.rs`, add:
+
+```rust
+#[test]
+fn bundle_as_skill_exports_existing_env_with_project_reference() {
+    let temp_dir = make_temp_dir("bundle-export-project");
+    write_minimal_env_state(&temp_dir, "demo");
+    let project = temp_dir.join("demo");
+    fs::create_dir_all(project.join("docs")).unwrap();
+    fs::write(project.join("docs/ARCHITECTURE.md"), "# Demo Architecture\n").unwrap();
+
+    let output_dir = temp_dir.join("demo-skill");
+    let output = Command::new(agentenv_bin())
+        .arg("bundle")
+        .arg(&project)
+        .arg("--as-skill")
+        .arg("--out")
+        .arg(&output_dir)
+        .arg("--author")
+        .arg("Alice Example")
+        .arg("--license")
+        .arg("MIT")
+        .arg("--tag")
+        .arg("rust")
+        .env("HOME", &temp_dir)
+        .current_dir(&temp_dir)
+        .output()
+        .unwrap();
+
+    assert!(
+        output.status.success(),
+        "stdout was: {}\nstderr was: {}",
+        String::from_utf8_lossy(&output.stdout),
+        String::from_utf8_lossy(&output.stderr)
+    );
+    assert!(output_dir.join("SKILL.md").is_file());
+    assert!(output_dir.join("skill.yaml").is_file());
+    assert!(output_dir.join("references/architecture.md").is_file());
+
+    let skill = fs::read_to_string(output_dir.join("SKILL.md")).unwrap();
+    assert!(skill.contains("author: Alice Example"));
+    assert!(skill.contains("license: MIT"));
+    assert!(skill.contains("tags: [rust]"));
+
+    let reference = fs::read_to_string(output_dir.join("references/architecture.md")).unwrap();
+    assert!(reference.contains("Source: `docs/ARCHITECTURE.md`"));
+    assert!(reference.contains("# Demo Architecture"));
+}
+```
+
+- [ ] **Step 2: Run test to verify it fails on lockfile verification or metadata gaps**
+
+Run:
+
+```bash
+cargo test -p agentenv --test cli_behavior bundle_as_skill_exports_existing_env_with_project_reference
+```
+
+Expected: FAIL if `write_minimal_env_state` writes a legacy lockfile that the bundle verifier rejects, or PASS if Task 3 already routes through `freeze_env_for_bundle` correctly. If it passes, continue to Step 4.
+
+- [ ] **Step 3: Ensure CLI uses frozen portable lockfile and discovered driver artifacts**
+
+If the test fails because the generated lockfile does not verify, keep the CLI call to `freeze_env_for_bundle` and verify `discover_runtime_driver_artifacts` is called after `runtime_options(true)`. Do not read `lock.yaml` directly in `bundle_cli.rs`.
+
+Use this call shape in `run_bundle`:
+
+```rust
+let options = crate::runtime_options(true)?;
+let frozen = agentenv_core::runtime::freeze_env_for_bundle(&options, &env_name)
+    .with_context(|| format!("environment `{env_name}` does not exist or cannot be frozen"))?;
+let driver_artifacts = crate::discover_runtime_driver_artifacts(&options)
+    .context("failed to discover driver artifacts for bundle verification")?;
+```
+
+- [ ] **Step 4: Add git and license detection helpers**
+
+Extend `build_metadata` in `crates/agentenv/src/bundle_cli.rs` so explicit CLI flags win and project detection fills absent optional fields:
+
+```rust
+let author = args
+    .author
+    .clone()
+    .or_else(|| project_path.and_then(detect_git_author));
+let license = args
+    .license
+    .clone()
+    .or_else(|| project_path.and_then(detect_license));
+```
+
+Add helper functions:
+
+```rust
+fn detect_git_author(project_path: &PathBuf) -> Option<String> {
+    let output = std::process::Command::new("git")
+        .args(["config", "user.name"])
+        .current_dir(project_path)
+        .output()
+        .ok()?;
+    if !output.status.success() {
+        return None;
+    }
+    let value = String::from_utf8(output.stdout).ok()?.trim().to_owned();
+    (!value.is_empty()).then_some(value)
+}
+
+fn detect_git_commit(project_path: &PathBuf) -> Option<String> {
+    let output = std::process::Command::new("git")
+        .args(["rev-parse", "HEAD"])
+        .current_dir(project_path)
+        .output()
+        .ok()?;
+    if !output.status.success() {
+        return None;
+    }
+    let value = String::from_utf8(output.stdout).ok()?.trim().to_owned();
+    (!value.is_empty()).then_some(value)
+}
+
+fn detect_git_dirty(project_path: &PathBuf) -> Option<bool> {
+    let output = std::process::Command::new("git")
+        .args(["status", "--porcelain"])
+        .current_dir(project_path)
+        .output()
+        .ok()?;
+    output.status.success().then(|| !output.stdout.is_empty())
+}
+
+fn detect_license(project_path: &PathBuf) -> Option<String> {
+    let cargo_toml = project_path.join("Cargo.toml");
+    if cargo_toml.is_file() {
+        let content = std::fs::read_to_string(cargo_toml).ok()?;
+        let value: toml::Value = toml::from_str(&content).ok()?;
+        if let Some(license) = value.get("package").and_then(|package| package.get("license")).and_then(|license| license.as_str()) {
+            return Some(license.to_owned());
+        }
+        if let Some(license) = value.get("workspace").and_then(|workspace| workspace.get("package")).and_then(|package| package.get("license")).and_then(|license| license.as_str()) {
+            return Some(license.to_owned());
+        }
+    }
+    for name in ["LICENSE-MIT", "LICENSE_APACHE", "LICENSE-APACHE", "LICENSE"] {
+        if project_path.join(name).is_file() {
+            return Some(name.trim_start_matches("LICENSE-").trim_start_matches("LICENSE_").to_owned()).filter(|value| !value.is_empty());
+        }
+    }
+    None
+}
+```
+
+When building `BundleSource`, set git fields:
+
+```rust
+let git_commit = project_path.as_ref().and_then(detect_git_commit);
+let git_dirty = project_path.as_ref().and_then(detect_git_dirty);
+```
+
+- [ ] **Step 5: Run metadata export test**
+
+Run:
+
+```bash
+cargo test -p agentenv --test cli_behavior bundle_as_skill_exports_existing_env_with_project_reference
+```
+
+Expected: PASS.
+
+- [ ] **Step 6: Commit metadata detection**
+
+```bash
+git add crates/agentenv/src/bundle_cli.rs crates/agentenv/tests/cli_behavior.rs
+git commit -m "feat: enrich skill bundle metadata"
+```
+
+## Task 5: JSON Output And Install Compatibility
+
+**Files:**
+- Modify: `crates/agentenv/tests/cli_behavior.rs`
+- Modify: `crates/agentenv/src/bundle_cli.rs`
+
+- [ ] **Step 1: Add failing JSON and install compatibility test**
+
+In `crates/agentenv/tests/cli_behavior.rs`, add:
+
+```rust
+#[test]
+fn bundle_as_skill_json_output_installs_as_local_skill() {
+    let temp_dir = make_temp_dir("bundle-json-install");
+    write_minimal_env_state(&temp_dir, "demo");
+    let output_dir = temp_dir.join("demo-skill");
+
+    let output = Command::new(agentenv_bin())
+        .arg("bundle")
+        .arg("demo")
+        .arg("--as-skill")
+        .arg("--out")
+        .arg(&output_dir)
+        .arg("--json")
+        .env("HOME", &temp_dir)
+        .current_dir(&temp_dir)
+        .output()
+        .unwrap();
+
+    assert!(
+        output.status.success(),
+        "stdout was: {}\nstderr was: {}",
+        String::from_utf8_lossy(&output.stdout),
+        String::from_utf8_lossy(&output.stderr)
+    );
+    let json: serde_json::Value = serde_json::from_slice(&output.stdout).unwrap();
+    assert_eq!(json["skill_name"], "demo");
+    assert_eq!(json["version"], "1.0.0");
+    assert!(json["bundle_digest"].as_str().unwrap().starts_with("sha256:"));
+    assert!(json["blueprint_digest"].as_str().unwrap().starts_with("sha256:"));
+    assert!(json["lockfile_digest"].as_str().unwrap().starts_with("sha256:"));
+
+    let install = Command::new(agentenv_bin())
+        .arg("skills")
+        .arg("install")
+        .arg("--from")
+        .arg(&output_dir)
+        .arg("--allow-unsigned")
+        .arg("--json")
+        .env("HOME", &temp_dir)
+        .current_dir(&temp_dir)
+        .output()
+        .unwrap();
+    assert!(
+        install.status.success(),
+        "stdout was: {}\nstderr was: {}",
+        String::from_utf8_lossy(&install.stdout),
+        String::from_utf8_lossy(&install.stderr)
+    );
+
+    let verify = Command::new(agentenv_bin())
+        .arg("skills")
+        .arg("verify")
+        .arg("demo")
+        .arg("--json")
+        .env("HOME", &temp_dir)
+        .current_dir(&temp_dir)
+        .output()
+        .unwrap();
+    assert!(
+        verify.status.success(),
+        "stdout was: {}\nstderr was: {}",
+        String::from_utf8_lossy(&verify.stdout),
+        String::from_utf8_lossy(&verify.stderr)
+    );
+}
+```
+
+- [ ] **Step 2: Run test to verify it fails if JSON shape or install compatibility is incomplete**
+
+Run:
+
+```bash
+cargo test -p agentenv --test cli_behavior bundle_as_skill_json_output_installs_as_local_skill
+```
+
+Expected: FAIL if JSON keys are absent or if `skill.yaml` does not declare all generated files.
+
+- [ ] **Step 3: Fix JSON output shape**
+
+Ensure `BundleJson` in `crates/agentenv/src/bundle_cli.rs` has exactly these fields:
+
+```rust
+#[derive(Debug, Serialize)]
+struct BundleJson {
+    output_dir: PathBuf,
+    skill_name: String,
+    version: String,
+    bundle_digest: String,
+    blueprint_digest: String,
+    lockfile_digest: String,
+}
+```
+
+Ensure `print_output` maps every field from `SkillBundleOutput` and prints pretty JSON with a trailing newline through `println!("{rendered}")`.
+
+- [ ] **Step 4: Fix manifest compatibility if needed**
+
+If install fails with an unsafe or missing bundle path, adjust `render_skill_yaml` in `crates/agentenv-core/src/bundle/render.rs` so `files` includes every generated regular file through accepted patterns:
+
+```yaml
+files:
+  - SKILL.md
+  - blueprint.yaml
+  - agentenv.lock
+  - scripts/**
+  - .agentenv/**
+```
+
+When a reference document exists, also include:
+
+```yaml
+  - references/**
+```
+
+Do not include `references/**` when no reference document exists because `load_skill_manifest` rejects empty glob matches.
+
+- [ ] **Step 5: Run compatibility test**
+
+Run:
+
+```bash
+cargo test -p agentenv --test cli_behavior bundle_as_skill_json_output_installs_as_local_skill
+```
+
+Expected: PASS.
+
+- [ ] **Step 6: Commit JSON and install compatibility**
+
+```bash
+git add crates/agentenv/src/bundle_cli.rs crates/agentenv-core/src/bundle/render.rs crates/agentenv/tests/cli_behavior.rs
+git commit -m "test: verify bundle installs as skill"
+```
+
+## Task 6: Final Verification And Documentation
+
+**Files:**
+- Modify: `docs/superpowers/specs/2026-05-09-m7-5-bundle-as-skill-design.md` if implementation names differ from the approved spec
+- Modify: `docs/superpowers/plans/2026-05-09-m7-5-bundle-as-skill.md` only if the executed implementation intentionally changes task ordering
+
+- [ ] **Step 1: Run focused tests**
+
+Run:
+
+```bash
+cargo test -p agentenv-core --test bundle
+cargo test -p agentenv-core runtime::tests::freeze_env_for_bundle_returns_persisted_blueprint_and_portable_lockfile
+cargo test -p agentenv --test cli_behavior bundle
+```
+
+Expected: all PASS.
+
+- [ ] **Step 2: Run formatting**
+
+Run:
+
+```bash
+cargo fmt
+```
+
+Expected: command exits 0 and formats touched Rust files.
+
+- [ ] **Step 3: Run clippy**
+
+Run:
+
+```bash
+cargo clippy --workspace -- -D warnings
+```
+
+Expected: PASS with no warnings.
+
+- [ ] **Step 4: Run workspace tests**
+
+Run:
+
+```bash
+cargo test --workspace
+```
+
+Expected: PASS.
+
+- [ ] **Step 5: Inspect final diff**
+
+Run:
+
+```bash
+git status --short
+git diff --stat
+git diff -- docs/superpowers/specs/2026-05-09-m7-5-bundle-as-skill-design.md docs/superpowers/plans/2026-05-09-m7-5-bundle-as-skill.md
+```
+
+Expected: only intentional source, test, and documentation changes remain.
+
+- [ ] **Step 6: Commit final verification fixes**
+
+If verification required fixes, commit them:
+
+```bash
+git add crates/agentenv-core/src crates/agentenv-core/tests crates/agentenv/src crates/agentenv/tests docs/superpowers/specs/2026-05-09-m7-5-bundle-as-skill-design.md docs/superpowers/plans/2026-05-09-m7-5-bundle-as-skill.md
+git commit -m "feat: emit agentenv bundles as skills"
+```
+
+If no fixes remain after prior task commits, do not create an empty commit.
+
+## Self-Review Notes
+
+- Spec coverage: the plan covers both metadata surfaces, strict frozen-env source material, output layout, bootstrap script, reference document selection, manifest/provenance generation, overwrite refusal, JSON output, and install compatibility.
+- Scope: this is one coherent subsystem. It touches core rendering, runtime freeze material, CLI wiring, and tests, but does not add a driver axis or registry behavior.
+- Type consistency: `SkillBundleInput`, `SkillBundleMetadata`, `BundleSource`, `ReferenceDocument`, and `SkillBundleOutput` use the same field names across core tests, core implementation, and CLI code.
+- Verification: focused tests, formatting, clippy, and full workspace tests are listed as required final commands.

--- a/docs/superpowers/specs/2026-05-09-m7-5-bundle-as-skill-design.md
+++ b/docs/superpowers/specs/2026-05-09-m7-5-bundle-as-skill-design.md
@@ -1,0 +1,572 @@
+# M7-5 Design: Blueprint To Skill Bundle Emission
+
+- Date: 2026-05-09
+- Issue: https://github.com/windoliver/agentenv/issues/31
+- Milestone: M7 Skills axis and registry
+- Depends on: https://github.com/windoliver/agentenv/issues/27, https://github.com/windoliver/agentenv/issues/29, M4-2 freeze/reproduce
+- Affected crates: `agentenv`, `agentenv-core`
+- Protocol impact: no driver protocol or schema-version change
+
+## 1. Context And Goals
+
+Issue #31 turns `agentenv` into a producer of portable agent skills. A working
+environment can be frozen and emitted as a skill bundle that other agents can
+load to reconstruct the same development environment.
+
+The design must satisfy two constraints that now exist in the repository:
+
+1. Issue #28 already implemented the `agentenv skills` lifecycle around a root
+   `skill.yaml` manifest. Registry, install, digest, and verification behavior
+   depend on that file.
+2. Issue #31 asks for an Anthropic-style `SKILL.md` with frontmatter so the
+   same artifact is useful to Claude, Gemini CLI, Codex, and other skill
+   consumers.
+
+The approved direction is to emit both metadata surfaces from one source of
+truth. `skill.yaml` remains the canonical `agentenv` package manifest.
+`SKILL.md` carries cross-agent frontmatter and the human instructions for
+reconstructing the environment.
+
+The bundle should represent a known-good frozen environment. It should not be a
+thin copy of arbitrary `agentenv.yaml` into a skill-shaped directory. The first
+implementation therefore exports from an existing environment and uses the
+same freeze path that powers `agentenv freeze`.
+
+## 2. Scope And Non-Goals
+
+In scope:
+
+1. Add `agentenv bundle <source> --as-skill --out <dir>` as the skill export
+   command.
+2. Export from an existing environment, freezing it through the current runtime
+   path before writing the bundle.
+3. Allow `<source>` to be either an environment name or a project directory
+   whose basename or explicit `--env <name>` identifies the environment to
+   freeze.
+4. Emit a portable skill directory with:
+
+```text
+<out>/
+|-- SKILL.md
+|-- skill.yaml
+|-- blueprint.yaml
+|-- agentenv.lock
+|-- scripts/
+|   `-- bootstrap.sh
+|-- references/
+|   `-- architecture.md
+`-- .agentenv/
+    |-- manifest.json
+    `-- provenance.json
+```
+
+5. Keep generated bundles installable through the existing
+   `agentenv skills install --from <dir> --allow-unsigned` path.
+6. Generate deterministic bundle content except for explicit provenance fields
+   such as `created_at`.
+7. Record digests for the emitted blueprint, lockfile, bootstrap script, skill
+   entrypoint, optional reference document, and bundle metadata.
+8. Generate a bootstrap script that uses existing CLI verbs:
+   `agentenv verify agentenv.lock` and `agentenv reproduce agentenv.lock`.
+9. Add tests for command parsing, output layout, metadata parity, provenance,
+   overwrite safety, and install compatibility.
+
+Out of scope:
+
+1. A new driver kind, registry adapter kind, or driver protocol method.
+2. Changing existing skill registries from `skill.yaml` to `SKILL.md`
+   frontmatter.
+3. Snapshotting workspace files, home directories, databases, or event stores.
+   That belongs to M6-4 snapshots, not skill bundle export.
+4. Publishing the generated bundle to HTTP, OCI, or filesystem registries.
+   Existing `agentenv skills publish` handles publishing after export.
+5. Signing exported skill bundles. The first slice emits unsigned local bundles
+   that can be installed with `--allow-unsigned`.
+6. A broad documentation packager. The first slice only includes one selected
+   reference document when one is available.
+7. Introducing a new `apply` command. The generated instructions should use
+   current `freeze` and `reproduce` vocabulary.
+
+## 3. Command Shape
+
+Add a top-level `Bundle(BundleArgs)` command to `crates/agentenv/src/main.rs`
+and keep the implementation in a small CLI facade:
+
+```text
+agentenv bundle <source> --as-skill --out <dir> [--env <name>] \
+  [--name <skill-name>] [--version <semver>] [--description <text>] \
+  [--author <text>] [--license <text>] [--tag <tag>]... [--json]
+```
+
+Required arguments:
+
+1. `<source>` is an existing environment name or a project directory.
+2. `--as-skill` is required for the first implementation. The verb is named
+   `bundle` so future bundle forms can share the command, but this issue only
+   implements skill emission.
+3. `--out <dir>` is required. The command rejects an existing path.
+
+Optional arguments:
+
+1. `--env <name>` disambiguates the environment when `<source>` is a project
+   directory.
+2. `--name <skill-name>` overrides the generated skill name. It must pass the
+   existing `skills::validate_skill_name` rules.
+3. `--version <semver>` overrides the skill version. Default: `1.0.0`.
+4. `--description <text>` overrides the generated description.
+5. `--author <text>` and `--license <text>` override detected metadata.
+6. `--tag <tag>` adds tags. Tags are lowercase ASCII identifiers using the
+   same character set as skill names, except dots are discouraged but accepted
+   for parity with skill names.
+7. `--json` prints a machine-readable summary containing output path, skill
+   name, version, bundle digest, blueprint digest, and lockfile digest.
+
+Do not add `--force` in the first slice. Refusing existing output keeps the
+first implementation simple and avoids deleting user files. A later PR can add
+safe replacement semantics after there is a generated-directory marker to
+validate.
+
+## 4. Source Resolution
+
+The exporter resolves `<source>` as follows:
+
+1. If `<source>` is not an existing filesystem path, treat it as an environment
+   name and freeze that environment.
+2. If `<source>` is a directory and `--env <name>` is provided, freeze that
+   environment and use the directory only for metadata detection and reference
+   document discovery.
+3. If `<source>` is a directory and no `--env` is provided, derive the
+   environment name from the directory basename and freeze that environment.
+4. If the derived or explicit environment does not exist, fail with an error
+   that tells the user to run `agentenv create <name> --blueprint <path>` and
+   then retry the bundle command.
+
+This preserves the issue's example shape:
+
+```text
+agentenv bundle ./myapp --as-skill --out ./myapp-skill/
+```
+
+after the user has materialized an environment named `myapp`.
+
+The bundle source model has two outputs:
+
+1. Frozen runtime state from `agentenv_core::runtime::freeze_env_lockfile`.
+2. Optional project metadata from the project directory, such as git author,
+   license, README, or `docs/ARCHITECTURE.md`.
+
+Project metadata must never replace the frozen runtime state. If the project
+directory's `agentenv.yaml` differs from the persisted environment blueprint,
+the command emits a warning and writes the frozen environment blueprint.
+
+## 5. Core Architecture
+
+Add `agentenv_core::bundle` with these focused responsibilities:
+
+1. `model` defines serializable bundle inputs, outputs, manifest JSON, and
+   provenance JSON.
+2. `metadata` normalizes skill names, versions, descriptions, tags, author, and
+   license.
+3. `writer` creates the output layout in a staging directory, writes files, and
+   atomically publishes the final directory.
+4. `references` selects at most one source document for
+   `references/architecture.md`.
+5. `digest` computes `sha256:<hex>` digests for emitted files and directories.
+
+The CLI owns source resolution and optional git metadata detection because it
+already depends on local process context. Core owns deterministic rendering and
+validation. Core errors use `thiserror`; the CLI wraps them with `anyhow`
+context.
+
+The core entrypoint should be shaped like this:
+
+```rust
+pub struct SkillBundleInput {
+    pub source: BundleSource,
+    pub metadata: SkillBundleMetadata,
+    pub blueprint_yaml: String,
+    pub lockfile_yaml: String,
+    pub reference_document: Option<ReferenceDocument>,
+    pub output_dir: PathBuf,
+}
+
+pub struct SkillBundleOutput {
+    pub output_dir: PathBuf,
+    pub skill_name: String,
+    pub version: String,
+    pub bundle_digest: String,
+    pub blueprint_digest: String,
+    pub lockfile_digest: String,
+}
+
+pub fn emit_skill_bundle(input: SkillBundleInput) -> Result<SkillBundleOutput, BundleError>;
+```
+
+The runtime layer should expose a small helper for the CLI to obtain frozen
+source material from an environment:
+
+```rust
+pub struct FrozenEnvBundleSource {
+    pub env_name: String,
+    pub blueprint_yaml: String,
+    pub lockfile_yaml: String,
+}
+
+pub fn freeze_env_for_bundle(
+    options: &RuntimeOptions,
+    name: &str,
+) -> RuntimeResult<FrozenEnvBundleSource>;
+```
+
+`freeze_env_for_bundle` should reuse the same validation as
+`freeze_env_lockfile` and return the persisted environment blueprint alongside
+the deterministic portable lockfile.
+
+## 6. Output Files
+
+### 6.1 `SKILL.md`
+
+`SKILL.md` is the skill entrypoint and contains frontmatter plus concise
+instructions:
+
+````markdown
+---
+name: myapp
+description: Reproducible dev env for myapp - Rust + Postgres + Redis
+version: 1.0.0
+author: Alice Example
+license: MIT
+tags: [rust, postgres, redis, dev-env]
+agentenv-bundle: true
+agentenv-schema: "0.1"
+---
+
+# myapp
+
+This skill reconstructs the `myapp` development environment with `agentenv`.
+
+## Bootstrap
+
+Run this from the skill directory:
+
+```bash
+scripts/bootstrap.sh
+```
+
+The script verifies `agentenv.lock` and reproduces the environment with:
+
+```bash
+agentenv verify agentenv.lock
+agentenv reproduce agentenv.lock --name myapp
+```
+
+## Included Files
+
+- `blueprint.yaml` is the frozen blueprint used to create the environment.
+- `agentenv.lock` pins drivers, artifacts, policy, and credential references.
+- `references/architecture.md` contains copied project architecture notes when available.
+````
+
+`author`, `license`, and `tags` are omitted from frontmatter when no value is
+available. The boolean `agentenv-bundle` and string `agentenv-schema` fields
+are always present.
+
+### 6.2 `skill.yaml`
+
+`skill.yaml` keeps compatibility with the existing skills package code:
+
+```yaml
+name: myapp
+version: 1.0.0
+description: Reproducible dev env for myapp - Rust + Postgres + Redis
+entry: SKILL.md
+files:
+  - SKILL.md
+  - blueprint.yaml
+  - agentenv.lock
+  - scripts/**
+  - .agentenv/**
+  - references/**
+agentenv_bundle: true
+agentenv_schema: "0.1"
+```
+
+If no reference document is emitted, omit `references/**` from `files`. This is
+required because the existing manifest parser rejects empty glob matches.
+
+The following fields must be generated from the same `SkillBundleMetadata`
+value in both `SKILL.md` and `skill.yaml`:
+
+1. name
+2. version
+3. description
+4. tags when present
+5. `agentenv` schema marker
+
+### 6.3 `blueprint.yaml`
+
+`blueprint.yaml` is the environment blueprint that corresponds to the frozen
+lockfile. It is copied from persisted runtime state, not from the source
+project directory. This prevents drift when the project file has changed since
+the environment was created.
+
+The writer must normalize the file with a trailing newline and must not perform
+credential interpolation. Credential values remain absent because persisted
+blueprints and portable lockfiles store references, not secrets.
+
+### 6.4 `agentenv.lock`
+
+`agentenv.lock` is the deterministic YAML returned by the existing portable
+lockfile path. The exporter verifies it with
+`portable_lockfile::verify_portable_lockfile_yaml` before writing output.
+
+The file name is `agentenv.lock` because it is the committed project artifact
+and the existing `reproduce` command accepts any lockfile path.
+
+### 6.5 `scripts/bootstrap.sh`
+
+The bootstrap script is POSIX shell:
+
+```bash
+#!/usr/bin/env bash
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+BUNDLE_DIR="$(cd "${SCRIPT_DIR}/.." && pwd)"
+ENV_NAME="${AGENTENV_ENV_NAME:-myapp}"
+
+cd "${BUNDLE_DIR}"
+agentenv verify agentenv.lock
+agentenv reproduce agentenv.lock --name "${ENV_NAME}"
+```
+
+On Unix, set mode `0o755`. On Windows, write the same file without relying on
+the executable bit.
+
+### 6.6 `references/architecture.md`
+
+When the source is a project directory, select the first existing file in this
+order:
+
+1. `docs/ARCHITECTURE.md`
+2. `ARCHITECTURE.md`
+3. `README.md`
+
+Copy it to `references/architecture.md` with a short generated header that
+records the source relative path. If none exist, omit `references/` and omit
+`references/**` from `skill.yaml`.
+
+The exporter must not copy arbitrary project files. Skill export packages
+instructions and reproducibility metadata, not source code.
+
+### 6.7 `.agentenv/manifest.json`
+
+`manifest.json` is the deterministic inventory for generated bundle content,
+excluding `.agentenv/provenance.json` to avoid timestamp churn.
+
+```json
+{
+  "version": "0.1",
+  "kind": "agentenv.skill_bundle",
+  "skill": {
+    "name": "myapp",
+    "version": "1.0.0",
+    "entry": "SKILL.md"
+  },
+  "agentenv": {
+    "schema": "0.1",
+    "bundle": true
+  },
+  "files": [
+    {"path": "SKILL.md", "sha256": "sha256:..."},
+    {"path": "skill.yaml", "sha256": "sha256:..."},
+    {"path": "blueprint.yaml", "sha256": "sha256:..."},
+    {"path": "agentenv.lock", "sha256": "sha256:..."},
+    {"path": "scripts/bootstrap.sh", "sha256": "sha256:..."},
+    {"path": "references/architecture.md", "sha256": "sha256:..."}
+  ]
+}
+```
+
+Files are listed in lexicographic path order. Paths are slash-separated,
+relative, UTF-8, and cannot contain `..`.
+
+### 6.8 `.agentenv/provenance.json`
+
+`provenance.json` records how the bundle was produced:
+
+```json
+{
+  "version": "0.1",
+  "created_at": "2026-05-09T00:00:00Z",
+  "agentenv_version": "0.0.1-alpha0",
+  "source": {
+    "kind": "environment",
+    "env_name": "myapp",
+    "project_path": "/abs/path/myapp",
+    "project_git_commit": "abc123",
+    "project_git_dirty": false
+  },
+  "digests": {
+    "blueprint": "sha256:...",
+    "lockfile": "sha256:...",
+    "manifest": "sha256:..."
+  }
+}
+```
+
+`project_path`, `project_git_commit`, and `project_git_dirty` are omitted when
+they are unavailable. Do not write fallback strings such as `unknown`.
+
+## 7. Metadata Detection
+
+Defaults:
+
+1. Skill name defaults to the environment name, normalized through
+   `validate_skill_name`. Invalid generated names require `--name`.
+2. Version defaults to `1.0.0`.
+3. Description defaults to `Reproducible dev env for <name>`.
+4. Tags default to detected driver names and selected blueprint attributes:
+   sandbox driver, agent driver, context driver, inference driver when present,
+   and `dev-env`.
+
+Project directory detection:
+
+1. Author comes from `git config user.name` in the source repository.
+2. License comes from package metadata when obvious, in this order:
+   root `Cargo.toml` package or workspace `license`, then a conventional
+   `LICENSE` file name whose stem is a known SPDX identifier.
+3. Git commit comes from `git rev-parse HEAD`.
+4. Dirty state comes from `git status --porcelain`.
+
+Detection failures are non-fatal. Omit unavailable optional fields instead of
+writing fallback values.
+
+## 8. Security And Safety
+
+Credential handling:
+
+1. The exporter writes the portable lockfile credential requirements and
+   references that `freeze` already emits.
+2. It must not read credential values from `agentenv-credstore`.
+3. It must not copy sandbox home directories, host home directories, or
+   arbitrary workspace files.
+
+Filesystem safety:
+
+1. Reject an output path that already exists.
+2. Write to a staging directory next to the target and atomically rename after
+   validation succeeds.
+3. Reject symlinks in the output path ancestry when creating the staging and
+   final directories.
+4. Use existing skill bundle path validation rules before computing the final
+   bundle digest.
+
+Network safety:
+
+1. The exporter does not fetch remote content.
+2. It does not publish to registries.
+3. It does not contact GitHub or other services during bundle creation.
+
+## 9. Validation Flow
+
+After writing the staging directory, validate it before publishing:
+
+1. Load `skill.yaml` with `skills::load_skill_manifest`.
+2. Compute `skills::compute_bundle_digest` over the generated bundle.
+3. Verify `agentenv.lock` with `portable_lockfile::verify_portable_lockfile_yaml`.
+4. Confirm the manifest inventory digests match the generated files.
+5. Confirm `SKILL.md` frontmatter and `skill.yaml` agree on name, version,
+   description, tags, and schema marker.
+6. Confirm `scripts/bootstrap.sh` references `agentenv verify` and
+   `agentenv reproduce`.
+
+If validation fails, remove the staging directory and leave no final output
+path.
+
+## 10. Error Handling
+
+Expected user-facing errors:
+
+1. Missing `--as-skill`: `bundle currently supports only --as-skill`.
+2. Missing `--out`: `bundle --as-skill requires --out <dir>`.
+3. Existing output path: `output path already exists`.
+4. Missing source environment: `environment '<name>' does not exist; create it before bundling`.
+5. Invalid generated skill name: `derived skill name '<name>' is invalid; pass --name`.
+6. Lockfile verification failure: include the portable lockfile verifier's
+   error details.
+7. Reference document read failure: include the selected source path.
+
+Warnings:
+
+1. Project `agentenv.yaml` differs from the frozen environment blueprint.
+2. Metadata fields such as author or license could not be detected.
+
+Warnings should print to stderr in text mode and appear in the `warnings` array
+for `--json`.
+
+## 11. Testing Strategy
+
+Core tests in `crates/agentenv-core/tests/bundle.rs`:
+
+1. `emit_skill_bundle_writes_expected_layout`
+2. `emit_skill_bundle_omits_references_when_no_document_exists`
+3. `emit_skill_bundle_keeps_skill_yaml_and_frontmatter_in_sync`
+4. `emit_skill_bundle_rejects_existing_output_path`
+5. `emit_skill_bundle_records_blueprint_lockfile_and_manifest_digests`
+6. `emit_skill_bundle_validates_with_existing_skill_manifest_loader`
+
+CLI tests in `crates/agentenv/tests/cli_behavior.rs`:
+
+1. `bundle_help_lists_as_skill_and_out_flags`
+2. `bundle_as_skill_rejects_missing_env`
+3. `bundle_as_skill_exports_existing_env`
+4. `bundle_as_skill_json_reports_digest_summary`
+5. `bundle_as_skill_output_installs_as_local_skill`
+
+The CLI export test can create a minimal environment using the existing test
+runtime helpers, freeze it, export the bundle, and run:
+
+```text
+agentenv skills install --from <bundle-dir> --allow-unsigned --json
+agentenv skills verify <skill-name> --json
+```
+
+Required final verification for the PR:
+
+```text
+cargo fmt
+cargo clippy --workspace -- -D warnings
+cargo test -p agentenv-core --test bundle
+cargo test -p agentenv --test cli_behavior bundle
+cargo test --workspace
+```
+
+## 12. Implementation Plan Shape
+
+The implementation plan should split work into these commits:
+
+1. Add core bundle models and deterministic writer tests.
+2. Add `freeze_env_for_bundle` runtime helper and source resolution tests.
+3. Wire `agentenv bundle --as-skill` CLI and help behavior.
+4. Add metadata detection and reference document selection.
+5. Add end-to-end CLI tests proving install compatibility.
+6. Update docs and issue references.
+
+Each commit should keep the CLI facade thin and preserve existing skills
+registry behavior.
+
+## 13. Trade-Offs
+
+Keeping `skill.yaml` avoids breaking the skills cache, registry adapters, and
+install verification that already exist. Adding `SKILL.md` frontmatter gives
+cross-agent consumers the portable surface requested by issue #31.
+
+Exporting from an existing environment makes the command stricter than a pure
+`agentenv.yaml` packager. That is intentional: a produced skill should mean
+the environment has already gone through the same lifecycle that `freeze` and
+`reproduce` trust.
+
+The first slice omits signing because local unsigned installs are already a
+supported workflow and because signing policy should be handled consistently
+across all skill publishing paths, not only bundle export.


### PR DESCRIPTION
## Summary
- Add `agentenv bundle <source> --as-skill --out <dir>` for exporting frozen environments as installable skill bundles.
- Emit both `SKILL.md` frontmatter and `skill.yaml`, plus blueprint, portable lockfile, bootstrap script, manifest, provenance, and optional project reference docs.
- Add metadata/provenance detection, overwrite/symlink safety, stable JSON output, and install/verify compatibility coverage.

## Validation
- `cargo test -p agentenv-core --test bundle`
- `cargo test -p agentenv-core runtime::tests::freeze_env_for_bundle_returns_persisted_blueprint_and_portable_lockfile`
- `cargo test -p agentenv --test cli_behavior bundle -- --nocapture`
- `cargo test -p agentenv --bin agentenv tests::cli_includes_commands`
- `cargo fmt --check && cargo clippy --workspace -- -D warnings`
- `cargo test --workspace`

Closes #31.
