### PR TITLE
M7-4 skill registry backends

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -149,6 +149,7 @@ dependencies = [
  "serde_json",
  "serde_yaml",
  "sha2",
+ "tar",
  "thiserror 1.0.69",
  "time",
  "tokio",
@@ -156,6 +157,7 @@ dependencies = [
  "url",
  "uuid",
  "windows-sys 0.61.2",
+ "zstd",
 ]
 
 [[package]]
@@ -656,6 +658,8 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d16d90359e986641506914ba71350897565610e87ce0ad9e6f28569db3dd5c6d"
 dependencies = [
  "find-msvc-tools",
+ "jobserver",
+ "libc",
  "shlex",
 ]
 
@@ -1231,6 +1235,16 @@ dependencies = [
  "libc",
  "thiserror 1.0.69",
  "winapi",
+]
+
+[[package]]
+name = "filetime"
+version = "0.2.28"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2d5b2eef6fafbf69f877e55509ce5b11a760690ac9700a2921be067aa6afaef6"
+dependencies = [
+ "cfg-if",
+ "libc",
 ]
 
 [[package]]
@@ -2029,6 +2043,16 @@ checksum = "38c0b942f458fe50cdac086d2f946512305e5631e720728f2a61aabcd47a6264"
 dependencies = [
  "quote",
  "syn 2.0.117",
+]
+
+[[package]]
+name = "jobserver"
+version = "0.1.34"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9afb3de4395d6b3e67a780b6de64b51c978ecf11cb9a462c66be7d4ca9039d33"
+dependencies = [
+ "getrandom 0.3.4",
+ "libc",
 ]
 
 [[package]]
@@ -3566,6 +3590,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "tar"
+version = "0.4.45"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "22692a6476a21fa75fdfc11d452fda482af402c008cdbaf3476414e122040973"
+dependencies = [
+ "filetime",
+ "libc",
+ "xattr",
+]
+
+[[package]]
 name = "tempfile"
 version = "3.16.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4600,6 +4635,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1ffae5123b2d3fc086436f8834ae3ab053a283cfac8fe0a0b8eaae044768a4c4"
 
 [[package]]
+name = "xattr"
+version = "1.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "32e45ad4206f6d2479085147f02bc2ef834ac85886624a23575ae137c8aa8156"
+dependencies = [
+ "libc",
+ "rustix 1.1.4",
+]
+
+[[package]]
 name = "xdg-home"
 version = "1.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4783,6 +4828,34 @@ name = "zmij"
 version = "1.0.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b8848ee67ecc8aedbaf3e4122217aff892639231befc6a1b58d29fff4c2cabaa"
+
+[[package]]
+name = "zstd"
+version = "0.13.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e91ee311a569c327171651566e07972200e76fcfe2242a4fa446149a3881c08a"
+dependencies = [
+ "zstd-safe",
+]
+
+[[package]]
+name = "zstd-safe"
+version = "7.2.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8f49c4d5f0abb602a93fb8736af2a4f4dd9512e36f7f570d66e65ff867ed3b9d"
+dependencies = [
+ "zstd-sys",
+]
+
+[[package]]
+name = "zstd-sys"
+version = "2.0.16+zstd.1.5.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "91e19ebc2adc8f83e43039e79776e3fda8ca919132d68a1fed6a5faca2683748"
+dependencies = [
+ "cc",
+ "pkg-config",
+]
 
 [[package]]
 name = "zvariant"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -93,6 +93,8 @@ dirs = "5"
 uuid = { version = "1", features = ["v4", "v7"] }
 once_cell = "1"
 libc = "0.2"
+tar = "0.4"
+zstd = "0.13"
 windows-sys = { version = "0.61", features = ["Win32_Storage_FileSystem"] }
 humantime = "2"
 humantime-serde = "1"

--- a/crates/agentenv-core/Cargo.toml
+++ b/crates/agentenv-core/Cargo.toml
@@ -37,3 +37,5 @@ time = { workspace = true, features = ["formatting"] }
 tokio = { workspace = true }
 uuid.workspace = true
 semver = "1"
+tar.workspace = true
+zstd.workspace = true

--- a/crates/agentenv-core/src/skills/config.rs
+++ b/crates/agentenv-core/src/skills/config.rs
@@ -158,6 +158,10 @@ fn registry_from_override_source(source: &str) -> Result<Option<RegistryConfig>,
             normalize_oci_reference(&oci_reference_from_url(&url)?)?,
             None,
         ))),
+        "git+https" => Ok(Some(RegistryConfig::git(
+            CLI_REGISTRY_NAME,
+            normalize_git_url(url.as_str())?,
+        ))),
         scheme => Err(invalid_config(format!(
             "unsupported registry URL scheme `{scheme}`"
         ))),
@@ -225,6 +229,11 @@ fn normalize_registry_values(config: &mut SkillsConfig) -> Result<(), SkillError
             RegistryKind::Oci => {
                 if let Some(reference) = registry.url.as_mut() {
                     *reference = normalize_oci_reference(reference)?;
+                }
+            }
+            RegistryKind::Git => {
+                if let Some(url) = registry.url.as_mut() {
+                    *url = normalize_git_url(url)?;
                 }
             }
         }
@@ -326,6 +335,20 @@ fn validate_registry_required_fields(registry: &RegistryConfig) -> Result<(), Sk
             };
             normalize_oci_reference(reference)?;
         }
+        RegistryKind::Git => {
+            let Some(url) = registry
+                .url
+                .as_deref()
+                .map(str::trim)
+                .filter(|url| !url.is_empty())
+            else {
+                return Err(invalid_config(format!(
+                    "git registry `{}` requires url",
+                    registry.name
+                )));
+            };
+            normalize_git_url(url)?;
+        }
     }
 
     Ok(())
@@ -370,6 +393,43 @@ fn normalize_oci_reference(reference: &str) -> Result<String, SkillError> {
         )));
     }
     Ok(reference.to_owned())
+}
+
+fn normalize_git_url(value: &str) -> Result<String, SkillError> {
+    let value = value.trim();
+    let url = Url::parse(value).map_err(|source| {
+        invalid_config(format!("invalid git registry URL `{value}`: {source}"))
+    })?;
+    validate_git_url(&url)?;
+    Ok(url.to_string())
+}
+
+fn validate_git_url(url: &Url) -> Result<(), SkillError> {
+    if url.scheme() != "git+https" {
+        return Err(invalid_config(format!(
+            "git registry URL uses unsupported scheme `{}`",
+            url.scheme()
+        )));
+    }
+    if url.host_str().is_none_or(str::is_empty) {
+        return Err(invalid_config("git registry URL must include a host"));
+    }
+    if !url.username().is_empty() || url.password().is_some() {
+        return Err(invalid_config(
+            "git registry URL must not include user info",
+        ));
+    }
+    if url.query().is_some() || url.fragment().is_some() {
+        return Err(invalid_config(
+            "git registry URL must not include query or fragment",
+        ));
+    }
+    if url.path() == "/" || url.path().trim_matches('/').is_empty() {
+        return Err(invalid_config(
+            "git registry URL must include a repository path",
+        ));
+    }
+    Ok(())
 }
 
 fn is_bare_oci_reference(value: &str) -> bool {

--- a/crates/agentenv-core/src/skills/error.rs
+++ b/crates/agentenv-core/src/skills/error.rs
@@ -46,8 +46,12 @@ pub enum SkillError {
     CredentialReferenceUnavailable { name: String },
     #[error("unsupported registry authentication scheme `{scheme}`")]
     UnsupportedRegistryAuth { scheme: String },
+    #[error("registry `{registry}` of type `{kind}` does not support publishing")]
+    UnsupportedRegistryPublish { registry: String, kind: String },
     #[error("invalid OCI registry reference `{reference}`")]
     InvalidOciReference { reference: String },
+    #[error("git registry `{url}` failed: {message}")]
+    GitRegistry { url: String, message: String },
     #[error("invalid skills config: {message}")]
     InvalidConfig { message: String },
     #[error("invalid skill version `{version}`: {source}")]

--- a/crates/agentenv-core/src/skills/mod.rs
+++ b/crates/agentenv-core/src/skills/mod.rs
@@ -6,6 +6,7 @@ mod index;
 mod manifest;
 mod registry;
 mod registry_filesystem;
+mod registry_git;
 mod registry_http;
 mod registry_oci;
 mod service;

--- a/crates/agentenv-core/src/skills/registry.rs
+++ b/crates/agentenv-core/src/skills/registry.rs
@@ -49,6 +49,16 @@ impl RegistryConfig {
             auth,
         }
     }
+
+    pub fn git(name: impl Into<String>, url: impl Into<String>) -> Self {
+        Self {
+            name: name.into(),
+            kind: RegistryKind::Git,
+            url: Some(url.into()),
+            path: None,
+            auth: None,
+        }
+    }
 }
 
 #[derive(Debug, Clone, Copy, serde::Serialize, serde::Deserialize, PartialEq, Eq)]
@@ -57,6 +67,7 @@ pub enum RegistryKind {
     Filesystem,
     Http,
     Oci,
+    Git,
 }
 
 #[derive(Debug, Clone, serde::Serialize, serde::Deserialize, PartialEq, Eq)]

--- a/crates/agentenv-core/src/skills/registry_filesystem.rs
+++ b/crates/agentenv-core/src/skills/registry_filesystem.rs
@@ -31,6 +31,18 @@ struct FilesystemRegistryIndex {
     skills: Vec<SkillSearchHit>,
 }
 
+#[derive(Debug, Clone)]
+struct ResolvedFilesystemHit {
+    hit: SkillSearchHit,
+    source: FilesystemHitSource,
+}
+
+#[derive(Debug, Clone)]
+enum FilesystemHitSource {
+    Indexed,
+    Scanned(PathBuf),
+}
+
 impl FilesystemRegistryAdapter {
     pub(crate) fn new(name: impl Into<String>, root: impl Into<PathBuf>) -> Self {
         Self {
@@ -180,7 +192,7 @@ impl FilesystemRegistryAdapter {
         &self,
         name: &str,
         version: Option<&str>,
-    ) -> Result<SkillSearchHit, SkillError> {
+    ) -> Result<ResolvedFilesystemHit, SkillError> {
         validate_skill_name(name)?;
         if let Some(version) = version {
             version
@@ -191,17 +203,37 @@ impl FilesystemRegistryAdapter {
                 })?;
         }
 
-        let index = self.read_index()?;
-        let matches = index
-            .skills
-            .into_iter()
+        let persisted = self.read_persisted_index()?;
+        let scanned = self.scan_index()?;
+        let persisted_hits = persisted.skills;
+        let mut matches = persisted_hits
+            .iter()
             .filter(|hit| hit.name == name)
+            .cloned()
+            .map(|hit| ResolvedFilesystemHit {
+                hit,
+                source: FilesystemHitSource::Indexed,
+            })
             .collect::<Vec<_>>();
+        for hit in scanned.skills {
+            if contains_hit(&persisted_hits, &hit) || hit.name != name {
+                continue;
+            }
+            let path = self.scanned_bundle_path_for_hit(&hit)?.ok_or_else(|| {
+                SkillError::SkillNotInstalled {
+                    name: hit.name.clone(),
+                }
+            })?;
+            matches.push(ResolvedFilesystemHit {
+                hit,
+                source: FilesystemHitSource::Scanned(path),
+            });
+        }
 
         if let Some(version) = version {
             return matches
                 .into_iter()
-                .find(|hit| hit.version == version)
+                .find(|resolved| resolved.hit.version == version)
                 .ok_or_else(|| SkillError::SkillNotInstalled {
                     name: name.to_owned(),
                 });
@@ -209,18 +241,29 @@ impl FilesystemRegistryAdapter {
 
         matches
             .into_iter()
-            .max_by(|left, right| compare_versions(&left.version, &right.version))
+            .max_by(|left, right| compare_versions(&left.hit.version, &right.hit.version))
             .ok_or_else(|| SkillError::SkillNotInstalled {
                 name: name.to_owned(),
             })
     }
 
-    fn bundle_path_for_hit(&self, hit: &SkillSearchHit) -> Result<Option<PathBuf>, SkillError> {
-        if let Some(path) =
-            existing_child_directory(&self.root, &[BUNDLES_DIR, &hit.name, &hit.version])?
-        {
-            return Ok(Some(path));
+    fn bundle_path_for_hit(&self, resolved: &ResolvedFilesystemHit) -> Result<PathBuf, SkillError> {
+        match &resolved.source {
+            FilesystemHitSource::Indexed => existing_child_directory(
+                &self.root,
+                &[BUNDLES_DIR, &resolved.hit.name, &resolved.hit.version],
+            )?
+            .ok_or_else(|| SkillError::SkillNotInstalled {
+                name: resolved.hit.name.clone(),
+            }),
+            FilesystemHitSource::Scanned(path) => Ok(path.clone()),
         }
+    }
+
+    fn scanned_bundle_path_for_hit(
+        &self,
+        hit: &SkillSearchHit,
+    ) -> Result<Option<PathBuf>, SkillError> {
         for entry in fs::read_dir(&self.root).map_err(|source| SkillError::Io {
             path: self.root.clone(),
             source,
@@ -283,12 +326,9 @@ impl RegistryAdapter for FilesystemRegistryAdapter {
 
     async fn fetch(&self, name: &str, version: Option<&str>) -> Result<FetchedSkill, SkillError> {
         ensure_directory(&self.root)?;
-        let hit = self.resolved_hit(name, version)?;
-        let bundle_path =
-            self.bundle_path_for_hit(&hit)?
-                .ok_or_else(|| SkillError::SkillNotInstalled {
-                    name: hit.name.clone(),
-                })?;
+        let resolved = self.resolved_hit(name, version)?;
+        let hit = &resolved.hit;
+        let bundle_path = self.bundle_path_for_hit(&resolved)?;
         let manifest = super::load_skill_manifest(&bundle_path)?;
         if manifest.name != hit.name || manifest.version.to_string() != hit.version {
             return Err(SkillError::UnsafeBundlePath {

--- a/crates/agentenv-core/src/skills/registry_filesystem.rs
+++ b/crates/agentenv-core/src/skills/registry_filesystem.rs
@@ -48,7 +48,7 @@ impl FilesystemRegistryAdapter {
             Ok(metadata) if metadata.file_type().is_file() => {}
             Ok(_) => return Err(SkillError::UnsafeBundlePath { path }),
             Err(source) if source.kind() == std::io::ErrorKind::NotFound => {
-                return Ok(FilesystemRegistryIndex::default());
+                return self.scan_index();
             }
             Err(source) => {
                 return Err(SkillError::Io { path, source });
@@ -62,6 +62,39 @@ impl FilesystemRegistryAdapter {
             self.validate_hit(hit)?;
         }
         Ok(index)
+    }
+
+    fn scan_index(&self) -> Result<FilesystemRegistryIndex, SkillError> {
+        let mut skills = Vec::new();
+        for entry in fs::read_dir(&self.root).map_err(|source| SkillError::Io {
+            path: self.root.clone(),
+            source,
+        })? {
+            let entry = entry.map_err(|source| SkillError::Io {
+                path: self.root.clone(),
+                source,
+            })?;
+            let path = entry.path();
+            let metadata = fs::symlink_metadata(&path).map_err(|source| SkillError::Io {
+                path: path.clone(),
+                source,
+            })?;
+            if !metadata.file_type().is_dir() {
+                continue;
+            }
+            if path.file_name().and_then(|name| name.to_str()) == Some(BUNDLES_DIR) {
+                continue;
+            }
+            let manifest_path = path.join(MANIFEST_FILE);
+            if !manifest_path.is_file() {
+                continue;
+            }
+            let manifest = super::load_skill_manifest(&path)?;
+            let digest = compute_bundle_digest(&path, &manifest)?;
+            skills.push(self.hit_for_manifest(&manifest, digest));
+        }
+        sort_hits(&mut skills);
+        Ok(FilesystemRegistryIndex { skills })
     }
 
     fn validate_hit(&self, hit: &mut SkillSearchHit) -> Result<(), SkillError> {
@@ -159,6 +192,45 @@ impl FilesystemRegistryAdapter {
                 name: name.to_owned(),
             })
     }
+
+    fn bundle_path_for_hit(&self, hit: &SkillSearchHit) -> Result<Option<PathBuf>, SkillError> {
+        if let Some(path) =
+            existing_child_directory(&self.root, &[BUNDLES_DIR, &hit.name, &hit.version])?
+        {
+            return Ok(Some(path));
+        }
+        for entry in fs::read_dir(&self.root).map_err(|source| SkillError::Io {
+            path: self.root.clone(),
+            source,
+        })? {
+            let entry = entry.map_err(|source| SkillError::Io {
+                path: self.root.clone(),
+                source,
+            })?;
+            let path = entry.path();
+            if !fs::symlink_metadata(&path)
+                .map_err(|source| SkillError::Io {
+                    path: path.clone(),
+                    source,
+                })?
+                .file_type()
+                .is_dir()
+            {
+                continue;
+            }
+            if path.file_name().and_then(|name| name.to_str()) == Some(BUNDLES_DIR) {
+                continue;
+            }
+            if !path.join(MANIFEST_FILE).is_file() {
+                continue;
+            }
+            let manifest = super::load_skill_manifest(&path)?;
+            if manifest.name == hit.name && manifest.version.to_string() == hit.version {
+                return Ok(Some(path));
+            }
+        }
+        Ok(None)
+    }
 }
 
 #[async_trait::async_trait]
@@ -191,7 +263,7 @@ impl RegistryAdapter for FilesystemRegistryAdapter {
         ensure_directory(&self.root)?;
         let hit = self.resolved_hit(name, version)?;
         let bundle_path =
-            existing_child_directory(&self.root, &[BUNDLES_DIR, &hit.name, &hit.version])?
+            self.bundle_path_for_hit(&hit)?
                 .ok_or_else(|| SkillError::SkillNotInstalled {
                     name: hit.name.clone(),
                 })?;

--- a/crates/agentenv-core/src/skills/registry_filesystem.rs
+++ b/crates/agentenv-core/src/skills/registry_filesystem.rs
@@ -111,7 +111,7 @@ impl FilesystemRegistryAdapter {
                 continue;
             }
             let manifest_path = path.join(MANIFEST_FILE);
-            if !manifest_path.is_file() {
+            if !manifest_path_is_regular_file(&manifest_path)? {
                 continue;
             }
             let manifest = super::load_skill_manifest(&path)?;
@@ -295,6 +295,17 @@ impl FilesystemRegistryAdapter {
             }
         }
         Ok(None)
+    }
+}
+
+fn manifest_path_is_regular_file(path: &Path) -> Result<bool, SkillError> {
+    match fs::symlink_metadata(path) {
+        Ok(metadata) => Ok(metadata.file_type().is_file()),
+        Err(source) if source.kind() == std::io::ErrorKind::NotFound => Ok(false),
+        Err(source) => Err(SkillError::Io {
+            path: path.to_path_buf(),
+            source,
+        }),
     }
 }
 

--- a/crates/agentenv-core/src/skills/registry_filesystem.rs
+++ b/crates/agentenv-core/src/skills/registry_filesystem.rs
@@ -1,5 +1,6 @@
 use std::{
     cmp::Ordering,
+    collections::HashSet,
     fs,
     path::{Path, PathBuf},
 };
@@ -43,12 +44,23 @@ impl FilesystemRegistryAdapter {
     }
 
     fn read_index(&self) -> Result<FilesystemRegistryIndex, SkillError> {
+        let mut index = self.read_persisted_index()?;
+        let mut scanned = self.scan_index()?;
+        scanned
+            .skills
+            .retain(|scanned| !contains_hit(&index.skills, scanned));
+        index.skills.extend(scanned.skills);
+        sort_hits(&mut index.skills);
+        Ok(index)
+    }
+
+    fn read_persisted_index(&self) -> Result<FilesystemRegistryIndex, SkillError> {
         let path = self.index_path();
         match fs::symlink_metadata(&path) {
             Ok(metadata) if metadata.file_type().is_file() => {}
             Ok(_) => return Err(SkillError::UnsafeBundlePath { path }),
             Err(source) if source.kind() == std::io::ErrorKind::NotFound => {
-                return self.scan_index();
+                return Ok(FilesystemRegistryIndex::default());
             }
             Err(source) => {
                 return Err(SkillError::Io { path, source });
@@ -66,6 +78,7 @@ impl FilesystemRegistryAdapter {
 
     fn scan_index(&self) -> Result<FilesystemRegistryIndex, SkillError> {
         let mut skills = Vec::new();
+        let mut seen = HashSet::new();
         for entry in fs::read_dir(&self.root).map_err(|source| SkillError::Io {
             path: self.root.clone(),
             source,
@@ -90,6 +103,15 @@ impl FilesystemRegistryAdapter {
                 continue;
             }
             let manifest = super::load_skill_manifest(&path)?;
+            let version = manifest.version.to_string();
+            if !seen.insert((manifest.name.clone(), version.clone())) {
+                return Err(SkillError::InvalidConfig {
+                    message: format!(
+                        "filesystem registry `{}` has duplicate scanned skill `{}` version `{}`",
+                        self.name, manifest.name, version
+                    ),
+                });
+            }
             let digest = compute_bundle_digest(&path, &manifest)?;
             skills.push(self.hit_for_manifest(&manifest, digest));
         }
@@ -115,7 +137,7 @@ impl FilesystemRegistryAdapter {
     }
 
     fn upsert_hit(&self, hit: SkillSearchHit) -> Result<(), SkillError> {
-        let mut index = self.read_index()?;
+        let mut index = self.read_persisted_index()?;
         index
             .skills
             .retain(|existing| existing.name != hit.name || existing.version != hit.version);
@@ -358,6 +380,11 @@ fn verify_publish_signature(
         })?;
 
     verify_ed25519_signature(manifest, digest, signature, public_key)
+}
+
+fn contains_hit(hits: &[SkillSearchHit], needle: &SkillSearchHit) -> bool {
+    hits.iter()
+        .any(|hit| hit.name == needle.name && hit.version == needle.version)
 }
 
 fn copy_bundle_contents(

--- a/crates/agentenv-core/src/skills/registry_git.rs
+++ b/crates/agentenv-core/src/skills/registry_git.rs
@@ -1,0 +1,46 @@
+use std::path::Path;
+
+use super::{FetchedSkill, RegistryAdapter, SkillError, SkillSearchHit};
+
+const SOURCE_TYPE: &str = "git";
+
+#[derive(Debug, Clone)]
+pub(crate) struct GitRegistryAdapter {
+    name: String,
+    _url: String,
+}
+
+impl GitRegistryAdapter {
+    pub(crate) fn new(name: impl Into<String>, url: impl Into<String>) -> Self {
+        Self {
+            name: name.into(),
+            _url: url.into(),
+        }
+    }
+}
+
+#[async_trait::async_trait]
+impl RegistryAdapter for GitRegistryAdapter {
+    async fn search(&self, _query: &str) -> Result<Vec<SkillSearchHit>, SkillError> {
+        Err(SkillError::InvalidConfig {
+            message: format!("git registry `{}` is not implemented yet", self.name),
+        })
+    }
+
+    async fn fetch(&self, name: &str, _version: Option<&str>) -> Result<FetchedSkill, SkillError> {
+        Err(SkillError::SkillNotInstalled {
+            name: name.to_owned(),
+        })
+    }
+
+    async fn publish(
+        &self,
+        _bundle_path: &Path,
+        _allow_unsigned: bool,
+    ) -> Result<SkillSearchHit, SkillError> {
+        Err(SkillError::UnsupportedRegistryPublish {
+            registry: self.name.clone(),
+            kind: SOURCE_TYPE.to_owned(),
+        })
+    }
+}

--- a/crates/agentenv-core/src/skills/registry_git.rs
+++ b/crates/agentenv-core/src/skills/registry_git.rs
@@ -2,7 +2,7 @@ use std::{
     cmp::Ordering,
     collections::HashSet,
     fs,
-    path::{Path, PathBuf},
+    path::{Component, Path, PathBuf},
     process::Command,
     sync::Arc,
 };
@@ -12,7 +12,7 @@ use semver::Version;
 use url::Url;
 
 use super::{
-    compute_bundle_digest, manifest::validated_bundle_file, validate_skill_name, FetchedSkill,
+    compute_bundle_digest, manifest::normalize_bundle_path, validate_skill_name, FetchedSkill,
     RegistryAdapter, SkillError, SkillManifest, SkillSearchHit,
 };
 
@@ -469,11 +469,15 @@ fn staging_fetch_path(cache_root: &Path, name: &str, version: &str) -> Result<Pa
     })
 }
 
-fn copy_regular_file(source: &Path, destination: &Path) -> Result<(), SkillError> {
+fn copy_regular_file(
+    source_root: &Path,
+    relative_source: &Path,
+    destination: &Path,
+) -> Result<(), SkillError> {
     if let Some(parent) = destination.parent() {
         ensure_directory(parent)?;
     }
-    let mut source_file = open_regular_file(source)?;
+    let mut source_file = open_regular_file_under_root(source_root, relative_source)?;
     let mut destination_file = fs::File::create(destination).map_err(|source| SkillError::Io {
         path: destination.to_path_buf(),
         source,
@@ -486,29 +490,87 @@ fn copy_regular_file(source: &Path, destination: &Path) -> Result<(), SkillError
 }
 
 #[cfg(unix)]
-fn open_regular_file(path: &Path) -> Result<fs::File, SkillError> {
-    use std::{fs::OpenOptions, os::unix::fs::OpenOptionsExt};
+fn open_regular_file_under_root(root: &Path, relative_path: &Path) -> Result<fs::File, SkillError> {
+    use rustix::fs::{Mode, OFlags};
 
-    let file = OpenOptions::new()
-        .read(true)
-        .custom_flags(libc::O_NOFOLLOW)
-        .open(path)
-        .map_err(|source| SkillError::Io {
-            path: path.to_path_buf(),
-            source,
-        })?;
-    ensure_opened_regular_file(path, &file)?;
+    let relative_path = normalize_bundle_path(relative_path)?;
+    let mut components = relative_path.components().peekable();
+    let mut directory = open_directory_no_follow(root)?;
+
+    while let Some(component) = components.next() {
+        let Component::Normal(part) = component else {
+            return Err(SkillError::UnsafeBundlePath {
+                path: relative_path.clone(),
+            });
+        };
+        let is_final = components.peek().is_none();
+        let flags = if is_final {
+            OFlags::RDONLY | OFlags::CLOEXEC | OFlags::NOFOLLOW
+        } else {
+            OFlags::RDONLY | OFlags::CLOEXEC | OFlags::DIRECTORY | OFlags::NOFOLLOW
+        };
+        let opened = rustix::fs::openat(&directory, part, flags, Mode::empty())
+            .map(fs::File::from)
+            .map_err(|source| SkillError::Io {
+                path: root.join(&relative_path),
+                source: std::io::Error::from(source),
+            })?;
+        if is_final {
+            ensure_opened_regular_file(&root.join(&relative_path), &opened)?;
+            return Ok(opened);
+        }
+        ensure_opened_directory(&root.join(&relative_path), &opened)?;
+        directory = opened;
+    }
+
+    Err(SkillError::UnsafeBundlePath {
+        path: relative_path,
+    })
+}
+
+#[cfg(unix)]
+fn open_directory_no_follow(path: &Path) -> Result<fs::File, SkillError> {
+    use rustix::fs::{Mode, OFlags};
+
+    let file = rustix::fs::open(
+        path,
+        OFlags::RDONLY | OFlags::CLOEXEC | OFlags::DIRECTORY | OFlags::NOFOLLOW,
+        Mode::empty(),
+    )
+    .map(fs::File::from)
+    .map_err(|source| SkillError::Io {
+        path: path.to_path_buf(),
+        source: std::io::Error::from(source),
+    })?;
+    ensure_opened_directory(path, &file)?;
     Ok(file)
 }
 
 #[cfg(not(unix))]
-fn open_regular_file(path: &Path) -> Result<fs::File, SkillError> {
-    let file = fs::File::open(path).map_err(|source| SkillError::Io {
+fn open_regular_file_under_root(root: &Path, relative_path: &Path) -> Result<fs::File, SkillError> {
+    let relative_path = normalize_bundle_path(relative_path)?;
+    let path = root.join(&relative_path);
+    let file = fs::File::open(&path).map_err(|source| SkillError::Io {
+        path: path.clone(),
+        source,
+    })?;
+    ensure_opened_regular_file(&path, &file)?;
+    Ok(file)
+}
+
+#[cfg(unix)]
+fn ensure_opened_directory(path: &Path, file: &fs::File) -> Result<(), SkillError> {
+    let metadata = file.metadata().map_err(|source| SkillError::Io {
         path: path.to_path_buf(),
         source,
     })?;
-    ensure_opened_regular_file(path, &file)?;
-    Ok(file)
+    if metadata.file_type().is_dir() {
+        Ok(())
+    } else {
+        Err(SkillError::UnsafeBundlePath {
+            path: path.to_path_buf(),
+        })
+    }
 }
 
 fn ensure_opened_regular_file(path: &Path, file: &fs::File) -> Result<(), SkillError> {
@@ -532,12 +594,16 @@ fn copy_bundle_contents(
 ) -> Result<(), SkillError> {
     ensure_directory(destination_root)?;
     copy_regular_file(
-        &source_root.join(MANIFEST_FILE),
+        source_root,
+        Path::new(MANIFEST_FILE),
         &destination_root.join(MANIFEST_FILE),
     )?;
     for declared_file in &manifest.declared_files {
-        let source = validated_bundle_file(source_root, declared_file)?;
-        copy_regular_file(&source, &destination_root.join(declared_file))?;
+        copy_regular_file(
+            source_root,
+            declared_file,
+            &destination_root.join(declared_file),
+        )?;
     }
     Ok(())
 }
@@ -756,6 +822,71 @@ mod tests {
         assert_eq!(fetched.source_type, "git");
         assert_eq!(fetched.version, "0.3.0");
         assert!(fetched.staging_path.join("SKILL.md").is_file());
+    }
+
+    #[tokio::test]
+    async fn git_registry_fetch_exact_version_copies_selected_bundle() {
+        let checkout = temp_dir("skill-git-fetch-exact");
+        write_file(
+            &checkout.join("old/skill.yaml"),
+            "name: exact-git\nversion: 0.1.0\nentry: SKILL.md\nfiles:\n  - SKILL.md\n",
+        );
+        write_file(&checkout.join("old/SKILL.md"), "# Old\n");
+        write_file(
+            &checkout.join("new/skill.yaml"),
+            "name: exact-git\nversion: 0.3.0\nentry: SKILL.md\nfiles:\n  - SKILL.md\n",
+        );
+        write_file(&checkout.join("new/SKILL.md"), "# New\n");
+        let adapter = GitRegistryAdapter::with_checkout_and_ssrf(
+            "git-dev",
+            "git+https://127.0.0.1/acme/skills",
+            temp_dir("skill-git-cache"),
+            Arc::new(StaticCheckout { path: checkout }),
+            loopback_ssrf_options(),
+        );
+
+        let fetched = adapter.fetch("exact-git", Some("0.1.0")).await.unwrap();
+
+        assert_eq!(fetched.source_type, "git");
+        assert_eq!(fetched.version, "0.1.0");
+        assert_eq!(
+            fs::read_to_string(fetched.staging_path.join("SKILL.md")).unwrap(),
+            "# Old\n"
+        );
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn git_bundle_copy_rejects_symlinked_declared_file_parent() {
+        let source = temp_dir("skill-git-copy-symlink-parent-source");
+        let destination = temp_dir("skill-git-copy-symlink-parent-destination");
+        let outside = temp_dir("skill-git-copy-symlink-parent-outside");
+        write_file(
+            &source.join("skill.yaml"),
+            "name: symlink-parent-git\nversion: 0.1.0\nentry: docs/SKILL.md\nfiles:\n  - docs/SKILL.md\n",
+        );
+        write_file(&outside.join("SKILL.md"), "# Outside\n");
+        std::os::unix::fs::symlink(&outside, source.join("docs")).unwrap();
+        let manifest = SkillManifest {
+            name: "symlink-parent-git".to_owned(),
+            version: Version::parse("0.1.0").unwrap(),
+            description: None,
+            entry: PathBuf::from("docs/SKILL.md"),
+            declared_files: vec![PathBuf::from("docs/SKILL.md")],
+            self_test_command: None,
+            signature_ed25519: None,
+            signature_public_key_ed25519: None,
+            extra: std::collections::BTreeMap::new(),
+        };
+
+        let error = copy_bundle_contents(&source, &destination, &manifest)
+            .expect_err("copy must not follow symlinked parents");
+
+        assert!(matches!(
+            error,
+            SkillError::Io { .. } | SkillError::UnsafeBundlePath { .. }
+        ));
+        assert!(!destination.join("docs/SKILL.md").exists());
     }
 
     #[tokio::test]

--- a/crates/agentenv-core/src/skills/registry_git.rs
+++ b/crates/agentenv-core/src/skills/registry_git.rs
@@ -1,35 +1,199 @@
-use std::path::Path;
+use std::{
+    cmp::Ordering,
+    fs,
+    path::{Path, PathBuf},
+    process::Command,
+    sync::Arc,
+};
 
-use super::{FetchedSkill, RegistryAdapter, SkillError, SkillSearchHit};
+use semver::Version;
 
+use super::{
+    compute_bundle_digest, manifest::validated_bundle_file, validate_skill_name, FetchedSkill,
+    RegistryAdapter, SkillError, SkillManifest, SkillSearchHit,
+};
+
+const MANIFEST_FILE: &str = "skill.yaml";
 const SOURCE_TYPE: &str = "git";
+
+pub(crate) trait GitCheckout: Send + Sync + std::fmt::Debug {
+    fn checkout(&self, url: &str, cache_root: &Path) -> Result<PathBuf, SkillError>;
+}
+
+#[derive(Debug)]
+struct CommandGitCheckout;
+
+#[derive(Debug, Clone)]
+struct ScannedGitSkill {
+    path: PathBuf,
+    manifest: SkillManifest,
+    digest: String,
+}
 
 #[derive(Debug, Clone)]
 pub(crate) struct GitRegistryAdapter {
     name: String,
-    _url: String,
+    url: String,
+    cache_root: PathBuf,
+    checkout: Arc<dyn GitCheckout>,
+}
+
+impl GitCheckout for CommandGitCheckout {
+    fn checkout(&self, url: &str, cache_root: &Path) -> Result<PathBuf, SkillError> {
+        ensure_directory(cache_root)?;
+        let checkout = cache_root.join("checkout");
+        if checkout.join(".git").is_dir() {
+            run_git(
+                &[
+                    "-C".to_owned(),
+                    path_arg(&checkout),
+                    "fetch".to_owned(),
+                    "--all".to_owned(),
+                    "--tags".to_owned(),
+                    "--prune".to_owned(),
+                ],
+                url,
+            )?;
+            run_git(
+                &[
+                    "-C".to_owned(),
+                    path_arg(&checkout),
+                    "reset".to_owned(),
+                    "--hard".to_owned(),
+                    "origin/HEAD".to_owned(),
+                ],
+                url,
+            )?;
+            return Ok(checkout);
+        }
+
+        let clone_url = clone_url(url)?;
+        run_git(
+            &[
+                "clone".to_owned(),
+                "--filter=blob:none".to_owned(),
+                "--depth=1".to_owned(),
+                clone_url,
+                path_arg(&checkout),
+            ],
+            url,
+        )?;
+        Ok(checkout)
+    }
 }
 
 impl GitRegistryAdapter {
-    pub(crate) fn new(name: impl Into<String>, url: impl Into<String>) -> Self {
+    pub(crate) fn new(
+        name: impl Into<String>,
+        url: impl Into<String>,
+        cache_root: impl Into<PathBuf>,
+    ) -> Self {
+        Self::with_checkout(name, url, cache_root, Arc::new(CommandGitCheckout))
+    }
+
+    pub(crate) fn with_checkout(
+        name: impl Into<String>,
+        url: impl Into<String>,
+        cache_root: impl Into<PathBuf>,
+        checkout: Arc<dyn GitCheckout>,
+    ) -> Self {
         Self {
             name: name.into(),
-            _url: url.into(),
+            url: url.into(),
+            cache_root: cache_root.into(),
+            checkout,
+        }
+    }
+
+    fn checkout_path(&self) -> Result<PathBuf, SkillError> {
+        self.checkout.checkout(&self.url, &self.cache_root)
+    }
+
+    fn scan(&self) -> Result<Vec<ScannedGitSkill>, SkillError> {
+        let checkout_path = self.checkout_path()?;
+        let mut skills = Vec::new();
+        scan_directory(&checkout_path, &mut skills)?;
+        Ok(skills)
+    }
+
+    fn hit_for_manifest(&self, manifest: &SkillManifest, digest: String) -> SkillSearchHit {
+        SkillSearchHit {
+            name: manifest.name.clone(),
+            version: manifest.version.to_string(),
+            description: manifest.description.clone(),
+            registry: self.name.clone(),
+            digest: Some(digest),
+            signature_ed25519: manifest.signature_ed25519.clone(),
+            public_key_ed25519: manifest.signature_public_key_ed25519.clone(),
         }
     }
 }
 
 #[async_trait::async_trait]
 impl RegistryAdapter for GitRegistryAdapter {
-    async fn search(&self, _query: &str) -> Result<Vec<SkillSearchHit>, SkillError> {
-        Err(SkillError::InvalidConfig {
-            message: format!("git registry `{}` is not implemented yet", self.name),
-        })
+    async fn search(&self, query: &str) -> Result<Vec<SkillSearchHit>, SkillError> {
+        let query = query.to_ascii_lowercase();
+        let mut hits = self
+            .scan()?
+            .into_iter()
+            .filter_map(|skill| {
+                let description = skill.manifest.description.as_deref().unwrap_or_default();
+                let matches = query.is_empty()
+                    || skill.manifest.name.to_ascii_lowercase().contains(&query)
+                    || description.to_ascii_lowercase().contains(&query);
+                matches.then(|| self.hit_for_manifest(&skill.manifest, skill.digest))
+            })
+            .collect::<Vec<_>>();
+        sort_hits(&mut hits);
+        Ok(hits)
     }
 
-    async fn fetch(&self, name: &str, _version: Option<&str>) -> Result<FetchedSkill, SkillError> {
-        Err(SkillError::SkillNotInstalled {
-            name: name.to_owned(),
+    async fn fetch(&self, name: &str, version: Option<&str>) -> Result<FetchedSkill, SkillError> {
+        validate_skill_name(name)?;
+        if let Some(version) = version {
+            version
+                .parse::<Version>()
+                .map_err(|source| SkillError::InvalidVersion {
+                    version: version.to_owned(),
+                    source,
+                })?;
+        }
+
+        let mut matches = self
+            .scan()?
+            .into_iter()
+            .filter(|skill| {
+                skill.manifest.name == name
+                    && version
+                        .map(|version| skill.manifest.version.to_string() == version)
+                        .unwrap_or(true)
+            })
+            .collect::<Vec<_>>();
+        matches.sort_by(|left, right| {
+            compare_versions(
+                &left.manifest.version.to_string(),
+                &right.manifest.version.to_string(),
+            )
+        });
+        let skill =
+            matches
+                .into_iter()
+                .next_back()
+                .ok_or_else(|| SkillError::SkillNotInstalled {
+                    name: name.to_owned(),
+                })?;
+
+        let version = skill.manifest.version.to_string();
+        let staging_path = staging_fetch_path(&skill.manifest.name, &version);
+        remove_directory_if_exists(&staging_path)?;
+        copy_bundle_contents(&skill.path, &staging_path, &skill.manifest)?;
+
+        Ok(FetchedSkill {
+            staging_path,
+            registry: self.name.clone(),
+            source_type: SOURCE_TYPE.to_owned(),
+            name: skill.manifest.name,
+            version,
         })
     }
 
@@ -42,5 +206,298 @@ impl RegistryAdapter for GitRegistryAdapter {
             registry: self.name.clone(),
             kind: SOURCE_TYPE.to_owned(),
         })
+    }
+}
+
+fn scan_directory(root: &Path, skills: &mut Vec<ScannedGitSkill>) -> Result<(), SkillError> {
+    for entry in fs::read_dir(root).map_err(|source| SkillError::Io {
+        path: root.to_path_buf(),
+        source,
+    })? {
+        let entry = entry.map_err(|source| SkillError::Io {
+            path: root.to_path_buf(),
+            source,
+        })?;
+        let path = entry.path();
+        let metadata = fs::symlink_metadata(&path).map_err(|source| SkillError::Io {
+            path: path.clone(),
+            source,
+        })?;
+        if !metadata.file_type().is_dir() {
+            continue;
+        }
+        if path.file_name().and_then(|name| name.to_str()) == Some(".git") {
+            continue;
+        }
+
+        let manifest_path = path.join(MANIFEST_FILE);
+        if manifest_path_is_file(&manifest_path)? {
+            let manifest = super::load_skill_manifest(&path)?;
+            let digest = compute_bundle_digest(&path, &manifest)?;
+            skills.push(ScannedGitSkill {
+                path: path.clone(),
+                manifest,
+                digest,
+            });
+        }
+        scan_directory(&path, skills)?;
+    }
+    Ok(())
+}
+
+fn manifest_path_is_file(path: &Path) -> Result<bool, SkillError> {
+    match fs::symlink_metadata(path) {
+        Ok(metadata) => {
+            if metadata.file_type().is_file() {
+                Ok(true)
+            } else {
+                Err(SkillError::UnsafeBundlePath {
+                    path: path.to_path_buf(),
+                })
+            }
+        }
+        Err(source) if source.kind() == std::io::ErrorKind::NotFound => Ok(false),
+        Err(source) => Err(SkillError::Io {
+            path: path.to_path_buf(),
+            source,
+        }),
+    }
+}
+
+fn clone_url(url: &str) -> Result<String, SkillError> {
+    let Some(stripped) = url.strip_prefix("git+") else {
+        return Err(SkillError::GitRegistry {
+            url: url.to_owned(),
+            message: "git registry URL must use git+https".to_owned(),
+        });
+    };
+    if !stripped.starts_with("https://") {
+        return Err(SkillError::GitRegistry {
+            url: url.to_owned(),
+            message: "git registry URL must use git+https".to_owned(),
+        });
+    }
+    Ok(stripped.to_owned())
+}
+
+fn run_git(args: &[String], url: &str) -> Result<(), SkillError> {
+    let output = Command::new("git")
+        .args(args)
+        .env("GIT_TERMINAL_PROMPT", "0")
+        .output()
+        .map_err(|source| SkillError::GitRegistry {
+            url: url.to_owned(),
+            message: format!("failed to run git: {source}"),
+        })?;
+    if output.status.success() {
+        return Ok(());
+    }
+
+    let stderr = String::from_utf8_lossy(&output.stderr).trim().to_owned();
+    let message = if stderr.is_empty() {
+        format!("git exited with status {}", output.status)
+    } else {
+        format!("git exited with status {}: {stderr}", output.status)
+    };
+    Err(SkillError::GitRegistry {
+        url: url.to_owned(),
+        message,
+    })
+}
+
+fn path_arg(path: &Path) -> String {
+    path.to_string_lossy().into_owned()
+}
+
+fn staging_fetch_path(name: &str, version: &str) -> PathBuf {
+    std::env::temp_dir().join(format!(
+        "agentenv-skill-git-fetch-{name}-{version}-{}-{}",
+        std::process::id(),
+        temporary_suffix()
+    ))
+}
+
+fn remove_directory_if_exists(path: &Path) -> Result<(), SkillError> {
+    match fs::symlink_metadata(path) {
+        Ok(metadata) if metadata.file_type().is_dir() => {
+            fs::remove_dir_all(path).map_err(|source| SkillError::Io {
+                path: path.to_path_buf(),
+                source,
+            })
+        }
+        Ok(_) => Err(SkillError::UnsafeBundlePath {
+            path: path.to_path_buf(),
+        }),
+        Err(source) if source.kind() == std::io::ErrorKind::NotFound => Ok(()),
+        Err(source) => Err(SkillError::Io {
+            path: path.to_path_buf(),
+            source,
+        }),
+    }
+}
+
+fn copy_regular_file(source: &Path, destination: &Path) -> Result<(), SkillError> {
+    let metadata = fs::symlink_metadata(source).map_err(|source_error| SkillError::Io {
+        path: source.to_path_buf(),
+        source: source_error,
+    })?;
+    if !metadata.file_type().is_file() {
+        return Err(SkillError::UnsafeBundlePath {
+            path: source.to_path_buf(),
+        });
+    }
+    if let Some(parent) = destination.parent() {
+        ensure_directory(parent)?;
+    }
+    fs::copy(source, destination).map_err(|source| SkillError::Io {
+        path: destination.to_path_buf(),
+        source,
+    })?;
+    Ok(())
+}
+
+fn copy_bundle_contents(
+    source_root: &Path,
+    destination_root: &Path,
+    manifest: &SkillManifest,
+) -> Result<(), SkillError> {
+    ensure_directory(destination_root)?;
+    copy_regular_file(
+        &source_root.join(MANIFEST_FILE),
+        &destination_root.join(MANIFEST_FILE),
+    )?;
+    for declared_file in &manifest.declared_files {
+        let source = validated_bundle_file(source_root, declared_file)?;
+        copy_regular_file(&source, &destination_root.join(declared_file))?;
+    }
+    Ok(())
+}
+
+fn sort_hits(hits: &mut [SkillSearchHit]) {
+    hits.sort_by(|left, right| {
+        left.name
+            .cmp(&right.name)
+            .then_with(|| compare_versions(&left.version, &right.version))
+            .then_with(|| left.registry.cmp(&right.registry))
+    });
+}
+
+fn compare_versions(left: &str, right: &str) -> Ordering {
+    match (left.parse::<Version>(), right.parse::<Version>()) {
+        (Ok(left), Ok(right)) => left.cmp(&right),
+        _ => left.cmp(right),
+    }
+}
+
+fn ensure_directory(path: &Path) -> Result<(), SkillError> {
+    match fs::symlink_metadata(path) {
+        Ok(metadata) if metadata.file_type().is_dir() => Ok(()),
+        Ok(_) => Err(SkillError::UnsafeBundlePath {
+            path: path.to_path_buf(),
+        }),
+        Err(source) if source.kind() == std::io::ErrorKind::NotFound => fs::create_dir_all(path)
+            .map_err(|source| SkillError::Io {
+                path: path.to_path_buf(),
+                source,
+            }),
+        Err(source) => Err(SkillError::Io {
+            path: path.to_path_buf(),
+            source,
+        }),
+    }
+}
+
+fn temporary_suffix() -> u128 {
+    match std::time::SystemTime::now().duration_since(std::time::UNIX_EPOCH) {
+        Ok(duration) => duration.as_nanos(),
+        Err(_) => 0,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::{fs, path::PathBuf, sync::Arc};
+
+    #[derive(Debug)]
+    struct StaticCheckout {
+        path: PathBuf,
+    }
+
+    impl GitCheckout for StaticCheckout {
+        fn checkout(&self, _url: &str, _cache_root: &Path) -> Result<PathBuf, SkillError> {
+            Ok(self.path.clone())
+        }
+    }
+
+    fn temp_dir(prefix: &str) -> PathBuf {
+        let mut path = std::env::temp_dir();
+        path.push(format!(
+            "{prefix}-{}-{}",
+            std::process::id(),
+            std::time::SystemTime::now()
+                .duration_since(std::time::UNIX_EPOCH)
+                .unwrap()
+                .as_nanos()
+        ));
+        fs::create_dir_all(&path).unwrap();
+        path
+    }
+
+    fn write_file(path: &Path, content: &str) {
+        if let Some(parent) = path.parent() {
+            fs::create_dir_all(parent).unwrap();
+        }
+        fs::write(path, content).unwrap();
+    }
+
+    #[tokio::test]
+    async fn git_registry_search_scans_skill_directories() {
+        let checkout = temp_dir("skill-git-search");
+        write_file(
+            &checkout.join("tools/review/skill.yaml"),
+            "name: review-skill\nversion: 0.2.0\ndescription: Review helper\nentry: SKILL.md\nfiles:\n  - SKILL.md\n",
+        );
+        write_file(&checkout.join("tools/review/SKILL.md"), "# Review\n");
+        let adapter = GitRegistryAdapter::with_checkout(
+            "git-dev",
+            "git+https://github.com/acme/skills",
+            temp_dir("skill-git-cache"),
+            Arc::new(StaticCheckout { path: checkout }),
+        );
+
+        let hits = adapter.search("review").await.unwrap();
+
+        assert_eq!(hits.len(), 1);
+        assert_eq!(hits[0].name, "review-skill");
+        assert_eq!(hits[0].version, "0.2.0");
+        assert_eq!(hits[0].registry, "git-dev");
+    }
+
+    #[tokio::test]
+    async fn git_registry_fetch_selects_highest_semver_and_copies_bundle() {
+        let checkout = temp_dir("skill-git-fetch");
+        write_file(
+            &checkout.join("old/skill.yaml"),
+            "name: versioned-git\nversion: 0.1.0\nentry: SKILL.md\nfiles:\n  - SKILL.md\n",
+        );
+        write_file(&checkout.join("old/SKILL.md"), "# Old\n");
+        write_file(
+            &checkout.join("new/skill.yaml"),
+            "name: versioned-git\nversion: 0.3.0\nentry: SKILL.md\nfiles:\n  - SKILL.md\n",
+        );
+        write_file(&checkout.join("new/SKILL.md"), "# New\n");
+        let adapter = GitRegistryAdapter::with_checkout(
+            "git-dev",
+            "git+https://github.com/acme/skills",
+            temp_dir("skill-git-cache"),
+            Arc::new(StaticCheckout { path: checkout }),
+        );
+
+        let fetched = adapter.fetch("versioned-git", None).await.unwrap();
+
+        assert_eq!(fetched.source_type, "git");
+        assert_eq!(fetched.version, "0.3.0");
+        assert!(fetched.staging_path.join("SKILL.md").is_file());
     }
 }

--- a/crates/agentenv-core/src/skills/registry_git.rs
+++ b/crates/agentenv-core/src/skills/registry_git.rs
@@ -2,9 +2,12 @@ use std::{
     cmp::Ordering,
     collections::HashSet,
     fs,
+    io::Read,
     path::{Path, PathBuf},
-    process::Command,
+    process::{Command, Stdio},
     sync::Arc,
+    thread,
+    time::{Duration, Instant},
 };
 
 use crate::security::ssrf::{validate_outbound, SsrfOptions};
@@ -18,6 +21,7 @@ use super::{
 
 const MANIFEST_FILE: &str = "skill.yaml";
 const SOURCE_TYPE: &str = "git";
+const GIT_COMMAND_TIMEOUT: Duration = Duration::from_secs(120);
 
 pub(crate) trait GitCheckout: Send + Sync + std::fmt::Debug {
     fn checkout(&self, url: &str, cache_root: &Path) -> Result<PathBuf, SkillError>;
@@ -29,7 +33,10 @@ struct CommandGitCheckout {
 }
 
 #[derive(Debug)]
-struct RealGitCommandRunner;
+struct RealGitCommandRunner {
+    program: PathBuf,
+    timeout: Duration,
+}
 
 trait GitCommandRunner: Send + Sync + std::fmt::Debug {
     fn run(
@@ -75,7 +82,7 @@ impl GitCheckout for CommandGitCheckout {
         let checkout = cache_root.join("checkout");
         match fs::symlink_metadata(&checkout) {
             Ok(metadata) if metadata.file_type().is_dir() => {
-                if !checkout.join(".git").is_dir() {
+                if !checkout_git_dir_exists(&checkout)? {
                     return Err(SkillError::GitRegistry {
                         url: url.to_owned(),
                         message: format!(
@@ -111,14 +118,27 @@ impl GitCheckout for CommandGitCheckout {
             }
         }
 
-        if checkout.join(".git").is_dir() {
+        if checkout_git_dir_exists(&checkout)? {
+            let clone_url = clone_url(url)?;
+            run_git(
+                self.runner.as_ref(),
+                &[
+                    "-C".to_owned(),
+                    path_arg(&checkout),
+                    "remote".to_owned(),
+                    "set-url".to_owned(),
+                    "origin".to_owned(),
+                    clone_url,
+                ],
+                url,
+            )?;
             run_git(
                 self.runner.as_ref(),
                 &[
                     "-C".to_owned(),
                     path_arg(&checkout),
                     "fetch".to_owned(),
-                    "--all".to_owned(),
+                    "origin".to_owned(),
                     "--tags".to_owned(),
                     "--prune".to_owned(),
                 ],
@@ -291,7 +311,7 @@ impl RegistryAdapter for GitRegistryAdapter {
 impl CommandGitCheckout {
     fn new() -> Self {
         Self {
-            runner: Arc::new(RealGitCommandRunner),
+            runner: Arc::new(RealGitCommandRunner::new()),
         }
     }
 
@@ -301,13 +321,30 @@ impl CommandGitCheckout {
     }
 }
 
+impl RealGitCommandRunner {
+    fn new() -> Self {
+        Self {
+            program: PathBuf::from("git"),
+            timeout: GIT_COMMAND_TIMEOUT,
+        }
+    }
+
+    #[cfg(test)]
+    fn with_program_and_timeout(program: impl Into<PathBuf>, timeout: Duration) -> Self {
+        Self {
+            program: program.into(),
+            timeout,
+        }
+    }
+}
+
 impl GitCommandRunner for RealGitCommandRunner {
     fn run(
         &self,
         args: &[String],
         environment: &GitCommandEnvironment,
     ) -> Result<GitCommandOutput, String> {
-        let mut command = Command::new("git");
+        let mut command = Command::new(&self.program);
         command.args(args);
         for name in &environment.remove {
             command.env_remove(name);
@@ -315,16 +352,79 @@ impl GitCommandRunner for RealGitCommandRunner {
         for (name, value) in &environment.set {
             command.env(name, value);
         }
-        let output = command
-            .output()
+        command.stdout(Stdio::piped()).stderr(Stdio::piped());
+        let mut child = command
+            .spawn()
             .map_err(|source| format!("failed to run git: {source}"))?;
+        let stdout = child
+            .stdout
+            .take()
+            .ok_or_else(|| "failed to capture git stdout".to_owned())?;
+        let stderr = child
+            .stderr
+            .take()
+            .ok_or_else(|| "failed to capture git stderr".to_owned())?;
+        let stdout_reader = read_child_pipe(stdout);
+        let stderr_reader = read_child_pipe(stderr);
+        let deadline = Instant::now() + self.timeout;
+
+        let status = loop {
+            if let Some(status) = child
+                .try_wait()
+                .map_err(|source| format!("failed to wait for git: {source}"))?
+            {
+                break status;
+            }
+            if Instant::now() >= deadline {
+                let _ = child.kill();
+                let _ = child.wait();
+                let _ = join_child_pipe(stdout_reader, "stdout");
+                let _ = join_child_pipe(stderr_reader, "stderr");
+                return Err(format!(
+                    "git command timed out after {}",
+                    timeout_diagnostic(self.timeout)
+                ));
+            }
+            thread::sleep(Duration::from_millis(10));
+        };
+
+        let stdout = join_child_pipe(stdout_reader, "stdout")?;
+        let stderr = join_child_pipe(stderr_reader, "stderr")?;
 
         Ok(GitCommandOutput {
-            success: output.status.success(),
-            status: output.status.to_string(),
-            stdout: String::from_utf8_lossy(&output.stdout).trim().to_owned(),
-            stderr: String::from_utf8_lossy(&output.stderr).trim().to_owned(),
+            success: status.success(),
+            status: status.to_string(),
+            stdout: String::from_utf8_lossy(&stdout).trim().to_owned(),
+            stderr: String::from_utf8_lossy(&stderr).trim().to_owned(),
         })
+    }
+}
+
+fn read_child_pipe(
+    mut pipe: impl Read + Send + 'static,
+) -> thread::JoinHandle<std::io::Result<Vec<u8>>> {
+    thread::spawn(move || {
+        let mut buffer = Vec::new();
+        pipe.read_to_end(&mut buffer)?;
+        Ok(buffer)
+    })
+}
+
+fn join_child_pipe(
+    handle: thread::JoinHandle<std::io::Result<Vec<u8>>>,
+    stream_name: &str,
+) -> Result<Vec<u8>, String> {
+    handle
+        .join()
+        .map_err(|_| format!("failed to read git {stream_name}: reader thread panicked"))?
+        .map_err(|source| format!("failed to read git {stream_name}: {source}"))
+}
+
+fn timeout_diagnostic(timeout: Duration) -> String {
+    if timeout.as_secs() > 0 {
+        format!("{}s", timeout.as_secs())
+    } else {
+        format!("{}ms", timeout.as_millis())
     }
 }
 
@@ -397,6 +497,19 @@ fn clone_url(url: &str) -> Result<String, SkillError> {
         });
     }
     Ok(stripped.to_owned())
+}
+
+fn checkout_git_dir_exists(checkout: &Path) -> Result<bool, SkillError> {
+    let git_dir = checkout.join(".git");
+    match fs::symlink_metadata(&git_dir) {
+        Ok(metadata) if metadata.file_type().is_dir() => Ok(true),
+        Ok(_) => Err(SkillError::UnsafeBundlePath { path: git_dir }),
+        Err(source) if source.kind() == std::io::ErrorKind::NotFound => Ok(false),
+        Err(source) => Err(SkillError::Io {
+            path: git_dir,
+            source,
+        }),
+    }
 }
 
 fn validate_git_registry_url(url: &str, options: &SsrfOptions) -> Result<(), SkillError> {
@@ -1135,8 +1248,19 @@ mod tests {
                     args: expected_isolated_args(vec![
                         "-C".to_owned(),
                         path_arg(&cache_root.join("checkout")),
+                        "remote".to_owned(),
+                        "set-url".to_owned(),
+                        "origin".to_owned(),
+                        "https://github.com/acme/skills".to_owned(),
+                    ]),
+                    environment: expected_git_environment(),
+                },
+                RecordedGitCommand {
+                    args: expected_isolated_args(vec![
+                        "-C".to_owned(),
+                        path_arg(&cache_root.join("checkout")),
                         "fetch".to_owned(),
-                        "--all".to_owned(),
+                        "origin".to_owned(),
                         "--tags".to_owned(),
                         "--prune".to_owned(),
                     ]),
@@ -1154,5 +1278,26 @@ mod tests {
                 },
             ]
         );
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn real_git_runner_times_out_stalled_commands() {
+        use std::os::unix::fs::PermissionsExt;
+
+        let root = temp_dir("skill-git-command-timeout");
+        let fake_git = root.join("git");
+        fs::write(&fake_git, "#!/bin/sh\nsleep 5\n").unwrap();
+        let mut permissions = fs::metadata(&fake_git).unwrap().permissions();
+        permissions.set_mode(0o755);
+        fs::set_permissions(&fake_git, permissions).unwrap();
+        let runner =
+            RealGitCommandRunner::with_program_and_timeout(fake_git, Duration::from_millis(25));
+
+        let error = runner
+            .run(&["status".to_owned()], &isolated_git_environment())
+            .expect_err("stalled git commands must time out");
+
+        assert!(error.contains("timed out"), "error was: {error}");
     }
 }

--- a/crates/agentenv-core/src/skills/registry_git.rs
+++ b/crates/agentenv-core/src/skills/registry_git.rs
@@ -2,7 +2,7 @@ use std::{
     cmp::Ordering,
     collections::HashSet,
     fs,
-    path::{Component, Path, PathBuf},
+    path::{Path, PathBuf},
     process::Command,
     sync::Arc,
 };
@@ -498,7 +498,7 @@ fn open_regular_file_under_root(root: &Path, relative_path: &Path) -> Result<fs:
     let mut directory = open_directory_no_follow(root)?;
 
     while let Some(component) = components.next() {
-        let Component::Normal(part) = component else {
+        let std::path::Component::Normal(part) = component else {
             return Err(SkillError::UnsafeBundlePath {
                 path: relative_path.clone(),
             });
@@ -547,15 +547,15 @@ fn open_directory_no_follow(path: &Path) -> Result<fs::File, SkillError> {
 }
 
 #[cfg(not(unix))]
-fn open_regular_file_under_root(root: &Path, relative_path: &Path) -> Result<fs::File, SkillError> {
-    let relative_path = normalize_bundle_path(relative_path)?;
-    let path = root.join(&relative_path);
-    let file = fs::File::open(&path).map_err(|source| SkillError::Io {
-        path: path.clone(),
-        source,
-    })?;
-    ensure_opened_regular_file(&path, &file)?;
-    Ok(file)
+fn open_regular_file_under_root(
+    _root: &Path,
+    _relative_path: &Path,
+) -> Result<fs::File, SkillError> {
+    Err(SkillError::GitRegistry {
+        url: SOURCE_TYPE.to_owned(),
+        message: "git registry fetch is unsupported on this platform because safe no-follow staging is unavailable"
+            .to_owned(),
+    })
 }
 
 #[cfg(unix)]
@@ -887,6 +887,35 @@ mod tests {
             SkillError::Io { .. } | SkillError::UnsafeBundlePath { .. }
         ));
         assert!(!destination.join("docs/SKILL.md").exists());
+    }
+
+    #[cfg(not(unix))]
+    #[test]
+    fn git_bundle_copy_fails_closed_without_safe_nofollow_staging() {
+        let source = temp_dir("skill-git-copy-non-unix-source");
+        let destination = temp_dir("skill-git-copy-non-unix-destination");
+        write_file(
+            &source.join("skill.yaml"),
+            "name: non-unix-git\nversion: 0.1.0\nentry: SKILL.md\nfiles:\n  - SKILL.md\n",
+        );
+        write_file(&source.join("SKILL.md"), "# Non-Unix\n");
+        let manifest = SkillManifest {
+            name: "non-unix-git".to_owned(),
+            version: Version::parse("0.1.0").unwrap(),
+            description: None,
+            entry: PathBuf::from("SKILL.md"),
+            declared_files: vec![PathBuf::from("SKILL.md")],
+            self_test_command: None,
+            signature_ed25519: None,
+            signature_public_key_ed25519: None,
+            extra: std::collections::BTreeMap::new(),
+        };
+
+        let error = copy_bundle_contents(&source, &destination, &manifest)
+            .expect_err("non-Unix staging must fail closed without no-follow support");
+
+        assert!(matches!(error, SkillError::GitRegistry { .. }));
+        assert!(!destination.join("SKILL.md").exists());
     }
 
     #[tokio::test]

--- a/crates/agentenv-core/src/skills/registry_git.rs
+++ b/crates/agentenv-core/src/skills/registry_git.rs
@@ -32,7 +32,17 @@ struct CommandGitCheckout {
 struct RealGitCommandRunner;
 
 trait GitCommandRunner: Send + Sync + std::fmt::Debug {
-    fn run(&self, args: &[String], terminal_prompt: &str) -> Result<GitCommandOutput, String>;
+    fn run(
+        &self,
+        args: &[String],
+        environment: &GitCommandEnvironment,
+    ) -> Result<GitCommandOutput, String>;
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+struct GitCommandEnvironment {
+    set: Vec<(String, String)>,
+    remove: Vec<String>,
 }
 
 #[derive(Debug, Clone)]
@@ -292,10 +302,20 @@ impl CommandGitCheckout {
 }
 
 impl GitCommandRunner for RealGitCommandRunner {
-    fn run(&self, args: &[String], terminal_prompt: &str) -> Result<GitCommandOutput, String> {
-        let output = Command::new("git")
-            .args(args)
-            .env("GIT_TERMINAL_PROMPT", terminal_prompt)
+    fn run(
+        &self,
+        args: &[String],
+        environment: &GitCommandEnvironment,
+    ) -> Result<GitCommandOutput, String> {
+        let mut command = Command::new("git");
+        command.args(args);
+        for name in &environment.remove {
+            command.env_remove(name);
+        }
+        for (name, value) in &environment.set {
+            command.env(name, value);
+        }
+        let output = command
             .output()
             .map_err(|source| format!("failed to run git: {source}"))?;
 
@@ -394,8 +414,10 @@ fn validate_git_registry_url(url: &str, options: &SsrfOptions) -> Result<(), Ski
 }
 
 fn run_git(runner: &dyn GitCommandRunner, args: &[String], url: &str) -> Result<(), SkillError> {
+    let args = isolated_git_args(args);
+    let environment = isolated_git_environment();
     let output = runner
-        .run(args, "0")
+        .run(&args, &environment)
         .map_err(|message| SkillError::GitRegistry {
             url: url.to_owned(),
             message,
@@ -422,6 +444,72 @@ fn run_git(runner: &dyn GitCommandRunner, args: &[String], url: &str) -> Result<
         url: url.to_owned(),
         message,
     })
+}
+
+fn isolated_git_args(args: &[String]) -> Vec<String> {
+    let mut isolated = [
+        "-c",
+        "http.followRedirects=false",
+        "-c",
+        "protocol.allow=never",
+        "-c",
+        "protocol.https.allow=always",
+        "-c",
+        "credential.helper=",
+        "-c",
+        "core.askPass=",
+    ]
+    .into_iter()
+    .map(str::to_owned)
+    .collect::<Vec<_>>();
+    isolated.extend(args.iter().cloned());
+    isolated
+}
+
+fn isolated_git_environment() -> GitCommandEnvironment {
+    GitCommandEnvironment {
+        set: vec![
+            ("GIT_TERMINAL_PROMPT".to_owned(), "0".to_owned()),
+            ("GIT_CONFIG_NOSYSTEM".to_owned(), "1".to_owned()),
+            (
+                "GIT_CONFIG_SYSTEM".to_owned(),
+                git_null_config_path().to_owned(),
+            ),
+            (
+                "GIT_CONFIG_GLOBAL".to_owned(),
+                git_null_config_path().to_owned(),
+            ),
+            ("GIT_CONFIG_COUNT".to_owned(), "0".to_owned()),
+        ],
+        remove: [
+            "GIT_CONFIG",
+            "GIT_DIR",
+            "GIT_WORK_TREE",
+            "GIT_SSH",
+            "GIT_SSH_COMMAND",
+            "GIT_ASKPASS",
+            "GIT_PROXY_COMMAND",
+            "HTTP_PROXY",
+            "HTTPS_PROXY",
+            "ALL_PROXY",
+            "NO_PROXY",
+            "http_proxy",
+            "https_proxy",
+            "all_proxy",
+            "no_proxy",
+        ]
+        .into_iter()
+        .map(str::to_owned)
+        .collect(),
+    }
+}
+
+fn git_null_config_path() -> &'static str {
+    if cfg!(windows) {
+        "NUL"
+    } else {
+        "/dev/null"
+    }
 }
 
 fn bounded_diagnostic(text: &str) -> String {
@@ -708,7 +796,7 @@ mod tests {
     #[derive(Debug, Clone, PartialEq, Eq)]
     struct RecordedGitCommand {
         args: Vec<String>,
-        terminal_prompt: String,
+        environment: GitCommandEnvironment,
     }
 
     #[derive(Debug)]
@@ -729,10 +817,14 @@ mod tests {
     }
 
     impl GitCommandRunner for RecordingGitCommandRunner {
-        fn run(&self, args: &[String], terminal_prompt: &str) -> Result<GitCommandOutput, String> {
+        fn run(
+            &self,
+            args: &[String],
+            environment: &GitCommandEnvironment,
+        ) -> Result<GitCommandOutput, String> {
             self.commands.lock().unwrap().push(RecordedGitCommand {
                 args: args.to_vec(),
-                terminal_prompt: terminal_prompt.to_owned(),
+                environment: environment.clone(),
             });
             Ok(GitCommandOutput {
                 success: true,
@@ -741,6 +833,14 @@ mod tests {
                 stderr: String::new(),
             })
         }
+    }
+
+    fn expected_isolated_args(args: Vec<String>) -> Vec<String> {
+        isolated_git_args(&args)
+    }
+
+    fn expected_git_environment() -> GitCommandEnvironment {
+        isolated_git_environment()
     }
 
     fn temp_dir(prefix: &str) -> PathBuf {
@@ -980,16 +1080,40 @@ mod tests {
         assert_eq!(
             runner.commands(),
             vec![RecordedGitCommand {
-                args: vec![
+                args: expected_isolated_args(vec![
                     "clone".to_owned(),
                     "--filter=blob:none".to_owned(),
                     "--depth=1".to_owned(),
                     "https://github.com/acme/skills".to_owned(),
                     path_arg(&cache_root.join("checkout")),
-                ],
-                terminal_prompt: "0".to_owned(),
+                ]),
+                environment: expected_git_environment(),
             }]
         );
+        let command = &runner.commands()[0];
+        assert!(command
+            .args
+            .windows(2)
+            .any(|pair| pair == ["-c".to_owned(), "http.followRedirects=false".to_owned()]));
+        assert!(command
+            .args
+            .windows(2)
+            .any(|pair| pair == ["-c".to_owned(), "protocol.allow=never".to_owned()]));
+        assert!(command
+            .environment
+            .set
+            .iter()
+            .any(|(name, value)| { name == "GIT_TERMINAL_PROMPT" && value == "0" }));
+        assert!(command
+            .environment
+            .set
+            .iter()
+            .any(|(name, value)| { name == "GIT_CONFIG_NOSYSTEM" && value == "1" }));
+        assert!(command
+            .environment
+            .remove
+            .iter()
+            .any(|name| name == "HTTPS_PROXY"));
     }
 
     #[test]
@@ -1008,25 +1132,25 @@ mod tests {
             runner.commands(),
             vec![
                 RecordedGitCommand {
-                    args: vec![
+                    args: expected_isolated_args(vec![
                         "-C".to_owned(),
                         path_arg(&cache_root.join("checkout")),
                         "fetch".to_owned(),
                         "--all".to_owned(),
                         "--tags".to_owned(),
                         "--prune".to_owned(),
-                    ],
-                    terminal_prompt: "0".to_owned(),
+                    ]),
+                    environment: expected_git_environment(),
                 },
                 RecordedGitCommand {
-                    args: vec![
+                    args: expected_isolated_args(vec![
                         "-C".to_owned(),
                         path_arg(&cache_root.join("checkout")),
                         "reset".to_owned(),
                         "--hard".to_owned(),
                         "origin/HEAD".to_owned(),
-                    ],
-                    terminal_prompt: "0".to_owned(),
+                    ]),
+                    environment: expected_git_environment(),
                 },
             ]
         );

--- a/crates/agentenv-core/src/skills/registry_git.rs
+++ b/crates/agentenv-core/src/skills/registry_git.rs
@@ -1,12 +1,15 @@
 use std::{
     cmp::Ordering,
+    collections::HashSet,
     fs,
     path::{Path, PathBuf},
     process::Command,
     sync::Arc,
 };
 
+use crate::security::ssrf::{validate_outbound, SsrfOptions};
 use semver::Version;
+use url::Url;
 
 use super::{
     compute_bundle_digest, manifest::validated_bundle_file, validate_skill_name, FetchedSkill,
@@ -21,7 +24,24 @@ pub(crate) trait GitCheckout: Send + Sync + std::fmt::Debug {
 }
 
 #[derive(Debug)]
-struct CommandGitCheckout;
+struct CommandGitCheckout {
+    runner: Arc<dyn GitCommandRunner>,
+}
+
+#[derive(Debug)]
+struct RealGitCommandRunner;
+
+trait GitCommandRunner: Send + Sync + std::fmt::Debug {
+    fn run(&self, args: &[String], terminal_prompt: &str) -> Result<GitCommandOutput, String>;
+}
+
+#[derive(Debug, Clone)]
+struct GitCommandOutput {
+    success: bool,
+    status: String,
+    stdout: String,
+    stderr: String,
+}
 
 #[derive(Debug, Clone)]
 struct ScannedGitSkill {
@@ -36,14 +56,54 @@ pub(crate) struct GitRegistryAdapter {
     url: String,
     cache_root: PathBuf,
     checkout: Arc<dyn GitCheckout>,
+    ssrf_options: SsrfOptions,
 }
 
 impl GitCheckout for CommandGitCheckout {
     fn checkout(&self, url: &str, cache_root: &Path) -> Result<PathBuf, SkillError> {
         ensure_directory(cache_root)?;
         let checkout = cache_root.join("checkout");
+        match fs::symlink_metadata(&checkout) {
+            Ok(metadata) if metadata.file_type().is_dir() => {
+                if !checkout.join(".git").is_dir() {
+                    return Err(SkillError::GitRegistry {
+                        url: url.to_owned(),
+                        message: format!(
+                            "cache checkout path `{}` exists but is not a git repository",
+                            checkout.display()
+                        ),
+                    });
+                }
+            }
+            Ok(_) => {
+                return Err(SkillError::UnsafeBundlePath { path: checkout });
+            }
+            Err(source) if source.kind() == std::io::ErrorKind::NotFound => {
+                let clone_url = clone_url(url)?;
+                run_git(
+                    self.runner.as_ref(),
+                    &[
+                        "clone".to_owned(),
+                        "--filter=blob:none".to_owned(),
+                        "--depth=1".to_owned(),
+                        clone_url,
+                        path_arg(&checkout),
+                    ],
+                    url,
+                )?;
+                return Ok(checkout);
+            }
+            Err(source) => {
+                return Err(SkillError::Io {
+                    path: checkout,
+                    source,
+                });
+            }
+        }
+
         if checkout.join(".git").is_dir() {
             run_git(
+                self.runner.as_ref(),
                 &[
                     "-C".to_owned(),
                     path_arg(&checkout),
@@ -55,6 +115,7 @@ impl GitCheckout for CommandGitCheckout {
                 url,
             )?;
             run_git(
+                self.runner.as_ref(),
                 &[
                     "-C".to_owned(),
                     path_arg(&checkout),
@@ -66,19 +127,7 @@ impl GitCheckout for CommandGitCheckout {
             )?;
             return Ok(checkout);
         }
-
-        let clone_url = clone_url(url)?;
-        run_git(
-            &[
-                "clone".to_owned(),
-                "--filter=blob:none".to_owned(),
-                "--depth=1".to_owned(),
-                clone_url,
-                path_arg(&checkout),
-            ],
-            url,
-        )?;
-        Ok(checkout)
+        unreachable!("non-git checkout paths are returned above")
     }
 }
 
@@ -87,25 +136,45 @@ impl GitRegistryAdapter {
         name: impl Into<String>,
         url: impl Into<String>,
         cache_root: impl Into<PathBuf>,
+        ssrf_options: SsrfOptions,
     ) -> Self {
-        Self::with_checkout(name, url, cache_root, Arc::new(CommandGitCheckout))
+        Self::with_checkout_and_ssrf(
+            name,
+            url,
+            cache_root,
+            Arc::new(CommandGitCheckout::new()),
+            ssrf_options,
+        )
     }
 
+    #[cfg(test)]
     pub(crate) fn with_checkout(
         name: impl Into<String>,
         url: impl Into<String>,
         cache_root: impl Into<PathBuf>,
         checkout: Arc<dyn GitCheckout>,
     ) -> Self {
+        Self::with_checkout_and_ssrf(name, url, cache_root, checkout, SsrfOptions::default())
+    }
+
+    pub(crate) fn with_checkout_and_ssrf(
+        name: impl Into<String>,
+        url: impl Into<String>,
+        cache_root: impl Into<PathBuf>,
+        checkout: Arc<dyn GitCheckout>,
+        ssrf_options: SsrfOptions,
+    ) -> Self {
         Self {
             name: name.into(),
             url: url.into(),
             cache_root: cache_root.into(),
             checkout,
+            ssrf_options,
         }
     }
 
     fn checkout_path(&self) -> Result<PathBuf, SkillError> {
+        validate_git_registry_url(&self.url, &self.ssrf_options)?;
         self.checkout.checkout(&self.url, &self.cache_root)
     }
 
@@ -113,6 +182,7 @@ impl GitRegistryAdapter {
         let checkout_path = self.checkout_path()?;
         let mut skills = Vec::new();
         scan_directory(&checkout_path, &mut skills)?;
+        reject_duplicate_manifests(&self.name, &skills)?;
         Ok(skills)
     }
 
@@ -184,8 +254,7 @@ impl RegistryAdapter for GitRegistryAdapter {
                 })?;
 
         let version = skill.manifest.version.to_string();
-        let staging_path = staging_fetch_path(&skill.manifest.name, &version);
-        remove_directory_if_exists(&staging_path)?;
+        let staging_path = staging_fetch_path(&self.cache_root, &skill.manifest.name, &version)?;
         copy_bundle_contents(&skill.path, &staging_path, &skill.manifest)?;
 
         Ok(FetchedSkill {
@@ -205,6 +274,36 @@ impl RegistryAdapter for GitRegistryAdapter {
         Err(SkillError::UnsupportedRegistryPublish {
             registry: self.name.clone(),
             kind: SOURCE_TYPE.to_owned(),
+        })
+    }
+}
+
+impl CommandGitCheckout {
+    fn new() -> Self {
+        Self {
+            runner: Arc::new(RealGitCommandRunner),
+        }
+    }
+
+    #[cfg(test)]
+    fn with_runner(runner: Arc<dyn GitCommandRunner>) -> Self {
+        Self { runner }
+    }
+}
+
+impl GitCommandRunner for RealGitCommandRunner {
+    fn run(&self, args: &[String], terminal_prompt: &str) -> Result<GitCommandOutput, String> {
+        let output = Command::new("git")
+            .args(args)
+            .env("GIT_TERMINAL_PROMPT", terminal_prompt)
+            .output()
+            .map_err(|source| format!("failed to run git: {source}"))?;
+
+        Ok(GitCommandOutput {
+            success: output.status.success(),
+            status: output.status.to_string(),
+            stdout: String::from_utf8_lossy(&output.stdout).trim().to_owned(),
+            stderr: String::from_utf8_lossy(&output.stderr).trim().to_owned(),
         })
     }
 }
@@ -280,24 +379,44 @@ fn clone_url(url: &str) -> Result<String, SkillError> {
     Ok(stripped.to_owned())
 }
 
-fn run_git(args: &[String], url: &str) -> Result<(), SkillError> {
-    let output = Command::new("git")
-        .args(args)
-        .env("GIT_TERMINAL_PROMPT", "0")
-        .output()
-        .map_err(|source| SkillError::GitRegistry {
+fn validate_git_registry_url(url: &str, options: &SsrfOptions) -> Result<(), SkillError> {
+    let clone_url = clone_url(url)?;
+    let parsed = Url::parse(&clone_url).map_err(|source| SkillError::GitRegistry {
+        url: url.to_owned(),
+        message: format!("invalid git registry URL: {source}"),
+    })?;
+    validate_outbound(&parsed, options.clone())
+        .map(|_| ())
+        .map_err(|source| SkillError::RegistryUrlBlocked {
             url: url.to_owned(),
-            message: format!("failed to run git: {source}"),
+            source: Box::new(source),
+        })
+}
+
+fn run_git(runner: &dyn GitCommandRunner, args: &[String], url: &str) -> Result<(), SkillError> {
+    let output = runner
+        .run(args, "0")
+        .map_err(|message| SkillError::GitRegistry {
+            url: url.to_owned(),
+            message,
         })?;
-    if output.status.success() {
+    if output.success {
         return Ok(());
     }
 
-    let stderr = String::from_utf8_lossy(&output.stderr).trim().to_owned();
-    let message = if stderr.is_empty() {
-        format!("git exited with status {}", output.status)
+    let message = if output.stderr.is_empty() {
+        let stdout = bounded_diagnostic(&output.stdout);
+        if stdout.is_empty() {
+            format!("git exited with status {}", output.status)
+        } else {
+            format!("git exited with status {}: {stdout}", output.status)
+        }
     } else {
-        format!("git exited with status {}: {stderr}", output.status)
+        format!(
+            "git exited with status {}: {}",
+            output.status,
+            bounded_diagnostic(&output.stderr)
+        )
     };
     Err(SkillError::GitRegistry {
         url: url.to_owned(),
@@ -305,55 +424,105 @@ fn run_git(args: &[String], url: &str) -> Result<(), SkillError> {
     })
 }
 
+fn bounded_diagnostic(text: &str) -> String {
+    const LIMIT: usize = 512;
+    let text = text.trim();
+    if text.len() <= LIMIT {
+        return text.to_owned();
+    }
+
+    let mut end = LIMIT;
+    while !text.is_char_boundary(end) {
+        end -= 1;
+    }
+    format!("{}...", &text[..end])
+}
+
 fn path_arg(path: &Path) -> String {
     path.to_string_lossy().into_owned()
 }
 
-fn staging_fetch_path(name: &str, version: &str) -> PathBuf {
-    std::env::temp_dir().join(format!(
-        "agentenv-skill-git-fetch-{name}-{version}-{}-{}",
-        std::process::id(),
-        temporary_suffix()
-    ))
-}
-
-fn remove_directory_if_exists(path: &Path) -> Result<(), SkillError> {
-    match fs::symlink_metadata(path) {
-        Ok(metadata) if metadata.file_type().is_dir() => {
-            fs::remove_dir_all(path).map_err(|source| SkillError::Io {
-                path: path.to_path_buf(),
-                source,
-            })
+fn staging_fetch_path(cache_root: &Path, name: &str, version: &str) -> Result<PathBuf, SkillError> {
+    let staging_root = cache_root.join("staging");
+    ensure_directory(&staging_root)?;
+    for _ in 0..16 {
+        let candidate = staging_root.join(format!(
+            "{name}-{version}-{}-{}",
+            std::process::id(),
+            temporary_suffix()
+        ));
+        match fs::create_dir(&candidate) {
+            Ok(()) => return Ok(candidate),
+            Err(source) if source.kind() == std::io::ErrorKind::AlreadyExists => continue,
+            Err(source) => {
+                return Err(SkillError::Io {
+                    path: candidate,
+                    source,
+                });
+            }
         }
-        Ok(_) => Err(SkillError::UnsafeBundlePath {
-            path: path.to_path_buf(),
-        }),
-        Err(source) if source.kind() == std::io::ErrorKind::NotFound => Ok(()),
-        Err(source) => Err(SkillError::Io {
-            path: path.to_path_buf(),
-            source,
-        }),
     }
+
+    Err(SkillError::GitRegistry {
+        url: SOURCE_TYPE.to_owned(),
+        message: "failed to allocate unique git skill staging directory".to_owned(),
+    })
 }
 
 fn copy_regular_file(source: &Path, destination: &Path) -> Result<(), SkillError> {
-    let metadata = fs::symlink_metadata(source).map_err(|source_error| SkillError::Io {
-        path: source.to_path_buf(),
-        source: source_error,
-    })?;
-    if !metadata.file_type().is_file() {
-        return Err(SkillError::UnsafeBundlePath {
-            path: source.to_path_buf(),
-        });
-    }
     if let Some(parent) = destination.parent() {
         ensure_directory(parent)?;
     }
-    fs::copy(source, destination).map_err(|source| SkillError::Io {
+    let mut source_file = open_regular_file(source)?;
+    let mut destination_file = fs::File::create(destination).map_err(|source| SkillError::Io {
+        path: destination.to_path_buf(),
+        source,
+    })?;
+    std::io::copy(&mut source_file, &mut destination_file).map_err(|source| SkillError::Io {
         path: destination.to_path_buf(),
         source,
     })?;
     Ok(())
+}
+
+#[cfg(unix)]
+fn open_regular_file(path: &Path) -> Result<fs::File, SkillError> {
+    use std::{fs::OpenOptions, os::unix::fs::OpenOptionsExt};
+
+    let file = OpenOptions::new()
+        .read(true)
+        .custom_flags(libc::O_NOFOLLOW)
+        .open(path)
+        .map_err(|source| SkillError::Io {
+            path: path.to_path_buf(),
+            source,
+        })?;
+    ensure_opened_regular_file(path, &file)?;
+    Ok(file)
+}
+
+#[cfg(not(unix))]
+fn open_regular_file(path: &Path) -> Result<fs::File, SkillError> {
+    let file = fs::File::open(path).map_err(|source| SkillError::Io {
+        path: path.to_path_buf(),
+        source,
+    })?;
+    ensure_opened_regular_file(path, &file)?;
+    Ok(file)
+}
+
+fn ensure_opened_regular_file(path: &Path, file: &fs::File) -> Result<(), SkillError> {
+    let metadata = file.metadata().map_err(|source| SkillError::Io {
+        path: path.to_path_buf(),
+        source,
+    })?;
+    if metadata.file_type().is_file() {
+        Ok(())
+    } else {
+        Err(SkillError::UnsafeBundlePath {
+            path: path.to_path_buf(),
+        })
+    }
 }
 
 fn copy_bundle_contents(
@@ -380,6 +549,25 @@ fn sort_hits(hits: &mut [SkillSearchHit]) {
             .then_with(|| compare_versions(&left.version, &right.version))
             .then_with(|| left.registry.cmp(&right.registry))
     });
+}
+
+fn reject_duplicate_manifests(
+    registry: &str,
+    skills: &[ScannedGitSkill],
+) -> Result<(), SkillError> {
+    let mut seen = HashSet::new();
+    for skill in skills {
+        let version = skill.manifest.version.to_string();
+        if !seen.insert((skill.manifest.name.clone(), version.clone())) {
+            return Err(SkillError::InvalidConfig {
+                message: format!(
+                    "git registry `{registry}` has duplicate skill `{}` version `{version}`",
+                    skill.manifest.name
+                ),
+            });
+        }
+    }
+    Ok(())
 }
 
 fn compare_versions(left: &str, right: &str) -> Ordering {
@@ -417,7 +605,15 @@ fn temporary_suffix() -> u128 {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use std::{fs, path::PathBuf, sync::Arc};
+    use crate::security::ssrf::SsrfOptions;
+    use std::{
+        fs,
+        path::PathBuf,
+        sync::{
+            atomic::{AtomicUsize, Ordering as AtomicOrdering},
+            Arc, Mutex,
+        },
+    };
 
     #[derive(Debug)]
     struct StaticCheckout {
@@ -427,6 +623,57 @@ mod tests {
     impl GitCheckout for StaticCheckout {
         fn checkout(&self, _url: &str, _cache_root: &Path) -> Result<PathBuf, SkillError> {
             Ok(self.path.clone())
+        }
+    }
+
+    #[derive(Debug)]
+    struct CountingCheckout {
+        calls: AtomicUsize,
+        path: PathBuf,
+    }
+
+    impl GitCheckout for CountingCheckout {
+        fn checkout(&self, _url: &str, _cache_root: &Path) -> Result<PathBuf, SkillError> {
+            self.calls.fetch_add(1, AtomicOrdering::SeqCst);
+            Ok(self.path.clone())
+        }
+    }
+
+    #[derive(Debug, Clone, PartialEq, Eq)]
+    struct RecordedGitCommand {
+        args: Vec<String>,
+        terminal_prompt: String,
+    }
+
+    #[derive(Debug)]
+    struct RecordingGitCommandRunner {
+        commands: Mutex<Vec<RecordedGitCommand>>,
+    }
+
+    impl RecordingGitCommandRunner {
+        fn new() -> Self {
+            Self {
+                commands: Mutex::new(Vec::new()),
+            }
+        }
+
+        fn commands(&self) -> Vec<RecordedGitCommand> {
+            self.commands.lock().unwrap().clone()
+        }
+    }
+
+    impl GitCommandRunner for RecordingGitCommandRunner {
+        fn run(&self, args: &[String], terminal_prompt: &str) -> Result<GitCommandOutput, String> {
+            self.commands.lock().unwrap().push(RecordedGitCommand {
+                args: args.to_vec(),
+                terminal_prompt: terminal_prompt.to_owned(),
+            });
+            Ok(GitCommandOutput {
+                success: true,
+                status: "exit status: 0".to_owned(),
+                stdout: String::new(),
+                stderr: String::new(),
+            })
         }
     }
 
@@ -451,6 +698,14 @@ mod tests {
         fs::write(path, content).unwrap();
     }
 
+    fn loopback_ssrf_options() -> SsrfOptions {
+        SsrfOptions {
+            allow_loopback: true,
+            allow_private: true,
+            ..SsrfOptions::default()
+        }
+    }
+
     #[tokio::test]
     async fn git_registry_search_scans_skill_directories() {
         let checkout = temp_dir("skill-git-search");
@@ -459,11 +714,12 @@ mod tests {
             "name: review-skill\nversion: 0.2.0\ndescription: Review helper\nentry: SKILL.md\nfiles:\n  - SKILL.md\n",
         );
         write_file(&checkout.join("tools/review/SKILL.md"), "# Review\n");
-        let adapter = GitRegistryAdapter::with_checkout(
+        let adapter = GitRegistryAdapter::with_checkout_and_ssrf(
             "git-dev",
-            "git+https://github.com/acme/skills",
+            "git+https://127.0.0.1/acme/skills",
             temp_dir("skill-git-cache"),
             Arc::new(StaticCheckout { path: checkout }),
+            loopback_ssrf_options(),
         );
 
         let hits = adapter.search("review").await.unwrap();
@@ -487,11 +743,12 @@ mod tests {
             "name: versioned-git\nversion: 0.3.0\nentry: SKILL.md\nfiles:\n  - SKILL.md\n",
         );
         write_file(&checkout.join("new/SKILL.md"), "# New\n");
-        let adapter = GitRegistryAdapter::with_checkout(
+        let adapter = GitRegistryAdapter::with_checkout_and_ssrf(
             "git-dev",
-            "git+https://github.com/acme/skills",
+            "git+https://127.0.0.1/acme/skills",
             temp_dir("skill-git-cache"),
             Arc::new(StaticCheckout { path: checkout }),
+            loopback_ssrf_options(),
         );
 
         let fetched = adapter.fetch("versioned-git", None).await.unwrap();
@@ -499,5 +756,119 @@ mod tests {
         assert_eq!(fetched.source_type, "git");
         assert_eq!(fetched.version, "0.3.0");
         assert!(fetched.staging_path.join("SKILL.md").is_file());
+    }
+
+    #[tokio::test]
+    async fn git_registry_blocks_ssrf_url_before_checkout() {
+        let checkout = Arc::new(CountingCheckout {
+            calls: AtomicUsize::new(0),
+            path: temp_dir("skill-git-ssrf-checkout"),
+        });
+        let adapter = GitRegistryAdapter::with_checkout(
+            "git-dev",
+            "git+https://127.0.0.1/acme/skills",
+            temp_dir("skill-git-cache"),
+            checkout.clone(),
+        );
+
+        let error = adapter
+            .search("anything")
+            .await
+            .expect_err("blocked URL should stop before checkout");
+
+        assert!(matches!(error, SkillError::RegistryUrlBlocked { .. }));
+        assert_eq!(checkout.calls.load(AtomicOrdering::SeqCst), 0);
+    }
+
+    #[tokio::test]
+    async fn git_registry_scan_rejects_duplicate_name_version_manifests() {
+        let checkout = temp_dir("skill-git-duplicates");
+        for directory in ["one", "two"] {
+            write_file(
+                &checkout.join(directory).join("skill.yaml"),
+                "name: duplicate-git\nversion: 0.1.0\nentry: SKILL.md\nfiles:\n  - SKILL.md\n",
+            );
+            write_file(&checkout.join(directory).join("SKILL.md"), "# Duplicate\n");
+        }
+        let adapter = GitRegistryAdapter::with_checkout_and_ssrf(
+            "git-dev",
+            "git+https://127.0.0.1/acme/skills",
+            temp_dir("skill-git-cache"),
+            Arc::new(StaticCheckout { path: checkout }),
+            loopback_ssrf_options(),
+        );
+
+        let error = adapter
+            .search("duplicate")
+            .await
+            .expect_err("duplicate manifests must be rejected");
+
+        assert!(matches!(error, SkillError::InvalidConfig { .. }));
+    }
+
+    #[test]
+    fn command_checkout_clones_stripped_git_url_into_cache_root() {
+        let cache_root = temp_dir("skill-git-command-clone");
+        let runner = Arc::new(RecordingGitCommandRunner::new());
+        let checkout = CommandGitCheckout::with_runner(runner.clone());
+
+        let path = checkout
+            .checkout("git+https://github.com/acme/skills", &cache_root)
+            .unwrap();
+
+        assert_eq!(path, cache_root.join("checkout"));
+        assert_eq!(
+            runner.commands(),
+            vec![RecordedGitCommand {
+                args: vec![
+                    "clone".to_owned(),
+                    "--filter=blob:none".to_owned(),
+                    "--depth=1".to_owned(),
+                    "https://github.com/acme/skills".to_owned(),
+                    path_arg(&cache_root.join("checkout")),
+                ],
+                terminal_prompt: "0".to_owned(),
+            }]
+        );
+    }
+
+    #[test]
+    fn command_checkout_fetches_and_resets_existing_checkout() {
+        let cache_root = temp_dir("skill-git-command-fetch");
+        fs::create_dir_all(cache_root.join("checkout/.git")).unwrap();
+        let runner = Arc::new(RecordingGitCommandRunner::new());
+        let checkout = CommandGitCheckout::with_runner(runner.clone());
+
+        let path = checkout
+            .checkout("git+https://github.com/acme/skills", &cache_root)
+            .unwrap();
+
+        assert_eq!(path, cache_root.join("checkout"));
+        assert_eq!(
+            runner.commands(),
+            vec![
+                RecordedGitCommand {
+                    args: vec![
+                        "-C".to_owned(),
+                        path_arg(&cache_root.join("checkout")),
+                        "fetch".to_owned(),
+                        "--all".to_owned(),
+                        "--tags".to_owned(),
+                        "--prune".to_owned(),
+                    ],
+                    terminal_prompt: "0".to_owned(),
+                },
+                RecordedGitCommand {
+                    args: vec![
+                        "-C".to_owned(),
+                        path_arg(&cache_root.join("checkout")),
+                        "reset".to_owned(),
+                        "--hard".to_owned(),
+                        "origin/HEAD".to_owned(),
+                    ],
+                    terminal_prompt: "0".to_owned(),
+                },
+            ]
+        );
     }
 }

--- a/crates/agentenv-core/src/skills/registry_git.rs
+++ b/crates/agentenv-core/src/skills/registry_git.rs
@@ -155,6 +155,16 @@ impl GitCheckout for CommandGitCheckout {
                 ],
                 url,
             )?;
+            run_git(
+                self.runner.as_ref(),
+                &[
+                    "-C".to_owned(),
+                    path_arg(&checkout),
+                    "clean".to_owned(),
+                    "-fdx".to_owned(),
+                ],
+                url,
+            )?;
             return Ok(checkout);
         }
         unreachable!("non-git checkout paths are returned above")
@@ -1273,6 +1283,15 @@ mod tests {
                         "reset".to_owned(),
                         "--hard".to_owned(),
                         "origin/HEAD".to_owned(),
+                    ]),
+                    environment: expected_git_environment(),
+                },
+                RecordedGitCommand {
+                    args: expected_isolated_args(vec![
+                        "-C".to_owned(),
+                        path_arg(&cache_root.join("checkout")),
+                        "clean".to_owned(),
+                        "-fdx".to_owned(),
                     ]),
                     environment: expected_git_environment(),
                 },

--- a/crates/agentenv-core/src/skills/registry_http.rs
+++ b/crates/agentenv-core/src/skills/registry_http.rs
@@ -41,6 +41,12 @@ struct HttpRegistryIndex {
     skills: Vec<SkillSearchHit>,
 }
 
+#[derive(Debug, Clone, Copy)]
+enum HttpRegistryIndexFormat {
+    Json,
+    Yaml,
+}
+
 impl HttpRegistryAdapter {
     pub(crate) fn new(
         name: impl Into<String>,
@@ -131,17 +137,25 @@ impl HttpRegistryAdapter {
     }
 
     async fn read_index(&self) -> Result<HttpRegistryIndex, SkillError> {
+        self.read_index_with_format()
+            .await
+            .map(|(index, _format)| index)
+    }
+
+    async fn read_index_with_format(
+        &self,
+    ) -> Result<(HttpRegistryIndex, HttpRegistryIndexFormat), SkillError> {
         if let Some(content) = self.get_optional_text(self.index_json_url()?).await? {
             let mut index: HttpRegistryIndex =
                 serde_json::from_str(&content).map_err(|source| SkillError::InvalidConfig {
                     message: format!("failed to parse HTTP registry index JSON: {source}"),
                 })?;
             self.validate_index(&mut index)?;
-            return Ok(index);
+            return Ok((index, HttpRegistryIndexFormat::Json));
         }
 
         let Some(content) = self.get_optional_text(self.index_yaml_url()?).await? else {
-            return Ok(HttpRegistryIndex::default());
+            return Ok((HttpRegistryIndex::default(), HttpRegistryIndexFormat::Yaml));
         };
         let mut index: HttpRegistryIndex =
             serde_yaml::from_str(&content).map_err(|source| SkillError::Yaml {
@@ -149,7 +163,7 @@ impl HttpRegistryAdapter {
                 source,
             })?;
         self.validate_index(&mut index)?;
-        Ok(index)
+        Ok((index, HttpRegistryIndexFormat::Yaml))
     }
 
     fn validate_index(&self, index: &mut HttpRegistryIndex) -> Result<(), SkillError> {
@@ -159,14 +173,31 @@ impl HttpRegistryAdapter {
         Ok(())
     }
 
-    async fn write_index(&self, mut index: HttpRegistryIndex) -> Result<(), SkillError> {
+    async fn write_index(
+        &self,
+        mut index: HttpRegistryIndex,
+        format: HttpRegistryIndexFormat,
+    ) -> Result<(), SkillError> {
         sort_hits(&mut index.skills);
-        let content = serde_yaml::to_string(&index).map_err(|source| SkillError::Serde {
-            path: PathBuf::from(INDEX_YAML_FILE),
-            source,
-        })?;
-        self.put_bytes(self.index_yaml_url()?, content.into_bytes())
-            .await
+        match format {
+            HttpRegistryIndexFormat::Json => {
+                let content = serde_json::to_vec_pretty(&index).map_err(|source| {
+                    SkillError::InvalidConfig {
+                        message: format!("failed to serialize HTTP registry index JSON: {source}"),
+                    }
+                })?;
+                self.put_bytes(self.index_json_url()?, content).await
+            }
+            HttpRegistryIndexFormat::Yaml => {
+                let content =
+                    serde_yaml::to_string(&index).map_err(|source| SkillError::Serde {
+                        path: PathBuf::from(INDEX_YAML_FILE),
+                        source,
+                    })?;
+                self.put_bytes(self.index_yaml_url()?, content.into_bytes())
+                    .await
+            }
+        }
     }
 
     fn validate_hit(&self, hit: &mut SkillSearchHit) -> Result<(), SkillError> {
@@ -429,7 +460,7 @@ impl RegistryAdapter for HttpRegistryAdapter {
         verify_publish_signature(&manifest, &digest, allow_unsigned)?;
         let version = manifest.version.to_string();
         let hit = self.hit_for_manifest(&manifest, digest.clone());
-        let mut index = self.read_index().await?;
+        let (mut index, index_format) = self.read_index_with_format().await?;
 
         if let Some(existing) = index
             .skills
@@ -465,7 +496,7 @@ impl RegistryAdapter for HttpRegistryAdapter {
             .skills
             .retain(|existing| existing.name != hit.name || existing.version != hit.version);
         index.skills.push(hit.clone());
-        self.write_index(index).await?;
+        self.write_index(index, index_format).await?;
         Ok(hit)
     }
 }

--- a/crates/agentenv-core/src/skills/registry_http.rs
+++ b/crates/agentenv-core/src/skills/registry_http.rs
@@ -14,14 +14,15 @@ use crate::security::ssrf::{validate_outbound, SsrfOptions};
 
 use super::{
     compute_bundle_digest,
-    manifest::{load_remote_skill_manifest, validated_bundle_file},
+    manifest::{load_remote_skill_manifest, normalize_bundle_path, validated_bundle_file},
     validate_skill_name, verify_ed25519_signature, FetchedSkill, RegistryAdapter, SkillError,
     SkillManifest, SkillSearchHit,
 };
 
 const BUNDLES_DIR: &str = "bundles";
 const CONTENT_DIR: &str = "content";
-const INDEX_FILE: &str = "index.yaml";
+const INDEX_JSON_FILE: &str = "index.json";
+const INDEX_YAML_FILE: &str = "index.yaml";
 const MANIFEST_FILE: &str = "skill.yaml";
 const SOURCE_TYPE: &str = "http";
 
@@ -69,12 +70,20 @@ impl HttpRegistryAdapter {
         })
     }
 
-    fn index_url(&self) -> Result<Url, SkillError> {
-        self.url_for(&[INDEX_FILE])
+    fn index_json_url(&self) -> Result<Url, SkillError> {
+        self.url_for(&[INDEX_JSON_FILE])
+    }
+
+    fn index_yaml_url(&self) -> Result<Url, SkillError> {
+        self.url_for(&[INDEX_YAML_FILE])
     }
 
     fn manifest_url(&self, name: &str, version: &str) -> Result<Url, SkillError> {
         self.url_for(&[BUNDLES_DIR, name, version, MANIFEST_FILE])
+    }
+
+    fn tarball_url(&self, name: &str, version: &str) -> Result<Url, SkillError> {
+        self.url_for(&["skills", name, &format!("{version}.tar.zst")])
     }
 
     fn content_url(
@@ -122,28 +131,41 @@ impl HttpRegistryAdapter {
     }
 
     async fn read_index(&self) -> Result<HttpRegistryIndex, SkillError> {
-        let url = self.index_url()?;
-        let Some(content) = self.get_optional_text(url).await? else {
+        if let Some(content) = self.get_optional_text(self.index_json_url()?).await? {
+            let mut index: HttpRegistryIndex =
+                serde_json::from_str(&content).map_err(|source| SkillError::InvalidConfig {
+                    message: format!("failed to parse HTTP registry index JSON: {source}"),
+                })?;
+            self.validate_index(&mut index)?;
+            return Ok(index);
+        }
+
+        let Some(content) = self.get_optional_text(self.index_yaml_url()?).await? else {
             return Ok(HttpRegistryIndex::default());
         };
         let mut index: HttpRegistryIndex =
             serde_yaml::from_str(&content).map_err(|source| SkillError::Yaml {
-                path: PathBuf::from(INDEX_FILE),
+                path: PathBuf::from(INDEX_YAML_FILE),
                 source,
             })?;
+        self.validate_index(&mut index)?;
+        Ok(index)
+    }
+
+    fn validate_index(&self, index: &mut HttpRegistryIndex) -> Result<(), SkillError> {
         for hit in &mut index.skills {
             self.validate_hit(hit)?;
         }
-        Ok(index)
+        Ok(())
     }
 
     async fn write_index(&self, mut index: HttpRegistryIndex) -> Result<(), SkillError> {
         sort_hits(&mut index.skills);
         let content = serde_yaml::to_string(&index).map_err(|source| SkillError::Serde {
-            path: PathBuf::from(INDEX_FILE),
+            path: PathBuf::from(INDEX_YAML_FILE),
             source,
         })?;
-        self.put_bytes(self.index_url()?, content.into_bytes())
+        self.put_bytes(self.index_yaml_url()?, content.into_bytes())
             .await
     }
 
@@ -239,6 +261,26 @@ impl HttpRegistryAdapter {
             })
     }
 
+    async fn get_optional_bytes(&self, url: Url) -> Result<Option<Vec<u8>>, SkillError> {
+        let url_text = url.to_string();
+        let response = self
+            .request(Method::GET, url.clone(), None)
+            .await
+            .map_err(|source| map_request_error(url_text.clone(), source))?;
+        if response.status() == reqwest::StatusCode::NOT_FOUND {
+            return Ok(None);
+        }
+        ensure_success(&url, response.status())?;
+        response
+            .bytes()
+            .await
+            .map(|bytes| Some(bytes.to_vec()))
+            .map_err(|source| SkillError::HttpRegistry {
+                url: url.to_string(),
+                source: Box::new(source),
+            })
+    }
+
     async fn get_bytes(&self, url: Url) -> Result<Vec<u8>, SkillError> {
         let response = self.request(Method::GET, url.clone(), None).await?;
         ensure_success(&url, response.status())?;
@@ -250,6 +292,38 @@ impl HttpRegistryAdapter {
                 url: url.to_string(),
                 source: Box::new(source),
             })
+    }
+
+    async fn fetch_expanded_bundle(
+        &self,
+        hit: &SkillSearchHit,
+        staging_path: &Path,
+    ) -> Result<(), SkillError> {
+        let manifest_url = self.manifest_url(&hit.name, &hit.version)?;
+        let manifest_content = self.get_text(manifest_url).await?;
+        let remote_manifest =
+            load_remote_skill_manifest(&manifest_content, Path::new(MANIFEST_FILE))?;
+        if remote_manifest.name != hit.name || remote_manifest.version.to_string() != hit.version {
+            return Err(SkillError::InvalidConfig {
+                message: format!(
+                    "HTTP registry index selected `{}` version `{}`, but manifest is `{}` version `{}`",
+                    hit.name, hit.version, remote_manifest.name, remote_manifest.version
+                ),
+            });
+        }
+        write_file(
+            &staging_path.join(MANIFEST_FILE),
+            manifest_content.as_bytes(),
+        )?;
+
+        for declared_file in &remote_manifest.declared_files {
+            let content = self
+                .get_bytes(self.content_url(&hit.name, &hit.version, declared_file)?)
+                .await?;
+            write_file(&staging_path.join(declared_file), &content)?;
+        }
+
+        Ok(())
     }
 
     async fn put_bytes(&self, url: Url, body: Vec<u8>) -> Result<(), SkillError> {
@@ -308,31 +382,24 @@ impl RegistryAdapter for HttpRegistryAdapter {
             source,
         })?;
 
-        let manifest_url = self.manifest_url(&hit.name, &hit.version)?;
-        let manifest_content = self.get_text(manifest_url).await?;
-        let remote_manifest =
-            load_remote_skill_manifest(&manifest_content, Path::new(MANIFEST_FILE))?;
-        if remote_manifest.name != hit.name || remote_manifest.version.to_string() != hit.version {
-            return Err(SkillError::InvalidConfig {
-                message: format!(
-                    "HTTP registry index selected `{}` version `{}`, but manifest is `{}` version `{}`",
-                    hit.name, hit.version, remote_manifest.name, remote_manifest.version
-                ),
-            });
-        }
-        write_file(
-            &staging_path.join(MANIFEST_FILE),
-            manifest_content.as_bytes(),
-        )?;
-
-        for declared_file in &remote_manifest.declared_files {
-            let content = self
-                .get_bytes(self.content_url(&hit.name, &hit.version, declared_file)?)
-                .await?;
-            write_file(&staging_path.join(declared_file), &content)?;
+        if let Some(bytes) = self
+            .get_optional_bytes(self.tarball_url(&hit.name, &hit.version)?)
+            .await?
+        {
+            unpack_tar_zst(&bytes, &staging_path)?;
+        } else {
+            self.fetch_expanded_bundle(&hit, &staging_path).await?;
         }
 
         let manifest = super::load_skill_manifest(&staging_path)?;
+        if manifest.name != hit.name || manifest.version.to_string() != hit.version {
+            return Err(SkillError::InvalidConfig {
+                message: format!(
+                    "HTTP registry index selected `{}` version `{}`, but manifest is `{}` version `{}`",
+                    hit.name, hit.version, manifest.name, manifest.version
+                ),
+            });
+        }
         let digest = compute_bundle_digest(&staging_path, &manifest)?;
         if let Some(expected) = hit.digest.as_deref() {
             if expected != digest {
@@ -401,6 +468,56 @@ impl RegistryAdapter for HttpRegistryAdapter {
         self.write_index(index).await?;
         Ok(hit)
     }
+}
+
+fn unpack_tar_zst(bytes: &[u8], destination: &Path) -> Result<(), SkillError> {
+    let decoder = zstd::stream::read::Decoder::new(bytes).map_err(|source| SkillError::Io {
+        path: destination.to_path_buf(),
+        source,
+    })?;
+    let mut archive = tar::Archive::new(decoder);
+    let entries = archive.entries().map_err(|source| SkillError::Io {
+        path: destination.to_path_buf(),
+        source,
+    })?;
+
+    for entry in entries {
+        let mut entry = entry.map_err(|source| SkillError::Io {
+            path: destination.to_path_buf(),
+            source,
+        })?;
+        let entry_path = entry
+            .path()
+            .map_err(|source| SkillError::Io {
+                path: destination.to_path_buf(),
+                source,
+            })?
+            .into_owned();
+        let normalized = normalize_bundle_path(&entry_path)?;
+        let target = destination.join(normalized);
+        let entry_type = entry.header().entry_type();
+        if entry_type.is_dir() {
+            fs::create_dir_all(&target).map_err(|source| SkillError::Io {
+                path: target,
+                source,
+            })?;
+        } else if entry_type.is_file() {
+            if let Some(parent) = target.parent() {
+                fs::create_dir_all(parent).map_err(|source| SkillError::Io {
+                    path: parent.to_path_buf(),
+                    source,
+                })?;
+            }
+            entry.unpack(&target).map_err(|source| SkillError::Io {
+                path: target,
+                source,
+            })?;
+        } else {
+            return Err(SkillError::UnsafeBundlePath { path: entry_path });
+        }
+    }
+
+    Ok(())
 }
 
 fn validate_registry_url(url: &Url, options: &SsrfOptions) -> Result<(), SkillError> {

--- a/crates/agentenv-core/src/skills/registry_http.rs
+++ b/crates/agentenv-core/src/skills/registry_http.rs
@@ -92,6 +92,10 @@ impl HttpRegistryAdapter {
         self.url_for(&["skills", name, &format!("{version}.tar.zst")])
     }
 
+    fn tarball_signature_url(&self, name: &str, version: &str) -> Result<Url, SkillError> {
+        self.url_for(&["skills", name, &format!("{version}.tar.zst.sig")])
+    }
+
     fn content_url(
         &self,
         name: &str,
@@ -155,7 +159,7 @@ impl HttpRegistryAdapter {
         }
 
         let Some(content) = self.get_optional_text(self.index_yaml_url()?).await? else {
-            return Ok((HttpRegistryIndex::default(), HttpRegistryIndexFormat::Yaml));
+            return Ok((HttpRegistryIndex::default(), HttpRegistryIndexFormat::Json));
         };
         let mut index: HttpRegistryIndex =
             serde_yaml::from_str(&content).map_err(|source| SkillError::Yaml {
@@ -357,6 +361,53 @@ impl HttpRegistryAdapter {
         Ok(())
     }
 
+    async fn verify_tarball_signature_sidecar(
+        &self,
+        hit: &SkillSearchHit,
+        manifest: &SkillManifest,
+        digest: &str,
+    ) -> Result<(), SkillError> {
+        if hit.signature_ed25519.is_none() && hit.public_key_ed25519.is_none() {
+            return Ok(());
+        }
+
+        let public_key =
+            hit.public_key_ed25519
+                .as_deref()
+                .ok_or_else(|| SkillError::MissingSignature {
+                    name: hit.name.clone(),
+                    version: hit.version.clone(),
+                })?;
+        let signature_bytes = self
+            .get_bytes(self.tarball_signature_url(&hit.name, &hit.version)?)
+            .await?;
+        let signature = std::str::from_utf8(&signature_bytes)
+            .map_err(|source| SkillError::InvalidSignature {
+                name: hit.name.clone(),
+                version: hit.version.clone(),
+                message: format!("signature sidecar is not valid UTF-8: {source}"),
+            })?
+            .trim();
+        if signature.is_empty() {
+            return Err(SkillError::InvalidSignature {
+                name: hit.name.clone(),
+                version: hit.version.clone(),
+                message: "signature sidecar is empty".to_owned(),
+            });
+        }
+        if let Some(index_signature) = hit.signature_ed25519.as_deref() {
+            if index_signature != signature {
+                return Err(SkillError::InvalidSignature {
+                    name: hit.name.clone(),
+                    version: hit.version.clone(),
+                    message: "signature sidecar does not match index signature".to_owned(),
+                });
+            }
+        }
+
+        verify_ed25519_signature(manifest, digest, signature, public_key)
+    }
+
     async fn put_bytes(&self, url: Url, body: Vec<u8>) -> Result<(), SkillError> {
         let response = self.request(Method::PUT, url.clone(), Some(body)).await?;
         ensure_success(&url, response.status())
@@ -413,14 +464,16 @@ impl RegistryAdapter for HttpRegistryAdapter {
             source,
         })?;
 
-        if let Some(bytes) = self
+        let used_tarball = if let Some(bytes) = self
             .get_optional_bytes(self.tarball_url(&hit.name, &hit.version)?)
             .await?
         {
             unpack_tar_zst(&bytes, &staging_path)?;
+            true
         } else {
             self.fetch_expanded_bundle(&hit, &staging_path).await?;
-        }
+            false
+        };
 
         let manifest = super::load_skill_manifest(&staging_path)?;
         if manifest.name != hit.name || manifest.version.to_string() != hit.version {
@@ -439,6 +492,10 @@ impl RegistryAdapter for HttpRegistryAdapter {
                     actual: digest,
                 });
             }
+        }
+        if used_tarball {
+            self.verify_tarball_signature_sidecar(&hit, &manifest, &digest)
+                .await?;
         }
 
         Ok(FetchedSkill {

--- a/crates/agentenv-core/src/skills/service.rs
+++ b/crates/agentenv-core/src/skills/service.rs
@@ -230,6 +230,7 @@ impl SkillService {
                 )?))
             }
             RegistryKind::Git => {
+                validate_skill_name(&registry.name)?;
                 let url = registry
                     .url
                     .clone()
@@ -243,6 +244,7 @@ impl SkillService {
                         .join("cache")
                         .join("skill-git")
                         .join(&registry.name),
+                    self.ssrf_options.clone(),
                 )))
             }
         }

--- a/crates/agentenv-core/src/skills/service.rs
+++ b/crates/agentenv-core/src/skills/service.rs
@@ -10,7 +10,7 @@ use crate::security::ssrf::SsrfOptions;
 
 use super::{
     info_installed_skill, install_local_skill, list_installed_skills, registry_filesystem,
-    registry_http, registry_oci, remove_installed_skill, validate_skill_name,
+    registry_git, registry_http, registry_oci, remove_installed_skill, validate_skill_name,
     verify_installed_skill, InstalledSkill, InstalledSkillSelector, RegistryAdapter,
     RegistryConfig, RegistryKind, SkillError, SkillInstallOptions, SkillSearchHit, SkillsConfig,
 };
@@ -228,6 +228,18 @@ impl SkillService {
                     self.bearer_token_for(registry)?,
                     self.ssrf_options.clone(),
                 )?))
+            }
+            RegistryKind::Git => {
+                let url = registry
+                    .url
+                    .clone()
+                    .ok_or_else(|| SkillError::InvalidConfig {
+                        message: format!("git registry `{}` requires url", registry.name),
+                    })?;
+                Ok(Box::new(registry_git::GitRegistryAdapter::new(
+                    registry.name.clone(),
+                    url,
+                )))
             }
         }
     }

--- a/crates/agentenv-core/src/skills/service.rs
+++ b/crates/agentenv-core/src/skills/service.rs
@@ -239,6 +239,10 @@ impl SkillService {
                 Ok(Box::new(registry_git::GitRegistryAdapter::new(
                     registry.name.clone(),
                     url,
+                    self.root
+                        .join("cache")
+                        .join("skill-git")
+                        .join(&registry.name),
                 )))
             }
         }

--- a/crates/agentenv-core/src/skills/service.rs
+++ b/crates/agentenv-core/src/skills/service.rs
@@ -5,6 +5,7 @@ use std::{
 };
 
 use semver::Version;
+use sha2::{Digest, Sha256};
 
 use crate::security::ssrf::SsrfOptions;
 
@@ -225,11 +226,8 @@ impl SkillService {
                     })?;
                 Ok(Box::new(registry_git::GitRegistryAdapter::new(
                     registry.name.clone(),
-                    url,
-                    self.root
-                        .join("cache")
-                        .join("skill-git")
-                        .join(&registry.name),
+                    url.clone(),
+                    git_cache_root(&self.root, &registry.name, &url)?,
                     self.ssrf_options.clone(),
                 )))
             }
@@ -344,6 +342,56 @@ fn source_label_for_fetched(fetched: &FetchedSkill) -> String {
     )
 }
 
+fn git_cache_root(root: &Path, registry_name: &str, url: &str) -> Result<PathBuf, SkillError> {
+    let url_digest = git_cache_url_digest(url);
+    ensure_owned_directory_path(root, &["cache", "skill-git", registry_name, &url_digest])
+}
+
+fn git_cache_url_digest(url: &str) -> String {
+    let digest = Sha256::digest(url.as_bytes());
+    hex::encode(&digest[..8])
+}
+
+fn ensure_owned_directory_path(root: &Path, components: &[&str]) -> Result<PathBuf, SkillError> {
+    ensure_owned_directory(root)?;
+    let mut path = root.to_path_buf();
+    for component in components {
+        path.push(component);
+        ensure_owned_directory(&path)?;
+    }
+    Ok(path)
+}
+
+fn ensure_owned_directory(path: &Path) -> Result<(), SkillError> {
+    match fs::symlink_metadata(path) {
+        Ok(metadata) if metadata.file_type().is_dir() => Ok(()),
+        Ok(_) => Err(SkillError::UnsafeBundlePath {
+            path: path.to_path_buf(),
+        }),
+        Err(source) if source.kind() == std::io::ErrorKind::NotFound => {
+            fs::create_dir(path).map_err(|source| SkillError::Io {
+                path: path.to_path_buf(),
+                source,
+            })?;
+            let metadata = fs::symlink_metadata(path).map_err(|source| SkillError::Io {
+                path: path.to_path_buf(),
+                source,
+            })?;
+            if metadata.file_type().is_dir() {
+                Ok(())
+            } else {
+                Err(SkillError::UnsafeBundlePath {
+                    path: path.to_path_buf(),
+                })
+            }
+        }
+        Err(source) => Err(SkillError::Io {
+            path: path.to_path_buf(),
+            source,
+        }),
+    }
+}
+
 fn sort_hits(hits: &mut [SkillSearchHit]) {
     hits.sort_by(|left, right| {
         left.name
@@ -420,6 +468,42 @@ mod tests {
         assert_eq!(installed.source_type, "git");
         assert_eq!(installed.source_label, "git:git-dev:provenance-git@0.4.0");
         assert!(!bundle.exists());
+    }
+
+    #[test]
+    fn git_cache_root_changes_when_registry_url_changes() {
+        let root = temp_dir("skill-service-git-cache-url").join(".agentenv");
+
+        let first =
+            git_cache_root(&root, "git-dev", "git+https://github.com/acme/skills-one").unwrap();
+        let second =
+            git_cache_root(&root, "git-dev", "git+https://github.com/acme/skills-two").unwrap();
+
+        assert_ne!(first, second);
+        assert_eq!(
+            first.parent().and_then(Path::file_name),
+            Some(std::ffi::OsStr::new("git-dev"))
+        );
+        assert_eq!(
+            second.parent().and_then(Path::file_name),
+            Some(std::ffi::OsStr::new("git-dev"))
+        );
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn git_cache_root_rejects_symlinked_cache_parent() {
+        let home = temp_dir("skill-service-git-cache-symlink-home");
+        let root = home.join(".agentenv");
+        let outside = temp_dir("skill-service-git-cache-symlink-outside");
+        fs::create_dir_all(&root).unwrap();
+        std::os::unix::fs::symlink(&outside, root.join("cache")).unwrap();
+
+        let error = git_cache_root(&root, "git-dev", "git+https://github.com/acme/skills")
+            .expect_err("git cache parent symlink must be rejected");
+
+        assert!(matches!(error, SkillError::UnsafeBundlePath { .. }));
+        assert!(!outside.join("skill-git").exists());
     }
 
     fn temp_dir(prefix: &str) -> PathBuf {

--- a/crates/agentenv-core/src/skills/service.rs
+++ b/crates/agentenv-core/src/skills/service.rs
@@ -11,7 +11,7 @@ use crate::security::ssrf::SsrfOptions;
 use super::{
     info_installed_skill, install_local_skill, list_installed_skills, registry_filesystem,
     registry_git, registry_http, registry_oci, remove_installed_skill, validate_skill_name,
-    verify_installed_skill, InstalledSkill, InstalledSkillSelector, RegistryAdapter,
+    verify_installed_skill, FetchedSkill, InstalledSkill, InstalledSkillSelector, RegistryAdapter,
     RegistryConfig, RegistryKind, SkillError, SkillInstallOptions, SkillSearchHit, SkillsConfig,
 };
 
@@ -81,21 +81,7 @@ impl SkillService {
             let adapter = self.adapter_for(registry)?;
             match adapter.fetch(&parsed.name, parsed.version.as_deref()).await {
                 Ok(fetched) => {
-                    let source_label = format!(
-                        "{}:{}:{}@{}",
-                        fetched.source_type, fetched.registry, fetched.name, fetched.version
-                    );
-                    let installed = install_local_skill(
-                        &self.root,
-                        &fetched.staging_path,
-                        SkillInstallOptions {
-                            allow_unsigned: request.allow_unsigned,
-                            source_type: fetched.source_type.clone(),
-                            source_label,
-                        },
-                    );
-                    cleanup_staging_path(&fetched.staging_path);
-                    return installed;
+                    return self.install_fetched_skill(fetched, request.allow_unsigned);
                 }
                 Err(SkillError::SkillNotInstalled { .. }) => {
                     continue;
@@ -283,6 +269,25 @@ impl SkillService {
             })
             .map(Some)
     }
+
+    fn install_fetched_skill(
+        &self,
+        fetched: FetchedSkill,
+        allow_unsigned: bool,
+    ) -> Result<InstalledSkill, SkillError> {
+        let source_label = source_label_for_fetched(&fetched);
+        let installed = install_local_skill(
+            &self.root,
+            &fetched.staging_path,
+            SkillInstallOptions {
+                allow_unsigned,
+                source_type: fetched.source_type.clone(),
+                source_label,
+            },
+        );
+        cleanup_staging_path(&fetched.staging_path);
+        installed
+    }
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -332,6 +337,13 @@ fn cleanup_staging_path(path: &Path) {
     }
 }
 
+fn source_label_for_fetched(fetched: &FetchedSkill) -> String {
+    format!(
+        "{}:{}:{}@{}",
+        fetched.source_type, fetched.registry, fetched.name, fetched.version
+    )
+}
+
 fn sort_hits(hits: &mut [SkillSearchHit]) {
     hits.sort_by(|left, right| {
         left.name
@@ -360,4 +372,74 @@ fn default_bearer_credential_name(registry_name: &str) -> String {
         })
         .collect::<String>();
     format!("AGENTENV_SKILLS_{normalized}_TOKEN")
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn git_fetched_skill_source_label_records_registry_name_and_version() {
+        let fetched = FetchedSkill {
+            staging_path: PathBuf::from("/tmp/staged-git-skill"),
+            registry: "git-dev".to_owned(),
+            source_type: "git".to_owned(),
+            name: "provenance-git".to_owned(),
+            version: "0.4.0".to_owned(),
+        };
+
+        assert_eq!(
+            source_label_for_fetched(&fetched),
+            "git:git-dev:provenance-git@0.4.0"
+        );
+    }
+
+    #[test]
+    fn service_installs_git_fetched_skill_with_provenance_label() {
+        let root = temp_dir("skill-service-git-provenance-home").join(".agentenv");
+        let bundle = temp_dir("skill-service-git-provenance-bundle");
+        write_file(&bundle.join("SKILL.md"), "# Git provenance\n");
+        write_file(
+            &bundle.join("skill.yaml"),
+            "name: provenance-git\nversion: 0.4.0\nentry: SKILL.md\nfiles:\n  - SKILL.md\n",
+        );
+        let service = SkillService::new(&root, SkillsConfig::default());
+        let fetched = FetchedSkill {
+            staging_path: bundle.clone(),
+            registry: "git-dev".to_owned(),
+            source_type: "git".to_owned(),
+            name: "provenance-git".to_owned(),
+            version: "0.4.0".to_owned(),
+        };
+
+        let installed = service
+            .install_fetched_skill(fetched, true)
+            .expect("fetched git skill should install");
+
+        assert_eq!(installed.name, "provenance-git");
+        assert_eq!(installed.source_type, "git");
+        assert_eq!(installed.source_label, "git:git-dev:provenance-git@0.4.0");
+        assert!(!bundle.exists());
+    }
+
+    fn temp_dir(prefix: &str) -> PathBuf {
+        let mut path = std::env::temp_dir();
+        path.push(format!(
+            "{prefix}-{}-{}",
+            std::process::id(),
+            std::time::SystemTime::now()
+                .duration_since(std::time::UNIX_EPOCH)
+                .unwrap()
+                .as_nanos()
+        ));
+        fs::create_dir_all(&path).unwrap();
+        path
+    }
+
+    fn write_file(path: &Path, content: &str) {
+        if let Some(parent) = path.parent() {
+            fs::create_dir_all(parent).unwrap();
+        }
+        fs::write(path, content).unwrap();
+    }
 }

--- a/crates/agentenv-core/src/skills/store.rs
+++ b/crates/agentenv-core/src/skills/store.rs
@@ -475,7 +475,9 @@ fn cache_can_be_repaired(error: &SkillError) -> bool {
         | SkillError::HttpStatus { .. }
         | SkillError::CredentialReferenceUnavailable { .. }
         | SkillError::UnsupportedRegistryAuth { .. }
+        | SkillError::UnsupportedRegistryPublish { .. }
         | SkillError::InvalidOciReference { .. }
+        | SkillError::GitRegistry { .. }
         | SkillError::InvalidConfig { .. }
         | SkillError::SelfTestFailed { .. } => false,
     }

--- a/crates/agentenv-core/tests/skills.rs
+++ b/crates/agentenv-core/tests/skills.rs
@@ -1346,6 +1346,66 @@ async fn filesystem_registry_add_uses_scanned_subdirectory_without_index() {
 }
 
 #[tokio::test]
+async fn filesystem_registry_publish_keeps_scanned_subdirectories_ephemeral() {
+    let home = temp_dir("skill-fs-scan-ephemeral-home");
+    let registry = temp_dir("skill-fs-scan-ephemeral-registry");
+    write_file(
+        &registry.join("scan-live/skill.yaml"),
+        "name: scan-live\nversion: 0.1.0\ndescription: Before publish\nentry: SKILL.md\nfiles:\n  - SKILL.md\n",
+    );
+    write_file(&registry.join("scan-live/SKILL.md"), "# Scan live\n");
+    let service = filesystem_skill_service(&home, &registry);
+
+    service
+        .publish(SkillPublishRequest {
+            bundle_path: skill_bundle("published-skill", "0.1.0", "Published"),
+            registry: Some("local-dev".to_owned()),
+            allow_unsigned: true,
+        })
+        .await
+        .expect("publish should succeed");
+
+    write_file(
+        &registry.join("scan-live/skill.yaml"),
+        "name: scan-live\nversion: 0.1.0\ndescription: After publish\nentry: SKILL.md\nfiles:\n  - SKILL.md\n",
+    );
+
+    let hits = service
+        .search("After publish")
+        .await
+        .expect("search should use live scanned metadata");
+
+    assert_eq!(hits.len(), 1);
+    assert_eq!(hits[0].name, "scan-live");
+    let index = fs::read_to_string(registry.join("index.yaml")).unwrap();
+    assert!(!index.contains("scan-live"));
+}
+
+#[tokio::test]
+async fn filesystem_registry_rejects_duplicate_scanned_skill_versions() {
+    let home = temp_dir("skill-fs-scan-duplicate-home");
+    let registry = temp_dir("skill-fs-scan-duplicate-registry");
+    write_file(
+        &registry.join("first/skill.yaml"),
+        "name: duplicate-scan\nversion: 0.1.0\ndescription: First duplicate\nentry: SKILL.md\nfiles:\n  - SKILL.md\n",
+    );
+    write_file(&registry.join("first/SKILL.md"), "# First duplicate\n");
+    write_file(
+        &registry.join("second/skill.yaml"),
+        "name: duplicate-scan\nversion: 0.1.0\ndescription: Second duplicate\nentry: SKILL.md\nfiles:\n  - SKILL.md\n",
+    );
+    write_file(&registry.join("second/SKILL.md"), "# Second duplicate\n");
+    let service = filesystem_skill_service(&home, &registry);
+
+    let error = service
+        .search("duplicate")
+        .await
+        .expect_err("duplicate scanned skill versions must be rejected");
+
+    assert!(matches!(error, SkillError::InvalidConfig { .. }));
+}
+
+#[tokio::test]
 async fn skill_service_add_without_version_installs_highest_semver() {
     let home = temp_dir("skill-fs-highest-home");
     let registry = temp_dir("skill-fs-highest-registry");

--- a/crates/agentenv-core/tests/skills.rs
+++ b/crates/agentenv-core/tests/skills.rs
@@ -941,6 +941,76 @@ auth = "bearer-from-credstore:CORP_SKILLS_TOKEN"
 }
 
 #[test]
+fn skills_config_loads_git_registry_from_project_yaml() {
+    let yaml = r#"
+skills:
+  registries:
+    - name: git-dev
+      type: git
+      url: git+https://github.com/acme/skills
+"#;
+
+    let config = load_project_skills_config(yaml).unwrap();
+
+    assert_eq!(config.registries[0].name, "git-dev");
+    assert_eq!(config.registries[0].kind, RegistryKind::Git);
+    assert_eq!(
+        config.registries[0].url.as_deref(),
+        Some("git+https://github.com/acme/skills")
+    );
+}
+
+#[test]
+fn skills_config_loads_git_registry_from_user_toml() {
+    let toml = r#"
+[[skills.registries]]
+name = "git-dev"
+type = "git"
+url = "git+https://github.com/acme/skills"
+"#;
+
+    let config = load_user_skills_config(toml).unwrap();
+
+    assert_eq!(config.registries[0].kind, RegistryKind::Git);
+}
+
+#[test]
+fn cli_registry_override_parses_git_source() {
+    let merged = merge_skills_config(
+        SkillsConfig::default(),
+        None,
+        SkillsConfigOverride {
+            registry: Some("git+https://github.com/acme/skills".to_owned()),
+        },
+    )
+    .unwrap();
+
+    assert_eq!(merged.registries[0].name, "cli");
+    assert_eq!(merged.registries[0].kind, RegistryKind::Git);
+    assert_eq!(merged.registry_order, vec!["cli"]);
+}
+
+#[test]
+fn skills_config_rejects_unsafe_git_registry_urls() {
+    for url in [
+        "https://github.com/acme/skills",
+        "git+ssh://github.com/acme/skills",
+        "git+https://user:pass@github.com/acme/skills",
+        "git+https://github.com/acme/skills?branch=main",
+        "git+https://github.com/acme/skills#main",
+    ] {
+        let yaml = format!(
+            "skills:\n  registries:\n    - name: git-dev\n      type: git\n      url: {url}\n"
+        );
+
+        let error = load_project_skills_config(&yaml)
+            .expect_err("unsafe git registry URL must be rejected");
+
+        assert!(matches!(error, SkillError::InvalidConfig { .. }));
+    }
+}
+
+#[test]
 fn cli_registry_override_wins_over_project_and_user_config() {
     let user = SkillsConfig {
         registries: vec![agentenv_core::skills::RegistryConfig::filesystem(

--- a/crates/agentenv-core/tests/skills.rs
+++ b/crates/agentenv-core/tests/skills.rs
@@ -1690,6 +1690,37 @@ async fn http_registry_search_reads_static_index() {
 }
 
 #[tokio::test]
+async fn http_registry_search_prefers_index_json() {
+    let server = TestHttpRegistry::start().await;
+    server
+        .add_response(
+            "GET",
+            "/index.json",
+            r#"{"skills":[{"name":"json-demo","version":"0.1.0","description":"JSON demo","registry":"ignored","digest":null,"signature_ed25519":null,"public_key_ed25519":null}]}"#,
+        )
+        .await;
+    server
+        .add_response(
+            "GET",
+            "/index.yaml",
+            "skills:\n  - name: yaml-demo\n    version: 0.1.0\n    registry: ignored\n",
+        )
+        .await;
+    let home = temp_dir("skill-http-json-home");
+    let service =
+        http_skill_service(&home, &server).with_ssrf_options(test_http_registry_ssrf_options());
+
+    let hits = service
+        .search("demo")
+        .await
+        .expect("search should use JSON");
+
+    assert_eq!(hits.len(), 1);
+    assert_eq!(hits[0].name, "json-demo");
+    assert_eq!(hits[0].registry, "http-dev");
+}
+
+#[tokio::test]
 async fn http_registry_publish_and_add_round_trip() {
     let server = TestHttpRegistry::start().await;
     server
@@ -1720,6 +1751,40 @@ async fn http_registry_publish_and_add_round_trip() {
     assert_eq!(installed.name, "http-skill");
     assert_eq!(installed.source_type, "http");
     assert_eq!(installed.source_label, "http:http-dev:http-skill@0.1.0");
+}
+
+#[tokio::test]
+async fn http_registry_add_downloads_tar_zst_skill_artifact() {
+    let server = TestHttpRegistry::start().await;
+    let bundle = skill_bundle("tarball-skill", "0.1.0", "Tarball skill");
+    let manifest = load_skill_manifest(&bundle).unwrap();
+    let digest = compute_bundle_digest(&bundle, &manifest).unwrap();
+    let index = format!(
+        r#"{{"skills":[{{"name":"tarball-skill","version":"0.1.0","description":null,"registry":"ignored","digest":"{digest}","signature_ed25519":null,"public_key_ed25519":null}}]}}"#
+    );
+    server.add_response("GET", "/index.json", &index).await;
+    add_binary_response(
+        &server,
+        "GET",
+        "/skills/tarball-skill/0.1.0.tar.zst",
+        tar_zst_bundle_bytes(&bundle),
+    )
+    .await;
+    let home = temp_dir("skill-http-tarball-home");
+    let service =
+        http_skill_service(&home, &server).with_ssrf_options(test_http_registry_ssrf_options());
+
+    let installed = service
+        .add(SkillAddRequest {
+            handle: "tarball-skill@0.1.0".to_owned(),
+            registry: Some("http-dev".to_owned()),
+            allow_unsigned: true,
+        })
+        .await
+        .expect("add should unpack tar.zst artifact");
+
+    assert_eq!(installed.name, "tarball-skill");
+    assert_eq!(installed.source_label, "http:http-dev:tarball-skill@0.1.0");
 }
 
 #[tokio::test]
@@ -1893,6 +1958,25 @@ fn skill_bundle(name: &str, version: &str, content: &str) -> PathBuf {
     bundle
 }
 
+fn tar_zst_bundle_bytes(bundle_path: &Path) -> Vec<u8> {
+    let mut tar_bytes = Vec::new();
+    {
+        let mut builder = tar::Builder::new(&mut tar_bytes);
+        builder
+            .append_path_with_name(bundle_path.join("skill.yaml"), "skill.yaml")
+            .unwrap();
+        builder
+            .append_path_with_name(bundle_path.join("SKILL.md"), "SKILL.md")
+            .unwrap();
+        builder.finish().unwrap();
+    }
+    zstd::stream::encode_all(tar_bytes.as_slice(), 0).unwrap()
+}
+
+async fn add_binary_response(server: &TestHttpRegistry, method: &str, path: &str, body: Vec<u8>) {
+    server.add_binary_response(method, path, body).await;
+}
+
 #[derive(Clone)]
 struct TestHttpRegistry {
     addr: SocketAddr,
@@ -1957,6 +2041,14 @@ impl TestHttpRegistry {
             (method.to_owned(), path.to_owned()),
             body.as_bytes().to_vec(),
         );
+    }
+
+    async fn add_binary_response(&self, method: &str, path: &str, body: Vec<u8>) {
+        self.state
+            .lock()
+            .unwrap()
+            .responses
+            .insert((method.to_owned(), path.to_owned()), body);
     }
 
     async fn require_authorization(&self, token: &str) {

--- a/crates/agentenv-core/tests/skills.rs
+++ b/crates/agentenv-core/tests/skills.rs
@@ -1402,7 +1402,39 @@ async fn filesystem_registry_rejects_duplicate_scanned_skill_versions() {
         .await
         .expect_err("duplicate scanned skill versions must be rejected");
 
-    assert!(matches!(error, SkillError::InvalidConfig { .. }));
+    assert!(matches!(&error, SkillError::InvalidConfig { message }
+            if message.contains("duplicate-scan") && message.contains("0.1.0")));
+}
+
+#[tokio::test]
+async fn filesystem_registry_fetch_does_not_fallback_to_shadowed_scanned_directory() {
+    let home = temp_dir("skill-fs-shadow-home");
+    let registry = temp_dir("skill-fs-shadow-registry");
+    write_file(
+        &registry.join("index.yaml"),
+        "skills:\n  - name: shadowed-skill\n    version: 0.1.0\n    registry: local-dev\n",
+    );
+    write_file(
+        &registry.join("dev-copy/skill.yaml"),
+        "name: shadowed-skill\nversion: 0.1.0\nentry: SKILL.md\nfiles:\n  - SKILL.md\n",
+    );
+    write_file(
+        &registry.join("dev-copy/SKILL.md"),
+        "# Should not install\n",
+    );
+    let service = filesystem_skill_service(&home, &registry);
+
+    let error = service
+        .add(SkillAddRequest {
+            handle: "shadowed-skill@0.1.0".to_owned(),
+            registry: None,
+            allow_unsigned: true,
+        })
+        .await
+        .expect_err("indexed hit with missing bundle must not fall back to scanned directory");
+
+    assert!(matches!(error, SkillError::SkillNotInstalled { name } if name == "shadowed-skill"));
+    assert!(service.list().unwrap().is_empty());
 }
 
 #[tokio::test]

--- a/crates/agentenv-core/tests/skills.rs
+++ b/crates/agentenv-core/tests/skills.rs
@@ -1318,6 +1318,33 @@ async fn filesystem_registry_search_scans_skill_subdirectories_without_index() {
     assert_eq!(hits[0].registry, "local-dev");
 }
 
+#[cfg(unix)]
+#[tokio::test]
+async fn filesystem_registry_scan_ignores_symlinked_manifest_files() {
+    let home = temp_dir("skill-fs-scan-symlink-manifest-home");
+    let registry = temp_dir("skill-fs-scan-symlink-manifest-registry");
+    let outside = temp_dir("skill-fs-scan-symlink-manifest-outside");
+    fs::create_dir_all(registry.join("linked-manifest")).unwrap();
+    write_file(
+        &outside.join("skill.yaml"),
+        "name: linked-manifest\nversion: 0.1.0\nentry: SKILL.md\nfiles:\n  - SKILL.md\n",
+    );
+    std::os::unix::fs::symlink(
+        outside.join("skill.yaml"),
+        registry.join("linked-manifest/skill.yaml"),
+    )
+    .unwrap();
+    write_file(&registry.join("linked-manifest/SKILL.md"), "# Linked\n");
+    let service = filesystem_skill_service(&home, &registry);
+
+    let hits = service
+        .search("linked")
+        .await
+        .expect("symlinked manifests should be skipped during scan");
+
+    assert!(hits.is_empty());
+}
+
 #[tokio::test]
 async fn filesystem_registry_add_uses_scanned_subdirectory_without_index() {
     let home = temp_dir("skill-fs-scan-add-home");
@@ -1785,6 +1812,31 @@ async fn http_registry_publish_updates_existing_index_json() {
 }
 
 #[tokio::test]
+async fn http_registry_publish_defaults_missing_index_to_json() {
+    let server = TestHttpRegistry::start().await;
+    let home = temp_dir("skill-http-missing-index-json-home");
+    let service =
+        http_skill_service(&home, &server).with_ssrf_options(test_http_registry_ssrf_options());
+
+    service
+        .publish(SkillPublishRequest {
+            bundle_path: skill_bundle("json-default", "0.1.0", "JSON default"),
+            registry: Some("http-dev".to_owned()),
+            allow_unsigned: true,
+        })
+        .await
+        .expect("publish should create a new JSON index");
+
+    let index_json = server
+        .response_body("GET", "/index.json")
+        .await
+        .expect("new HTTP registries should use index.json");
+    let index: serde_json::Value = serde_json::from_slice(&index_json).unwrap();
+    assert_eq!(index["skills"][0]["name"], "json-default");
+    assert!(server.response_body("GET", "/index.yaml").await.is_none());
+}
+
+#[tokio::test]
 async fn http_registry_add_downloads_tar_zst_skill_artifact() {
     let server = TestHttpRegistry::start().await;
     let bundle = skill_bundle("tarball-skill", "0.1.0", "Tarball skill");
@@ -1816,6 +1868,93 @@ async fn http_registry_add_downloads_tar_zst_skill_artifact() {
 
     assert_eq!(installed.name, "tarball-skill");
     assert_eq!(installed.source_label, "http:http-dev:tarball-skill@0.1.0");
+}
+
+#[tokio::test]
+async fn http_registry_add_verifies_tar_zst_signature_sidecar() {
+    let server = TestHttpRegistry::start().await;
+    let bundle = skill_bundle("signed-tarball-skill", "0.1.0", "Signed tarball skill");
+    let manifest = load_skill_manifest(&bundle).unwrap();
+    let digest = compute_bundle_digest(&bundle, &manifest).unwrap();
+    let signing_key = SigningKey::from_bytes(&[42; 32]);
+    let public_key = hex::encode(signing_key.verifying_key().to_bytes());
+    let payload = agentenv_core::skills::signature_payload(&manifest, &digest).unwrap();
+    let signature = hex::encode(signing_key.sign(&payload).to_bytes());
+    let index = format!(
+        r#"{{"skills":[{{"name":"signed-tarball-skill","version":"0.1.0","description":null,"registry":"ignored","digest":"{digest}","signature_ed25519":"{signature}","public_key_ed25519":"{public_key}"}}]}}"#
+    );
+    server.add_response("GET", "/index.json", &index).await;
+    add_binary_response(
+        &server,
+        "GET",
+        "/skills/signed-tarball-skill/0.1.0.tar.zst",
+        tar_zst_bundle_bytes(&bundle),
+    )
+    .await;
+    server
+        .add_response(
+            "GET",
+            "/skills/signed-tarball-skill/0.1.0.tar.zst.sig",
+            &signature,
+        )
+        .await;
+    let home = temp_dir("skill-http-signed-tarball-home");
+    let service =
+        http_skill_service(&home, &server).with_ssrf_options(test_http_registry_ssrf_options());
+
+    let installed = service
+        .add(SkillAddRequest {
+            handle: "signed-tarball-skill@0.1.0".to_owned(),
+            registry: Some("http-dev".to_owned()),
+            allow_unsigned: true,
+        })
+        .await
+        .expect("add should verify the tar.zst signature sidecar");
+
+    assert_eq!(installed.name, "signed-tarball-skill");
+}
+
+#[tokio::test]
+async fn http_registry_add_rejects_invalid_tar_zst_signature_sidecar() {
+    let server = TestHttpRegistry::start().await;
+    let bundle = skill_bundle("bad-signature-tarball", "0.1.0", "Bad signature tarball");
+    let manifest = load_skill_manifest(&bundle).unwrap();
+    let digest = compute_bundle_digest(&bundle, &manifest).unwrap();
+    let signing_key = SigningKey::from_bytes(&[7; 32]);
+    let public_key = hex::encode(signing_key.verifying_key().to_bytes());
+    let index = format!(
+        r#"{{"skills":[{{"name":"bad-signature-tarball","version":"0.1.0","description":null,"registry":"ignored","digest":"{digest}","signature_ed25519":null,"public_key_ed25519":"{public_key}"}}]}}"#
+    );
+    server.add_response("GET", "/index.json", &index).await;
+    add_binary_response(
+        &server,
+        "GET",
+        "/skills/bad-signature-tarball/0.1.0.tar.zst",
+        tar_zst_bundle_bytes(&bundle),
+    )
+    .await;
+    server
+        .add_response(
+            "GET",
+            "/skills/bad-signature-tarball/0.1.0.tar.zst.sig",
+            "00",
+        )
+        .await;
+    let home = temp_dir("skill-http-bad-signature-tarball-home");
+    let service =
+        http_skill_service(&home, &server).with_ssrf_options(test_http_registry_ssrf_options());
+
+    let error = service
+        .add(SkillAddRequest {
+            handle: "bad-signature-tarball@0.1.0".to_owned(),
+            registry: Some("http-dev".to_owned()),
+            allow_unsigned: true,
+        })
+        .await
+        .expect_err("add should reject an invalid tar.zst signature sidecar");
+
+    assert!(matches!(error, SkillError::InvalidSignature { .. }));
+    assert!(service.list().unwrap().is_empty());
 }
 
 #[tokio::test]
@@ -2327,6 +2466,15 @@ impl TestHttpRegistry {
             .iter()
             .map(|request| request.authorization.clone())
             .collect()
+    }
+
+    async fn response_body(&self, method: &str, path: &str) -> Option<Vec<u8>> {
+        self.state
+            .lock()
+            .unwrap()
+            .responses
+            .get(&(method.to_owned(), path.to_owned()))
+            .cloned()
     }
 }
 

--- a/crates/agentenv-core/tests/skills.rs
+++ b/crates/agentenv-core/tests/skills.rs
@@ -1,6 +1,6 @@
 use std::{
     collections::BTreeMap,
-    fs,
+    fs, io,
     net::SocketAddr,
     path::{Path, PathBuf},
     sync::{Arc, Mutex},
@@ -1754,6 +1754,37 @@ async fn http_registry_publish_and_add_round_trip() {
 }
 
 #[tokio::test]
+async fn http_registry_publish_updates_existing_index_json() {
+    let server = TestHttpRegistry::start().await;
+    server
+        .add_response("GET", "/index.json", r#"{"skills":[]}"#)
+        .await;
+    let home = temp_dir("skill-http-json-publish-home");
+    let service =
+        http_skill_service(&home, &server).with_ssrf_options(test_http_registry_ssrf_options());
+
+    service
+        .publish(SkillPublishRequest {
+            bundle_path: skill_bundle("json-published", "0.1.0", "JSON publish"),
+            registry: Some("http-dev".to_owned()),
+            allow_unsigned: true,
+        })
+        .await
+        .expect("publish should update existing JSON index");
+
+    let installed = service
+        .add(SkillAddRequest {
+            handle: "json-published@0.1.0".to_owned(),
+            registry: Some("http-dev".to_owned()),
+            allow_unsigned: true,
+        })
+        .await
+        .expect("add should read updated JSON index");
+
+    assert_eq!(installed.name, "json-published");
+}
+
+#[tokio::test]
 async fn http_registry_add_downloads_tar_zst_skill_artifact() {
     let server = TestHttpRegistry::start().await;
     let bundle = skill_bundle("tarball-skill", "0.1.0", "Tarball skill");
@@ -1785,6 +1816,79 @@ async fn http_registry_add_downloads_tar_zst_skill_artifact() {
 
     assert_eq!(installed.name, "tarball-skill");
     assert_eq!(installed.source_label, "http:http-dev:tarball-skill@0.1.0");
+}
+
+#[tokio::test]
+async fn http_registry_add_rejects_tar_zst_parent_traversal_entry() {
+    let server = TestHttpRegistry::start().await;
+    let bundle = skill_bundle("unsafe-tarball-skill", "0.1.0", "Unsafe tarball skill");
+    server
+        .add_response(
+            "GET",
+            "/index.json",
+            r#"{"skills":[{"name":"unsafe-tarball-skill","version":"0.1.0","description":null,"registry":"ignored","digest":null,"signature_ed25519":null,"public_key_ed25519":null}]}"#,
+        )
+        .await;
+    add_binary_response(
+        &server,
+        "GET",
+        "/skills/unsafe-tarball-skill/0.1.0.tar.zst",
+        tar_zst_bundle_bytes_with_extra_file(&bundle, "../evil", b"evil"),
+    )
+    .await;
+    let home = temp_dir("skill-http-tarball-traversal-home");
+    let service =
+        http_skill_service(&home, &server).with_ssrf_options(test_http_registry_ssrf_options());
+
+    let error = service
+        .add(SkillAddRequest {
+            handle: "unsafe-tarball-skill@0.1.0".to_owned(),
+            registry: Some("http-dev".to_owned()),
+            allow_unsigned: true,
+        })
+        .await
+        .expect_err("add should reject unsafe tar path");
+
+    assert!(matches!(
+        error,
+        SkillError::UnsafeBundlePath { .. } | SkillError::InvalidConfig { .. }
+    ));
+    assert!(service.list().unwrap().is_empty());
+}
+
+#[tokio::test]
+async fn http_registry_add_rejects_tar_zst_symlink_entry() {
+    let server = TestHttpRegistry::start().await;
+    let bundle = skill_bundle("symlink-tarball-skill", "0.1.0", "Symlink tarball skill");
+    server
+        .add_response(
+            "GET",
+            "/index.json",
+            r#"{"skills":[{"name":"symlink-tarball-skill","version":"0.1.0","description":null,"registry":"ignored","digest":null,"signature_ed25519":null,"public_key_ed25519":null}]}"#,
+        )
+        .await;
+    add_binary_response(
+        &server,
+        "GET",
+        "/skills/symlink-tarball-skill/0.1.0.tar.zst",
+        tar_zst_bundle_bytes_with_symlink(&bundle, "linked-skill.md", "SKILL.md"),
+    )
+    .await;
+    let home = temp_dir("skill-http-tarball-symlink-home");
+    let service =
+        http_skill_service(&home, &server).with_ssrf_options(test_http_registry_ssrf_options());
+
+    let error = service
+        .add(SkillAddRequest {
+            handle: "symlink-tarball-skill@0.1.0".to_owned(),
+            registry: Some("http-dev".to_owned()),
+            allow_unsigned: true,
+        })
+        .await
+        .expect_err("add should reject tar symlink");
+
+    assert!(matches!(error, SkillError::UnsafeBundlePath { .. }));
+    assert!(service.list().unwrap().is_empty());
 }
 
 #[tokio::test]
@@ -1962,15 +2066,60 @@ fn tar_zst_bundle_bytes(bundle_path: &Path) -> Vec<u8> {
     let mut tar_bytes = Vec::new();
     {
         let mut builder = tar::Builder::new(&mut tar_bytes);
+        append_bundle_minimal_files(&mut builder, bundle_path);
+        builder.finish().unwrap();
+    }
+    zstd::stream::encode_all(tar_bytes.as_slice(), 0).unwrap()
+}
+
+fn tar_zst_bundle_bytes_with_extra_file(
+    bundle_path: &Path,
+    entry_path: &str,
+    content: &[u8],
+) -> Vec<u8> {
+    let mut tar_bytes = Vec::new();
+    {
+        let mut builder = tar::Builder::new(&mut tar_bytes);
+        append_bundle_minimal_files(&mut builder, bundle_path);
+        let mut header = tar::Header::new_gnu();
+        header.set_size(content.len() as u64);
+        header.as_mut_bytes()[0..entry_path.len()].copy_from_slice(entry_path.as_bytes());
+        header.set_cksum();
+        builder.append(&header, io::Cursor::new(content)).unwrap();
+        builder.finish().unwrap();
+    }
+    zstd::stream::encode_all(tar_bytes.as_slice(), 0).unwrap()
+}
+
+fn tar_zst_bundle_bytes_with_symlink(
+    bundle_path: &Path,
+    entry_path: &str,
+    target_path: &str,
+) -> Vec<u8> {
+    let mut tar_bytes = Vec::new();
+    {
+        let mut builder = tar::Builder::new(&mut tar_bytes);
+        append_bundle_minimal_files(&mut builder, bundle_path);
+        let mut header = tar::Header::new_gnu();
+        header.set_entry_type(tar::EntryType::Symlink);
+        header.set_size(0);
+        header.set_link_name(target_path).unwrap();
+        header.set_cksum();
         builder
-            .append_path_with_name(bundle_path.join("skill.yaml"), "skill.yaml")
-            .unwrap();
-        builder
-            .append_path_with_name(bundle_path.join("SKILL.md"), "SKILL.md")
+            .append_data(&mut header, entry_path, io::empty())
             .unwrap();
         builder.finish().unwrap();
     }
     zstd::stream::encode_all(tar_bytes.as_slice(), 0).unwrap()
+}
+
+fn append_bundle_minimal_files<W: io::Write>(builder: &mut tar::Builder<W>, bundle_path: &Path) {
+    builder
+        .append_path_with_name(bundle_path.join("skill.yaml"), "skill.yaml")
+        .unwrap();
+    builder
+        .append_path_with_name(bundle_path.join("SKILL.md"), "SKILL.md")
+        .unwrap();
 }
 
 async fn add_binary_response(server: &TestHttpRegistry, method: &str, path: &str, body: Vec<u8>) {

--- a/crates/agentenv-core/tests/skills.rs
+++ b/crates/agentenv-core/tests/skills.rs
@@ -2043,6 +2043,35 @@ async fn git_registry_publish_is_reported_as_unsupported() {
     ));
 }
 
+#[tokio::test]
+async fn git_registry_rejects_invalid_registry_name_before_cache_path_use() {
+    let home = temp_dir("skill-git-invalid-registry-home");
+    let service = SkillService::new(
+        home.join(".agentenv"),
+        SkillsConfig {
+            registries: vec![agentenv_core::skills::RegistryConfig::git(
+                "../../outside",
+                "git+https://github.com/acme/skills",
+            )],
+            registry_order: vec!["../../outside".to_owned()],
+        },
+    );
+
+    let error = service
+        .publish(SkillPublishRequest {
+            bundle_path: skill_bundle("git-name-reject", "0.1.0", "Git name reject"),
+            registry: Some("../../outside".to_owned()),
+            allow_unsigned: true,
+        })
+        .await
+        .expect_err("invalid registry names must be rejected before adapter construction");
+
+    assert!(matches!(
+        error,
+        SkillError::InvalidSkillName { name } if name == "../../outside"
+    ));
+}
+
 #[cfg(windows)]
 fn self_test_file_exists_command() -> &'static str {
     "if exist SKILL.md (exit /B 0) else (exit /B 1)"

--- a/crates/agentenv-core/tests/skills.rs
+++ b/crates/agentenv-core/tests/skills.rs
@@ -1892,6 +1892,43 @@ async fn http_registry_add_rejects_tar_zst_symlink_entry() {
 }
 
 #[tokio::test]
+async fn http_registry_rejects_tarball_hardlink_entries() {
+    let server = TestHttpRegistry::start().await;
+    server
+        .add_response(
+            "GET",
+            "/index.json",
+            r#"{"skills":[{"name":"hardlink-skill","version":"0.1.0","description":null,"registry":"ignored","digest":null,"signature_ed25519":null,"public_key_ed25519":null}]}"#,
+        )
+        .await;
+    add_binary_response(
+        &server,
+        "GET",
+        "/skills/hardlink-skill/0.1.0.tar.zst",
+        tar_zst_bundle_with_hardlink("hardlink-skill", "0.1.0"),
+    )
+    .await;
+    let home = temp_dir("skill-http-tar-hardlink-home");
+    let service =
+        http_skill_service(&home, &server).with_ssrf_options(test_http_registry_ssrf_options());
+
+    let error = service
+        .add(SkillAddRequest {
+            handle: "hardlink-skill@0.1.0".to_owned(),
+            registry: Some("http-dev".to_owned()),
+            allow_unsigned: true,
+        })
+        .await
+        .expect_err("hardlink tar entries must be rejected");
+
+    assert!(matches!(
+        error,
+        SkillError::UnsafeBundlePath { .. } | SkillError::InvalidConfig { .. }
+    ));
+    assert!(service.list().unwrap().is_empty());
+}
+
+#[tokio::test]
 async fn http_registry_uses_bearer_token_from_credential_resolver() {
     let server = TestHttpRegistry::start().await;
     server.require_authorization("secret-token").await;
@@ -2107,6 +2144,25 @@ fn tar_zst_bundle_bytes_with_symlink(
         header.set_cksum();
         builder
             .append_data(&mut header, entry_path, io::empty())
+            .unwrap();
+        builder.finish().unwrap();
+    }
+    zstd::stream::encode_all(tar_bytes.as_slice(), 0).unwrap()
+}
+
+fn tar_zst_bundle_with_hardlink(name: &str, version: &str) -> Vec<u8> {
+    let bundle = skill_bundle(name, version, "Hardlink tarball skill");
+    let mut tar_bytes = Vec::new();
+    {
+        let mut builder = tar::Builder::new(&mut tar_bytes);
+        append_bundle_minimal_files(&mut builder, &bundle);
+        let mut header = tar::Header::new_gnu();
+        header.set_entry_type(tar::EntryType::Link);
+        header.set_size(0);
+        header.set_link_name("SKILL.md").unwrap();
+        header.set_cksum();
+        builder
+            .append_data(&mut header, "hardlink-skill.md", io::empty())
             .unwrap();
         builder.finish().unwrap();
     }

--- a/crates/agentenv-core/tests/skills.rs
+++ b/crates/agentenv-core/tests/skills.rs
@@ -2013,6 +2013,36 @@ async fn oci_registry_search_add_and_publish_use_distribution_api() {
     assert_eq!(installed.source_label, "oci:oci-dev:oci-skill@0.1.0");
 }
 
+#[tokio::test]
+async fn git_registry_publish_is_reported_as_unsupported() {
+    let home = temp_dir("skill-git-publish-home");
+    let service = SkillService::new(
+        home.join(".agentenv"),
+        SkillsConfig {
+            registries: vec![agentenv_core::skills::RegistryConfig::git(
+                "git-dev",
+                "git+https://github.com/acme/skills",
+            )],
+            registry_order: vec!["git-dev".to_owned()],
+        },
+    );
+
+    let error = service
+        .publish(SkillPublishRequest {
+            bundle_path: skill_bundle("git-publish", "0.1.0", "Git publish"),
+            registry: Some("git-dev".to_owned()),
+            allow_unsigned: true,
+        })
+        .await
+        .expect_err("git publish should be read-only");
+
+    assert!(matches!(
+        error,
+        SkillError::UnsupportedRegistryPublish { registry, kind }
+            if registry == "git-dev" && kind == "git"
+    ));
+}
+
 #[cfg(windows)]
 fn self_test_file_exists_command() -> &'static str {
     "if exist SKILL.md (exit /B 0) else (exit /B 1)"

--- a/crates/agentenv-core/tests/skills.rs
+++ b/crates/agentenv-core/tests/skills.rs
@@ -1300,6 +1300,52 @@ async fn filesystem_registry_search_add_and_publish_work() {
 }
 
 #[tokio::test]
+async fn filesystem_registry_search_scans_skill_subdirectories_without_index() {
+    let home = temp_dir("skill-fs-scan-home");
+    let registry = temp_dir("skill-fs-scan-registry");
+    write_file(
+        &registry.join("scan-skill/skill.yaml"),
+        "name: scan-skill\nversion: 0.2.0\ndescription: Scan demo\nentry: SKILL.md\nfiles:\n  - SKILL.md\n",
+    );
+    write_file(&registry.join("scan-skill/SKILL.md"), "# Scan demo\n");
+    let service = filesystem_skill_service(&home, &registry);
+
+    let hits = service.search("scan").await.expect("search should scan");
+
+    assert_eq!(hits.len(), 1);
+    assert_eq!(hits[0].name, "scan-skill");
+    assert_eq!(hits[0].version, "0.2.0");
+    assert_eq!(hits[0].registry, "local-dev");
+}
+
+#[tokio::test]
+async fn filesystem_registry_add_uses_scanned_subdirectory_without_index() {
+    let home = temp_dir("skill-fs-scan-add-home");
+    let registry = temp_dir("skill-fs-scan-add-registry");
+    write_file(
+        &registry.join("scan-add/skill.yaml"),
+        "name: scan-add\nversion: 0.1.0\nentry: SKILL.md\nfiles:\n  - SKILL.md\n",
+    );
+    write_file(&registry.join("scan-add/SKILL.md"), "# Scan add\n");
+    let service = filesystem_skill_service(&home, &registry);
+
+    let installed = service
+        .add(SkillAddRequest {
+            handle: "scan-add".to_owned(),
+            registry: None,
+            allow_unsigned: true,
+        })
+        .await
+        .expect("add should use scanned directory");
+
+    assert_eq!(installed.name, "scan-add");
+    assert_eq!(
+        installed.source_label,
+        "filesystem:local-dev:scan-add@0.1.0"
+    );
+}
+
+#[tokio::test]
 async fn skill_service_add_without_version_installs_highest_semver() {
     let home = temp_dir("skill-fs-highest-home");
     let registry = temp_dir("skill-fs-highest-registry");

--- a/crates/agentenv-events/src/otel.rs
+++ b/crates/agentenv-events/src/otel.rs
@@ -153,6 +153,9 @@ fn activity_kind_name(kind: ActivityKind) -> &'static str {
         ActivityKind::SpawnRejected => "spawn_rejected",
         ActivityKind::SpawnStarted => "spawn_started",
         ActivityKind::SpawnReady => "spawn_ready",
+        ActivityKind::BuildOneflightHit => "build_oneflight_hit",
+        ActivityKind::BuildOneflightMiss => "build_oneflight_miss",
+        ActivityKind::BuildQueueDepth => "build_queue_depth",
         ActivityKind::Log => "log",
     }
 }
@@ -182,5 +185,21 @@ mod tests {
         assert_eq!(mapped["agentenv.reason_code"], "created");
         assert_eq!(mapped["agentenv.trace_id"], "trace-otel");
         assert_eq!(mapped["agentenv.latency_ms"], "42");
+    }
+
+    #[test]
+    fn maps_build_activity_kinds_to_otel_names() {
+        assert_eq!(
+            activity_kind_name(ActivityKind::BuildOneflightHit),
+            "build_oneflight_hit"
+        );
+        assert_eq!(
+            activity_kind_name(ActivityKind::BuildOneflightMiss),
+            "build_oneflight_miss"
+        );
+        assert_eq!(
+            activity_kind_name(ActivityKind::BuildQueueDepth),
+            "build_queue_depth"
+        );
     }
 }

--- a/crates/agentenv/tests/cli_behavior.rs
+++ b/crates/agentenv/tests/cli_behavior.rs
@@ -1272,7 +1272,7 @@ fn skills_search_accepts_git_registry_override_syntax() {
         "stderr was: {stderr}"
     );
     assert!(
-        stderr.contains("blocked by SSRF policy") || stderr.contains("git registry"),
+        stderr.contains("blocked by SSRF policy"),
         "stderr was: {stderr}"
     );
 }

--- a/crates/agentenv/tests/cli_behavior.rs
+++ b/crates/agentenv/tests/cli_behavior.rs
@@ -1251,6 +1251,33 @@ fn skills_registry_cli_path_override_publishes_searches_and_adds() {
 }
 
 #[test]
+fn skills_search_accepts_git_registry_override_syntax() {
+    let temp_dir = make_temp_dir("skills-cli-git-registry-override");
+
+    let search = Command::new(agentenv_bin())
+        .arg("skills")
+        .arg("search")
+        .arg("registry")
+        .arg("--registry")
+        .arg("git+https://127.0.0.1/acme/skills")
+        .env("HOME", &temp_dir)
+        .current_dir(&temp_dir)
+        .output()
+        .unwrap();
+
+    assert!(!search.status.success());
+    let stderr = String::from_utf8_lossy(&search.stderr);
+    assert!(
+        !stderr.contains("unsupported registry URL scheme"),
+        "stderr was: {stderr}"
+    );
+    assert!(
+        stderr.contains("blocked by SSRF policy") || stderr.contains("git registry"),
+        "stderr was: {stderr}"
+    );
+}
+
+#[test]
 fn skills_registry_config_precedence_is_user_project_then_cli() {
     let temp_dir = make_temp_dir("skills-cli-registry-precedence");
     let user_registry = temp_dir.join("user-registry");

--- a/crates/agentenv/tests/cli_behavior.rs
+++ b/crates/agentenv/tests/cli_behavior.rs
@@ -1278,6 +1278,38 @@ fn skills_search_accepts_git_registry_override_syntax() {
 }
 
 #[test]
+fn skills_publish_reports_git_registry_override_as_read_only() {
+    let temp_dir = make_temp_dir("skills-cli-git-publish-registry-override");
+    let bundle = temp_dir.join("bundle");
+    fs::create_dir_all(&bundle).unwrap();
+    fs::write(bundle.join("SKILL.md"), "# Git Publish\n").unwrap();
+    fs::write(
+        bundle.join("skill.yaml"),
+        "name: git-publish-cli\nversion: 0.1.0\ndescription: Git publish CLI\nentry: SKILL.md\nfiles:\n  - SKILL.md\n",
+    )
+    .unwrap();
+
+    let publish = Command::new(agentenv_bin())
+        .arg("skills")
+        .arg("publish")
+        .arg(&bundle)
+        .arg("--registry")
+        .arg("git+https://127.0.0.1/acme/skills")
+        .arg("--allow-unsigned")
+        .env("HOME", &temp_dir)
+        .current_dir(&temp_dir)
+        .output()
+        .unwrap();
+
+    assert!(!publish.status.success());
+    let stderr = String::from_utf8_lossy(&publish.stderr);
+    assert!(
+        stderr.contains("registry `cli` of type `git` does not support publishing"),
+        "stderr was: {stderr}"
+    );
+}
+
+#[test]
 fn skills_registry_config_precedence_is_user_project_then_cli() {
     let temp_dir = make_temp_dir("skills-cli-registry-precedence");
     let user_registry = temp_dir.join("user-registry");

--- a/crates/agentenv/tests/cli_behavior.rs
+++ b/crates/agentenv/tests/cli_behavior.rs
@@ -1251,6 +1251,85 @@ fn skills_registry_cli_path_override_publishes_searches_and_adds() {
 }
 
 #[test]
+fn skills_cli_filesystem_registry_scans_indexless_subdirectories_e2e() {
+    let temp_dir = make_temp_dir("skills-cli-indexless-filesystem-registry");
+    let registry = temp_dir.join("registry");
+    write_indexless_filesystem_registry_skill(
+        &registry,
+        "indexless-cli-skill",
+        "0.2.0",
+        "Indexless CLI demo",
+    );
+    fs::write(
+        temp_dir.join("agentenv.yaml"),
+        format!(
+            "skills:\n  registries:\n    - name: local-dev\n      type: filesystem\n      path: {}\n",
+            registry.display()
+        ),
+    )
+    .unwrap();
+
+    let search = Command::new(agentenv_bin())
+        .arg("skills")
+        .arg("search")
+        .arg("indexless")
+        .arg("--json")
+        .env("HOME", &temp_dir)
+        .current_dir(&temp_dir)
+        .output()
+        .unwrap();
+    assert!(search.status.success(), "{}", output_summary(&search));
+    assert_skill_search_names(&search.stdout, &["indexless-cli-skill"]);
+
+    let add = Command::new(agentenv_bin())
+        .arg("skills")
+        .arg("add")
+        .arg("indexless-cli-skill")
+        .arg("--allow-unsigned")
+        .arg("--json")
+        .env("HOME", &temp_dir)
+        .current_dir(&temp_dir)
+        .output()
+        .unwrap();
+    assert!(add.status.success(), "{}", output_summary(&add));
+    let add_json: serde_json::Value = serde_json::from_slice(&add.stdout).unwrap();
+    assert_eq!(add_json["name"], "indexless-cli-skill");
+    assert_eq!(add_json["version"], "0.2.0");
+    assert_eq!(add_json["source_type"], "filesystem");
+    assert_eq!(
+        add_json["source_label"],
+        "filesystem:local-dev:indexless-cli-skill@0.2.0"
+    );
+}
+
+#[test]
+fn skills_search_reports_http_registry_override_ssrf_block() {
+    let temp_dir = make_temp_dir("skills-cli-http-registry-override-ssrf");
+
+    let search = Command::new(agentenv_bin())
+        .arg("skills")
+        .arg("search")
+        .arg("registry")
+        .arg("--registry")
+        .arg("http://127.0.0.1:9/skills")
+        .env("HOME", &temp_dir)
+        .current_dir(&temp_dir)
+        .output()
+        .unwrap();
+
+    assert!(!search.status.success());
+    let stderr = String::from_utf8_lossy(&search.stderr);
+    assert!(
+        !stderr.contains("unsupported registry URL scheme"),
+        "stderr was: {stderr}"
+    );
+    assert!(
+        stderr.contains("blocked by SSRF policy"),
+        "stderr was: {stderr}"
+    );
+}
+
+#[test]
 fn skills_search_accepts_git_registry_override_syntax() {
     let temp_dir = make_temp_dir("skills-cli-git-registry-override");
 
@@ -1267,6 +1346,34 @@ fn skills_search_accepts_git_registry_override_syntax() {
 
     assert!(!search.status.success());
     let stderr = String::from_utf8_lossy(&search.stderr);
+    assert!(
+        !stderr.contains("unsupported registry URL scheme"),
+        "stderr was: {stderr}"
+    );
+    assert!(
+        stderr.contains("blocked by SSRF policy"),
+        "stderr was: {stderr}"
+    );
+}
+
+#[test]
+fn skills_add_accepts_git_registry_override_syntax_until_ssrf_block() {
+    let temp_dir = make_temp_dir("skills-cli-git-add-registry-override");
+
+    let add = Command::new(agentenv_bin())
+        .arg("skills")
+        .arg("add")
+        .arg("registry-skill@0.1.0")
+        .arg("--registry")
+        .arg("git+https://127.0.0.1/acme/skills")
+        .arg("--allow-unsigned")
+        .env("HOME", &temp_dir)
+        .current_dir(&temp_dir)
+        .output()
+        .unwrap();
+
+    assert!(!add.status.success());
+    let stderr = String::from_utf8_lossy(&add.stderr);
     assert!(
         !stderr.contains("unsupported registry URL scheme"),
         "stderr was: {stderr}"
@@ -4533,6 +4640,28 @@ fn write_filesystem_registry_skill(registry: &Path, name: &str, version: &str, d
         registry.join("index.yaml"),
         format!(
             "skills:\n  - name: {name}\n    version: {version}\n    description: {description}\n    registry: local\n"
+        ),
+    )
+    .unwrap();
+}
+
+fn write_indexless_filesystem_registry_skill(
+    registry: &Path,
+    name: &str,
+    version: &str,
+    description: &str,
+) {
+    let bundle = registry.join(name);
+    fs::create_dir_all(&bundle).unwrap();
+    fs::write(
+        bundle.join("SKILL.md"),
+        format!("# {description}\n\n{name}\n"),
+    )
+    .unwrap();
+    fs::write(
+        bundle.join("skill.yaml"),
+        format!(
+            "name: {name}\nversion: {version}\ndescription: {description}\nentry: SKILL.md\nfiles:\n  - SKILL.md\n"
         ),
     )
     .unwrap();

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -126,6 +126,10 @@ Core owns the skill lifecycle:
 - Expose only the selected skill bundle to the sandbox; credential values do
   not flow through skill fetching or generic driver RPC.
 
+Supported registry adapters are filesystem registries, HTTP static indexes
+(`index.yaml` or `index.json` plus `.tar.zst` bundle artifacts), OCI artifacts,
+and git repositories, all resolved by core before sandbox creation.
+
 Registry adapters are not JSON-RPC drivers. They are core-managed fetch and
 verify backends, analogous to package registries in Cargo, npm, and pip. If a
 registry adapter needs network access, its URLs pass through the SSRF validator

--- a/docs/superpowers/plans/2026-05-10-m7-4-skill-registry-backends.md
+++ b/docs/superpowers/plans/2026-05-10-m7-4-skill-registry-backends.md
@@ -1,0 +1,1524 @@
+# M7-4 Skill Registry Backends Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Complete the skill registry backend surface for filesystem, HTTP, OCI, and git on top of the current `agentenv-core::skills` service.
+
+**Architecture:** Keep skills as core-managed artifacts and preserve the existing `SkillService` plus `RegistryAdapter` boundary. Add `git` as a new adapter, make filesystem and HTTP additive-compatible with the issue layouts, and keep shared manifest/digest/install/provenance handling in the existing store and service paths.
+
+**Tech Stack:** Rust 2021, `tokio`, `async-trait`, `serde`, `serde_json`, `serde_yaml`, `reqwest` with `rustls`, `semver`, `tar`, `zstd`, std `Command` for git subprocesses.
+
+---
+
+## File Structure
+
+- Modify `Cargo.toml`: add workspace dependencies for `tar` and `zstd`.
+- Modify `crates/agentenv-core/Cargo.toml`: depend on workspace `tar` and `zstd`.
+- Modify `crates/agentenv-core/src/skills/registry.rs`: add `RegistryKind::Git` and `RegistryConfig::git`.
+- Modify `crates/agentenv-core/src/skills/config.rs`: validate `git+https://...`, parse CLI direct-source overrides, normalize git URLs.
+- Modify `crates/agentenv-core/src/skills/error.rs`: add typed git and unsupported-publish errors.
+- Modify `crates/agentenv-core/src/skills/mod.rs`: register the new git adapter module.
+- Modify `crates/agentenv-core/src/skills/service.rs`: wire `RegistryKind::Git` to `GitRegistryAdapter`.
+- Modify `crates/agentenv-core/src/skills/registry_filesystem.rs`: scan issue-compatible subdirectories when no index exists.
+- Modify `crates/agentenv-core/src/skills/registry_http.rs`: prefer `index.json`, keep `index.yaml` fallback, fetch `.tar.zst` artifacts before expanded legacy bundles.
+- Create `crates/agentenv-core/src/skills/registry_git.rs`: implement search/fetch/read-only publish for git registries.
+- Modify `crates/agentenv-core/tests/skills.rs`: add integration tests for config, filesystem scan fallback, HTTP JSON/tarball support, service-level git publish behavior, and provenance.
+- Modify `crates/agentenv/tests/cli_behavior.rs`: add CLI coverage only for behavior reachable without network or host-specific git setup.
+- Modify `docs/superpowers/specs/2026-05-10-m7-4-skill-registry-backends-design.md`: already adjusted to allow small Rust archive crates.
+
+## Task 1: Git Registry Config And Service Wiring
+
+**Files:**
+- Modify: `crates/agentenv-core/src/skills/registry.rs`
+- Modify: `crates/agentenv-core/src/skills/config.rs`
+- Modify: `crates/agentenv-core/src/skills/error.rs`
+- Modify: `crates/agentenv-core/src/skills/mod.rs`
+- Modify: `crates/agentenv-core/src/skills/service.rs`
+- Create: `crates/agentenv-core/src/skills/registry_git.rs`
+- Test: `crates/agentenv-core/tests/skills.rs`
+
+- [ ] **Step 1: Write failing config tests**
+
+Append these tests near the existing skills config tests in `crates/agentenv-core/tests/skills.rs`:
+
+```rust
+#[test]
+fn skills_config_loads_git_registry_from_project_yaml() {
+    let yaml = r#"
+skills:
+  registries:
+    - name: git-dev
+      type: git
+      url: git+https://github.com/acme/skills
+"#;
+
+    let config = load_project_skills_config(yaml).unwrap();
+
+    assert_eq!(config.registries[0].name, "git-dev");
+    assert_eq!(config.registries[0].kind, RegistryKind::Git);
+    assert_eq!(
+        config.registries[0].url.as_deref(),
+        Some("git+https://github.com/acme/skills")
+    );
+}
+
+#[test]
+fn skills_config_loads_git_registry_from_user_toml() {
+    let toml = r#"
+[[skills.registries]]
+name = "git-dev"
+type = "git"
+url = "git+https://github.com/acme/skills"
+"#;
+
+    let config = load_user_skills_config(toml).unwrap();
+
+    assert_eq!(config.registries[0].kind, RegistryKind::Git);
+}
+
+#[test]
+fn cli_registry_override_parses_git_source() {
+    let merged = merge_skills_config(
+        SkillsConfig::default(),
+        None,
+        SkillsConfigOverride {
+            registry: Some("git+https://github.com/acme/skills".to_owned()),
+        },
+    )
+    .unwrap();
+
+    assert_eq!(merged.registries[0].name, "cli");
+    assert_eq!(merged.registries[0].kind, RegistryKind::Git);
+    assert_eq!(merged.registry_order, vec!["cli"]);
+}
+
+#[test]
+fn skills_config_rejects_unsafe_git_registry_urls() {
+    for url in [
+        "https://github.com/acme/skills",
+        "git+ssh://github.com/acme/skills",
+        "git+https://user:pass@github.com/acme/skills",
+        "git+https://github.com/acme/skills?branch=main",
+        "git+https://github.com/acme/skills#main",
+    ] {
+        let yaml = format!(
+            "skills:\n  registries:\n    - name: git-dev\n      type: git\n      url: {url}\n"
+        );
+
+        let error = load_project_skills_config(&yaml)
+            .expect_err("unsafe git registry URL must be rejected");
+
+        assert!(matches!(error, SkillError::InvalidConfig { .. }));
+    }
+}
+```
+
+- [ ] **Step 2: Run the config tests and verify RED**
+
+Run:
+
+```bash
+cargo test -p agentenv-core --test skills git
+```
+
+Expected: fail to compile because `RegistryKind::Git` does not exist.
+
+- [ ] **Step 3: Add git registry config types**
+
+In `crates/agentenv-core/src/skills/registry.rs`, add the constructor and enum variant:
+
+```rust
+    pub fn git(name: impl Into<String>, url: impl Into<String>) -> Self {
+        Self {
+            name: name.into(),
+            kind: RegistryKind::Git,
+            url: Some(url.into()),
+            path: None,
+            auth: None,
+        }
+    }
+```
+
+```rust
+pub enum RegistryKind {
+    Filesystem,
+    Http,
+    Oci,
+    Git,
+}
+```
+
+- [ ] **Step 4: Add git URL parsing and validation**
+
+In `crates/agentenv-core/src/skills/config.rs`, add git direct-source parsing:
+
+```rust
+        "git+https" => Ok(Some(RegistryConfig::git(
+            CLI_REGISTRY_NAME,
+            normalize_git_url(url.as_str())?,
+        ))),
+```
+
+Update `normalize_registry_values`:
+
+```rust
+            RegistryKind::Git => {
+                if let Some(url) = registry.url.as_mut() {
+                    *url = normalize_git_url(url)?;
+                }
+            }
+```
+
+Update `validate_registry_required_fields`:
+
+```rust
+        RegistryKind::Git => {
+            let Some(url) = registry
+                .url
+                .as_deref()
+                .map(str::trim)
+                .filter(|url| !url.is_empty())
+            else {
+                return Err(invalid_config(format!(
+                    "git registry `{}` requires url",
+                    registry.name
+                )));
+            };
+            normalize_git_url(url)?;
+        }
+```
+
+Add helper:
+
+```rust
+fn normalize_git_url(value: &str) -> Result<String, SkillError> {
+    let value = value.trim();
+    let url = Url::parse(value).map_err(|source| {
+        invalid_config(format!("invalid git registry URL `{value}`: {source}"))
+    })?;
+    validate_git_url(&url)?;
+    Ok(url.to_string())
+}
+
+fn validate_git_url(url: &Url) -> Result<(), SkillError> {
+    if url.scheme() != "git+https" {
+        return Err(invalid_config(format!(
+            "git registry URL uses unsupported scheme `{}`",
+            url.scheme()
+        )));
+    }
+    if url.host_str().is_none_or(str::is_empty) {
+        return Err(invalid_config("git registry URL must include a host"));
+    }
+    if !url.username().is_empty() || url.password().is_some() {
+        return Err(invalid_config("git registry URL must not include user info"));
+    }
+    if url.query().is_some() || url.fragment().is_some() {
+        return Err(invalid_config(
+            "git registry URL must not include query or fragment",
+        ));
+    }
+    if url.path() == "/" || url.path().trim_matches('/').is_empty() {
+        return Err(invalid_config("git registry URL must include a repository path"));
+    }
+    Ok(())
+}
+```
+
+- [ ] **Step 5: Add a compiling git adapter stub and service wiring**
+
+In `crates/agentenv-core/src/skills/mod.rs`:
+
+```rust
+mod registry_git;
+```
+
+Create `crates/agentenv-core/src/skills/registry_git.rs`:
+
+```rust
+use std::path::Path;
+
+use super::{FetchedSkill, RegistryAdapter, SkillError, SkillSearchHit};
+
+const SOURCE_TYPE: &str = "git";
+
+#[derive(Debug, Clone)]
+pub(crate) struct GitRegistryAdapter {
+    name: String,
+    url: String,
+}
+
+impl GitRegistryAdapter {
+    pub(crate) fn new(name: impl Into<String>, url: impl Into<String>) -> Self {
+        Self {
+            name: name.into(),
+            url: url.into(),
+        }
+    }
+}
+
+#[async_trait::async_trait]
+impl RegistryAdapter for GitRegistryAdapter {
+    async fn search(&self, _query: &str) -> Result<Vec<SkillSearchHit>, SkillError> {
+        Err(SkillError::InvalidConfig {
+            message: format!("git registry `{}` is not implemented yet", self.name),
+        })
+    }
+
+    async fn fetch(&self, name: &str, _version: Option<&str>) -> Result<FetchedSkill, SkillError> {
+        Err(SkillError::SkillNotInstalled {
+            name: name.to_owned(),
+        })
+    }
+
+    async fn publish(
+        &self,
+        _bundle_path: &Path,
+        _allow_unsigned: bool,
+    ) -> Result<SkillSearchHit, SkillError> {
+        Err(SkillError::UnsupportedRegistryPublish {
+            registry: self.name.clone(),
+            kind: SOURCE_TYPE.to_owned(),
+        })
+    }
+}
+```
+
+In `SkillError`, add:
+
+```rust
+    #[error("registry `{registry}` of type `{kind}` does not support publishing")]
+    UnsupportedRegistryPublish { registry: String, kind: String },
+    #[error("git registry `{url}` failed: {message}")]
+    GitRegistry { url: String, message: String },
+```
+
+In `SkillService::adapter_for`, add:
+
+```rust
+            RegistryKind::Git => {
+                let url = registry
+                    .url
+                    .clone()
+                    .ok_or_else(|| SkillError::InvalidConfig {
+                        message: format!("git registry `{}` requires url", registry.name),
+                    })?;
+                Ok(Box::new(registry_git::GitRegistryAdapter::new(
+                    registry.name.clone(),
+                    url,
+                )))
+            }
+```
+
+- [ ] **Step 6: Run tests and verify GREEN**
+
+Run:
+
+```bash
+cargo test -p agentenv-core --test skills git
+```
+
+Expected: all four tests pass.
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add crates/agentenv-core/src/skills/registry.rs crates/agentenv-core/src/skills/config.rs crates/agentenv-core/src/skills/error.rs crates/agentenv-core/src/skills/mod.rs crates/agentenv-core/src/skills/service.rs crates/agentenv-core/src/skills/registry_git.rs crates/agentenv-core/tests/skills.rs
+git commit -m "feat: add git skill registry config"
+```
+
+## Task 2: Filesystem Registry Indexless Scan
+
+**Files:**
+- Modify: `crates/agentenv-core/src/skills/registry_filesystem.rs`
+- Test: `crates/agentenv-core/tests/skills.rs`
+
+- [ ] **Step 1: Write failing filesystem scan tests**
+
+Append near existing filesystem registry tests:
+
+```rust
+#[tokio::test]
+async fn filesystem_registry_search_scans_skill_subdirectories_without_index() {
+    let home = temp_dir("skill-fs-scan-home");
+    let registry = temp_dir("skill-fs-scan-registry");
+    write_file(
+        &registry.join("scan-skill/skill.yaml"),
+        "name: scan-skill\nversion: 0.2.0\ndescription: Scan demo\nentry: SKILL.md\nfiles:\n  - SKILL.md\n",
+    );
+    write_file(&registry.join("scan-skill/SKILL.md"), "# Scan demo\n");
+    let service = filesystem_skill_service(&home, &registry);
+
+    let hits = service.search("scan").await.expect("search should scan");
+
+    assert_eq!(hits.len(), 1);
+    assert_eq!(hits[0].name, "scan-skill");
+    assert_eq!(hits[0].version, "0.2.0");
+    assert_eq!(hits[0].registry, "local-dev");
+}
+
+#[tokio::test]
+async fn filesystem_registry_add_uses_scanned_subdirectory_without_index() {
+    let home = temp_dir("skill-fs-scan-add-home");
+    let registry = temp_dir("skill-fs-scan-add-registry");
+    write_file(
+        &registry.join("scan-add/skill.yaml"),
+        "name: scan-add\nversion: 0.1.0\nentry: SKILL.md\nfiles:\n  - SKILL.md\n",
+    );
+    write_file(&registry.join("scan-add/SKILL.md"), "# Scan add\n");
+    let service = filesystem_skill_service(&home, &registry);
+
+    let installed = service
+        .add(SkillAddRequest {
+            handle: "scan-add".to_owned(),
+            registry: None,
+            allow_unsigned: true,
+        })
+        .await
+        .expect("add should use scanned directory");
+
+    assert_eq!(installed.name, "scan-add");
+    assert_eq!(installed.source_label, "filesystem:local-dev:scan-add@0.1.0");
+}
+```
+
+- [ ] **Step 2: Run tests and verify RED**
+
+Run:
+
+```bash
+cargo test -p agentenv-core --test skills filesystem_registry
+```
+
+Expected: fail because `read_index` returns an empty index when `index.yaml` is absent.
+
+- [ ] **Step 3: Implement scan fallback**
+
+In `registry_filesystem.rs`, change `read_index` missing-file behavior to call a scanner:
+
+```rust
+            Err(source) if source.kind() == std::io::ErrorKind::NotFound => {
+                return self.scan_index();
+            }
+```
+
+Add these helpers:
+
+```rust
+    fn scan_index(&self) -> Result<FilesystemRegistryIndex, SkillError> {
+        let mut skills = Vec::new();
+        for entry in fs::read_dir(&self.root).map_err(|source| SkillError::Io {
+            path: self.root.clone(),
+            source,
+        })? {
+            let entry = entry.map_err(|source| SkillError::Io {
+                path: self.root.clone(),
+                source,
+            })?;
+            let path = entry.path();
+            let metadata = fs::symlink_metadata(&path).map_err(|source| SkillError::Io {
+                path: path.clone(),
+                source,
+            })?;
+            if !metadata.file_type().is_dir() {
+                continue;
+            }
+            if path.file_name().and_then(|name| name.to_str()) == Some(BUNDLES_DIR) {
+                continue;
+            }
+            let manifest_path = path.join(MANIFEST_FILE);
+            if !manifest_path.is_file() {
+                continue;
+            }
+            let manifest = super::load_skill_manifest(&path)?;
+            let digest = compute_bundle_digest(&path, &manifest)?;
+            skills.push(self.hit_for_manifest(&manifest, digest));
+        }
+        sort_hits(&mut skills);
+        Ok(FilesystemRegistryIndex { skills })
+    }
+```
+
+Update `fetch` to use a helper that can resolve either indexed `bundles/<name>/<version>` or scanned root subdirectories:
+
+```rust
+        let bundle_path = self.bundle_path_for_hit(&hit)?.ok_or_else(|| {
+            SkillError::SkillNotInstalled {
+                name: hit.name.clone(),
+            }
+        })?;
+```
+
+Add:
+
+```rust
+    fn bundle_path_for_hit(&self, hit: &SkillSearchHit) -> Result<Option<PathBuf>, SkillError> {
+        if let Some(path) = existing_child_directory(&self.root, &[BUNDLES_DIR, &hit.name, &hit.version])? {
+            return Ok(Some(path));
+        }
+        for entry in fs::read_dir(&self.root).map_err(|source| SkillError::Io {
+            path: self.root.clone(),
+            source,
+        })? {
+            let entry = entry.map_err(|source| SkillError::Io {
+                path: self.root.clone(),
+                source,
+            })?;
+            let path = entry.path();
+            if !fs::symlink_metadata(&path)
+                .map_err(|source| SkillError::Io {
+                    path: path.clone(),
+                    source,
+                })?
+                .file_type()
+                .is_dir()
+            {
+                continue;
+            }
+            if path.file_name().and_then(|name| name.to_str()) == Some(BUNDLES_DIR) {
+                continue;
+            }
+            if !path.join(MANIFEST_FILE).is_file() {
+                continue;
+            }
+            let manifest = super::load_skill_manifest(&path)?;
+            if manifest.name == hit.name && manifest.version.to_string() == hit.version {
+                return Ok(Some(path));
+            }
+        }
+        Ok(None)
+    }
+```
+
+- [ ] **Step 4: Run tests and verify GREEN**
+
+Run:
+
+```bash
+cargo test -p agentenv-core --test skills filesystem_registry
+```
+
+Expected: both tests pass.
+
+- [ ] **Step 5: Run existing filesystem tests**
+
+Run:
+
+```bash
+cargo test -p agentenv-core --test skills filesystem_registry
+```
+
+Expected: existing filesystem registry tests still pass.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add crates/agentenv-core/src/skills/registry_filesystem.rs crates/agentenv-core/tests/skills.rs
+git commit -m "feat: scan filesystem skill registries"
+```
+
+## Task 3: HTTP `index.json` And Tarball Fetch Compatibility
+
+**Files:**
+- Modify: `Cargo.toml`
+- Modify: `crates/agentenv-core/Cargo.toml`
+- Modify: `crates/agentenv-core/src/skills/registry_http.rs`
+- Test: `crates/agentenv-core/tests/skills.rs`
+
+- [ ] **Step 1: Write failing HTTP JSON index test**
+
+Append near HTTP registry tests:
+
+```rust
+#[tokio::test]
+async fn http_registry_search_prefers_index_json() {
+    let server = TestHttpRegistry::start().await;
+    server
+        .add_response(
+            "GET",
+            "/index.json",
+            r#"{"skills":[{"name":"json-demo","version":"0.1.0","description":"JSON demo","registry":"ignored","digest":null,"signature_ed25519":null,"public_key_ed25519":null}]}"#,
+        )
+        .await;
+    server
+        .add_response(
+            "GET",
+            "/index.yaml",
+            "skills:\n  - name: yaml-demo\n    version: 0.1.0\n    registry: ignored\n",
+        )
+        .await;
+    let home = temp_dir("skill-http-json-home");
+    let service =
+        http_skill_service(&home, &server).with_ssrf_options(test_http_registry_ssrf_options());
+
+    let hits = service.search("demo").await.expect("search should use JSON");
+
+    assert_eq!(hits.len(), 1);
+    assert_eq!(hits[0].name, "json-demo");
+    assert_eq!(hits[0].registry, "http-dev");
+}
+```
+
+- [ ] **Step 2: Write failing HTTP tarball fetch test**
+
+Add helper functions to `crates/agentenv-core/tests/skills.rs`:
+
+```rust
+fn tar_zst_bundle_bytes(bundle_path: &Path) -> Vec<u8> {
+    let mut tar_bytes = Vec::new();
+    {
+        let mut builder = tar::Builder::new(&mut tar_bytes);
+        builder
+            .append_path_with_name(bundle_path.join("skill.yaml"), "skill.yaml")
+            .unwrap();
+        builder
+            .append_path_with_name(bundle_path.join("SKILL.md"), "SKILL.md")
+            .unwrap();
+        builder.finish().unwrap();
+    }
+    zstd::stream::encode_all(tar_bytes.as_slice(), 0).unwrap()
+}
+
+async fn add_binary_response(server: &TestHttpRegistry, method: &str, path: &str, body: Vec<u8>) {
+    server.add_binary_response(method, path, body).await;
+}
+```
+
+Extend `TestHttpRegistry` with `add_binary_response` in the test harness:
+
+```rust
+    async fn add_binary_response(&self, method: &str, path: &str, body: Vec<u8>) {
+        self.state
+            .lock()
+            .unwrap()
+            .responses
+            .insert((method.to_owned(), path.to_owned()), body);
+    }
+```
+
+Then add the test:
+
+```rust
+#[tokio::test]
+async fn http_registry_add_downloads_tar_zst_skill_artifact() {
+    let server = TestHttpRegistry::start().await;
+    let bundle = skill_bundle("tarball-skill", "0.1.0", "Tarball skill");
+    let manifest = load_skill_manifest(&bundle).unwrap();
+    let digest = compute_bundle_digest(&bundle, &manifest).unwrap();
+    let index = format!(
+        r#"{{"skills":[{{"name":"tarball-skill","version":"0.1.0","description":null,"registry":"ignored","digest":"{digest}","signature_ed25519":null,"public_key_ed25519":null}}]}}"#
+    );
+    server.add_response("GET", "/index.json", &index).await;
+    add_binary_response(
+        &server,
+        "GET",
+        "/skills/tarball-skill/0.1.0.tar.zst",
+        tar_zst_bundle_bytes(&bundle),
+    )
+    .await;
+    let home = temp_dir("skill-http-tarball-home");
+    let service =
+        http_skill_service(&home, &server).with_ssrf_options(test_http_registry_ssrf_options());
+
+    let installed = service
+        .add(SkillAddRequest {
+            handle: "tarball-skill@0.1.0".to_owned(),
+            registry: Some("http-dev".to_owned()),
+            allow_unsigned: true,
+        })
+        .await
+        .expect("add should unpack tar.zst artifact");
+
+    assert_eq!(installed.name, "tarball-skill");
+    assert_eq!(installed.source_label, "http:http-dev:tarball-skill@0.1.0");
+}
+```
+
+- [ ] **Step 3: Run tests and verify RED**
+
+Run:
+
+```bash
+cargo test -p agentenv-core --test skills http_registry
+```
+
+Expected: first fails because HTTP reads `index.yaml`; second fails to compile until `tar` and `zstd` dependencies are added.
+
+- [ ] **Step 4: Add archive dependencies**
+
+In workspace `Cargo.toml`:
+
+```toml
+tar = "0.4"
+zstd = "0.13"
+```
+
+In `crates/agentenv-core/Cargo.toml`:
+
+```toml
+tar.workspace = true
+zstd.workspace = true
+```
+
+- [ ] **Step 5: Implement JSON index preference**
+
+In `registry_http.rs`, replace `const INDEX_FILE` with:
+
+```rust
+const INDEX_JSON_FILE: &str = "index.json";
+const INDEX_YAML_FILE: &str = "index.yaml";
+```
+
+Add:
+
+```rust
+fn index_json_url(&self) -> Result<Url, SkillError> {
+    self.url_for(&[INDEX_JSON_FILE])
+}
+
+fn index_yaml_url(&self) -> Result<Url, SkillError> {
+    self.url_for(&[INDEX_YAML_FILE])
+}
+```
+
+Update `read_index`:
+
+```rust
+    async fn read_index(&self) -> Result<HttpRegistryIndex, SkillError> {
+        if let Some(content) = self.get_optional_text(self.index_json_url()?).await? {
+            let mut index: HttpRegistryIndex =
+                serde_json::from_str(&content).map_err(|source| SkillError::InvalidConfig {
+                    message: format!("failed to parse HTTP registry index.json: {source}"),
+                })?;
+            for hit in &mut index.skills {
+                self.validate_hit(hit)?;
+            }
+            return Ok(index);
+        }
+
+        let Some(content) = self.get_optional_text(self.index_yaml_url()?).await? else {
+            return Ok(HttpRegistryIndex::default());
+        };
+        let mut index: HttpRegistryIndex =
+            serde_yaml::from_str(&content).map_err(|source| SkillError::Yaml {
+                path: PathBuf::from(INDEX_YAML_FILE),
+                source,
+            })?;
+        for hit in &mut index.skills {
+            self.validate_hit(hit)?;
+        }
+        Ok(index)
+    }
+```
+
+Keep `write_index` on YAML fallback for existing publish tests, or write both JSON and YAML if the test harness makes that cheap.
+
+- [ ] **Step 6: Implement tarball fetch before legacy expanded fetch**
+
+Add URL helper:
+
+```rust
+fn tarball_url(&self, name: &str, version: &str) -> Result<Url, SkillError> {
+    self.url_for(&["skills", name, &format!("{version}.tar.zst")])
+}
+```
+
+Add unpack helper:
+
+```rust
+fn unpack_tar_zst(bytes: &[u8], destination: &Path) -> Result<(), SkillError> {
+    let decoder = zstd::stream::read::Decoder::new(bytes).map_err(|source| {
+        SkillError::InvalidConfig {
+            message: format!("failed to decode skill tar.zst: {source}"),
+        }
+    })?;
+    let mut archive = tar::Archive::new(decoder);
+    for entry in archive.entries().map_err(|source| SkillError::InvalidConfig {
+        message: format!("failed to read skill tar entries: {source}"),
+    })? {
+        let mut entry = entry.map_err(|source| SkillError::InvalidConfig {
+            message: format!("failed to read skill tar entry: {source}"),
+        })?;
+        let path = entry.path().map_err(|source| SkillError::InvalidConfig {
+            message: format!("failed to read skill tar path: {source}"),
+        })?;
+        let relative = super::manifest::normalize_bundle_path(&path)?;
+        entry
+            .unpack(destination.join(relative))
+            .map_err(|source| SkillError::Io {
+                path: destination.to_path_buf(),
+                source,
+            })?;
+    }
+    Ok(())
+}
+```
+
+In `fetch`, before legacy manifest/content downloads:
+
+```rust
+        let tarball_url = self.tarball_url(&hit.name, &hit.version)?;
+        match self.get_optional_bytes(tarball_url).await? {
+            Some(bytes) => {
+                unpack_tar_zst(&bytes, &staging_path)?;
+            }
+            None => {
+                self.fetch_expanded_bundle(&hit, &staging_path).await?;
+            }
+        }
+```
+
+Extract the existing expanded fetch body into:
+
+```rust
+async fn fetch_expanded_bundle(
+    &self,
+    hit: &SkillSearchHit,
+    staging_path: &Path,
+) -> Result<(), SkillError> {
+    let manifest_url = self.manifest_url(&hit.name, &hit.version)?;
+    let manifest_content = self.get_text(manifest_url).await?;
+    let remote_manifest = load_remote_skill_manifest(&manifest_content, Path::new(MANIFEST_FILE))?;
+    if remote_manifest.name != hit.name || remote_manifest.version.to_string() != hit.version {
+        return Err(SkillError::InvalidConfig {
+            message: format!(
+                "HTTP registry index selected `{}` version `{}`, but manifest is `{}` version `{}`",
+                hit.name, hit.version, remote_manifest.name, remote_manifest.version
+            ),
+        });
+    }
+    write_file(&staging_path.join(MANIFEST_FILE), manifest_content.as_bytes())?;
+    for declared_file in &remote_manifest.declared_files {
+        let content = self
+            .get_bytes(self.content_url(&hit.name, &hit.version, declared_file)?)
+            .await?;
+        write_file(&staging_path.join(declared_file), &content)?;
+    }
+    Ok(())
+}
+```
+
+Add `get_optional_bytes` matching `get_optional_text`.
+
+- [ ] **Step 7: Run HTTP tests and verify GREEN**
+
+Run:
+
+```bash
+cargo test -p agentenv-core --test skills http_registry
+```
+
+Expected: all pass.
+
+- [ ] **Step 8: Commit**
+
+```bash
+git add Cargo.toml Cargo.lock crates/agentenv-core/Cargo.toml crates/agentenv-core/src/skills/registry_http.rs crates/agentenv-core/tests/skills.rs docs/superpowers/specs/2026-05-10-m7-4-skill-registry-backends-design.md
+git commit -m "feat: support http skill registry artifacts"
+```
+
+## Task 4: Git Registry Adapter Search And Fetch
+
+**Files:**
+- Modify: `crates/agentenv-core/src/skills/registry_git.rs`
+- Modify: `crates/agentenv-core/src/skills/service.rs`
+- Test: `crates/agentenv-core/src/skills/registry_git.rs`
+- Test: `crates/agentenv-core/tests/skills.rs`
+
+- [ ] **Step 1: Add unit tests with a fake checkout**
+
+Inside `registry_git.rs`, add:
+
+```rust
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::{fs, path::PathBuf, sync::Arc};
+
+    #[derive(Debug)]
+    struct StaticCheckout {
+        path: PathBuf,
+    }
+
+    impl GitCheckout for StaticCheckout {
+        fn checkout(&self, _url: &str, _cache_root: &Path) -> Result<PathBuf, SkillError> {
+            Ok(self.path.clone())
+        }
+    }
+
+    fn temp_dir(prefix: &str) -> PathBuf {
+        let mut path = std::env::temp_dir();
+        path.push(format!(
+            "{prefix}-{}-{}",
+            std::process::id(),
+            std::time::SystemTime::now()
+                .duration_since(std::time::UNIX_EPOCH)
+                .unwrap()
+                .as_nanos()
+        ));
+        fs::create_dir_all(&path).unwrap();
+        path
+    }
+
+    fn write_file(path: &Path, content: &str) {
+        if let Some(parent) = path.parent() {
+            fs::create_dir_all(parent).unwrap();
+        }
+        fs::write(path, content).unwrap();
+    }
+
+    #[tokio::test]
+    async fn git_registry_search_scans_skill_directories() {
+        let checkout = temp_dir("skill-git-search");
+        write_file(
+            &checkout.join("tools/review/skill.yaml"),
+            "name: review-skill\nversion: 0.2.0\ndescription: Review helper\nentry: SKILL.md\nfiles:\n  - SKILL.md\n",
+        );
+        write_file(&checkout.join("tools/review/SKILL.md"), "# Review\n");
+        let adapter = GitRegistryAdapter::with_checkout(
+            "git-dev",
+            "git+https://github.com/acme/skills",
+            temp_dir("skill-git-cache"),
+            Arc::new(StaticCheckout { path: checkout }),
+        );
+
+        let hits = adapter.search("review").await.unwrap();
+
+        assert_eq!(hits.len(), 1);
+        assert_eq!(hits[0].name, "review-skill");
+        assert_eq!(hits[0].version, "0.2.0");
+        assert_eq!(hits[0].registry, "git-dev");
+    }
+
+    #[tokio::test]
+    async fn git_registry_fetch_selects_highest_semver_and_copies_bundle() {
+        let checkout = temp_dir("skill-git-fetch");
+        write_file(
+            &checkout.join("old/skill.yaml"),
+            "name: versioned-git\nversion: 0.1.0\nentry: SKILL.md\nfiles:\n  - SKILL.md\n",
+        );
+        write_file(&checkout.join("old/SKILL.md"), "# Old\n");
+        write_file(
+            &checkout.join("new/skill.yaml"),
+            "name: versioned-git\nversion: 0.3.0\nentry: SKILL.md\nfiles:\n  - SKILL.md\n",
+        );
+        write_file(&checkout.join("new/SKILL.md"), "# New\n");
+        let adapter = GitRegistryAdapter::with_checkout(
+            "git-dev",
+            "git+https://github.com/acme/skills",
+            temp_dir("skill-git-cache"),
+            Arc::new(StaticCheckout { path: checkout }),
+        );
+
+        let fetched = adapter.fetch("versioned-git", None).await.unwrap();
+
+        assert_eq!(fetched.source_type, "git");
+        assert_eq!(fetched.version, "0.3.0");
+        assert!(fetched.staging_path.join("SKILL.md").is_file());
+    }
+}
+```
+
+- [ ] **Step 2: Run tests and verify RED**
+
+Run:
+
+```bash
+cargo test -p agentenv-core registry_git
+```
+
+Expected: fail to compile because `GitCheckout`, `with_checkout`, and real scanning are missing.
+
+- [ ] **Step 3: Implement checkout seam and scanning**
+
+Replace the stub in `registry_git.rs` with:
+
+```rust
+use std::{
+    cmp::Ordering,
+    fs,
+    path::{Path, PathBuf},
+    process::Command,
+    sync::Arc,
+};
+
+use semver::Version;
+
+use super::{
+    compute_bundle_digest, manifest::validated_bundle_file, validate_skill_name, FetchedSkill,
+    RegistryAdapter, SkillError, SkillManifest, SkillSearchHit,
+};
+
+const MANIFEST_FILE: &str = "skill.yaml";
+const SOURCE_TYPE: &str = "git";
+
+pub(crate) trait GitCheckout: Send + Sync + std::fmt::Debug {
+    fn checkout(&self, url: &str, cache_root: &Path) -> Result<PathBuf, SkillError>;
+}
+
+#[derive(Debug)]
+struct CommandGitCheckout;
+
+impl GitCheckout for CommandGitCheckout {
+    fn checkout(&self, url: &str, cache_root: &Path) -> Result<PathBuf, SkillError> {
+        fs::create_dir_all(cache_root).map_err(|source| SkillError::Io {
+            path: cache_root.to_path_buf(),
+            source,
+        })?;
+        let checkout = cache_root.join("checkout");
+        if checkout.join(".git").is_dir() {
+            run_git(
+                &[
+                    "-C".to_owned(),
+                    path_arg(&checkout),
+                    "fetch".to_owned(),
+                    "--all".to_owned(),
+                    "--tags".to_owned(),
+                    "--prune".to_owned(),
+                ],
+                url,
+            )?;
+            run_git(
+                &[
+                    "-C".to_owned(),
+                    path_arg(&checkout),
+                    "reset".to_owned(),
+                    "--hard".to_owned(),
+                    "origin/HEAD".to_owned(),
+                ],
+                url,
+            )?;
+        } else {
+            let clone_url = clone_url(url)?;
+            run_git(
+                &[
+                    "clone".to_owned(),
+                    "--filter=blob:none".to_owned(),
+                    "--depth=1".to_owned(),
+                    clone_url,
+                    path_arg(&checkout),
+                ],
+                url,
+            )?;
+        }
+        Ok(checkout)
+    }
+}
+
+#[derive(Debug, Clone)]
+pub(crate) struct GitRegistryAdapter {
+    name: String,
+    url: String,
+    cache_root: PathBuf,
+    checkout: Arc<dyn GitCheckout>,
+}
+
+impl GitRegistryAdapter {
+    pub(crate) fn new(
+        name: impl Into<String>,
+        url: impl Into<String>,
+        cache_root: impl Into<PathBuf>,
+    ) -> Self {
+        Self::with_checkout(name, url, cache_root, Arc::new(CommandGitCheckout))
+    }
+
+    pub(crate) fn with_checkout(
+        name: impl Into<String>,
+        url: impl Into<String>,
+        cache_root: impl Into<PathBuf>,
+        checkout: Arc<dyn GitCheckout>,
+    ) -> Self {
+        Self {
+            name: name.into(),
+            url: url.into(),
+            cache_root: cache_root.into(),
+            checkout,
+        }
+    }
+
+    fn checkout_path(&self) -> Result<PathBuf, SkillError> {
+        self.checkout.checkout(&self.url, &self.cache_root)
+    }
+
+    fn scan(&self, root: &Path) -> Result<Vec<(SkillManifest, PathBuf, String)>, SkillError> {
+        let mut found = Vec::new();
+        scan_dir(root, &mut found)?;
+        found.sort_by(|left, right| {
+            left.0
+                .name
+                .cmp(&right.0.name)
+                .then_with(|| left.0.version.cmp(&right.0.version))
+                .then_with(|| left.1.cmp(&right.1))
+        });
+        Ok(found)
+    }
+
+    fn hit_for_manifest(&self, manifest: &SkillManifest, digest: String) -> SkillSearchHit {
+        SkillSearchHit {
+            name: manifest.name.clone(),
+            version: manifest.version.to_string(),
+            description: manifest.description.clone(),
+            registry: self.name.clone(),
+            digest: Some(digest),
+            signature_ed25519: manifest.signature_ed25519.clone(),
+            public_key_ed25519: manifest.signature_public_key_ed25519.clone(),
+        }
+    }
+}
+```
+
+Add helpers:
+
+```rust
+fn scan_dir(dir: &Path, found: &mut Vec<(SkillManifest, PathBuf, String)>) -> Result<(), SkillError> {
+    for entry in fs::read_dir(dir).map_err(|source| SkillError::Io {
+        path: dir.to_path_buf(),
+        source,
+    })? {
+        let entry = entry.map_err(|source| SkillError::Io {
+            path: dir.to_path_buf(),
+            source,
+        })?;
+        let path = entry.path();
+        let metadata = fs::symlink_metadata(&path).map_err(|source| SkillError::Io {
+            path: path.clone(),
+            source,
+        })?;
+        if !metadata.file_type().is_dir() {
+            continue;
+        }
+        if path.file_name().and_then(|name| name.to_str()) == Some(".git") {
+            continue;
+        }
+        if path.join(MANIFEST_FILE).is_file() {
+            let manifest = super::load_skill_manifest(&path)?;
+            let digest = compute_bundle_digest(&path, &manifest)?;
+            found.push((manifest, path, digest));
+            continue;
+        }
+        scan_dir(&path, found)?;
+    }
+    Ok(())
+}
+
+fn copy_bundle_contents(
+    source_root: &Path,
+    destination_root: &Path,
+    manifest: &SkillManifest,
+) -> Result<(), SkillError> {
+    fs::create_dir_all(destination_root).map_err(|source| SkillError::Io {
+        path: destination_root.to_path_buf(),
+        source,
+    })?;
+    copy_regular_file(
+        &source_root.join(MANIFEST_FILE),
+        &destination_root.join(MANIFEST_FILE),
+    )?;
+    for declared_file in &manifest.declared_files {
+        let source = validated_bundle_file(source_root, declared_file)?;
+        copy_regular_file(&source, &destination_root.join(declared_file))?;
+    }
+    Ok(())
+}
+```
+
+Implement `RegistryAdapter`:
+
+```rust
+#[async_trait::async_trait]
+impl RegistryAdapter for GitRegistryAdapter {
+    async fn search(&self, query: &str) -> Result<Vec<SkillSearchHit>, SkillError> {
+        let checkout = self.checkout_path()?;
+        let query = query.to_ascii_lowercase();
+        let mut hits = self
+            .scan(&checkout)?
+            .into_iter()
+            .filter_map(|(manifest, _path, digest)| {
+                let description = manifest.description.as_deref().unwrap_or_default();
+                let matches = query.is_empty()
+                    || manifest.name.to_ascii_lowercase().contains(&query)
+                    || description.to_ascii_lowercase().contains(&query);
+                matches.then(|| self.hit_for_manifest(&manifest, digest))
+            })
+            .collect::<Vec<_>>();
+        sort_hits(&mut hits);
+        Ok(hits)
+    }
+
+    async fn fetch(&self, name: &str, version: Option<&str>) -> Result<FetchedSkill, SkillError> {
+        validate_skill_name(name)?;
+        if let Some(version) = version {
+            version.parse::<Version>().map_err(|source| SkillError::InvalidVersion {
+                version: version.to_owned(),
+                source,
+            })?;
+        }
+        let checkout = self.checkout_path()?;
+        let mut matches = self
+            .scan(&checkout)?
+            .into_iter()
+            .filter(|(manifest, _path, _digest)| manifest.name == name)
+            .collect::<Vec<_>>();
+        if let Some(version) = version {
+            matches.retain(|(manifest, _path, _digest)| manifest.version.to_string() == version);
+        }
+        let (manifest, source_path, _digest) = matches
+            .into_iter()
+            .max_by(|left, right| left.0.version.cmp(&right.0.version))
+            .ok_or_else(|| SkillError::SkillNotInstalled {
+                name: name.to_owned(),
+            })?;
+        let staging_path = staging_fetch_path(&manifest.name, &manifest.version.to_string());
+        remove_directory_if_exists(&staging_path)?;
+        copy_bundle_contents(&source_path, &staging_path, &manifest)?;
+        Ok(FetchedSkill {
+            staging_path,
+            registry: self.name.clone(),
+            source_type: SOURCE_TYPE.to_owned(),
+            name: manifest.name,
+            version: manifest.version.to_string(),
+        })
+    }
+
+    async fn publish(
+        &self,
+        _bundle_path: &Path,
+        _allow_unsigned: bool,
+    ) -> Result<SkillSearchHit, SkillError> {
+        Err(SkillError::UnsupportedRegistryPublish {
+            registry: self.name.clone(),
+            kind: SOURCE_TYPE.to_owned(),
+        })
+    }
+}
+```
+
+Add these private helpers in `registry_git.rs`; they keep git execution non-interactive and avoid shell interpolation:
+
+```rust
+fn clone_url(url: &str) -> Result<String, SkillError> {
+    url.strip_prefix("git+")
+        .filter(|value| value.starts_with("https://"))
+        .map(ToOwned::to_owned)
+        .ok_or_else(|| SkillError::InvalidConfig {
+            message: format!("invalid git registry URL `{url}`"),
+        })
+}
+
+fn run_git(args: &[String], url: &str) -> Result<(), SkillError> {
+    let output = Command::new("git")
+        .args(args)
+        .env("GIT_TERMINAL_PROMPT", "0")
+        .output()
+        .map_err(|source| SkillError::GitRegistry {
+            url: url.to_owned(),
+            message: format!("failed to start git: {source}"),
+        })?;
+    if output.status.success() {
+        return Ok(());
+    }
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    Err(SkillError::GitRegistry {
+        url: url.to_owned(),
+        message: stderr.trim().to_owned(),
+    })
+}
+
+fn path_arg(path: &Path) -> String {
+    path.to_string_lossy().into_owned()
+}
+
+fn staging_fetch_path(name: &str, version: &str) -> PathBuf {
+    let mut path = std::env::temp_dir();
+    path.push(format!(
+        "agentenv-git-skill-fetch-{name}-{version}-{}",
+        std::process::id()
+    ));
+    path
+}
+
+fn remove_directory_if_exists(path: &Path) -> Result<(), SkillError> {
+    match fs::symlink_metadata(path) {
+        Ok(metadata) if metadata.file_type().is_dir() => {
+            fs::remove_dir_all(path).map_err(|source| SkillError::Io {
+                path: path.to_path_buf(),
+                source,
+            })
+        }
+        Ok(_) => Err(SkillError::UnsafeBundlePath {
+            path: path.to_path_buf(),
+        }),
+        Err(source) if source.kind() == std::io::ErrorKind::NotFound => Ok(()),
+        Err(source) => Err(SkillError::Io {
+            path: path.to_path_buf(),
+            source,
+        }),
+    }
+}
+
+fn copy_regular_file(source: &Path, destination: &Path) -> Result<(), SkillError> {
+    let metadata = fs::symlink_metadata(source).map_err(|source_error| SkillError::Io {
+        path: source.to_path_buf(),
+        source: source_error,
+    })?;
+    if !metadata.file_type().is_file() {
+        return Err(SkillError::UnsafeBundlePath {
+            path: source.to_path_buf(),
+        });
+    }
+    if let Some(parent) = destination.parent() {
+        fs::create_dir_all(parent).map_err(|source_error| SkillError::Io {
+            path: parent.to_path_buf(),
+            source: source_error,
+        })?;
+    }
+    fs::copy(source, destination).map_err(|source_error| SkillError::Io {
+        path: destination.to_path_buf(),
+        source: source_error,
+    })?;
+    Ok(())
+}
+
+fn sort_hits(hits: &mut [SkillSearchHit]) {
+    hits.sort_by(|left, right| {
+        left.name
+            .cmp(&right.name)
+            .then_with(|| compare_versions(&left.version, &right.version))
+            .then_with(|| left.registry.cmp(&right.registry))
+    });
+}
+
+fn compare_versions(left: &str, right: &str) -> Ordering {
+    match (left.parse::<Version>(), right.parse::<Version>()) {
+        (Ok(left), Ok(right)) => left.cmp(&right),
+        _ => left.cmp(right),
+    }
+}
+```
+
+- [ ] **Step 4: Wire cache root in service**
+
+Update `SkillService::adapter_for` git arm:
+
+```rust
+Ok(Box::new(registry_git::GitRegistryAdapter::new(
+    registry.name.clone(),
+    url,
+    self.root.join("cache").join("skill-git").join(&registry.name),
+)))
+```
+
+- [ ] **Step 5: Add integration test for unsupported publish**
+
+In `crates/agentenv-core/tests/skills.rs`:
+
+```rust
+#[tokio::test]
+async fn git_registry_publish_is_reported_as_unsupported() {
+    let home = temp_dir("skill-git-publish-home");
+    let service = SkillService::new(
+        home.join(".agentenv"),
+        SkillsConfig {
+            registries: vec![agentenv_core::skills::RegistryConfig::git(
+                "git-dev",
+                "git+https://github.com/acme/skills",
+            )],
+            registry_order: vec!["git-dev".to_owned()],
+        },
+    );
+
+    let error = service
+        .publish(SkillPublishRequest {
+            bundle_path: skill_bundle("git-publish", "0.1.0", "Git publish"),
+            registry: Some("git-dev".to_owned()),
+            allow_unsigned: true,
+        })
+        .await
+        .expect_err("git publish should be read-only");
+
+    assert!(matches!(
+        error,
+        SkillError::UnsupportedRegistryPublish { registry, kind }
+            if registry == "git-dev" && kind == "git"
+    ));
+}
+```
+
+- [ ] **Step 6: Run tests and verify GREEN**
+
+Run:
+
+```bash
+cargo test -p agentenv-core registry_git
+cargo test -p agentenv-core --test skills git_registry_publish_is_reported_as_unsupported
+```
+
+Expected: all pass.
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add crates/agentenv-core/src/skills/registry_git.rs crates/agentenv-core/src/skills/service.rs crates/agentenv-core/tests/skills.rs
+git commit -m "feat: add git skill registry backend"
+```
+
+## Task 5: CLI Coverage And Documentation Polish
+
+**Files:**
+- Modify: `crates/agentenv/tests/cli_behavior.rs`
+- Modify: `docs/ARCHITECTURE.md` if registry backend text is missing git or index layouts
+- Modify: `docs/superpowers/specs/2026-05-10-m7-4-skill-registry-backends-design.md` only for implementation-discovered clarifications
+
+- [ ] **Step 1: Find existing skills CLI tests**
+
+Run:
+
+```bash
+rg -n "skills|Skills" crates/agentenv/tests/cli_behavior.rs
+```
+
+Expected: existing command inventory and skills lifecycle tests are listed.
+
+- [ ] **Step 2: Add CLI test for git registry override validation**
+
+In `crates/agentenv/tests/cli_behavior.rs`, add a test near other skills CLI tests:
+
+```rust
+#[test]
+fn skills_search_accepts_git_registry_override_syntax() {
+    let home = temp_dir("skills-cli-git-override-home");
+    let output = agentenv_cmd()
+        .env("HOME", &home)
+        .args([
+            "skills",
+            "search",
+            "anything",
+            "--registry",
+            "git+https://github.com/acme/skills",
+            "--json",
+        ])
+        .output()
+        .expect("command should run");
+
+    assert!(
+        !output.status.success(),
+        "search may fail because fixture repo is not reachable, but CLI/config parsing must accept the git override"
+    );
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    assert!(
+        !stderr.contains("unsupported registry URL scheme"),
+        "git+https should be parsed as a git registry override: {stderr}"
+    );
+}
+```
+
+If the test harness has a stricter stderr style, adapt the assertion to its helpers but keep the behavioral check: the failure must not be config parsing.
+
+- [ ] **Step 3: Update docs only if needed**
+
+Run:
+
+```bash
+rg -n "Skills as a core-managed resource|registry adapters|git\\+https|index.json|tar.zst" docs/ARCHITECTURE.md docs/ROADMAP.md README.md
+```
+
+If `docs/ARCHITECTURE.md` lacks git registry wording, add one sentence under "Skills as a core-managed resource":
+
+```markdown
+Supported registry adapters are filesystem, HTTP static indexes, OCI artifacts, and git repositories; all are resolved by core before sandbox creation.
+```
+
+- [ ] **Step 4: Run CLI tests and verify GREEN**
+
+Run:
+
+```bash
+cargo test -p agentenv --test cli_behavior skills
+```
+
+Expected: skills-related CLI tests pass.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add crates/agentenv/tests/cli_behavior.rs docs/ARCHITECTURE.md docs/superpowers/specs/2026-05-10-m7-4-skill-registry-backends-design.md
+git commit -m "test: cover skill registry cli behavior"
+```
+
+## Task 6: Final Verification And Cleanup
+
+**Files:**
+- Review all touched files.
+
+- [ ] **Step 1: Check for accidental broad changes**
+
+Run:
+
+```bash
+git diff --stat origin/main..HEAD
+git diff --name-only origin/main..HEAD
+```
+
+Expected: changes are limited to skill registry implementation, tests, and docs.
+
+- [ ] **Step 2: Format**
+
+Run:
+
+```bash
+cargo fmt --all --check
+```
+
+Expected: pass. If it fails, run `cargo fmt --all`, inspect the diff, and commit formatting with the relevant task commit or a final `style:` commit.
+
+- [ ] **Step 3: Clippy**
+
+Run:
+
+```bash
+cargo clippy --workspace --all-targets -- -D warnings
+```
+
+Expected: pass with no warnings.
+
+- [ ] **Step 4: Workspace tests**
+
+Run:
+
+```bash
+cargo test --workspace
+```
+
+Expected: pass. If host git is unavailable and a test depends on it, gate only that subprocess-dependent test with a clear skip and keep pure validation tests active.
+
+- [ ] **Step 5: Final commit if needed**
+
+If verification fixes changed files:
+
+```bash
+git add <changed-files>
+git commit -m "fix: stabilize skill registry backends"
+```
+
+- [ ] **Step 6: Summarize PR scope**
+
+Prepare this PR summary:
+
+```markdown
+Summary:
+- added git skill registry config, search/fetch support, and read-only publish diagnostics
+- completed filesystem indexless scan and HTTP index.json/tar.zst compatibility
+- preserved existing filesystem/HTTP/OCI behavior and provenance shape
+
+Affected crates:
+- agentenv-core
+- agentenv
+
+Protocol:
+- no agentenv-proto schema changes
+
+Verification:
+- cargo fmt --all --check
+- cargo clippy --workspace --all-targets -- -D warnings
+- cargo test --workspace
+```

--- a/docs/superpowers/specs/2026-05-10-m7-4-skill-registry-backends-design.md
+++ b/docs/superpowers/specs/2026-05-10-m7-4-skill-registry-backends-design.md
@@ -45,7 +45,9 @@ config parsing, CLI overrides, provenance, documentation, and tests.
 - Do not add a fifth pluggable axis.
 - Do not add a `SkillsDriver` or any JSON-RPC driver method.
 - Do not introduce libgit2, OpenSSL, Python, Node, Docker, ORAS, or any
-  other build-time dependency to core.
+  external runtime dependency to core. Small Rust crate dependencies for
+  archive decoding are acceptable when they preserve the single-binary
+  distribution story and avoid OpenSSL.
 - Do not redesign the whole skills cache or CLI if the existing M7-2/M7-3
   implementation already satisfies the contract.
 - Do not implement in-sandbox agent discovery beyond preserving installed

--- a/docs/superpowers/specs/2026-05-10-m7-4-skill-registry-backends-design.md
+++ b/docs/superpowers/specs/2026-05-10-m7-4-skill-registry-backends-design.md
@@ -1,0 +1,309 @@
+# M7-4 Skill Registry Backends Design
+
+- Date: 2026-05-10
+- Issue: https://github.com/windoliver/agentenv/issues/30
+- Milestone: M7 Skills axis and registry
+- Depends on:
+  - https://github.com/windoliver/agentenv/issues/27
+  - https://github.com/windoliver/agentenv/issues/28
+- Affected crates: `agentenv-core`, `agentenv`
+
+## Context
+
+M7-1 decided that skills are core-managed resources, not a new driver
+kind and not a `ContextDriver` subtype. M7-2 added the first
+`agentenv skills` lifecycle CLI and the core skill service. Current
+`origin/main` already contains filesystem, HTTP, and OCI registry
+adapters under `agentenv-core::skills`.
+
+This issue completes the registry-backend surface as a cohesive feature:
+audit the existing filesystem, HTTP, and OCI adapters against the issue
+contract, add the missing git backend, and close integration gaps in
+config parsing, CLI overrides, provenance, documentation, and tests.
+
+## Goals
+
+- Keep skills as core-managed artifacts resolved before sandbox creation.
+- Keep registry adapters out of the driver protocol and avoid a schema
+  bump in `agentenv-proto`.
+- Support the four registry types from the issue: filesystem, OCI, HTTP,
+  and git.
+- Reuse the existing `SkillService` and `RegistryAdapter` shape unless
+  tests expose a real contract mismatch.
+- Preserve the config precedence from M7-2: CLI flag, then project
+  `agentenv.yaml`, then user `~/.config/agentenv/config.toml`.
+- Preserve shared manifest, digest, signature, install, and provenance
+  handling across all backends.
+- Prefer additive compatibility when current M7-2 behavior differs from
+  the issue text, so existing filesystem, HTTP, and OCI users do not lose
+  working registry layouts.
+- Add coverage that proves full-registry behavior rather than only config
+  parsing.
+
+## Non-Goals
+
+- Do not add a fifth pluggable axis.
+- Do not add a `SkillsDriver` or any JSON-RPC driver method.
+- Do not introduce libgit2, OpenSSL, Python, Node, Docker, ORAS, or any
+  other build-time dependency to core.
+- Do not redesign the whole skills cache or CLI if the existing M7-2/M7-3
+  implementation already satisfies the contract.
+- Do not implement in-sandbox agent discovery beyond preserving installed
+  skill metadata for later injection work.
+
+## Architecture
+
+The implementation remains inside `agentenv-core::skills`.
+
+The existing service boundary should stay the main entry point:
+
+```rust
+pub struct SkillService { /* root, config, credentials, ssrf */ }
+
+impl SkillService {
+    pub async fn search(&self, query: &str) -> Result<Vec<SkillSearchHit>, SkillError>;
+    pub async fn add(&self, request: SkillAddRequest) -> Result<InstalledSkill, SkillError>;
+    pub async fn publish(&self, request: SkillPublishRequest) -> Result<SkillSearchHit, SkillError>;
+}
+```
+
+Each backend implements the existing `RegistryAdapter` trait:
+
+```rust
+#[async_trait]
+pub trait RegistryAdapter {
+    async fn search(&self, query: &str) -> Result<Vec<SkillSearchHit>, SkillError>;
+    async fn fetch(&self, name: &str, version: Option<&str>) -> Result<FetchedSkill, SkillError>;
+    async fn publish(
+        &self,
+        bundle_path: &Path,
+        allow_unsigned: bool,
+    ) -> Result<SkillSearchHit, SkillError>;
+}
+```
+
+The adapter owns transport details only. Identity validation, manifest
+loading, digest checks, signature enforcement, staging cleanup, and final
+install remain shared service/store behavior. Installed provenance should
+continue to use source labels in the existing pattern:
+
+```text
+filesystem:<registry>:<name>@<version>
+http:<registry>:<name>@<version>
+oci:<registry>:<name>@<version>
+git:<registry>:<name>@<version>
+```
+
+## Registry Config
+
+The config model supports all four registry kinds:
+
+```yaml
+skills:
+  registries:
+    - name: community
+      type: oci
+      url: ghcr.io/agentenv-community
+    - name: corp
+      type: http
+      url: https://skills.acme.internal
+      auth: bearer-from-credstore
+    - name: local-dev
+      type: filesystem
+      path: /home/alice/dev/skills
+    - name: git-dev
+      type: git
+      url: git+https://github.com/acme/skills
+```
+
+Validation rules:
+
+- `filesystem` requires `path`.
+- `http` requires an `http` or `https` URL with no user info.
+- `oci` requires a normalized registry/repository reference or `oci://`
+  URL that normalizes to one.
+- `git` requires a `git+https` URL, with no user info, query, or fragment.
+- Registry names keep the same conservative skill-name validation already
+  used by M7-2.
+- CLI `--registry` direct-source overrides may accept `git+https://...`;
+  ambiguous shorthand remains OCI-oriented and should not be extended to git.
+
+## Backend Behavior
+
+### Filesystem
+
+Filesystem remains the local development backend:
+
+- `path` points at a local registry directory.
+- Search reads the existing registry index layout and, if no index is
+  present, scans issue-compatible skill subdirectories that contain
+  `skill.yaml` or `SKILL.md` frontmatter.
+- Fetch copies a specific skill version into a staging directory.
+- Fetch without a version selects the highest semver version.
+- Publish writes an immutable `bundles/<name>/<version>` tree and updates
+  the registry index.
+- Publishing the same version with different digest remains an error.
+
+The audit should confirm filesystem index entries cannot bypass manifest
+identity checks or escape the registry root through symlinks or traversal.
+The subdirectory scanner is read-only compatibility; publish continues to
+use the indexed layout so local registries remain deterministic.
+
+### HTTP
+
+HTTP remains a static registry backend:
+
+- Search reads the issue layout at `<url>/index.json`. Existing YAML index
+  support may stay as a fallback for already-landed tests and registries.
+- Fetch downloads `<url>/skills/<name>/<version>.tar.zst` and verifies the
+  sidecar signature at `<url>/skills/<name>/<version>.tar.zst.sig` when a
+  signature is declared. Existing expanded static-bundle fetch support may
+  stay as a compatibility path.
+- Signature sidecars are used where the current implementation supports
+  them.
+- Every outbound URL is validated through the existing SSRF module before
+  request.
+- Auth uses the current bearer credential resolver and must not put token
+  values in persisted metadata or error strings.
+
+The audit should confirm relative artifact paths cannot redirect fetches
+outside the configured registry authority.
+
+### OCI
+
+OCI remains the preferred remote registry backend:
+
+- `url` is an OCI reference such as `ghcr.io/<org>[/<repo>]`.
+- Skill artifacts use media type
+  `application/vnd.agentenv.skill.v1+tar`.
+- Search, fetch, and publish use the OCI Distribution API through
+  `reqwest` with `rustls`.
+- Auth stays bearer-token based through the same credential resolver.
+- No Docker, ORAS, or external registry CLI dependency is added.
+
+The audit should confirm references are normalized consistently and unsafe
+authorities are rejected before network access.
+
+### Git
+
+Git is the new backend:
+
+- `url: git+https://github.com/<org>/<repo>` identifies the source repo.
+- Skills are subdirectories in the repository. A valid skill directory is
+  one containing `skill.yaml` and its declared entry file.
+- Version resolution supports semantic versions from skill manifests. If
+  the requested handle omits a version, fetch selects the highest semver
+  version discovered for that skill.
+- Fetch supports exact semver versions and commit-ish refs where the
+  implementation can resolve them safely without ambiguity.
+- Search inspects a local clone cache and returns matching skill summaries.
+- Publish is unsupported in the first implementation and returns a typed
+  `SkillError` explaining that git registry publish is not supported.
+
+Implementation should shell out to `git` rather than link a new git
+library. Commands must be non-interactive and bounded:
+
+- use `GIT_TERMINAL_PROMPT=0`
+- avoid shell interpolation by using `std::process::Command` arguments
+- use a cache path under the agentenv root or a temporary staging area
+- validate clone/fetch destination paths through existing safe-path helpers
+  or new equivalents
+- prefer sparse checkout for large repos when it can be added without
+  making correctness depend on optional git features
+
+Git URL validation is intentionally conservative for this issue:
+`git+https` only. SSH, local `file://`, raw `https://` inference, and
+authenticated URLs can be added later with explicit policy and credential
+design.
+
+Tests that need a local repository should use a small command-runner seam
+or an internal fixture path that does not broaden production URL policy.
+
+## Error Handling
+
+Library errors stay in `SkillError` using `thiserror`. CLI commands add
+context with `anyhow` but do not pattern-match string messages.
+
+New or audited errors should cover:
+
+- invalid git registry URL
+- missing `git` executable
+- git clone/fetch/list failure
+- missing skill in git registry
+- ambiguous or invalid git skill version
+- unsupported git publish
+- unsafe artifact path or repository path
+- remote registry URL blocked by SSRF validation
+- artifact identity mismatch after fetch
+
+No `.unwrap()` should be introduced outside tests.
+
+## CLI Behavior
+
+The existing skills CLI should remain thin:
+
+```text
+agentenv skills search <query> [--registry <name-or-source>]
+agentenv skills add <name>[@version] [--registry <name-or-source>]
+agentenv skills publish <path> [--registry <name-or-source>]
+```
+
+`--registry git+https://github.com/acme/skills` should create a one-off git
+registry named `cli`, matching existing direct-source override behavior for
+file, HTTP, and OCI. `publish` to a git registry should fail with the typed
+unsupported-publish error.
+
+Output formats from M7-2 remain unchanged except for the new `git` source
+type appearing in JSON and table output where provenance is shown.
+
+## Testing Strategy
+
+Implementation should follow TDD for behavior changes.
+
+Core tests:
+
+- git registry config parses from project YAML and user TOML
+- direct CLI override parses `git+https://...`
+- invalid git URLs are rejected before any `git` command runs
+- HTTP registry search prefers `index.json` and keeps legacy index fallback
+- HTTP registry fetch validates tarball and signature-sidecar paths stay
+  under the configured authority
+- filesystem registry search scans subdirectories when no index exists
+- git registry search finds skills through a fake command runner or safe
+  local fixture
+- git registry add installs an exact version through the same seam
+- git registry add without version selects the highest semver
+- git registry fetch records `git:<registry>:<name>@<version>` provenance
+- git publish returns the unsupported-publish error
+- missing `git` executable is reported cleanly if command lookup can be
+  simulated without relying on host mutation
+- existing filesystem, HTTP, and OCI behavior remains green
+
+CLI tests:
+
+- command inventory still includes `skills`
+- `skills search --registry git+https://...` works against a local fixture
+  served through a safe test path or a temporary repo URL if practical
+- `skills add --registry git+https://...` installs and reports git
+  provenance
+- `skills publish --registry git+https://...` exits non-zero with a clear
+  unsupported-publish diagnostic
+
+Full verification before completion:
+
+```text
+cargo fmt --all --check
+cargo clippy --workspace --all-targets -- -D warnings
+cargo test --workspace
+```
+
+If host `git` is not available, git-backend tests should skip only the
+subprocess-dependent fixture tests and still run pure config/validation
+coverage.
+
+## Rollout Notes
+
+This issue should not require a driver protocol version bump. The PR
+description should list `agentenv-core` and `agentenv` as affected crates,
+note that `agentenv-proto` is unchanged, and call out any backend behavior
+that intentionally degrades, especially read-only git publish support.


### PR DESCRIPTION
## Summary
- Completes the M7-4 skill registry backend surface for filesystem, HTTP, OCI, and git on top of the existing core-managed skills service.
- Adds indexless filesystem scanning, HTTP `index.json`/`.tar.zst`/signature-sidecar behavior, git registry config/search/fetch with hardened cache and subprocess handling, and real CLI coverage for registry flows and override handling.
- Fixes OTEL feature builds by mapping the build oneflight/queue activity kinds to stable OTEL names.
- Updates architecture/design/implementation-plan docs and preserves the existing OCI adapter path.

Fixes #30

## Affected crates/docs
- `agentenv-core`
- `agentenv`
- `agentenv-events`
- `docs/ARCHITECTURE.md`
- `docs/superpowers/specs/2026-05-10-m7-4-skill-registry-backends-design.md`
- `docs/superpowers/plans/2026-05-10-m7-4-skill-registry-backends.md`

## Test Plan
- [x] `cargo fmt --check`
- [x] `cargo clippy --workspace -- -D warnings`
- [x] `cargo clippy --workspace --all-targets --all-features -- -D warnings`
- [x] `cargo test -p agentenv --test cli_behavior skills_ -- --nocapture`
- [x] `cargo test -p agentenv-events --features otel maps_build_activity_kinds_to_otel_names -- --nocapture`
- [x] `cargo test --workspace`
- [x] `cargo test --workspace --all-features`
- [x] `git diff --check`
- [x] GitHub CI run 102: macOS stable, macOS Rust 1.95.0, Ubuntu stable, Ubuntu Rust 1.95.0

## Notes
- Git registry fetch fails closed on non-Unix platforms until a safe no-follow staging implementation exists there.
- A positive live HTTP registry CLI test against loopback is intentionally blocked by production SSRF policy; CLI coverage verifies the fail-closed behavior while core registry tests cover HTTP registry search/add/publish behavior.
