### PR TITLE
[codex] Implement trace-derived skill proposer

### DIFF
--- a/crates/agentenv-core/src/skills/config.rs
+++ b/crates/agentenv-core/src/skills/config.rs
@@ -21,6 +21,41 @@ pub struct SkillsConfig {
     pub registries: Vec<RegistryConfig>,
     #[serde(default)]
     pub registry_order: Vec<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub proposal: Option<ProposalConfig>,
+}
+
+#[derive(Debug, Clone, Default, serde::Serialize, serde::Deserialize, PartialEq, Eq)]
+pub struct ProposalConfig {
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub llm: Option<ProposalLlmConfig>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub semantic: Option<ProposalSemanticConfig>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub pr: Option<ProposalPrConfig>,
+}
+
+#[derive(Debug, Clone, serde::Serialize, serde::Deserialize, PartialEq, Eq)]
+pub struct ProposalLlmConfig {
+    pub provider: String,
+    pub endpoint: String,
+    pub model: String,
+    pub credential: String,
+}
+
+#[derive(Debug, Clone, serde::Serialize, serde::Deserialize, PartialEq, Eq)]
+pub struct ProposalSemanticConfig {
+    pub backend: String,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub endpoint: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub credential: Option<String>,
+}
+
+#[derive(Debug, Clone, Default, serde::Serialize, serde::Deserialize, PartialEq, Eq)]
+pub struct ProposalPrConfig {
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub default_repo: Option<String>,
 }
 
 #[derive(Debug, Clone, Default, PartialEq, Eq)]
@@ -96,6 +131,7 @@ fn apply_registry_override(
         return normalize_config(SkillsConfig {
             registries: vec![registry],
             registry_order: vec![CLI_REGISTRY_NAME.to_owned()],
+            proposal: config.proposal,
         });
     }
 
@@ -103,6 +139,7 @@ fn apply_registry_override(
         return normalize_config(SkillsConfig {
             registries: vec![RegistryConfig::oci(CLI_REGISTRY_NAME, registry, None)],
             registry_order: vec![CLI_REGISTRY_NAME.to_owned()],
+            proposal: config.proposal,
         });
     }
     if registry.contains('/') {
@@ -113,8 +150,12 @@ fn apply_registry_override(
 
     validate_skill_name(registry)?;
     let config = normalize_config(config)?;
-    let selected = config
-        .registries
+    let SkillsConfig {
+        registries,
+        proposal,
+        ..
+    } = config;
+    let selected = registries
         .into_iter()
         .find(|candidate| candidate.name == registry)
         .ok_or_else(|| SkillError::RegistryNotFound {
@@ -124,6 +165,7 @@ fn apply_registry_override(
     Ok(SkillsConfig {
         registries: vec![selected],
         registry_order: vec![registry.to_owned()],
+        proposal,
     })
 }
 
@@ -239,6 +281,7 @@ fn merge_project_over_user(
 ) -> Result<SkillsConfig, SkillError> {
     let user = normalize_config(user)?;
     let project = normalize_config(project)?;
+    let proposal = project.proposal.or(user.proposal);
     let mut by_name = BTreeMap::new();
     let mut order = Vec::new();
 
@@ -265,6 +308,7 @@ fn merge_project_over_user(
     normalize_config(SkillsConfig {
         registries: by_name.into_values().collect(),
         registry_order: order,
+        proposal,
     })
 }
 
@@ -482,7 +526,7 @@ fn validate_registry_order(config: &SkillsConfig) -> Result<(), SkillError> {
 }
 
 fn has_skills_config(config: &SkillsConfig) -> bool {
-    !config.registries.is_empty() || !config.registry_order.is_empty()
+    !config.registries.is_empty() || !config.registry_order.is_empty() || config.proposal.is_some()
 }
 
 fn invalid_config(message: impl Into<String>) -> SkillError {

--- a/crates/agentenv-core/src/skills/mod.rs
+++ b/crates/agentenv-core/src/skills/mod.rs
@@ -4,6 +4,7 @@ mod digest;
 mod error;
 mod index;
 mod manifest;
+pub mod propose;
 mod registry;
 mod registry_filesystem;
 mod registry_http;

--- a/crates/agentenv-core/src/skills/mod.rs
+++ b/crates/agentenv-core/src/skills/mod.rs
@@ -21,7 +21,8 @@ pub use cache::{
     SkillVerifyOptions, SkillVerifyReport, SkillVerifyStatus, SKILL_METADATA_SCHEMA_VERSION,
 };
 pub use config::{
-    load_project_skills_config, load_user_skills_config, merge_skills_config, SkillsConfig,
+    load_project_skills_config, load_user_skills_config, merge_skills_config, ProposalConfig,
+    ProposalLlmConfig, ProposalPrConfig, ProposalSemanticConfig, SkillsConfig,
     SkillsConfigOverride,
 };
 pub use digest::compute_bundle_digest;

--- a/crates/agentenv-core/src/skills/propose/emit.rs
+++ b/crates/agentenv-core/src/skills/propose/emit.rs
@@ -1,0 +1,173 @@
+use std::{fs, path::Path};
+
+use serde::Serialize;
+
+use super::model::{ProposalEmitInput, ProposalEmitOutput};
+use crate::skills::{load_skill_manifest, validate_skill_name, SkillError};
+
+#[derive(Serialize)]
+struct ProposalYaml<'a> {
+    schema_version: &'static str,
+    status: &'static str,
+    blueprint_id: &'a str,
+    occurrences: usize,
+    novelty: f32,
+    utility: f32,
+    self_test_score: f32,
+    generated_by: GeneratedBy<'a>,
+}
+
+#[derive(Serialize)]
+struct GeneratedBy<'a> {
+    agentenv_version: &'a str,
+}
+
+#[derive(Serialize)]
+struct SkillYaml<'a> {
+    name: &'a str,
+    version: &'static str,
+    description: &'a str,
+    entry: &'static str,
+    files: &'static [&'static str],
+    self_test: SkillYamlSelfTest<'a>,
+    agentenv_proposal: bool,
+    agentenv_schema: &'static str,
+}
+
+#[derive(Serialize)]
+struct SkillYamlSelfTest<'a> {
+    command: &'a str,
+}
+
+pub fn emit_proposal(input: ProposalEmitInput) -> Result<ProposalEmitOutput, SkillError> {
+    validate_skill_name(&input.generalization.name)?;
+    let output = input.output_root.join(&input.generalization.name);
+    ensure_output_missing(&output)?;
+
+    let staging = input
+        .output_root
+        .join(format!(".{}.staging", input.generalization.name));
+    if staging.exists() {
+        fs::remove_dir_all(&staging).map_err(|source| SkillError::Io {
+            path: staging.clone(),
+            source,
+        })?;
+    }
+    fs::create_dir_all(staging.join("traces")).map_err(|source| SkillError::Io {
+        path: staging.clone(),
+        source,
+    })?;
+
+    write_file(&staging.join("SKILL.md"), render_skill_md(&input))?;
+    write_file(&staging.join("skill.yaml"), render_skill_yaml(&input)?)?;
+    write_file(
+        &staging.join("proposal.yaml"),
+        render_proposal_yaml(&input)?,
+    )?;
+    write_file(
+        &staging.join("self-test.json"),
+        json_pretty(&input.self_test, &staging.join("self-test.json"))?,
+    )?;
+    write_file(
+        &staging.join("traces/provenance.json"),
+        json_pretty(&input.candidate, &staging.join("traces/provenance.json"))?,
+    )?;
+
+    load_skill_manifest(&staging)?;
+    fs::rename(&staging, &output).map_err(|source| SkillError::Io {
+        path: output.clone(),
+        source,
+    })?;
+
+    Ok(ProposalEmitOutput {
+        name: input.generalization.name,
+        path: output,
+        novelty: input.score.novelty,
+        self_test_score: input.self_test.score,
+    })
+}
+
+fn ensure_output_missing(output: &Path) -> Result<(), SkillError> {
+    match fs::symlink_metadata(output) {
+        Ok(_) => Err(SkillError::InvalidConfig {
+            message: format!("proposal output `{}` already exists", output.display()),
+        }),
+        Err(source) if source.kind() == std::io::ErrorKind::NotFound => Ok(()),
+        Err(source) => Err(SkillError::Io {
+            path: output.to_path_buf(),
+            source,
+        }),
+    }
+}
+
+fn render_skill_md(input: &ProposalEmitInput) -> String {
+    format!(
+        "---\nname: {}\ndescription: {}\nversion: 0.1.0\ntags: [agentenv-proposed, trace-derived]\nagentenv-proposal: true\nagentenv-schema: \"0.1\"\n---\n\n# {}\n\n{}\n",
+        input.generalization.name,
+        input.generalization.description,
+        input.generalization.name,
+        input.generalization.skill_md_body
+    )
+}
+
+fn render_skill_yaml(input: &ProposalEmitInput) -> Result<String, SkillError> {
+    let value = SkillYaml {
+        name: &input.generalization.name,
+        version: "0.1.0",
+        description: &input.generalization.description,
+        entry: "SKILL.md",
+        files: &[
+            "SKILL.md",
+            "proposal.yaml",
+            "self-test.json",
+            "traces/provenance.json",
+        ],
+        self_test: SkillYamlSelfTest {
+            command: &input.generalization.self_test.command,
+        },
+        agentenv_proposal: true,
+        agentenv_schema: "0.1",
+    };
+    serde_yaml::to_string(&value).map_err(|source| SkillError::Serde {
+        path: input.output_root.join("skill.yaml"),
+        source,
+    })
+}
+
+fn render_proposal_yaml(input: &ProposalEmitInput) -> Result<String, SkillError> {
+    let value = ProposalYaml {
+        schema_version: "0.1",
+        status: "proposed",
+        blueprint_id: &input.candidate.blueprint_id,
+        occurrences: input.candidate.occurrences,
+        novelty: input.score.novelty,
+        utility: input.score.utility,
+        self_test_score: input.self_test.score,
+        generated_by: GeneratedBy {
+            agentenv_version: &input.agentenv_version,
+        },
+    };
+    serde_yaml::to_string(&value).map_err(|source| SkillError::Serde {
+        path: input.output_root.join("proposal.yaml"),
+        source,
+    })
+}
+
+fn write_file(path: &Path, content: String) -> Result<(), SkillError> {
+    if let Some(parent) = path.parent() {
+        fs::create_dir_all(parent).map_err(|source| SkillError::Io {
+            path: parent.to_path_buf(),
+            source,
+        })?;
+    }
+    fs::write(path, content).map_err(|source| SkillError::Io {
+        path: path.to_path_buf(),
+        source,
+    })
+}
+
+fn json_pretty<T: Serialize>(value: &T, path: &Path) -> Result<String, SkillError> {
+    serde_json::to_string_pretty(value).map_err(|source| SkillError::InvalidConfig {
+        message: format!("failed to serialize `{}`: {source}", path.display()),
+    })
+}

--- a/crates/agentenv-core/src/skills/propose/emit.rs
+++ b/crates/agentenv-core/src/skills/propose/emit.rs
@@ -7,7 +7,7 @@ use std::{
 
 use serde::Serialize;
 
-use super::model::{ProposalEmitInput, ProposalEmitOutput};
+use super::model::{ProposalEmitInput, ProposalEmitOutput, SAFE_PROPOSAL_SELF_TEST_COMMAND};
 use crate::skills::{load_skill_manifest, validate_skill_name, SkillError};
 
 static STAGING_COUNTER: AtomicU64 = AtomicU64::new(0);
@@ -253,7 +253,7 @@ fn render_skill_yaml(input: &ProposalEmitInput, path: &Path) -> Result<String, S
             "traces/provenance.json",
         ],
         self_test: SkillYamlSelfTest {
-            command: &input.generalization.self_test.command,
+            command: SAFE_PROPOSAL_SELF_TEST_COMMAND,
         },
         agentenv_proposal: true,
         agentenv_schema: "0.1",

--- a/crates/agentenv-core/src/skills/propose/emit.rs
+++ b/crates/agentenv-core/src/skills/propose/emit.rs
@@ -1,9 +1,16 @@
-use std::{fs, path::Path};
+use std::{
+    fs,
+    path::{Path, PathBuf},
+    sync::atomic::{AtomicU64, Ordering},
+    time::{SystemTime, UNIX_EPOCH},
+};
 
 use serde::Serialize;
 
 use super::model::{ProposalEmitInput, ProposalEmitOutput};
 use crate::skills::{load_skill_manifest, validate_skill_name, SkillError};
+
+static STAGING_COUNTER: AtomicU64 = AtomicU64::new(0);
 
 #[derive(Serialize)]
 struct ProposalYaml<'a> {
@@ -14,12 +21,25 @@ struct ProposalYaml<'a> {
     novelty: f32,
     utility: f32,
     self_test_score: f32,
+    created_at: &'a str,
     generated_by: GeneratedBy<'a>,
 }
 
 #[derive(Serialize)]
 struct GeneratedBy<'a> {
     agentenv_version: &'a str,
+}
+
+#[derive(Serialize)]
+struct SkillMdFrontmatter<'a> {
+    name: &'a str,
+    description: &'a str,
+    version: &'static str,
+    tags: &'static [&'static str],
+    #[serde(rename = "agentenv-proposal")]
+    agentenv_proposal: bool,
+    #[serde(rename = "agentenv-schema")]
+    agentenv_schema: &'static str,
 }
 
 #[derive(Serialize)]
@@ -42,75 +62,185 @@ struct SkillYamlSelfTest<'a> {
 pub fn emit_proposal(input: ProposalEmitInput) -> Result<ProposalEmitOutput, SkillError> {
     validate_skill_name(&input.generalization.name)?;
     let output = input.output_root.join(&input.generalization.name);
-    ensure_output_missing(&output)?;
+    let staging = create_unique_staging_dir(&input.output_root, &input.generalization.name)?;
 
-    let staging = input
-        .output_root
-        .join(format!(".{}.staging", input.generalization.name));
-    if staging.exists() {
-        fs::remove_dir_all(&staging).map_err(|source| SkillError::Io {
-            path: staging.clone(),
-            source,
-        })?;
+    if let Err(error) = write_validate_and_publish(&input, &staging, &output) {
+        cleanup_dir(&staging);
+        return Err(error);
     }
-    fs::create_dir_all(staging.join("traces")).map_err(|source| SkillError::Io {
-        path: staging.clone(),
-        source,
-    })?;
-
-    write_file(&staging.join("SKILL.md"), render_skill_md(&input))?;
-    write_file(&staging.join("skill.yaml"), render_skill_yaml(&input)?)?;
-    write_file(
-        &staging.join("proposal.yaml"),
-        render_proposal_yaml(&input)?,
-    )?;
-    write_file(
-        &staging.join("self-test.json"),
-        json_pretty(&input.self_test, &staging.join("self-test.json"))?,
-    )?;
-    write_file(
-        &staging.join("traces/provenance.json"),
-        json_pretty(&input.candidate, &staging.join("traces/provenance.json"))?,
-    )?;
-
-    load_skill_manifest(&staging)?;
-    fs::rename(&staging, &output).map_err(|source| SkillError::Io {
-        path: output.clone(),
-        source,
-    })?;
 
     Ok(ProposalEmitOutput {
         name: input.generalization.name,
         path: output,
         novelty: input.score.novelty,
+        utility: input.score.utility,
+        final_score: input.score.final_score,
         self_test_score: input.self_test.score,
     })
 }
 
-fn ensure_output_missing(output: &Path) -> Result<(), SkillError> {
-    match fs::symlink_metadata(output) {
-        Ok(_) => Err(SkillError::InvalidConfig {
-            message: format!("proposal output `{}` already exists", output.display()),
-        }),
-        Err(source) if source.kind() == std::io::ErrorKind::NotFound => Ok(()),
-        Err(source) => Err(SkillError::Io {
-            path: output.to_path_buf(),
-            source,
-        }),
+fn create_unique_staging_dir(output_root: &Path, name: &str) -> Result<PathBuf, SkillError> {
+    fs::create_dir_all(output_root).map_err(|source| SkillError::Io {
+        path: output_root.to_path_buf(),
+        source,
+    })?;
+
+    for _ in 0..16 {
+        let staging = output_root.join(format!(".{name}.staging-{}", unique_staging_suffix()));
+        match fs::create_dir(&staging) {
+            Ok(()) => return Ok(staging),
+            Err(source) if source.kind() == std::io::ErrorKind::AlreadyExists => {}
+            Err(source) => {
+                return Err(SkillError::Io {
+                    path: staging,
+                    source,
+                });
+            }
+        }
     }
+
+    Err(SkillError::InvalidConfig {
+        message: format!("could not allocate a unique staging directory for proposal `{name}`"),
+    })
 }
 
-fn render_skill_md(input: &ProposalEmitInput) -> String {
-    format!(
-        "---\nname: {}\ndescription: {}\nversion: 0.1.0\ntags: [agentenv-proposed, trace-derived]\nagentenv-proposal: true\nagentenv-schema: \"0.1\"\n---\n\n# {}\n\n{}\n",
-        input.generalization.name,
-        input.generalization.description,
-        input.generalization.name,
-        input.generalization.skill_md_body
-    )
+fn unique_staging_suffix() -> String {
+    let counter = STAGING_COUNTER.fetch_add(1, Ordering::Relaxed);
+    let nanos = SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .map(|duration| duration.as_nanos())
+        .unwrap_or(0);
+    format!("{}-{nanos}-{counter}", std::process::id())
 }
 
-fn render_skill_yaml(input: &ProposalEmitInput) -> Result<String, SkillError> {
+fn write_validate_and_publish(
+    input: &ProposalEmitInput,
+    staging: &Path,
+    output: &Path,
+) -> Result<(), SkillError> {
+    write_and_validate_staging(input, staging)?;
+    publish_staging(staging, output)
+}
+
+fn write_and_validate_staging(input: &ProposalEmitInput, staging: &Path) -> Result<(), SkillError> {
+    fs::create_dir(staging.join("traces")).map_err(|source| SkillError::Io {
+        path: staging.join("traces"),
+        source,
+    })?;
+
+    let skill_md_path = staging.join("SKILL.md");
+    let skill_yaml_path = staging.join("skill.yaml");
+    let proposal_yaml_path = staging.join("proposal.yaml");
+    let self_test_path = staging.join("self-test.json");
+    let provenance_path = staging.join("traces/provenance.json");
+
+    write_file(&skill_md_path, render_skill_md(input, &skill_md_path)?)?;
+    write_file(
+        &skill_yaml_path,
+        render_skill_yaml(input, &skill_yaml_path)?,
+    )?;
+    write_file(
+        &proposal_yaml_path,
+        render_proposal_yaml(input, &proposal_yaml_path)?,
+    )?;
+    write_file(
+        &self_test_path,
+        json_pretty(&input.self_test, &self_test_path)?,
+    )?;
+    write_file(
+        &provenance_path,
+        json_pretty(&input.candidate, &provenance_path)?,
+    )?;
+
+    load_skill_manifest(staging)?;
+    Ok(())
+}
+
+fn publish_staging(staging: &Path, output: &Path) -> Result<(), SkillError> {
+    match fs::create_dir(output) {
+        Ok(()) => {}
+        Err(source) if source.kind() == std::io::ErrorKind::AlreadyExists => {
+            return Err(SkillError::InvalidConfig {
+                message: format!("proposal output `{}` already exists", output.display()),
+            });
+        }
+        Err(source) => {
+            return Err(SkillError::Io {
+                path: output.to_path_buf(),
+                source,
+            });
+        }
+    }
+
+    if let Err(error) = move_staged_entries(staging, output) {
+        cleanup_dir(output);
+        return Err(error);
+    }
+    if let Err(error) = fs::remove_dir(staging) {
+        cleanup_dir(output);
+        return Err(SkillError::Io {
+            path: staging.to_path_buf(),
+            source: error,
+        });
+    }
+
+    Ok(())
+}
+
+fn move_staged_entries(staging: &Path, output: &Path) -> Result<(), SkillError> {
+    let entries = fs::read_dir(staging).map_err(|source| SkillError::Io {
+        path: staging.to_path_buf(),
+        source,
+    })?;
+    for entry in entries {
+        let entry = entry.map_err(|source| SkillError::Io {
+            path: staging.to_path_buf(),
+            source,
+        })?;
+        let from = entry.path();
+        let to = output.join(entry.file_name());
+        if to.exists() {
+            return Err(SkillError::InvalidConfig {
+                message: format!("proposal output path `{}` already exists", to.display()),
+            });
+        }
+        fs::rename(&from, &to).map_err(|source| SkillError::Io { path: to, source })?;
+    }
+    Ok(())
+}
+
+fn cleanup_dir(path: &Path) {
+    let _ = fs::remove_dir_all(path);
+}
+
+fn render_skill_md(input: &ProposalEmitInput, path: &Path) -> Result<String, SkillError> {
+    let frontmatter = SkillMdFrontmatter {
+        name: &input.generalization.name,
+        description: &input.generalization.description,
+        version: "0.1.0",
+        tags: &["agentenv-proposed", "trace-derived"],
+        agentenv_proposal: true,
+        agentenv_schema: "0.1",
+    };
+    let mut frontmatter =
+        serde_yaml::to_string(&frontmatter).map_err(|source| SkillError::Serde {
+            path: path.to_path_buf(),
+            source,
+        })?;
+    if let Some(stripped) = frontmatter.strip_prefix("---\n") {
+        frontmatter = stripped.to_owned();
+    }
+    if !frontmatter.ends_with('\n') {
+        frontmatter.push('\n');
+    }
+
+    Ok(format!(
+        "---\n{}---\n\n# {}\n\n{}\n",
+        frontmatter, input.generalization.name, input.generalization.skill_md_body
+    ))
+}
+
+fn render_skill_yaml(input: &ProposalEmitInput, path: &Path) -> Result<String, SkillError> {
     let value = SkillYaml {
         name: &input.generalization.name,
         version: "0.1.0",
@@ -129,12 +259,12 @@ fn render_skill_yaml(input: &ProposalEmitInput) -> Result<String, SkillError> {
         agentenv_schema: "0.1",
     };
     serde_yaml::to_string(&value).map_err(|source| SkillError::Serde {
-        path: input.output_root.join("skill.yaml"),
+        path: path.to_path_buf(),
         source,
     })
 }
 
-fn render_proposal_yaml(input: &ProposalEmitInput) -> Result<String, SkillError> {
+fn render_proposal_yaml(input: &ProposalEmitInput, path: &Path) -> Result<String, SkillError> {
     let value = ProposalYaml {
         schema_version: "0.1",
         status: "proposed",
@@ -143,12 +273,13 @@ fn render_proposal_yaml(input: &ProposalEmitInput) -> Result<String, SkillError>
         novelty: input.score.novelty,
         utility: input.score.utility,
         self_test_score: input.self_test.score,
+        created_at: &input.created_at,
         generated_by: GeneratedBy {
             agentenv_version: &input.agentenv_version,
         },
     };
     serde_yaml::to_string(&value).map_err(|source| SkillError::Serde {
-        path: input.output_root.join("proposal.yaml"),
+        path: path.to_path_buf(),
         source,
     })
 }

--- a/crates/agentenv-core/src/skills/propose/extract.rs
+++ b/crates/agentenv-core/src/skills/propose/extract.rs
@@ -1,0 +1,140 @@
+use std::collections::{BTreeMap, BTreeSet};
+
+use agentenv_events::TraceRun;
+use serde_json::Value;
+
+use super::model::{CandidateExtractionOptions, CandidateToolCall, ProposalCandidate};
+use crate::skills::SkillError;
+
+pub fn normalize_args_shape(value: &Value) -> Value {
+    normalize_value(value).0
+}
+
+pub fn extract_candidates(
+    traces: &[TraceRun],
+    options: CandidateExtractionOptions,
+) -> Result<Vec<ProposalCandidate>, SkillError> {
+    if options.min_occurrences < 2 {
+        return Err(SkillError::InvalidConfig {
+            message: "min occurrences must be at least 2".to_owned(),
+        });
+    }
+
+    let mut groups: BTreeMap<String, (Vec<CandidateToolCall>, BTreeSet<String>, usize)> =
+        BTreeMap::new();
+    for trace in traces {
+        if trace.blueprint_id != options.blueprint_id || trace.calls.is_empty() {
+            continue;
+        }
+        let mut redactions = 0usize;
+        let sequence = trace
+            .calls
+            .iter()
+            .map(|call| {
+                let (args_shape, count) = normalize_value(&call.args);
+                redactions += count;
+                CandidateToolCall {
+                    tool: call.tool.clone(),
+                    args_shape,
+                }
+            })
+            .collect::<Vec<_>>();
+        let fingerprint = fingerprint_for(&sequence)?;
+        let entry = groups
+            .entry(fingerprint)
+            .or_insert_with(|| (sequence, BTreeSet::new(), 0));
+        entry.1.insert(trace.trace_id.clone());
+        entry.2 += redactions;
+    }
+
+    let mut candidates = Vec::new();
+    for (fingerprint, (sequence, trace_ids, redaction_count)) in groups {
+        if trace_ids.len() < options.min_occurrences {
+            continue;
+        }
+        let source_trace_ids = trace_ids.into_iter().collect::<Vec<_>>();
+        let name_seed = sequence
+            .iter()
+            .map(|call| call.tool.replace('_', "-"))
+            .collect::<Vec<_>>()
+            .join("-");
+        candidates.push(ProposalCandidate {
+            name_seed,
+            blueprint_id: options.blueprint_id.clone(),
+            fingerprint,
+            occurrences: source_trace_ids.len(),
+            sequence,
+            source_trace_ids,
+            redaction_count,
+        });
+    }
+    candidates.sort_by(|left, right| {
+        right
+            .occurrences
+            .cmp(&left.occurrences)
+            .then(left.fingerprint.cmp(&right.fingerprint))
+    });
+    Ok(candidates)
+}
+
+fn normalize_value(value: &Value) -> (Value, usize) {
+    match value {
+        Value::Object(map) => {
+            let mut out = serde_json::Map::new();
+            let mut redactions = 0usize;
+            for (key, value) in map {
+                if is_secret_key(key) {
+                    out.insert(key.clone(), Value::String("[redacted]".to_owned()));
+                    redactions += 1;
+                } else {
+                    let (normalized, count) = normalize_value(value);
+                    out.insert(key.clone(), normalized);
+                    redactions += count;
+                }
+            }
+            (Value::Object(out), redactions)
+        }
+        Value::Array(values) => {
+            let mut redactions = 0usize;
+            let values = values
+                .iter()
+                .map(|value| {
+                    let (normalized, count) = normalize_value(value);
+                    redactions += count;
+                    normalized
+                })
+                .collect();
+            (Value::Array(values), redactions)
+        }
+        Value::String(text) if looks_like_path(text) => {
+            (Value::String("string:path".to_owned()), 0)
+        }
+        Value::String(text) if looks_like_url(text) => (Value::String("string:url".to_owned()), 0),
+        Value::String(_) => (Value::String("string".to_owned()), 0),
+        Value::Number(_) => (Value::String("number".to_owned()), 0),
+        Value::Bool(_) => (Value::String("bool".to_owned()), 0),
+        Value::Null => (Value::String("null".to_owned()), 0),
+    }
+}
+
+fn is_secret_key(key: &str) -> bool {
+    let key = key.to_ascii_lowercase();
+    key.contains("token")
+        || key.contains("secret")
+        || key.contains("authorization")
+        || key.contains("password")
+}
+
+fn looks_like_path(text: &str) -> bool {
+    text.starts_with('/') || text.contains(".rs") || text.contains(".md") || text.contains(".toml")
+}
+
+fn looks_like_url(text: &str) -> bool {
+    text.starts_with("http://") || text.starts_with("https://")
+}
+
+fn fingerprint_for(sequence: &[CandidateToolCall]) -> Result<String, SkillError> {
+    serde_json::to_string(sequence).map_err(|source| SkillError::InvalidConfig {
+        message: format!("failed to fingerprint proposal candidate: {source}"),
+    })
+}

--- a/crates/agentenv-core/src/skills/propose/generalize.rs
+++ b/crates/agentenv-core/src/skills/propose/generalize.rs
@@ -26,22 +26,36 @@ pub fn validate_generalization(
 ) -> Result<(), SkillError> {
     validate_skill_name(&generalization.name)?;
     require_non_empty("description", &generalization.description)?;
+    reject_secret_text(&generalization.description)?;
     require_non_empty("skill_md_body", &generalization.skill_md_body)?;
     reject_secret_text(&generalization.skill_md_body)?;
 
     let allowed_tools = allowed_tools.iter().cloned().collect::<BTreeSet<_>>();
-    let variables = generalization
-        .template_variables
-        .iter()
-        .map(|variable| variable.name.clone())
-        .collect::<BTreeSet<_>>();
+    let mut variables = BTreeSet::new();
     for variable in &generalization.template_variables {
         validate_skill_name(&variable.name)?;
+        if !variables.insert(variable.name.clone()) {
+            return Err(SkillError::InvalidConfig {
+                message: format!(
+                    "template variable `{}` is declared more than once",
+                    variable.name
+                ),
+            });
+        }
         require_non_empty("template variable description", &variable.description)?;
+        reject_secret_text(&variable.description)?;
+        reject_secret_text(&variable.example)?;
     }
+
+    let mut referenced_variables =
+        template_variables_in("skill_md_body", &generalization.skill_md_body)?;
     for step in &generalization.procedure_steps {
         require_non_empty("procedure step instruction", &step.instruction)?;
         reject_secret_text(&step.instruction)?;
+        referenced_variables.extend(template_variables_in(
+            "procedure step instruction",
+            &step.instruction,
+        )?);
         if let Some(tool) = &step.tool {
             if !allowed_tools.contains(tool) {
                 return Err(SkillError::InvalidConfig {
@@ -50,20 +64,22 @@ pub fn validate_generalization(
             }
         }
     }
-    for variable in variables {
-        let marker = format!("{{{{{variable}}}}}");
-        let referenced = generalization.skill_md_body.contains(&marker)
-            || generalization
-                .procedure_steps
-                .iter()
-                .any(|step| step.instruction.contains(&marker));
-        if !referenced {
+    for variable in &referenced_variables {
+        if !variables.contains(variable) {
+            return Err(SkillError::InvalidConfig {
+                message: format!("template variable `{variable}` is not declared"),
+            });
+        }
+    }
+    for variable in &variables {
+        if !referenced_variables.contains(variable) {
             return Err(SkillError::InvalidConfig {
                 message: format!("template variable `{variable}` is not referenced"),
             });
         }
     }
     require_non_empty("self-test command", &generalization.self_test.command)?;
+    reject_secret_text(&generalization.self_test.command)?;
     Ok(())
 }
 
@@ -78,10 +94,36 @@ fn require_non_empty(field: &str, value: &str) -> Result<(), SkillError> {
 
 fn reject_secret_text(value: &str) -> Result<(), SkillError> {
     let lowered = value.to_ascii_lowercase();
-    if lowered.contains("sk-") || lowered.contains("bearer ") || lowered.contains("token ") {
+    if lowered.contains("sk-")
+        || lowered.contains("bearer ")
+        || lowered.contains("token ")
+        || lowered.contains("token:")
+        || lowered.contains("api_key")
+        || lowered.contains("password")
+    {
         return Err(SkillError::InvalidConfig {
             message: "generalized skill text contains secret-like content".to_owned(),
         });
     }
     Ok(())
+}
+
+fn template_variables_in(field: &str, value: &str) -> Result<BTreeSet<String>, SkillError> {
+    let mut variables = BTreeSet::new();
+    let mut remainder = value;
+    while let Some(start) = remainder.find("{{") {
+        let after_start = &remainder[start + 2..];
+        let Some(end) = after_start.find("}}") else {
+            return Err(SkillError::InvalidConfig {
+                message: format!("{field} contains an unclosed template marker"),
+            });
+        };
+        let variable = &after_start[..end];
+        validate_skill_name(variable).map_err(|_| SkillError::InvalidConfig {
+            message: format!("{field} contains invalid template marker `{{{{{variable}}}}}`"),
+        })?;
+        variables.insert(variable.to_owned());
+        remainder = &after_start[end + 2..];
+    }
+    Ok(variables)
 }

--- a/crates/agentenv-core/src/skills/propose/generalize.rs
+++ b/crates/agentenv-core/src/skills/propose/generalize.rs
@@ -94,7 +94,7 @@ fn require_non_empty(field: &str, value: &str) -> Result<(), SkillError> {
 
 fn reject_secret_text(value: &str) -> Result<(), SkillError> {
     let lowered = value.to_ascii_lowercase();
-    if lowered.contains("sk-")
+    if contains_suspicious_sk_token(&lowered)
         || lowered.contains("bearer ")
         || lowered.contains("token ")
         || lowered.contains("token:")
@@ -108,10 +108,23 @@ fn reject_secret_text(value: &str) -> Result<(), SkillError> {
     Ok(())
 }
 
+fn contains_suspicious_sk_token(value: &str) -> bool {
+    value
+        .split(|character: char| {
+            !character.is_ascii_alphanumeric() && !matches!(character, '-' | '_')
+        })
+        .any(|token| {
+            token
+                .strip_prefix("sk-")
+                .is_some_and(|suffix| !suffix.is_empty())
+        })
+}
+
 fn template_variables_in(field: &str, value: &str) -> Result<BTreeSet<String>, SkillError> {
     let mut variables = BTreeSet::new();
     let mut remainder = value;
     while let Some(start) = remainder.find("{{") {
+        reject_stray_closing_marker(field, &remainder[..start])?;
         let after_start = &remainder[start + 2..];
         let Some(end) = after_start.find("}}") else {
             return Err(SkillError::InvalidConfig {
@@ -125,5 +138,15 @@ fn template_variables_in(field: &str, value: &str) -> Result<BTreeSet<String>, S
         variables.insert(variable.to_owned());
         remainder = &after_start[end + 2..];
     }
+    reject_stray_closing_marker(field, remainder)?;
     Ok(variables)
+}
+
+fn reject_stray_closing_marker(field: &str, value: &str) -> Result<(), SkillError> {
+    if value.contains("}}") {
+        return Err(SkillError::InvalidConfig {
+            message: format!("{field} contains a stray closing template marker"),
+        });
+    }
+    Ok(())
 }

--- a/crates/agentenv-core/src/skills/propose/generalize.rs
+++ b/crates/agentenv-core/src/skills/propose/generalize.rs
@@ -25,6 +25,7 @@ pub fn validate_generalization(
     allowed_tools: &[String],
 ) -> Result<(), SkillError> {
     validate_skill_name(&generalization.name)?;
+    reject_secret_text(&generalization.name)?;
     require_non_empty("description", &generalization.description)?;
     reject_secret_text(&generalization.description)?;
     require_non_empty("skill_md_body", &generalization.skill_md_body)?;
@@ -34,6 +35,7 @@ pub fn validate_generalization(
     let mut variables = BTreeSet::new();
     for variable in &generalization.template_variables {
         validate_skill_name(&variable.name)?;
+        reject_secret_text(&variable.name)?;
         if !variables.insert(variable.name.clone()) {
             return Err(SkillError::InvalidConfig {
                 message: format!(
@@ -44,6 +46,7 @@ pub fn validate_generalization(
         }
         require_non_empty("template variable description", &variable.description)?;
         reject_secret_text(&variable.description)?;
+        require_non_empty("template variable example", &variable.example)?;
         reject_secret_text(&variable.example)?;
     }
 

--- a/crates/agentenv-core/src/skills/propose/generalize.rs
+++ b/crates/agentenv-core/src/skills/propose/generalize.rs
@@ -2,7 +2,7 @@ use std::collections::BTreeSet;
 
 use async_trait::async_trait;
 
-use super::model::SkillGeneralization;
+use super::model::{SkillGeneralization, SAFE_PROPOSAL_SELF_TEST_COMMAND};
 use crate::skills::{validate_skill_name, SkillError};
 
 #[async_trait]
@@ -61,6 +61,12 @@ pub fn validate_generalization(
     for step in &generalization.procedure_steps {
         require_non_empty("procedure step instruction", &step.instruction)?;
         reject_secret_text(&step.instruction)?;
+        if !generalization.skill_md_body.contains(&step.instruction) {
+            return Err(SkillError::InvalidConfig {
+                message: "skill_md_body must include every validated procedure step instruction"
+                    .to_owned(),
+            });
+        }
         step_referenced_variables.extend(template_variables_in(
             "procedure step instruction",
             &step.instruction,
@@ -93,6 +99,7 @@ pub fn validate_generalization(
     }
     require_non_empty("self-test command", &generalization.self_test.command)?;
     reject_secret_text(&generalization.self_test.command)?;
+    validate_self_test_command(&generalization.self_test.command)?;
     Ok(())
 }
 
@@ -116,6 +123,15 @@ fn reject_secret_text(value: &str) -> Result<(), SkillError> {
     {
         return Err(SkillError::InvalidConfig {
             message: "generalized skill text contains secret-like content".to_owned(),
+        });
+    }
+    Ok(())
+}
+
+fn validate_self_test_command(command: &str) -> Result<(), SkillError> {
+    if command != SAFE_PROPOSAL_SELF_TEST_COMMAND {
+        return Err(SkillError::InvalidConfig {
+            message: format!("self-test command must be `{SAFE_PROPOSAL_SELF_TEST_COMMAND}`"),
         });
     }
     Ok(())

--- a/crates/agentenv-core/src/skills/propose/generalize.rs
+++ b/crates/agentenv-core/src/skills/propose/generalize.rs
@@ -1,0 +1,87 @@
+use std::collections::BTreeSet;
+
+use async_trait::async_trait;
+
+use super::model::SkillGeneralization;
+use crate::skills::{validate_skill_name, SkillError};
+
+#[async_trait]
+pub trait SkillGeneralizer: Send + Sync {
+    async fn generalize(
+        &self,
+        request: SkillGeneralizationRequest,
+    ) -> Result<SkillGeneralization, SkillError>;
+}
+
+#[derive(Debug, Clone, PartialEq, serde::Serialize, serde::Deserialize)]
+pub struct SkillGeneralizationRequest {
+    pub schema_version: String,
+    pub candidate_json: serde_json::Value,
+    pub existing_skill_summaries: Vec<String>,
+}
+
+pub fn validate_generalization(
+    generalization: &SkillGeneralization,
+    allowed_tools: &[String],
+) -> Result<(), SkillError> {
+    validate_skill_name(&generalization.name)?;
+    require_non_empty("description", &generalization.description)?;
+    require_non_empty("skill_md_body", &generalization.skill_md_body)?;
+    reject_secret_text(&generalization.skill_md_body)?;
+
+    let allowed_tools = allowed_tools.iter().cloned().collect::<BTreeSet<_>>();
+    let variables = generalization
+        .template_variables
+        .iter()
+        .map(|variable| variable.name.clone())
+        .collect::<BTreeSet<_>>();
+    for variable in &generalization.template_variables {
+        validate_skill_name(&variable.name)?;
+        require_non_empty("template variable description", &variable.description)?;
+    }
+    for step in &generalization.procedure_steps {
+        require_non_empty("procedure step instruction", &step.instruction)?;
+        reject_secret_text(&step.instruction)?;
+        if let Some(tool) = &step.tool {
+            if !allowed_tools.contains(tool) {
+                return Err(SkillError::InvalidConfig {
+                    message: format!("generalized step references unknown tool `{tool}`"),
+                });
+            }
+        }
+    }
+    for variable in variables {
+        let marker = format!("{{{{{variable}}}}}");
+        let referenced = generalization.skill_md_body.contains(&marker)
+            || generalization
+                .procedure_steps
+                .iter()
+                .any(|step| step.instruction.contains(&marker));
+        if !referenced {
+            return Err(SkillError::InvalidConfig {
+                message: format!("template variable `{variable}` is not referenced"),
+            });
+        }
+    }
+    require_non_empty("self-test command", &generalization.self_test.command)?;
+    Ok(())
+}
+
+fn require_non_empty(field: &str, value: &str) -> Result<(), SkillError> {
+    if value.trim().is_empty() {
+        return Err(SkillError::InvalidConfig {
+            message: format!("{field} must not be empty"),
+        });
+    }
+    Ok(())
+}
+
+fn reject_secret_text(value: &str) -> Result<(), SkillError> {
+    let lowered = value.to_ascii_lowercase();
+    if lowered.contains("sk-") || lowered.contains("bearer ") || lowered.contains("token ") {
+        return Err(SkillError::InvalidConfig {
+            message: "generalized skill text contains secret-like content".to_owned(),
+        });
+    }
+    Ok(())
+}

--- a/crates/agentenv-core/src/skills/propose/generalize.rs
+++ b/crates/agentenv-core/src/skills/propose/generalize.rs
@@ -49,13 +49,19 @@ pub fn validate_generalization(
         require_non_empty("template variable example", &variable.example)?;
         reject_secret_text(&variable.example)?;
     }
+    if generalization.procedure_steps.is_empty() {
+        return Err(SkillError::InvalidConfig {
+            message: "procedure_steps must not be empty".to_owned(),
+        });
+    }
 
-    let mut referenced_variables =
+    let body_referenced_variables =
         template_variables_in("skill_md_body", &generalization.skill_md_body)?;
+    let mut step_referenced_variables = BTreeSet::new();
     for step in &generalization.procedure_steps {
         require_non_empty("procedure step instruction", &step.instruction)?;
         reject_secret_text(&step.instruction)?;
-        referenced_variables.extend(template_variables_in(
+        step_referenced_variables.extend(template_variables_in(
             "procedure step instruction",
             &step.instruction,
         )?);
@@ -67,6 +73,8 @@ pub fn validate_generalization(
             }
         }
     }
+    let mut referenced_variables = body_referenced_variables;
+    referenced_variables.extend(step_referenced_variables.iter().cloned());
     for variable in &referenced_variables {
         if !variables.contains(variable) {
             return Err(SkillError::InvalidConfig {
@@ -75,9 +83,11 @@ pub fn validate_generalization(
         }
     }
     for variable in &variables {
-        if !referenced_variables.contains(variable) {
+        if !step_referenced_variables.contains(variable) {
             return Err(SkillError::InvalidConfig {
-                message: format!("template variable `{variable}` is not referenced"),
+                message: format!(
+                    "template variable `{variable}` is not referenced by a procedure step"
+                ),
             });
         }
     }

--- a/crates/agentenv-core/src/skills/propose/mod.rs
+++ b/crates/agentenv-core/src/skills/propose/mod.rs
@@ -1,5 +1,10 @@
 mod extract;
+mod generalize;
 mod model;
 
 pub use extract::{extract_candidates, normalize_args_shape};
-pub use model::{CandidateExtractionOptions, CandidateToolCall, ProposalCandidate};
+pub use generalize::{validate_generalization, SkillGeneralizationRequest, SkillGeneralizer};
+pub use model::{
+    CandidateExtractionOptions, CandidateToolCall, ProcedureStep, ProposalCandidate,
+    ProposedSelfTest, SkillGeneralization, TemplateVariable,
+};

--- a/crates/agentenv-core/src/skills/propose/mod.rs
+++ b/crates/agentenv-core/src/skills/propose/mod.rs
@@ -2,12 +2,14 @@ mod extract;
 mod generalize;
 mod model;
 mod score;
+mod self_test;
 
 pub use extract::{extract_candidates, normalize_args_shape};
 pub use generalize::{validate_generalization, SkillGeneralizationRequest, SkillGeneralizer};
 pub use model::{
     CandidateExtractionOptions, CandidateToolCall, ExistingSkillSummary, NoveltyBackend,
-    ProcedureStep, ProposalCandidate, ProposalScore, ProposalScoreInput, ProposedSelfTest,
-    SkillGeneralization, SkillMatch, TemplateVariable,
+    ProcedureStep, ProposalCandidate, ProposalScore, ProposalScoreInput, ProposalSelfTestInput,
+    ProposalSelfTestReport, ProposedSelfTest, SkillGeneralization, SkillMatch, TemplateVariable,
 };
 pub use score::score_proposal;
+pub use self_test::evaluate_self_test;

--- a/crates/agentenv-core/src/skills/propose/mod.rs
+++ b/crates/agentenv-core/src/skills/propose/mod.rs
@@ -1,15 +1,18 @@
+mod emit;
 mod extract;
 mod generalize;
 mod model;
 mod score;
 mod self_test;
 
+pub use emit::emit_proposal;
 pub use extract::{extract_candidates, normalize_args_shape};
 pub use generalize::{validate_generalization, SkillGeneralizationRequest, SkillGeneralizer};
 pub use model::{
     CandidateExtractionOptions, CandidateToolCall, ExistingSkillSummary, NoveltyBackend,
-    ProcedureStep, ProposalCandidate, ProposalScore, ProposalScoreInput, ProposalSelfTestInput,
-    ProposalSelfTestReport, ProposedSelfTest, SkillGeneralization, SkillMatch, TemplateVariable,
+    ProcedureStep, ProposalCandidate, ProposalEmitInput, ProposalEmitOutput, ProposalScore,
+    ProposalScoreInput, ProposalSelfTestInput, ProposalSelfTestReport, ProposedSelfTest,
+    SkillGeneralization, SkillMatch, TemplateVariable,
 };
 pub use score::score_proposal;
 pub use self_test::evaluate_self_test;

--- a/crates/agentenv-core/src/skills/propose/mod.rs
+++ b/crates/agentenv-core/src/skills/propose/mod.rs
@@ -1,0 +1,5 @@
+mod extract;
+mod model;
+
+pub use extract::{extract_candidates, normalize_args_shape};
+pub use model::{CandidateExtractionOptions, CandidateToolCall, ProposalCandidate};

--- a/crates/agentenv-core/src/skills/propose/mod.rs
+++ b/crates/agentenv-core/src/skills/propose/mod.rs
@@ -4,6 +4,7 @@ mod generalize;
 mod model;
 mod score;
 mod self_test;
+mod service;
 
 pub use emit::emit_proposal;
 pub use extract::{extract_candidates, normalize_args_shape};
@@ -11,8 +12,9 @@ pub use generalize::{validate_generalization, SkillGeneralizationRequest, SkillG
 pub use model::{
     CandidateExtractionOptions, CandidateToolCall, ExistingSkillSummary, NoveltyBackend,
     ProcedureStep, ProposalCandidate, ProposalEmitInput, ProposalEmitOutput, ProposalScore,
-    ProposalScoreInput, ProposalSelfTestInput, ProposalSelfTestReport, ProposedSelfTest,
-    SkillGeneralization, SkillMatch, TemplateVariable,
+    ProposalScoreInput, ProposalSelfTestInput, ProposalSelfTestReport, ProposeRunInput,
+    ProposeRunOutput, ProposedSelfTest, SkillGeneralization, SkillMatch, TemplateVariable,
 };
 pub use score::score_proposal;
 pub use self_test::evaluate_self_test;
+pub use service::ProposedSkillService;

--- a/crates/agentenv-core/src/skills/propose/mod.rs
+++ b/crates/agentenv-core/src/skills/propose/mod.rs
@@ -1,10 +1,13 @@
 mod extract;
 mod generalize;
 mod model;
+mod score;
 
 pub use extract::{extract_candidates, normalize_args_shape};
 pub use generalize::{validate_generalization, SkillGeneralizationRequest, SkillGeneralizer};
 pub use model::{
-    CandidateExtractionOptions, CandidateToolCall, ProcedureStep, ProposalCandidate,
-    ProposedSelfTest, SkillGeneralization, TemplateVariable,
+    CandidateExtractionOptions, CandidateToolCall, ExistingSkillSummary, NoveltyBackend,
+    ProcedureStep, ProposalCandidate, ProposalScore, ProposalScoreInput, ProposedSelfTest,
+    SkillGeneralization, SkillMatch, TemplateVariable,
 };
+pub use score::score_proposal;

--- a/crates/agentenv-core/src/skills/propose/model.rs
+++ b/crates/agentenv-core/src/skills/propose/model.rs
@@ -114,3 +114,22 @@ pub struct ProposalSelfTestReport {
     pub total_variables: u32,
     pub failures: Vec<String>,
 }
+
+#[derive(Debug, Clone)]
+pub struct ProposalEmitInput {
+    pub output_root: std::path::PathBuf,
+    pub candidate: ProposalCandidate,
+    pub generalization: SkillGeneralization,
+    pub score: ProposalScore,
+    pub self_test: ProposalSelfTestReport,
+    pub agentenv_version: String,
+    pub created_at: String,
+}
+
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+pub struct ProposalEmitOutput {
+    pub name: String,
+    pub path: std::path::PathBuf,
+    pub novelty: f32,
+    pub self_test_score: f32,
+}

--- a/crates/agentenv-core/src/skills/propose/model.rs
+++ b/crates/agentenv-core/src/skills/propose/model.rs
@@ -1,0 +1,25 @@
+use serde::{Deserialize, Serialize};
+use serde_json::Value;
+
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+pub struct ProposalCandidate {
+    pub name_seed: String,
+    pub blueprint_id: String,
+    pub fingerprint: String,
+    pub occurrences: usize,
+    pub sequence: Vec<CandidateToolCall>,
+    pub source_trace_ids: Vec<String>,
+    pub redaction_count: usize,
+}
+
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+pub struct CandidateToolCall {
+    pub tool: String,
+    pub args_shape: Value,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct CandidateExtractionOptions {
+    pub blueprint_id: String,
+    pub min_occurrences: usize,
+}

--- a/crates/agentenv-core/src/skills/propose/model.rs
+++ b/crates/agentenv-core/src/skills/propose/model.rs
@@ -95,3 +95,22 @@ pub struct ProposalScoreInput {
     pub existing_skills: Vec<ExistingSkillSummary>,
     pub backend: NoveltyBackend,
 }
+
+#[derive(Debug, Clone, PartialEq)]
+pub struct ProposalSelfTestInput {
+    pub source_tools: Vec<String>,
+    pub procedure_steps: Vec<ProcedureStep>,
+    pub template_variables: Vec<TemplateVariable>,
+    pub min_score: f32,
+}
+
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+pub struct ProposalSelfTestReport {
+    pub score: f32,
+    pub passed: bool,
+    pub matched_steps: u32,
+    pub total_steps: u32,
+    pub matched_variables: u32,
+    pub total_variables: u32,
+    pub failures: Vec<String>,
+}

--- a/crates/agentenv-core/src/skills/propose/model.rs
+++ b/crates/agentenv-core/src/skills/propose/model.rs
@@ -80,6 +80,25 @@ pub struct ExistingSkillSummary {
     pub fingerprint: Option<String>,
 }
 
+#[derive(Debug, Clone)]
+pub struct ProposeRunInput {
+    pub traces: Vec<agentenv_events::TraceRun>,
+    pub output_root: std::path::PathBuf,
+    pub blueprint_id: String,
+    pub min_occurrences: usize,
+    pub min_novelty: f32,
+    pub min_self_test_score: f32,
+    pub existing_skills: Vec<ExistingSkillSummary>,
+    pub agentenv_version: String,
+    pub created_at: String,
+}
+
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+pub struct ProposeRunOutput {
+    pub proposals: Vec<ProposalEmitOutput>,
+    pub warnings: Vec<String>,
+}
+
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum NoveltyBackend {
     Local,

--- a/crates/agentenv-core/src/skills/propose/model.rs
+++ b/crates/agentenv-core/src/skills/propose/model.rs
@@ -131,5 +131,7 @@ pub struct ProposalEmitOutput {
     pub name: String,
     pub path: std::path::PathBuf,
     pub novelty: f32,
+    pub utility: f32,
+    pub final_score: f32,
     pub self_test_score: f32,
 }

--- a/crates/agentenv-core/src/skills/propose/model.rs
+++ b/crates/agentenv-core/src/skills/propose/model.rs
@@ -1,6 +1,8 @@
 use serde::{Deserialize, Serialize};
 use serde_json::Value;
 
+pub const SAFE_PROPOSAL_SELF_TEST_COMMAND: &str = "test -f SKILL.md";
+
 #[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
 pub struct ProposalCandidate {
     pub name_seed: String,

--- a/crates/agentenv-core/src/skills/propose/model.rs
+++ b/crates/agentenv-core/src/skills/propose/model.rs
@@ -55,3 +55,43 @@ pub struct ProcedureStep {
 pub struct ProposedSelfTest {
     pub command: String,
 }
+
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+pub struct ProposalScore {
+    pub novelty: f32,
+    pub utility: f32,
+    pub final_score: f32,
+    pub nearest_matches: Vec<SkillMatch>,
+    pub reasons: Vec<String>,
+}
+
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+pub struct SkillMatch {
+    pub name: String,
+    pub similarity: f32,
+    pub reason: String,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct ExistingSkillSummary {
+    pub name: String,
+    pub description: String,
+    pub procedure_text: String,
+    pub fingerprint: Option<String>,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum NoveltyBackend {
+    Local,
+}
+
+#[derive(Debug, Clone, PartialEq)]
+pub struct ProposalScoreInput {
+    pub name: String,
+    pub description: String,
+    pub procedure_text: String,
+    pub fingerprint: String,
+    pub occurrences: usize,
+    pub existing_skills: Vec<ExistingSkillSummary>,
+    pub backend: NoveltyBackend,
+}

--- a/crates/agentenv-core/src/skills/propose/model.rs
+++ b/crates/agentenv-core/src/skills/propose/model.rs
@@ -23,3 +23,35 @@ pub struct CandidateExtractionOptions {
     pub blueprint_id: String,
     pub min_occurrences: usize,
 }
+
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct SkillGeneralization {
+    pub name: String,
+    pub description: String,
+    pub template_variables: Vec<TemplateVariable>,
+    pub procedure_steps: Vec<ProcedureStep>,
+    pub self_test: ProposedSelfTest,
+    pub skill_md_body: String,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct TemplateVariable {
+    pub name: String,
+    pub description: String,
+    pub example: String,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct ProcedureStep {
+    pub tool: Option<String>,
+    pub instruction: String,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct ProposedSelfTest {
+    pub command: String,
+}

--- a/crates/agentenv-core/src/skills/propose/score.rs
+++ b/crates/agentenv-core/src/skills/propose/score.rs
@@ -1,0 +1,85 @@
+use std::collections::BTreeSet;
+
+use super::model::{ProposalScore, ProposalScoreInput, SkillMatch};
+use crate::skills::SkillError;
+
+pub fn score_proposal(input: ProposalScoreInput) -> Result<ProposalScore, SkillError> {
+    let mut best: Option<SkillMatch> = None;
+    let mut novelty = 0.9f32;
+    let mut reasons = Vec::new();
+
+    for existing in &input.existing_skills {
+        if existing.fingerprint.as_deref() == Some(input.fingerprint.as_str()) {
+            novelty = 0.0;
+            best = Some(SkillMatch {
+                name: existing.name.clone(),
+                similarity: 1.0,
+                reason: "exact fingerprint match".to_owned(),
+            });
+            reasons.push("duplicate of existing skill".to_owned());
+            break;
+        }
+        let similarity = jaccard(&input.procedure_text, &existing.procedure_text)
+            .max(jaccard(&input.description, &existing.description));
+        if best
+            .as_ref()
+            .is_none_or(|current| similarity > current.similarity)
+        {
+            best = Some(SkillMatch {
+                name: existing.name.clone(),
+                similarity,
+                reason: "local semantic similarity".to_owned(),
+            });
+        }
+    }
+
+    if novelty != 0.0 {
+        if let Some(best) = &best {
+            novelty = if best.similarity >= 0.85 {
+                reasons.push("minor variation of existing skill".to_owned());
+                0.3
+            } else if best.similarity >= 0.45 {
+                reasons.push("distinct variant of existing skill family".to_owned());
+                0.6
+            } else {
+                reasons.push("new capability category".to_owned());
+                0.9
+            };
+        } else {
+            reasons.push("no existing skill matches".to_owned());
+        }
+    }
+
+    let utility = ((input.occurrences as f32) / 5.0).clamp(0.0, 1.0);
+    let final_score = (novelty * 0.7) + (utility * 0.3);
+    Ok(ProposalScore {
+        novelty,
+        utility,
+        final_score,
+        nearest_matches: best.into_iter().collect(),
+        reasons,
+    })
+}
+
+fn jaccard(left: &str, right: &str) -> f32 {
+    let left = tokens(left);
+    let right = tokens(right);
+    if left.is_empty() && right.is_empty() {
+        return 1.0;
+    }
+    let intersection = left.intersection(&right).count() as f32;
+    let union = left.union(&right).count() as f32;
+    if union == 0.0 {
+        0.0
+    } else {
+        intersection / union
+    }
+}
+
+fn tokens(value: &str) -> BTreeSet<String> {
+    value
+        .split(|character: char| !character.is_ascii_alphanumeric())
+        .filter(|token| !token.is_empty())
+        .map(|token| token.to_ascii_lowercase())
+        .collect()
+}

--- a/crates/agentenv-core/src/skills/propose/self_test.rs
+++ b/crates/agentenv-core/src/skills/propose/self_test.rs
@@ -17,23 +17,22 @@ pub fn evaluate_self_test(
         });
     }
 
-    let source_tools = input.source_tools.iter().cloned().collect::<BTreeSet<_>>();
-    let covered_source_tools = input
+    let source_tool_names = input.source_tools.iter().cloned().collect::<BTreeSet<_>>();
+    let generated_tools = input
         .procedure_steps
         .iter()
         .filter_map(|step| step.tool.as_ref())
-        .filter(|tool| source_tools.contains(*tool))
         .cloned()
-        .collect::<BTreeSet<_>>();
+        .collect::<Vec<_>>();
     let unknown_step_tools = input
         .procedure_steps
         .iter()
         .filter_map(|step| step.tool.as_ref())
-        .filter(|tool| !source_tools.contains(*tool))
+        .filter(|tool| !source_tool_names.contains(*tool))
         .cloned()
         .collect::<BTreeSet<_>>();
-    let total_steps = source_tools.len() as u32;
-    let matched_steps = covered_source_tools.len() as u32;
+    let matched_steps = ordered_match_count(&input.source_tools, &generated_tools) as u32;
+    let total_steps = input.source_tools.len() as u32;
 
     let all_text = input
         .procedure_steps
@@ -53,7 +52,9 @@ pub fn evaluate_self_test(
     let score = ((step_score * 0.7) + (variable_score * 0.3)).clamp(0.0, 1.0);
     let mut failures = Vec::new();
     if matched_steps != total_steps {
-        failures.push("not every source tool is covered by a procedure step".to_owned());
+        failures.push(
+            "not every source tool sequence occurrence is covered by a procedure step".to_owned(),
+        );
     }
     if !unknown_step_tools.is_empty() {
         failures.push(format!(
@@ -78,6 +79,21 @@ pub fn evaluate_self_test(
         total_variables,
         failures,
     })
+}
+
+fn ordered_match_count(source_tools: &[String], generated_tools: &[String]) -> usize {
+    let mut lengths = vec![vec![0usize; generated_tools.len() + 1]; source_tools.len() + 1];
+    for (source_index, source_tool) in source_tools.iter().enumerate() {
+        for (generated_index, generated_tool) in generated_tools.iter().enumerate() {
+            lengths[source_index + 1][generated_index + 1] = if source_tool == generated_tool {
+                lengths[source_index][generated_index] + 1
+            } else {
+                lengths[source_index][generated_index + 1]
+                    .max(lengths[source_index + 1][generated_index])
+            };
+        }
+    }
+    lengths[source_tools.len()][generated_tools.len()]
 }
 
 fn ratio(matched: u32, total: u32) -> f32 {

--- a/crates/agentenv-core/src/skills/propose/self_test.rs
+++ b/crates/agentenv-core/src/skills/propose/self_test.rs
@@ -11,18 +11,29 @@ pub fn evaluate_self_test(
             message: "min self-test score must be between 0.0 and 1.0".to_owned(),
         });
     }
+    if input.procedure_steps.is_empty() {
+        return Err(SkillError::InvalidConfig {
+            message: "self-test requires at least one procedure step".to_owned(),
+        });
+    }
 
     let source_tools = input.source_tools.iter().cloned().collect::<BTreeSet<_>>();
-    let total_steps = input.procedure_steps.len() as u32;
-    let matched_steps = input
+    let covered_source_tools = input
         .procedure_steps
         .iter()
-        .filter(|step| {
-            step.tool
-                .as_ref()
-                .is_some_and(|tool| source_tools.contains(tool))
-        })
-        .count() as u32;
+        .filter_map(|step| step.tool.as_ref())
+        .filter(|tool| source_tools.contains(*tool))
+        .cloned()
+        .collect::<BTreeSet<_>>();
+    let unknown_step_tools = input
+        .procedure_steps
+        .iter()
+        .filter_map(|step| step.tool.as_ref())
+        .filter(|tool| !source_tools.contains(*tool))
+        .cloned()
+        .collect::<BTreeSet<_>>();
+    let total_steps = source_tools.len() as u32;
+    let matched_steps = covered_source_tools.len() as u32;
 
     let all_text = input
         .procedure_steps
@@ -42,7 +53,17 @@ pub fn evaluate_self_test(
     let score = ((step_score * 0.7) + (variable_score * 0.3)).clamp(0.0, 1.0);
     let mut failures = Vec::new();
     if matched_steps != total_steps {
-        failures.push("not every procedure step maps to a source tool".to_owned());
+        failures.push("not every source tool is covered by a procedure step".to_owned());
+    }
+    if !unknown_step_tools.is_empty() {
+        failures.push(format!(
+            "generated step references tool outside source trace tools: {}",
+            unknown_step_tools
+                .iter()
+                .cloned()
+                .collect::<Vec<_>>()
+                .join(", ")
+        ));
     }
     if matched_variables != total_variables {
         failures.push("not every template variable is referenced by a step".to_owned());
@@ -50,7 +71,7 @@ pub fn evaluate_self_test(
 
     Ok(ProposalSelfTestReport {
         score,
-        passed: score >= input.min_score,
+        passed: failures.is_empty() && score >= input.min_score,
         matched_steps,
         total_steps,
         matched_variables,

--- a/crates/agentenv-core/src/skills/propose/self_test.rs
+++ b/crates/agentenv-core/src/skills/propose/self_test.rs
@@ -1,0 +1,68 @@
+use std::collections::BTreeSet;
+
+use super::model::{ProposalSelfTestInput, ProposalSelfTestReport};
+use crate::skills::SkillError;
+
+pub fn evaluate_self_test(
+    input: ProposalSelfTestInput,
+) -> Result<ProposalSelfTestReport, SkillError> {
+    if !(0.0..=1.0).contains(&input.min_score) {
+        return Err(SkillError::InvalidConfig {
+            message: "min self-test score must be between 0.0 and 1.0".to_owned(),
+        });
+    }
+
+    let source_tools = input.source_tools.iter().cloned().collect::<BTreeSet<_>>();
+    let total_steps = input.procedure_steps.len() as u32;
+    let matched_steps = input
+        .procedure_steps
+        .iter()
+        .filter(|step| {
+            step.tool
+                .as_ref()
+                .is_some_and(|tool| source_tools.contains(tool))
+        })
+        .count() as u32;
+
+    let all_text = input
+        .procedure_steps
+        .iter()
+        .map(|step| step.instruction.as_str())
+        .collect::<Vec<_>>()
+        .join("\n");
+    let total_variables = input.template_variables.len() as u32;
+    let matched_variables = input
+        .template_variables
+        .iter()
+        .filter(|variable| all_text.contains(&format!("{{{{{}}}}}", variable.name)))
+        .count() as u32;
+
+    let step_score = ratio(matched_steps, total_steps);
+    let variable_score = ratio(matched_variables, total_variables);
+    let score = ((step_score * 0.7) + (variable_score * 0.3)).clamp(0.0, 1.0);
+    let mut failures = Vec::new();
+    if matched_steps != total_steps {
+        failures.push("not every procedure step maps to a source tool".to_owned());
+    }
+    if matched_variables != total_variables {
+        failures.push("not every template variable is referenced by a step".to_owned());
+    }
+
+    Ok(ProposalSelfTestReport {
+        score,
+        passed: score >= input.min_score,
+        matched_steps,
+        total_steps,
+        matched_variables,
+        total_variables,
+        failures,
+    })
+}
+
+fn ratio(matched: u32, total: u32) -> f32 {
+    if total == 0 {
+        1.0
+    } else {
+        matched as f32 / total as f32
+    }
+}

--- a/crates/agentenv-core/src/skills/propose/service.rs
+++ b/crates/agentenv-core/src/skills/propose/service.rs
@@ -1,3 +1,5 @@
+use std::collections::BTreeSet;
+
 use super::{
     emit_proposal, evaluate_self_test, extract_candidates, score_proposal, validate_generalization,
     CandidateExtractionOptions, ProposalEmitInput, ProposalScoreInput, ProposalSelfTestInput,
@@ -15,6 +17,7 @@ impl ProposedSkillService {
     }
 
     pub async fn run(&self, input: ProposeRunInput) -> Result<ProposeRunOutput, SkillError> {
+        validate_min_novelty(input.min_novelty)?;
         let candidates = extract_candidates(
             &input.traces,
             CandidateExtractionOptions {
@@ -24,6 +27,7 @@ impl ProposedSkillService {
         )?;
         let mut proposals = Vec::new();
         let mut warnings = Vec::new();
+        let mut emitted_names = BTreeSet::new();
         for candidate in candidates {
             let request = SkillGeneralizationRequest {
                 schema_version: "0.1".to_owned(),
@@ -68,9 +72,18 @@ impl ProposedSkillService {
                 min_score: input.min_self_test_score,
             })?;
             if !self_test.passed {
+                warnings.push(self_test_warning(
+                    &generalization.name,
+                    self_test.score,
+                    input.min_self_test_score,
+                    &self_test.failures,
+                ));
+                continue;
+            }
+            if !emitted_names.insert(generalization.name.clone()) {
                 warnings.push(format!(
-                    "skipped `{}` because self-test score {} is below {}",
-                    generalization.name, self_test.score, input.min_self_test_score
+                    "skipped `{}` because duplicate generated name was already proposed",
+                    generalization.name
                 ));
                 continue;
             }
@@ -88,5 +101,37 @@ impl ProposedSkillService {
             proposals,
             warnings,
         })
+    }
+}
+
+fn validate_min_novelty(min_novelty: f32) -> Result<(), SkillError> {
+    if !min_novelty.is_finite() || !(0.0..=1.0).contains(&min_novelty) {
+        return Err(SkillError::InvalidConfig {
+            message: "min novelty must be a finite value between 0.0 and 1.0".to_owned(),
+        });
+    }
+    Ok(())
+}
+
+fn self_test_warning(
+    name: &str,
+    score: f32,
+    min_self_test_score: f32,
+    failures: &[String],
+) -> String {
+    let score_below_threshold = score < min_self_test_score;
+    match (failures.is_empty(), score_below_threshold) {
+        (true, true) => format!(
+            "skipped `{name}` because self-test score {score} is below {min_self_test_score}"
+        ),
+        (true, false) => format!("skipped `{name}` because self-test did not pass"),
+        (false, true) => format!(
+            "skipped `{name}` because self-test failed: {}; score {score} is below {min_self_test_score}",
+            failures.join("; ")
+        ),
+        (false, false) => format!(
+            "skipped `{name}` because self-test failed: {}",
+            failures.join("; ")
+        ),
     }
 }

--- a/crates/agentenv-core/src/skills/propose/service.rs
+++ b/crates/agentenv-core/src/skills/propose/service.rs
@@ -1,0 +1,92 @@
+use super::{
+    emit_proposal, evaluate_self_test, extract_candidates, score_proposal, validate_generalization,
+    CandidateExtractionOptions, ProposalEmitInput, ProposalScoreInput, ProposalSelfTestInput,
+    ProposeRunInput, ProposeRunOutput, SkillGeneralizationRequest, SkillGeneralizer,
+};
+use crate::skills::SkillError;
+
+pub struct ProposedSkillService {
+    generalizer: Box<dyn SkillGeneralizer>,
+}
+
+impl ProposedSkillService {
+    pub fn new(generalizer: Box<dyn SkillGeneralizer>) -> Self {
+        Self { generalizer }
+    }
+
+    pub async fn run(&self, input: ProposeRunInput) -> Result<ProposeRunOutput, SkillError> {
+        let candidates = extract_candidates(
+            &input.traces,
+            CandidateExtractionOptions {
+                blueprint_id: input.blueprint_id.clone(),
+                min_occurrences: input.min_occurrences,
+            },
+        )?;
+        let mut proposals = Vec::new();
+        let mut warnings = Vec::new();
+        for candidate in candidates {
+            let request = SkillGeneralizationRequest {
+                schema_version: "0.1".to_owned(),
+                candidate_json: serde_json::to_value(&candidate).map_err(|source| {
+                    SkillError::InvalidConfig {
+                        message: format!("failed to encode proposal candidate: {source}"),
+                    }
+                })?,
+                existing_skill_summaries: input
+                    .existing_skills
+                    .iter()
+                    .map(|skill| skill.name.clone())
+                    .collect(),
+            };
+            let generalization = self.generalizer.generalize(request).await?;
+            let allowed_tools = candidate
+                .sequence
+                .iter()
+                .map(|call| call.tool.clone())
+                .collect::<Vec<_>>();
+            validate_generalization(&generalization, &allowed_tools)?;
+            let score = score_proposal(ProposalScoreInput {
+                name: generalization.name.clone(),
+                description: generalization.description.clone(),
+                procedure_text: generalization.skill_md_body.clone(),
+                fingerprint: candidate.fingerprint.clone(),
+                occurrences: candidate.occurrences,
+                existing_skills: input.existing_skills.clone(),
+                backend: super::NoveltyBackend::Local,
+            })?;
+            if score.novelty < input.min_novelty {
+                warnings.push(format!(
+                    "skipped `{}` because novelty {} is below {}",
+                    generalization.name, score.novelty, input.min_novelty
+                ));
+                continue;
+            }
+            let self_test = evaluate_self_test(ProposalSelfTestInput {
+                source_tools: allowed_tools,
+                procedure_steps: generalization.procedure_steps.clone(),
+                template_variables: generalization.template_variables.clone(),
+                min_score: input.min_self_test_score,
+            })?;
+            if !self_test.passed {
+                warnings.push(format!(
+                    "skipped `{}` because self-test score {} is below {}",
+                    generalization.name, self_test.score, input.min_self_test_score
+                ));
+                continue;
+            }
+            proposals.push(emit_proposal(ProposalEmitInput {
+                output_root: input.output_root.clone(),
+                candidate,
+                generalization,
+                score,
+                self_test,
+                agentenv_version: input.agentenv_version.clone(),
+                created_at: input.created_at.clone(),
+            })?);
+        }
+        Ok(ProposeRunOutput {
+            proposals,
+            warnings,
+        })
+    }
+}

--- a/crates/agentenv-core/tests/skill_propose.rs
+++ b/crates/agentenv-core/tests/skill_propose.rs
@@ -389,6 +389,70 @@ fn self_test_missing_source_tool_coverage_fails() {
     assert!(!report.passed);
     assert!(report.matched_steps < report.total_steps);
     assert_eq!(report.matched_steps, 1);
+    assert_eq!(report.total_steps, 3);
+}
+
+#[test]
+fn self_test_missing_repeated_source_tool_fails() {
+    let report = evaluate_self_test(ProposalSelfTestInput {
+        source_tools: vec![
+            "fs_read".to_owned(),
+            "fs_write".to_owned(),
+            "fs_read".to_owned(),
+        ],
+        procedure_steps: vec![
+            ProcedureStep {
+                tool: Some("fs_read".to_owned()),
+                instruction: "Read {{target_path}} before editing.".to_owned(),
+            },
+            ProcedureStep {
+                tool: Some("fs_write".to_owned()),
+                instruction: "Write {{target_path}}.".to_owned(),
+            },
+        ],
+        template_variables: vec![TemplateVariable {
+            name: "target_path".to_owned(),
+            description: "Target path".to_owned(),
+            example: "src/lib.rs".to_owned(),
+        }],
+        min_score: 0.8,
+    })
+    .unwrap();
+
+    assert!(!report.passed);
+    assert_eq!(report.matched_steps, 2);
+    assert_eq!(report.total_steps, 3);
+    assert!(report
+        .failures
+        .iter()
+        .any(|failure| failure.contains("source tool sequence")));
+}
+
+#[test]
+fn self_test_order_sensitive_source_tool_coverage_fails() {
+    let report = evaluate_self_test(ProposalSelfTestInput {
+        source_tools: vec!["fs_read".to_owned(), "fs_write".to_owned()],
+        procedure_steps: vec![
+            ProcedureStep {
+                tool: Some("fs_write".to_owned()),
+                instruction: "Write {{target_path}}.".to_owned(),
+            },
+            ProcedureStep {
+                tool: Some("fs_read".to_owned()),
+                instruction: "Read {{target_path}} after writing.".to_owned(),
+            },
+        ],
+        template_variables: vec![TemplateVariable {
+            name: "target_path".to_owned(),
+            description: "Target path".to_owned(),
+            example: "src/lib.rs".to_owned(),
+        }],
+        min_score: 0.8,
+    })
+    .unwrap();
+
+    assert!(!report.passed);
+    assert_eq!(report.matched_steps, 1);
     assert_eq!(report.total_steps, 2);
 }
 
@@ -602,6 +666,128 @@ async fn proposal_service_runs_full_pipeline_with_fake_generalizer() {
     assert!(output.proposals[0].path.join("SKILL.md").is_file());
 }
 
+#[tokio::test]
+async fn proposal_service_skips_duplicate_generated_names_with_warning() {
+    let temp = temp_dir("proposal-service-duplicate");
+    let traces = vec![
+        trace("trace-1", vec![call("fs_read", "/repo/a.rs")]),
+        trace("trace-2", vec![call("fs_read", "/repo/b.rs")]),
+        trace("trace-3", vec![call("fs_read", "/repo/c.rs")]),
+        trace(
+            "trace-4",
+            vec![call("fs_read", "/repo/d.rs"), call("fs_read", "/repo/d.rs")],
+        ),
+        trace(
+            "trace-5",
+            vec![call("fs_read", "/repo/e.rs"), call("fs_read", "/repo/e.rs")],
+        ),
+        trace(
+            "trace-6",
+            vec![call("fs_read", "/repo/f.rs"), call("fs_read", "/repo/f.rs")],
+        ),
+    ];
+    let service = ProposedSkillService::new(Box::new(DuplicateNameGeneralizer));
+
+    let output = service
+        .run(ProposeRunInput {
+            traces,
+            output_root: temp.join("proposed"),
+            blueprint_id: "sha256:blueprint-a".to_owned(),
+            min_occurrences: 3,
+            min_novelty: 0.6,
+            min_self_test_score: 0.8,
+            existing_skills: Vec::new(),
+            agentenv_version: "0.0.1-alpha0".to_owned(),
+            created_at: "2026-05-11T00:00:00Z".to_owned(),
+        })
+        .await
+        .unwrap();
+
+    assert_eq!(output.proposals.len(), 1);
+    assert_eq!(output.proposals[0].name, "fs-edit-skill");
+    assert!(output
+        .warnings
+        .iter()
+        .any(|warning| warning.contains("duplicate generated name")));
+}
+
+#[tokio::test]
+async fn proposal_service_rejects_invalid_min_novelty_before_generalization() {
+    for min_novelty in [f32::NAN, -0.1, 1.1] {
+        let service = ProposedSkillService::new(Box::new(PanicGeneralizer));
+
+        let error = service
+            .run(ProposeRunInput {
+                traces: Vec::new(),
+                output_root: temp_dir("proposal-service-invalid-novelty").join("proposed"),
+                blueprint_id: "sha256:blueprint-a".to_owned(),
+                min_occurrences: 3,
+                min_novelty,
+                min_self_test_score: 0.8,
+                existing_skills: Vec::new(),
+                agentenv_version: "0.0.1-alpha0".to_owned(),
+                created_at: "2026-05-11T00:00:00Z".to_owned(),
+            })
+            .await
+            .unwrap_err();
+
+        assert!(error.to_string().contains("min novelty"));
+    }
+}
+
+#[tokio::test]
+async fn proposal_service_self_test_warning_includes_failures() {
+    let temp = temp_dir("proposal-service-self-test-warning");
+    let traces = vec![
+        trace(
+            "trace-1",
+            vec![
+                call("fs_read", "/repo/a.rs"),
+                call("fs_write", "/repo/a.rs"),
+                call("fs_read", "/repo/a.rs"),
+            ],
+        ),
+        trace(
+            "trace-2",
+            vec![
+                call("fs_read", "/repo/b.rs"),
+                call("fs_write", "/repo/b.rs"),
+                call("fs_read", "/repo/b.rs"),
+            ],
+        ),
+        trace(
+            "trace-3",
+            vec![
+                call("fs_read", "/repo/c.rs"),
+                call("fs_write", "/repo/c.rs"),
+                call("fs_read", "/repo/c.rs"),
+            ],
+        ),
+    ];
+    let service = ProposedSkillService::new(Box::new(IncompleteGeneralizer));
+
+    let output = service
+        .run(ProposeRunInput {
+            traces,
+            output_root: temp.join("proposed"),
+            blueprint_id: "sha256:blueprint-a".to_owned(),
+            min_occurrences: 3,
+            min_novelty: 0.6,
+            min_self_test_score: 0.8,
+            existing_skills: Vec::new(),
+            agentenv_version: "0.0.1-alpha0".to_owned(),
+            created_at: "2026-05-11T00:00:00Z".to_owned(),
+        })
+        .await
+        .unwrap();
+
+    assert!(output.proposals.is_empty());
+    assert!(output
+        .warnings
+        .iter()
+        .any(|warning| warning.contains("source tool sequence")));
+}
+
 struct FakeGeneralizer;
 
 #[async_trait]
@@ -611,6 +797,54 @@ impl SkillGeneralizer for FakeGeneralizer {
         _request: SkillGeneralizationRequest,
     ) -> Result<SkillGeneralization, agentenv_core::skills::SkillError> {
         Ok(valid_generalization())
+    }
+}
+
+struct DuplicateNameGeneralizer;
+
+#[async_trait]
+impl SkillGeneralizer for DuplicateNameGeneralizer {
+    async fn generalize(
+        &self,
+        request: SkillGeneralizationRequest,
+    ) -> Result<SkillGeneralization, agentenv_core::skills::SkillError> {
+        let count = request
+            .candidate_json
+            .get("sequence")
+            .and_then(serde_json::Value::as_array)
+            .map(Vec::len)
+            .unwrap_or(1);
+        Ok(generalization_with_tools(
+            "fs-edit-skill",
+            vec!["fs_read"; count],
+        ))
+    }
+}
+
+struct PanicGeneralizer;
+
+#[async_trait]
+impl SkillGeneralizer for PanicGeneralizer {
+    async fn generalize(
+        &self,
+        _request: SkillGeneralizationRequest,
+    ) -> Result<SkillGeneralization, agentenv_core::skills::SkillError> {
+        panic!("generalizer should not run for invalid service input")
+    }
+}
+
+struct IncompleteGeneralizer;
+
+#[async_trait]
+impl SkillGeneralizer for IncompleteGeneralizer {
+    async fn generalize(
+        &self,
+        _request: SkillGeneralizationRequest,
+    ) -> Result<SkillGeneralization, agentenv_core::skills::SkillError> {
+        Ok(generalization_with_tools(
+            "incomplete-fs-edit-skill",
+            vec!["fs_read", "fs_write"],
+        ))
     }
 }
 
@@ -651,6 +885,37 @@ fn valid_generalization() -> SkillGeneralization {
             command: "test -f SKILL.md".to_owned(),
         },
         skill_md_body: "Read {{target_path}}.".to_owned(),
+    }
+}
+
+fn generalization_with_tools(name: &str, tools: Vec<&str>) -> SkillGeneralization {
+    let procedure_steps = tools
+        .iter()
+        .enumerate()
+        .map(|(index, tool)| ProcedureStep {
+            tool: Some((*tool).to_owned()),
+            instruction: format!("Run {tool} for {{{{target_path}}}} at step {index}."),
+        })
+        .collect::<Vec<_>>();
+    let skill_md_body = procedure_steps
+        .iter()
+        .map(|step| step.instruction.as_str())
+        .collect::<Vec<_>>()
+        .join("\n");
+
+    SkillGeneralization {
+        name: name.to_owned(),
+        description: "Edit a repeated filesystem target.".to_owned(),
+        template_variables: vec![TemplateVariable {
+            name: "target_path".to_owned(),
+            description: "Target path".to_owned(),
+            example: "src/lib.rs".to_owned(),
+        }],
+        procedure_steps,
+        self_test: ProposedSelfTest {
+            command: "test -f SKILL.md".to_owned(),
+        },
+        skill_md_body,
     }
 }
 

--- a/crates/agentenv-core/tests/skill_propose.rs
+++ b/crates/agentenv-core/tests/skill_propose.rs
@@ -1,3 +1,4 @@
+use agentenv_core::skills::propose::{evaluate_self_test, ProposalSelfTestInput};
 use agentenv_core::skills::propose::{
     extract_candidates, normalize_args_shape, CandidateExtractionOptions, ProposalCandidate,
 };
@@ -325,6 +326,35 @@ fn scoring_maps_local_similarity_to_minor_and_distinct_variants() {
     })
     .unwrap();
     assert_eq!(distinct_variant.novelty, 0.6);
+}
+
+#[test]
+fn self_test_scores_step_and_variable_coverage() {
+    let report = evaluate_self_test(ProposalSelfTestInput {
+        source_tools: vec!["fs_read".to_owned(), "fs_write".to_owned()],
+        procedure_steps: vec![
+            ProcedureStep {
+                tool: Some("fs_read".to_owned()),
+                instruction: "Read {{target_path}}".to_owned(),
+            },
+            ProcedureStep {
+                tool: Some("fs_write".to_owned()),
+                instruction: "Write {{target_path}}".to_owned(),
+            },
+        ],
+        template_variables: vec![TemplateVariable {
+            name: "target_path".to_owned(),
+            description: "Target path".to_owned(),
+            example: "src/lib.rs".to_owned(),
+        }],
+        min_score: 0.8,
+    })
+    .unwrap();
+
+    assert!(report.passed);
+    assert!(report.score >= 0.8);
+    assert_eq!(report.matched_steps, 2);
+    assert_eq!(report.matched_variables, 1);
 }
 
 fn clean_generalization() -> SkillGeneralization {

--- a/crates/agentenv-core/tests/skill_propose.rs
+++ b/crates/agentenv-core/tests/skill_propose.rs
@@ -133,10 +133,37 @@ fn generalization_validation_rejects_secrets_in_llm_text_fields() {
 }
 
 #[test]
+fn generalization_validation_allows_non_secret_sk_words() {
+    let mut generalization = clean_generalization();
+    generalization.description =
+        "Use task-specific steps for disk-backed filesystem edits.".to_owned();
+    generalization.skill_md_body =
+        "Use task-specific steps for disk-backed edits to {{target_path}}.".to_owned();
+
+    validate_generalization(&generalization, &["fs_read".to_owned()]).unwrap();
+}
+
+#[test]
+fn generalization_validation_rejects_actual_sk_secret_tokens() {
+    let mut generalization = clean_generalization();
+    generalization.description = "Use sk-secret from the trace".to_owned();
+
+    assert!(validate_generalization(&generalization, &["fs_read".to_owned()]).is_err());
+}
+
+#[test]
 fn generalization_validation_rejects_undeclared_placeholders() {
     let mut generalization = clean_generalization();
     generalization.template_variables = Vec::new();
     generalization.skill_md_body = "Read {{target_path}} before editing.".to_owned();
+
+    assert!(validate_generalization(&generalization, &["fs_read".to_owned()]).is_err());
+}
+
+#[test]
+fn generalization_validation_rejects_stray_closing_placeholder_markers() {
+    let mut generalization = clean_generalization();
+    generalization.skill_md_body = "Read {{target_path}} before editing }}.".to_owned();
 
     assert!(validate_generalization(&generalization, &["fs_read".to_owned()]).is_err());
 }

--- a/crates/agentenv-core/tests/skill_propose.rs
+++ b/crates/agentenv-core/tests/skill_propose.rs
@@ -75,23 +75,7 @@ fn argument_shape_redacts_secret_like_values() {
 
 #[test]
 fn generalization_validation_accepts_schema_clean_output() {
-    let generalization = SkillGeneralization {
-        name: "fs-edit-skill".to_owned(),
-        description: "Edit a repeated filesystem target.".to_owned(),
-        template_variables: vec![TemplateVariable {
-            name: "target_path".to_owned(),
-            description: "Path to the file being edited.".to_owned(),
-            example: "src/lib.rs".to_owned(),
-        }],
-        procedure_steps: vec![ProcedureStep {
-            tool: Some("fs_read".to_owned()),
-            instruction: "Read {{target_path}} before editing.".to_owned(),
-        }],
-        self_test: ProposedSelfTest {
-            command: "test -f SKILL.md".to_owned(),
-        },
-        skill_md_body: "Read {{target_path}} before editing.".to_owned(),
-    };
+    let generalization = clean_generalization();
 
     validate_generalization(&generalization, &["fs_read".to_owned()]).unwrap();
 }
@@ -124,6 +108,77 @@ fn generalization_validation_rejects_invalid_names_and_secret_leaks() {
         skill_md_body: "token sk-secret".to_owned(),
     };
     assert!(validate_generalization(&secret_body, &["fs_read".to_owned()]).is_err());
+}
+
+#[test]
+fn generalization_validation_rejects_secrets_in_llm_text_fields() {
+    let mut secret_description = clean_generalization();
+    secret_description.description = "Use api_key from the trace".to_owned();
+    assert!(validate_generalization(&secret_description, &["fs_read".to_owned()]).is_err());
+
+    let mut secret_variable_description = clean_generalization();
+    secret_variable_description.template_variables[0].description =
+        "Password captured from args".to_owned();
+    assert!(
+        validate_generalization(&secret_variable_description, &["fs_read".to_owned()]).is_err()
+    );
+
+    let mut secret_variable_example = clean_generalization();
+    secret_variable_example.template_variables[0].example = "token: copied".to_owned();
+    assert!(validate_generalization(&secret_variable_example, &["fs_read".to_owned()]).is_err());
+
+    let mut secret_self_test = clean_generalization();
+    secret_self_test.self_test.command = "echo Bearer copied".to_owned();
+    assert!(validate_generalization(&secret_self_test, &["fs_read".to_owned()]).is_err());
+}
+
+#[test]
+fn generalization_validation_rejects_undeclared_placeholders() {
+    let mut generalization = clean_generalization();
+    generalization.template_variables = Vec::new();
+    generalization.skill_md_body = "Read {{target_path}} before editing.".to_owned();
+
+    assert!(validate_generalization(&generalization, &["fs_read".to_owned()]).is_err());
+}
+
+#[test]
+fn generalization_validation_rejects_duplicate_template_variables() {
+    let mut generalization = clean_generalization();
+    generalization.template_variables.push(TemplateVariable {
+        name: "target_path".to_owned(),
+        description: "Duplicate path variable.".to_owned(),
+        example: "src/main.rs".to_owned(),
+    });
+
+    assert!(validate_generalization(&generalization, &["fs_read".to_owned()]).is_err());
+}
+
+#[test]
+fn generalization_validation_rejects_unknown_procedure_step_tools() {
+    let mut generalization = clean_generalization();
+    generalization.procedure_steps[0].tool = Some("unknown_tool".to_owned());
+
+    assert!(validate_generalization(&generalization, &["fs_read".to_owned()]).is_err());
+}
+
+fn clean_generalization() -> SkillGeneralization {
+    SkillGeneralization {
+        name: "fs-edit-skill".to_owned(),
+        description: "Edit a repeated filesystem target.".to_owned(),
+        template_variables: vec![TemplateVariable {
+            name: "target_path".to_owned(),
+            description: "Path to the file being edited.".to_owned(),
+            example: "src/lib.rs".to_owned(),
+        }],
+        procedure_steps: vec![ProcedureStep {
+            tool: Some("fs_read".to_owned()),
+            instruction: "Read {{target_path}} before editing.".to_owned(),
+        }],
+        self_test: ProposedSelfTest {
+            command: "test -f SKILL.md".to_owned(),
+        },
+        skill_md_body: "Read {{target_path}} before editing.".to_owned(),
+    }
 }
 
 fn trace(trace_id: &str, calls: Vec<TraceToolCall>) -> TraceRun {

--- a/crates/agentenv-core/tests/skill_propose.rs
+++ b/crates/agentenv-core/tests/skill_propose.rs
@@ -218,6 +218,23 @@ fn generalization_validation_rejects_unreferenced_declared_variables() {
 }
 
 #[test]
+fn generalization_validation_rejects_empty_procedure_steps() {
+    let mut generalization = clean_generalization();
+    generalization.procedure_steps = Vec::new();
+
+    assert!(validate_generalization(&generalization, &["fs_read".to_owned()]).is_err());
+}
+
+#[test]
+fn generalization_validation_rejects_body_only_template_variable_references() {
+    let mut generalization = clean_generalization();
+    generalization.procedure_steps[0].instruction = "Read the target before editing.".to_owned();
+    generalization.skill_md_body = "Read {{target_path}} before editing.".to_owned();
+
+    assert!(validate_generalization(&generalization, &["fs_read".to_owned()]).is_err());
+}
+
+#[test]
 fn generalization_validation_rejects_duplicate_template_variables() {
     let mut generalization = clean_generalization();
     generalization.template_variables.push(TemplateVariable {

--- a/crates/agentenv-core/tests/skill_propose.rs
+++ b/crates/agentenv-core/tests/skill_propose.rs
@@ -1,0 +1,94 @@
+use agentenv_core::skills::propose::{
+    extract_candidates, normalize_args_shape, CandidateExtractionOptions, ProposalCandidate,
+};
+use agentenv_events::{ActivityResult, TraceRun, TraceToolCall};
+
+#[test]
+fn extraction_finds_repeated_tool_sequences_for_distinct_traces() {
+    let traces = vec![
+        trace(
+            "trace-1",
+            vec![
+                call("fs_read", "/repo/a.rs"),
+                call("fs_write", "/repo/a.rs"),
+            ],
+        ),
+        trace(
+            "trace-2",
+            vec![
+                call("fs_read", "/repo/b.rs"),
+                call("fs_write", "/repo/b.rs"),
+            ],
+        ),
+        trace(
+            "trace-3",
+            vec![
+                call("fs_read", "/repo/c.rs"),
+                call("fs_write", "/repo/c.rs"),
+            ],
+        ),
+        trace("trace-4", vec![call("fs_read", "/repo/solo.rs")]),
+    ];
+
+    let candidates: Vec<ProposalCandidate> = extract_candidates(
+        &traces,
+        CandidateExtractionOptions {
+            blueprint_id: "sha256:blueprint-a".to_owned(),
+            min_occurrences: 3,
+        },
+    )
+    .unwrap();
+
+    assert_eq!(candidates.len(), 1);
+    assert_eq!(candidates[0].occurrences, 3);
+    assert_eq!(
+        candidates[0]
+            .sequence
+            .iter()
+            .map(|call| call.tool.as_str())
+            .collect::<Vec<_>>(),
+        vec!["fs_read", "fs_write"]
+    );
+    assert_eq!(
+        candidates[0].source_trace_ids,
+        vec!["trace-1", "trace-2", "trace-3"]
+    );
+}
+
+#[test]
+fn argument_shape_redacts_secret_like_values() {
+    let shape = normalize_args_shape(&serde_json::json!({
+        "path": "/repo/src/lib.rs",
+        "token": "sk-secret",
+        "nested": {"authorization": "Bearer secret", "count": 1}
+    }));
+
+    let rendered = serde_json::to_string(&shape).unwrap();
+    assert!(!rendered.contains("sk-secret"));
+    assert!(!rendered.contains("Bearer secret"));
+    assert!(rendered.contains("[redacted]"));
+    assert!(rendered.contains("string:path"));
+}
+
+fn trace(trace_id: &str, calls: Vec<TraceToolCall>) -> TraceRun {
+    TraceRun {
+        trace_id: trace_id.to_owned(),
+        env: Some("demo".to_owned()),
+        blueprint_id: "sha256:blueprint-a".to_owned(),
+        started_at: "2026-05-11T00:00:00Z".to_owned(),
+        calls,
+        terminal_result: ActivityResult::Ok,
+        event_ids: Vec::new(),
+    }
+}
+
+fn call(tool: &str, path: &str) -> TraceToolCall {
+    TraceToolCall {
+        event_id: 0,
+        ordinal: 0,
+        tool: tool.to_owned(),
+        args: serde_json::json!({"path": path}),
+        result: ActivityResult::Ok,
+        subject: serde_json::json!({"tool": tool}),
+    }
+}

--- a/crates/agentenv-core/tests/skill_propose.rs
+++ b/crates/agentenv-core/tests/skill_propose.rs
@@ -357,6 +357,140 @@ fn self_test_scores_step_and_variable_coverage() {
     assert_eq!(report.matched_variables, 1);
 }
 
+#[test]
+fn self_test_missing_source_tool_coverage_fails() {
+    let report = evaluate_self_test(ProposalSelfTestInput {
+        source_tools: vec![
+            "fs_read".to_owned(),
+            "fs_write".to_owned(),
+            "fs_read".to_owned(),
+        ],
+        procedure_steps: vec![ProcedureStep {
+            tool: Some("fs_read".to_owned()),
+            instruction: "Read {{target_path}}".to_owned(),
+        }],
+        template_variables: vec![TemplateVariable {
+            name: "target_path".to_owned(),
+            description: "Target path".to_owned(),
+            example: "src/lib.rs".to_owned(),
+        }],
+        min_score: 0.8,
+    })
+    .unwrap();
+
+    assert!(!report.passed);
+    assert!(report.matched_steps < report.total_steps);
+    assert_eq!(report.matched_steps, 1);
+    assert_eq!(report.total_steps, 2);
+}
+
+#[test]
+fn self_test_human_instruction_steps_do_not_penalize_source_tool_coverage() {
+    let report = evaluate_self_test(ProposalSelfTestInput {
+        source_tools: vec!["fs_read".to_owned(), "fs_write".to_owned()],
+        procedure_steps: vec![
+            ProcedureStep {
+                tool: Some("fs_read".to_owned()),
+                instruction: "Read {{target_path}}".to_owned(),
+            },
+            ProcedureStep {
+                tool: None,
+                instruction: "Explain the intended change to {{target_path}}.".to_owned(),
+            },
+            ProcedureStep {
+                tool: Some("fs_write".to_owned()),
+                instruction: "Write {{target_path}}".to_owned(),
+            },
+        ],
+        template_variables: vec![TemplateVariable {
+            name: "target_path".to_owned(),
+            description: "Target path".to_owned(),
+            example: "src/lib.rs".to_owned(),
+        }],
+        min_score: 0.8,
+    })
+    .unwrap();
+
+    assert!(report.passed);
+    assert!(report.failures.is_empty());
+    assert_eq!(report.matched_steps, 2);
+    assert_eq!(report.total_steps, 2);
+}
+
+#[test]
+fn self_test_unknown_generated_tool_fails() {
+    let report = evaluate_self_test(ProposalSelfTestInput {
+        source_tools: vec!["fs_read".to_owned()],
+        procedure_steps: vec![
+            ProcedureStep {
+                tool: Some("fs_read".to_owned()),
+                instruction: "Read the target file.".to_owned(),
+            },
+            ProcedureStep {
+                tool: Some("unknown_tool".to_owned()),
+                instruction: "Use an unknown generated tool.".to_owned(),
+            },
+        ],
+        template_variables: Vec::new(),
+        min_score: 0.5,
+    })
+    .unwrap();
+
+    assert!(!report.passed);
+    assert!(report
+        .failures
+        .iter()
+        .any(|failure| failure.contains("unknown_tool")));
+}
+
+#[test]
+fn self_test_rejects_empty_procedure_steps() {
+    let error = evaluate_self_test(ProposalSelfTestInput {
+        source_tools: vec!["fs_read".to_owned()],
+        procedure_steps: Vec::new(),
+        template_variables: Vec::new(),
+        min_score: 0.8,
+    })
+    .unwrap_err();
+
+    assert!(error.to_string().contains("procedure step"));
+}
+
+#[test]
+fn self_test_rejects_out_of_range_min_score() {
+    let error = evaluate_self_test(ProposalSelfTestInput {
+        source_tools: vec!["fs_read".to_owned()],
+        procedure_steps: vec![ProcedureStep {
+            tool: Some("fs_read".to_owned()),
+            instruction: "Read the target file.".to_owned(),
+        }],
+        template_variables: Vec::new(),
+        min_score: 1.1,
+    })
+    .unwrap_err();
+
+    assert!(error.to_string().contains("between 0.0 and 1.0"));
+}
+
+#[test]
+fn self_test_no_variables_scores_variable_coverage_complete() {
+    let report = evaluate_self_test(ProposalSelfTestInput {
+        source_tools: vec!["fs_read".to_owned()],
+        procedure_steps: vec![ProcedureStep {
+            tool: Some("fs_read".to_owned()),
+            instruction: "Read the target file.".to_owned(),
+        }],
+        template_variables: Vec::new(),
+        min_score: 1.0,
+    })
+    .unwrap();
+
+    assert!(report.passed);
+    assert_eq!(report.matched_variables, 0);
+    assert_eq!(report.total_variables, 0);
+    assert_eq!(report.score, 1.0);
+}
+
 fn clean_generalization() -> SkillGeneralization {
     SkillGeneralization {
         name: "fs-edit-skill".to_owned(),

--- a/crates/agentenv-core/tests/skill_propose.rs
+++ b/crates/agentenv-core/tests/skill_propose.rs
@@ -1,6 +1,9 @@
 use agentenv_core::skills::propose::{
     extract_candidates, normalize_args_shape, CandidateExtractionOptions, ProposalCandidate,
 };
+use agentenv_core::skills::propose::{
+    validate_generalization, ProcedureStep, ProposedSelfTest, SkillGeneralization, TemplateVariable,
+};
 use agentenv_events::{ActivityResult, TraceRun, TraceToolCall};
 
 #[test]
@@ -68,6 +71,59 @@ fn argument_shape_redacts_secret_like_values() {
     assert!(!rendered.contains("Bearer secret"));
     assert!(rendered.contains("[redacted]"));
     assert!(rendered.contains("string:path"));
+}
+
+#[test]
+fn generalization_validation_accepts_schema_clean_output() {
+    let generalization = SkillGeneralization {
+        name: "fs-edit-skill".to_owned(),
+        description: "Edit a repeated filesystem target.".to_owned(),
+        template_variables: vec![TemplateVariable {
+            name: "target_path".to_owned(),
+            description: "Path to the file being edited.".to_owned(),
+            example: "src/lib.rs".to_owned(),
+        }],
+        procedure_steps: vec![ProcedureStep {
+            tool: Some("fs_read".to_owned()),
+            instruction: "Read {{target_path}} before editing.".to_owned(),
+        }],
+        self_test: ProposedSelfTest {
+            command: "test -f SKILL.md".to_owned(),
+        },
+        skill_md_body: "Read {{target_path}} before editing.".to_owned(),
+    };
+
+    validate_generalization(&generalization, &["fs_read".to_owned()]).unwrap();
+}
+
+#[test]
+fn generalization_validation_rejects_invalid_names_and_secret_leaks() {
+    let invalid_name = SkillGeneralization {
+        name: "../bad".to_owned(),
+        description: "Bad".to_owned(),
+        template_variables: Vec::new(),
+        procedure_steps: Vec::new(),
+        self_test: ProposedSelfTest {
+            command: "test -f SKILL.md".to_owned(),
+        },
+        skill_md_body: "Body".to_owned(),
+    };
+    assert!(validate_generalization(&invalid_name, &[]).is_err());
+
+    let secret_body = SkillGeneralization {
+        name: "secret-skill".to_owned(),
+        description: "Bad".to_owned(),
+        template_variables: Vec::new(),
+        procedure_steps: vec![ProcedureStep {
+            tool: Some("fs_read".to_owned()),
+            instruction: "Use token sk-secret".to_owned(),
+        }],
+        self_test: ProposedSelfTest {
+            command: "test -f SKILL.md".to_owned(),
+        },
+        skill_md_body: "token sk-secret".to_owned(),
+    };
+    assert!(validate_generalization(&secret_body, &["fs_read".to_owned()]).is_err());
 }
 
 fn trace(trace_id: &str, calls: Vec<TraceToolCall>) -> TraceRun {

--- a/crates/agentenv-core/tests/skill_propose.rs
+++ b/crates/agentenv-core/tests/skill_propose.rs
@@ -1,4 +1,8 @@
-use agentenv_core::skills::propose::{evaluate_self_test, ProposalSelfTestInput};
+use agentenv_core::skills::load_skill_manifest;
+use agentenv_core::skills::propose::{
+    emit_proposal, evaluate_self_test, CandidateToolCall, ProposalEmitInput, ProposalScore,
+    ProposalSelfTestInput,
+};
 use agentenv_core::skills::propose::{
     extract_candidates, normalize_args_shape, CandidateExtractionOptions, ProposalCandidate,
 };
@@ -491,6 +495,62 @@ fn self_test_no_variables_scores_variable_coverage_complete() {
     assert_eq!(report.score, 1.0);
 }
 
+#[test]
+fn proposal_writer_emits_skill_manifest_and_reports() {
+    let temp = temp_dir("proposal-writer");
+    let output_root = temp.join("proposed");
+    let generalization = valid_generalization();
+    let report = evaluate_self_test(ProposalSelfTestInput {
+        source_tools: vec!["fs_read".to_owned()],
+        procedure_steps: generalization.procedure_steps.clone(),
+        template_variables: generalization.template_variables.clone(),
+        min_score: 0.8,
+    })
+    .unwrap();
+
+    let output = emit_proposal(ProposalEmitInput {
+        output_root: output_root.clone(),
+        candidate: ProposalCandidate {
+            name_seed: "fs-read".to_owned(),
+            blueprint_id: "sha256:blueprint-a".to_owned(),
+            fingerprint: "fingerprint-a".to_owned(),
+            occurrences: 3,
+            sequence: vec![CandidateToolCall {
+                tool: "fs_read".to_owned(),
+                args_shape: serde_json::json!({"path": "string:path"}),
+            }],
+            source_trace_ids: vec![
+                "trace-1".to_owned(),
+                "trace-2".to_owned(),
+                "trace-3".to_owned(),
+            ],
+            redaction_count: 0,
+        },
+        generalization,
+        score: ProposalScore {
+            novelty: 0.9,
+            utility: 0.6,
+            final_score: 0.81,
+            nearest_matches: Vec::new(),
+            reasons: vec!["no existing skill matches".to_owned()],
+        },
+        self_test: report,
+        agentenv_version: "0.0.1-alpha0".to_owned(),
+        created_at: "2026-05-11T00:00:00Z".to_owned(),
+    })
+    .unwrap();
+
+    assert_eq!(output.name, "fs-edit-skill");
+    assert!(output.path.join("SKILL.md").is_file());
+    assert!(output.path.join("skill.yaml").is_file());
+    assert!(output.path.join("proposal.yaml").is_file());
+    assert!(output.path.join("self-test.json").is_file());
+    assert!(output.path.join("traces/provenance.json").is_file());
+    let manifest = load_skill_manifest(&output.path).unwrap();
+    assert_eq!(manifest.name, "fs-edit-skill");
+    assert_eq!(manifest.entry, std::path::PathBuf::from("SKILL.md"));
+}
+
 fn clean_generalization() -> SkillGeneralization {
     SkillGeneralization {
         name: "fs-edit-skill".to_owned(),
@@ -509,6 +569,39 @@ fn clean_generalization() -> SkillGeneralization {
         },
         skill_md_body: "Read {{target_path}} before editing.".to_owned(),
     }
+}
+
+fn valid_generalization() -> SkillGeneralization {
+    SkillGeneralization {
+        name: "fs-edit-skill".to_owned(),
+        description: "Edit a repeated filesystem target.".to_owned(),
+        template_variables: vec![TemplateVariable {
+            name: "target_path".to_owned(),
+            description: "Target path".to_owned(),
+            example: "src/lib.rs".to_owned(),
+        }],
+        procedure_steps: vec![ProcedureStep {
+            tool: Some("fs_read".to_owned()),
+            instruction: "Read {{target_path}}.".to_owned(),
+        }],
+        self_test: ProposedSelfTest {
+            command: "test -f SKILL.md".to_owned(),
+        },
+        skill_md_body: "Read {{target_path}}.".to_owned(),
+    }
+}
+
+fn temp_dir(prefix: &str) -> std::path::PathBuf {
+    let path = std::env::temp_dir().join(format!(
+        "{prefix}-{}-{}",
+        std::process::id(),
+        std::time::SystemTime::now()
+            .duration_since(std::time::UNIX_EPOCH)
+            .unwrap()
+            .as_nanos()
+    ));
+    std::fs::create_dir_all(&path).unwrap();
+    path
 }
 
 fn trace(trace_id: &str, calls: Vec<TraceToolCall>) -> TraceRun {

--- a/crates/agentenv-core/tests/skill_propose.rs
+++ b/crates/agentenv-core/tests/skill_propose.rs
@@ -2,6 +2,9 @@ use agentenv_core::skills::propose::{
     extract_candidates, normalize_args_shape, CandidateExtractionOptions, ProposalCandidate,
 };
 use agentenv_core::skills::propose::{
+    score_proposal, ExistingSkillSummary, NoveltyBackend, ProposalScoreInput,
+};
+use agentenv_core::skills::propose::{
     validate_generalization, ProcedureStep, ProposedSelfTest, SkillGeneralization, TemplateVariable,
 };
 use agentenv_events::{ActivityResult, TraceRun, TraceToolCall};
@@ -252,6 +255,76 @@ fn generalization_validation_rejects_unknown_procedure_step_tools() {
     generalization.procedure_steps[0].tool = Some("unknown_tool".to_owned());
 
     assert!(validate_generalization(&generalization, &["fs_read".to_owned()]).is_err());
+}
+
+#[test]
+fn scoring_maps_duplicate_minor_variant_and_new_capability_to_ladder() {
+    let duplicate = score_proposal(ProposalScoreInput {
+        name: "review-skill".to_owned(),
+        description: "Review code changes".to_owned(),
+        procedure_text: "read diff write review".to_owned(),
+        fingerprint: "same".to_owned(),
+        occurrences: 3,
+        existing_skills: vec![ExistingSkillSummary {
+            name: "review-skill".to_owned(),
+            description: "Review code changes".to_owned(),
+            procedure_text: "read diff write review".to_owned(),
+            fingerprint: Some("same".to_owned()),
+        }],
+        backend: NoveltyBackend::Local,
+    })
+    .unwrap();
+    assert_eq!(duplicate.novelty, 0.0);
+
+    let new_capability = score_proposal(ProposalScoreInput {
+        name: "snapshot-skill".to_owned(),
+        description: "Create and verify snapshots".to_owned(),
+        procedure_text: "snapshot verify restore".to_owned(),
+        fingerprint: "new".to_owned(),
+        occurrences: 5,
+        existing_skills: Vec::new(),
+        backend: NoveltyBackend::Local,
+    })
+    .unwrap();
+    assert_eq!(new_capability.novelty, 0.9);
+    assert!(new_capability.utility > 0.5);
+}
+
+#[test]
+fn scoring_maps_local_similarity_to_minor_and_distinct_variants() {
+    let minor_variation = score_proposal(ProposalScoreInput {
+        name: "review-skill-v2".to_owned(),
+        description: "Review code changes carefully".to_owned(),
+        procedure_text: "read diff write review".to_owned(),
+        fingerprint: "minor".to_owned(),
+        occurrences: 2,
+        existing_skills: vec![ExistingSkillSummary {
+            name: "review-skill".to_owned(),
+            description: "Review code changes".to_owned(),
+            procedure_text: "read diff write review".to_owned(),
+            fingerprint: Some("existing".to_owned()),
+        }],
+        backend: NoveltyBackend::Local,
+    })
+    .unwrap();
+    assert_eq!(minor_variation.novelty, 0.3);
+
+    let distinct_variant = score_proposal(ProposalScoreInput {
+        name: "review-tests-skill".to_owned(),
+        description: "Review test changes".to_owned(),
+        procedure_text: "read tests write review".to_owned(),
+        fingerprint: "distinct".to_owned(),
+        occurrences: 2,
+        existing_skills: vec![ExistingSkillSummary {
+            name: "review-skill".to_owned(),
+            description: "Review code changes".to_owned(),
+            procedure_text: "read diff write review".to_owned(),
+            fingerprint: Some("existing".to_owned()),
+        }],
+        backend: NoveltyBackend::Local,
+    })
+    .unwrap();
+    assert_eq!(distinct_variant.novelty, 0.6);
 }
 
 fn clean_generalization() -> SkillGeneralization {

--- a/crates/agentenv-core/tests/skill_propose.rs
+++ b/crates/agentenv-core/tests/skill_propose.rs
@@ -500,47 +500,12 @@ fn proposal_writer_emits_skill_manifest_and_reports() {
     let temp = temp_dir("proposal-writer");
     let output_root = temp.join("proposed");
     let generalization = valid_generalization();
-    let report = evaluate_self_test(ProposalSelfTestInput {
-        source_tools: vec!["fs_read".to_owned()],
-        procedure_steps: generalization.procedure_steps.clone(),
-        template_variables: generalization.template_variables.clone(),
-        min_score: 0.8,
-    })
-    .unwrap();
-
-    let output = emit_proposal(ProposalEmitInput {
-        output_root: output_root.clone(),
-        candidate: ProposalCandidate {
-            name_seed: "fs-read".to_owned(),
-            blueprint_id: "sha256:blueprint-a".to_owned(),
-            fingerprint: "fingerprint-a".to_owned(),
-            occurrences: 3,
-            sequence: vec![CandidateToolCall {
-                tool: "fs_read".to_owned(),
-                args_shape: serde_json::json!({"path": "string:path"}),
-            }],
-            source_trace_ids: vec![
-                "trace-1".to_owned(),
-                "trace-2".to_owned(),
-                "trace-3".to_owned(),
-            ],
-            redaction_count: 0,
-        },
-        generalization,
-        score: ProposalScore {
-            novelty: 0.9,
-            utility: 0.6,
-            final_score: 0.81,
-            nearest_matches: Vec::new(),
-            reasons: vec!["no existing skill matches".to_owned()],
-        },
-        self_test: report,
-        agentenv_version: "0.0.1-alpha0".to_owned(),
-        created_at: "2026-05-11T00:00:00Z".to_owned(),
-    })
-    .unwrap();
+    let output = emit_proposal(proposal_writer_input(output_root.clone(), generalization)).unwrap();
 
     assert_eq!(output.name, "fs-edit-skill");
+    assert_eq!(output.novelty, 0.9);
+    assert_eq!(output.utility, 0.6);
+    assert_eq!(output.final_score, 0.81);
     assert!(output.path.join("SKILL.md").is_file());
     assert!(output.path.join("skill.yaml").is_file());
     assert!(output.path.join("proposal.yaml").is_file());
@@ -549,6 +514,58 @@ fn proposal_writer_emits_skill_manifest_and_reports() {
     let manifest = load_skill_manifest(&output.path).unwrap();
     assert_eq!(manifest.name, "fs-edit-skill");
     assert_eq!(manifest.entry, std::path::PathBuf::from("SKILL.md"));
+
+    let proposal = read_yaml(&output.path.join("proposal.yaml"));
+    assert_eq!(
+        yaml_str(&proposal, "created_at"),
+        Some("2026-05-11T00:00:00Z")
+    );
+}
+
+#[test]
+fn proposal_writer_refuses_existing_output_and_preserves_contents() {
+    let temp = temp_dir("proposal-writer-existing");
+    let output_root = temp.join("proposed");
+    let existing = output_root.join("fs-edit-skill");
+    std::fs::create_dir_all(&existing).unwrap();
+    std::fs::write(existing.join("sentinel.txt"), "keep").unwrap();
+
+    let error = emit_proposal(proposal_writer_input(
+        output_root.clone(),
+        valid_generalization(),
+    ))
+    .unwrap_err();
+
+    assert!(error.to_string().contains("already exists"));
+    assert_eq!(
+        std::fs::read_to_string(existing.join("sentinel.txt")).unwrap(),
+        "keep"
+    );
+    assert!(!existing.join("SKILL.md").exists());
+    assert_no_staging_dirs(&output_root);
+}
+
+#[test]
+fn proposal_writer_serializes_skill_md_frontmatter_safely() {
+    let temp = temp_dir("proposal-writer-frontmatter");
+    let output_root = temp.join("proposed");
+    let mut generalization = valid_generalization();
+    generalization.description =
+        "Edit: a repeated filesystem target\nwith --- marker text".to_owned();
+
+    let output = emit_proposal(proposal_writer_input(output_root, generalization)).unwrap();
+    let skill_md = std::fs::read_to_string(output.path.join("SKILL.md")).unwrap();
+    let frontmatter = skill_md
+        .strip_prefix("---\n")
+        .and_then(|body| body.split_once("\n---\n"))
+        .map(|(frontmatter, _body)| frontmatter)
+        .expect("SKILL.md should contain YAML frontmatter");
+    let metadata: serde_yaml::Value = serde_yaml::from_str(frontmatter).unwrap();
+
+    assert_eq!(
+        yaml_str(&metadata, "description"),
+        Some("Edit: a repeated filesystem target\nwith --- marker text")
+    );
 }
 
 fn clean_generalization() -> SkillGeneralization {
@@ -591,6 +608,50 @@ fn valid_generalization() -> SkillGeneralization {
     }
 }
 
+fn proposal_writer_input(
+    output_root: std::path::PathBuf,
+    generalization: SkillGeneralization,
+) -> ProposalEmitInput {
+    let report = evaluate_self_test(ProposalSelfTestInput {
+        source_tools: vec!["fs_read".to_owned()],
+        procedure_steps: generalization.procedure_steps.clone(),
+        template_variables: generalization.template_variables.clone(),
+        min_score: 0.8,
+    })
+    .unwrap();
+
+    ProposalEmitInput {
+        output_root,
+        candidate: ProposalCandidate {
+            name_seed: "fs-read".to_owned(),
+            blueprint_id: "sha256:blueprint-a".to_owned(),
+            fingerprint: "fingerprint-a".to_owned(),
+            occurrences: 3,
+            sequence: vec![CandidateToolCall {
+                tool: "fs_read".to_owned(),
+                args_shape: serde_json::json!({"path": "string:path"}),
+            }],
+            source_trace_ids: vec![
+                "trace-1".to_owned(),
+                "trace-2".to_owned(),
+                "trace-3".to_owned(),
+            ],
+            redaction_count: 0,
+        },
+        generalization,
+        score: ProposalScore {
+            novelty: 0.9,
+            utility: 0.6,
+            final_score: 0.81,
+            nearest_matches: Vec::new(),
+            reasons: vec!["no existing skill matches".to_owned()],
+        },
+        self_test: report,
+        agentenv_version: "0.0.1-alpha0".to_owned(),
+        created_at: "2026-05-11T00:00:00Z".to_owned(),
+    }
+}
+
 fn temp_dir(prefix: &str) -> std::path::PathBuf {
     let path = std::env::temp_dir().join(format!(
         "{prefix}-{}-{}",
@@ -602,6 +663,32 @@ fn temp_dir(prefix: &str) -> std::path::PathBuf {
     ));
     std::fs::create_dir_all(&path).unwrap();
     path
+}
+
+fn read_yaml(path: &std::path::Path) -> serde_yaml::Value {
+    let yaml = std::fs::read_to_string(path).unwrap();
+    serde_yaml::from_str(&yaml).unwrap()
+}
+
+fn yaml_str<'a>(value: &'a serde_yaml::Value, key: &str) -> Option<&'a str> {
+    match value {
+        serde_yaml::Value::Mapping(mapping) => mapping
+            .get(serde_yaml::Value::String(key.to_owned()))
+            .and_then(serde_yaml::Value::as_str),
+        _ => None,
+    }
+}
+
+fn assert_no_staging_dirs(root: &std::path::Path) {
+    for entry in std::fs::read_dir(root).unwrap() {
+        let entry = entry.unwrap();
+        let file_name = entry.file_name();
+        let file_name = file_name.to_string_lossy();
+        assert!(
+            !file_name.contains(".staging"),
+            "unexpected staging directory left behind: {file_name}"
+        );
+    }
 }
 
 fn trace(trace_id: &str, calls: Vec<TraceToolCall>) -> TraceRun {

--- a/crates/agentenv-core/tests/skill_propose.rs
+++ b/crates/agentenv-core/tests/skill_propose.rs
@@ -145,12 +145,22 @@ fn generalization_validation_rejects_secrets_in_llm_text_fields() {
 }
 
 #[test]
+fn generalization_validation_rejects_unsafe_self_test_commands() {
+    let mut generalization = clean_generalization();
+    generalization.self_test.command = "sh -c 'rm -rf \"$HOME/.agentenv\"'".to_owned();
+
+    let error = validate_generalization(&generalization, &["fs_read".to_owned()]).unwrap_err();
+    assert!(error.to_string().contains("self-test command"));
+}
+
+#[test]
 fn generalization_validation_allows_non_secret_sk_words() {
     let mut generalization = clean_generalization();
     generalization.description =
         "Use task-specific steps for disk-backed filesystem edits.".to_owned();
     generalization.skill_md_body =
-        "Use task-specific steps for disk-backed edits to {{target_path}}.".to_owned();
+        "Read {{target_path}} before editing.\nUse task-specific steps for disk-backed edits."
+            .to_owned();
 
     validate_generalization(&generalization, &["fs_read".to_owned()]).unwrap();
 }
@@ -244,6 +254,15 @@ fn generalization_validation_rejects_body_only_template_variable_references() {
     generalization.skill_md_body = "Read {{target_path}} before editing.".to_owned();
 
     assert!(validate_generalization(&generalization, &["fs_read".to_owned()]).is_err());
+}
+
+#[test]
+fn generalization_validation_rejects_skill_body_without_validated_steps() {
+    let mut generalization = clean_generalization();
+    generalization.skill_md_body = "Use this skill for filesystem edits.".to_owned();
+
+    let error = validate_generalization(&generalization, &["fs_read".to_owned()]).unwrap_err();
+    assert!(error.to_string().contains("skill_md_body"));
 }
 
 #[test]

--- a/crates/agentenv-core/tests/skill_propose.rs
+++ b/crates/agentenv-core/tests/skill_propose.rs
@@ -152,6 +152,35 @@ fn generalization_validation_rejects_actual_sk_secret_tokens() {
 }
 
 #[test]
+fn generalization_validation_rejects_secret_shaped_skill_names() {
+    let mut generalization = clean_generalization();
+    generalization.name = "sk-secret".to_owned();
+
+    assert!(validate_generalization(&generalization, &["fs_read".to_owned()]).is_err());
+}
+
+#[test]
+fn generalization_validation_rejects_secret_shaped_template_variable_names() {
+    let mut generalization = clean_generalization();
+    generalization.template_variables.push(TemplateVariable {
+        name: "sk-secret".to_owned(),
+        description: "Secret-shaped variable name.".to_owned(),
+        example: "src/main.rs".to_owned(),
+    });
+
+    let error = validate_generalization(&generalization, &["fs_read".to_owned()]).unwrap_err();
+    assert!(error.to_string().contains("secret-like"));
+}
+
+#[test]
+fn generalization_validation_rejects_empty_template_variable_examples() {
+    let mut generalization = clean_generalization();
+    generalization.template_variables[0].example = "  ".to_owned();
+
+    assert!(validate_generalization(&generalization, &["fs_read".to_owned()]).is_err());
+}
+
+#[test]
 fn generalization_validation_rejects_undeclared_placeholders() {
     let mut generalization = clean_generalization();
     generalization.template_variables = Vec::new();
@@ -161,9 +190,29 @@ fn generalization_validation_rejects_undeclared_placeholders() {
 }
 
 #[test]
+fn generalization_validation_rejects_unclosed_placeholder_markers() {
+    let mut generalization = clean_generalization();
+    generalization.skill_md_body = "Read {{target_path before editing.".to_owned();
+
+    assert!(validate_generalization(&generalization, &["fs_read".to_owned()]).is_err());
+}
+
+#[test]
 fn generalization_validation_rejects_stray_closing_placeholder_markers() {
     let mut generalization = clean_generalization();
     generalization.skill_md_body = "Read {{target_path}} before editing }}.".to_owned();
+
+    assert!(validate_generalization(&generalization, &["fs_read".to_owned()]).is_err());
+}
+
+#[test]
+fn generalization_validation_rejects_unreferenced_declared_variables() {
+    let mut generalization = clean_generalization();
+    generalization.template_variables.push(TemplateVariable {
+        name: "unused_path".to_owned(),
+        description: "Unused path variable.".to_owned(),
+        example: "src/main.rs".to_owned(),
+    });
 
     assert!(validate_generalization(&generalization, &["fs_read".to_owned()]).is_err());
 }

--- a/crates/agentenv-core/tests/skill_propose.rs
+++ b/crates/agentenv-core/tests/skill_propose.rs
@@ -1,3 +1,5 @@
+use async_trait::async_trait;
+
 use agentenv_core::skills::load_skill_manifest;
 use agentenv_core::skills::propose::{
     emit_proposal, evaluate_self_test, CandidateToolCall, ProposalEmitInput, ProposalScore,
@@ -10,7 +12,9 @@ use agentenv_core::skills::propose::{
     score_proposal, ExistingSkillSummary, NoveltyBackend, ProposalScoreInput,
 };
 use agentenv_core::skills::propose::{
-    validate_generalization, ProcedureStep, ProposedSelfTest, SkillGeneralization, TemplateVariable,
+    validate_generalization, ProcedureStep, ProposeRunInput, ProposedSelfTest,
+    ProposedSkillService, SkillGeneralization, SkillGeneralizationRequest, SkillGeneralizer,
+    TemplateVariable,
 };
 use agentenv_events::{ActivityResult, TraceRun, TraceToolCall};
 
@@ -566,6 +570,48 @@ fn proposal_writer_serializes_skill_md_frontmatter_safely() {
         yaml_str(&metadata, "description"),
         Some("Edit: a repeated filesystem target\nwith --- marker text")
     );
+}
+
+#[tokio::test]
+async fn proposal_service_runs_full_pipeline_with_fake_generalizer() {
+    let temp = temp_dir("proposal-service");
+    let traces = vec![
+        trace("trace-1", vec![call("fs_read", "/repo/a.rs")]),
+        trace("trace-2", vec![call("fs_read", "/repo/b.rs")]),
+        trace("trace-3", vec![call("fs_read", "/repo/c.rs")]),
+    ];
+    let service = ProposedSkillService::new(Box::new(FakeGeneralizer));
+
+    let output = service
+        .run(ProposeRunInput {
+            traces,
+            output_root: temp.join("proposed"),
+            blueprint_id: "sha256:blueprint-a".to_owned(),
+            min_occurrences: 3,
+            min_novelty: 0.6,
+            min_self_test_score: 0.8,
+            existing_skills: Vec::new(),
+            agentenv_version: "0.0.1-alpha0".to_owned(),
+            created_at: "2026-05-11T00:00:00Z".to_owned(),
+        })
+        .await
+        .unwrap();
+
+    assert_eq!(output.proposals.len(), 1);
+    assert_eq!(output.proposals[0].name, "fs-edit-skill");
+    assert!(output.proposals[0].path.join("SKILL.md").is_file());
+}
+
+struct FakeGeneralizer;
+
+#[async_trait]
+impl SkillGeneralizer for FakeGeneralizer {
+    async fn generalize(
+        &self,
+        _request: SkillGeneralizationRequest,
+    ) -> Result<SkillGeneralization, agentenv_core::skills::SkillError> {
+        Ok(valid_generalization())
+    }
 }
 
 fn clean_generalization() -> SkillGeneralization {

--- a/crates/agentenv-core/tests/skills.rs
+++ b/crates/agentenv-core/tests/skills.rs
@@ -919,6 +919,29 @@ skills:
 }
 
 #[test]
+fn skills_config_loads_proposal_provider_settings() {
+    let yaml = r#"
+skills:
+  proposal:
+    llm:
+      provider: default
+      endpoint: https://llm.example.test/v1
+      model: proposal-generalizer
+      credential: AGENTENV_SKILL_PROPOSER_TOKEN
+    semantic:
+      backend: local
+    pr:
+      default_repo: owner/skills
+"#;
+
+    let config = load_project_skills_config(yaml).unwrap();
+    let proposal = config.proposal.unwrap();
+    assert_eq!(proposal.llm.unwrap().provider, "default");
+    assert_eq!(proposal.semantic.unwrap().backend, "local");
+    assert_eq!(proposal.pr.unwrap().default_repo.unwrap(), "owner/skills");
+}
+
+#[test]
 fn skills_config_loads_user_toml() {
     let toml = r#"
 [skills]
@@ -948,6 +971,7 @@ fn cli_registry_override_wins_over_project_and_user_config() {
             PathBuf::from("/user"),
         )],
         registry_order: vec!["user-local".to_owned()],
+        proposal: None,
     };
     let project = SkillsConfig {
         registries: vec![agentenv_core::skills::RegistryConfig::filesystem(
@@ -955,6 +979,7 @@ fn cli_registry_override_wins_over_project_and_user_config() {
             PathBuf::from("/project"),
         )],
         registry_order: vec!["project-local".to_owned()],
+        proposal: None,
     };
 
     let merged = merge_skills_config(
@@ -983,6 +1008,7 @@ fn cli_registry_override_selects_named_registry() {
             ),
         ],
         registry_order: vec!["local".to_owned(), "corp".to_owned()],
+        proposal: None,
     };
 
     let merged = merge_skills_config(
@@ -1011,6 +1037,7 @@ fn project_config_overrides_user_registries_by_name_without_erasing_others() {
             ),
         ],
         registry_order: vec!["local".to_owned(), "corp".to_owned()],
+        proposal: None,
     };
     let project = SkillsConfig {
         registries: vec![agentenv_core::skills::RegistryConfig::filesystem(
@@ -1018,6 +1045,7 @@ fn project_config_overrides_user_registries_by_name_without_erasing_others() {
             PathBuf::from("/project"),
         )],
         registry_order: vec!["local".to_owned()],
+        proposal: None,
     };
 
     let merged = merge_skills_config(
@@ -1041,6 +1069,7 @@ fn cli_registry_override_reports_missing_named_registry() {
             PathBuf::from("/local"),
         )],
         registry_order: vec!["local".to_owned()],
+        proposal: None,
     };
 
     let error = merge_skills_config(
@@ -1199,6 +1228,7 @@ async fn filesystem_registry_search_add_and_publish_work() {
                 registry.clone(),
             )],
             registry_order: vec!["local-dev".to_owned()],
+            proposal: None,
         },
     );
 
@@ -1450,6 +1480,7 @@ async fn http_registry_rejects_unsafe_url_before_request() {
                 None,
             )],
             registry_order: vec!["unsafe".to_owned()],
+            proposal: None,
         },
     );
 
@@ -1535,6 +1566,7 @@ async fn http_registry_uses_bearer_token_from_credential_resolver() {
                 Some("bearer-from-credstore:CUSTOM_SKILLS_TOKEN".to_owned()),
             )],
             registry_order: vec!["http-dev".to_owned()],
+            proposal: None,
         },
     )
     .with_ssrf_options(test_http_registry_ssrf_options())
@@ -1569,6 +1601,7 @@ async fn oci_registry_search_add_and_publish_use_distribution_api() {
                 None,
             )],
             registry_order: vec!["oci-dev".to_owned()],
+            proposal: None,
         },
     )
     .with_ssrf_options(test_http_registry_ssrf_options());
@@ -1636,6 +1669,7 @@ fn filesystem_skill_service(home: &Path, registry: &Path) -> SkillService {
                 registry.to_path_buf(),
             )],
             registry_order: vec!["local-dev".to_owned()],
+            proposal: None,
         },
     )
 }
@@ -1661,6 +1695,7 @@ fn http_skill_service(home: &Path, server: &TestHttpRegistry) -> SkillService {
                 None,
             )],
             registry_order: vec!["http-dev".to_owned()],
+            proposal: None,
         },
     )
 }

--- a/crates/agentenv-core/tests/skills.rs
+++ b/crates/agentenv-core/tests/skills.rs
@@ -2196,6 +2196,7 @@ async fn git_registry_publish_is_reported_as_unsupported() {
                 "git+https://github.com/acme/skills",
             )],
             registry_order: vec!["git-dev".to_owned()],
+            proposal: None,
         },
     );
 
@@ -2226,6 +2227,7 @@ async fn git_registry_rejects_invalid_registry_name_before_cache_path_use() {
                 "git+https://github.com/acme/skills",
             )],
             registry_order: vec!["../../outside".to_owned()],
+            proposal: None,
         },
     );
 

--- a/crates/agentenv-events/src/lib.rs
+++ b/crates/agentenv-events/src/lib.rs
@@ -10,6 +10,7 @@ pub mod otel;
 pub mod redaction;
 pub mod sink;
 pub mod store;
+pub mod trace;
 pub mod webhook;
 
 pub use activity::{ActivityEvent, ActivityKind, ActivityResult, ActorKind};
@@ -21,4 +22,6 @@ pub use local_ops::{
 #[cfg(feature = "otel")]
 pub use otel::OtelSink;
 pub use sink::{EventSink, SinkConfig, SinkError};
+pub use store::SqliteEventStore;
+pub use trace::{TraceQuery, TraceRun, TraceToolCall};
 pub use webhook::{WebhookConfig, WebhookSink};

--- a/crates/agentenv-events/src/store.rs
+++ b/crates/agentenv-events/src/store.rs
@@ -1,4 +1,4 @@
-use std::collections::{BTreeMap, BTreeSet};
+use std::collections::BTreeMap;
 use std::fs::File;
 use std::io::{BufRead, BufReader};
 use std::path::{Path, PathBuf};
@@ -282,7 +282,7 @@ impl SqliteEventStore {
                     matches_blueprint: false,
                     excluded: false,
                     unresolved_pending_approval: false,
-                    pending_approval_request_ids: BTreeSet::new(),
+                    pending_approval_request_ids: BTreeMap::new(),
                 });
 
             if event_blueprint_id(&event) == Some(query.blueprint_id.as_str()) {
@@ -291,12 +291,12 @@ impl SqliteEventStore {
             if immediately_excludes_trace(&event) {
                 accumulator.excluded = true;
             }
-            accumulator.record_approval_state(&event);
+            accumulator.record_approval_state(row.id, &event);
 
             accumulator.trace.terminal_result = event.result;
             accumulator.trace.event_ids.push(row.id);
 
-            if event.kind == ActivityKind::McpToolCall {
+            if event.kind == ActivityKind::McpToolCall && event.result == ActivityResult::Ok {
                 if let Some(tool) = event_tool_name(&event) {
                     accumulator.trace.calls.push(TraceToolCall {
                         event_id: row.id,
@@ -309,6 +309,8 @@ impl SqliteEventStore {
                 }
             }
         }
+
+        resolve_pending_approvals(&conn, &mut traces, query.env.as_deref())?;
 
         let mut runs = Vec::new();
         for trace_id in trace_ids {
@@ -702,15 +704,15 @@ struct TraceAccumulator {
     matches_blueprint: bool,
     excluded: bool,
     unresolved_pending_approval: bool,
-    pending_approval_request_ids: BTreeSet<String>,
+    pending_approval_request_ids: BTreeMap<String, i64>,
 }
 
 impl TraceAccumulator {
-    fn record_approval_state(&mut self, event: &ActivityEvent) {
+    fn record_approval_state(&mut self, event_id: i64, event: &ActivityEvent) {
         if event.result == ActivityResult::PendingApproval {
             if let Some(request_id) = event_request_id(event) {
                 self.pending_approval_request_ids
-                    .insert(request_id.to_owned());
+                    .insert(request_id.to_owned(), event_id);
             } else {
                 self.unresolved_pending_approval = true;
             }
@@ -728,6 +730,73 @@ impl TraceAccumulator {
             || self.unresolved_pending_approval
             || !self.pending_approval_request_ids.is_empty()
     }
+}
+
+fn resolve_pending_approvals(
+    conn: &Connection,
+    traces: &mut BTreeMap<String, TraceAccumulator>,
+    env: Option<&str>,
+) -> StoreResult<()> {
+    for accumulator in traces.values_mut() {
+        let pending = accumulator
+            .pending_approval_request_ids
+            .iter()
+            .map(|(request_id, event_id)| (request_id.clone(), *event_id))
+            .collect::<Vec<_>>();
+
+        for (request_id, request_event_id) in pending {
+            if approval_request_has_later_ok_decision(conn, &request_id, request_event_id, env)? {
+                accumulator.pending_approval_request_ids.remove(&request_id);
+            }
+        }
+    }
+
+    Ok(())
+}
+
+fn approval_request_has_later_ok_decision(
+    conn: &Connection,
+    request_id: &str,
+    request_event_id: i64,
+    env: Option<&str>,
+) -> StoreResult<bool> {
+    let approval_decided = enum_to_db_string(ActivityKind::ApprovalDecided, "kind")?;
+    let ok = enum_to_db_string(ActivityResult::Ok, "result")?;
+    let mut sql = String::from(
+        r#"
+        SELECT EXISTS(
+            SELECT 1
+            FROM activity_events
+            WHERE id > ?
+              AND kind = ?
+              AND result = ?
+              AND json_type(subject_json, '$.request_id') = 'text'
+              AND json_extract(subject_json, '$.request_id') = ?
+        "#,
+    );
+    let mut query_params = vec![
+        SqlValue::Integer(request_event_id),
+        SqlValue::Text(approval_decided),
+        SqlValue::Text(ok),
+        SqlValue::Text(request_id.to_owned()),
+    ];
+
+    if let Some(env) = env {
+        sql.push_str(" AND env = ?");
+        query_params.push(SqlValue::Text(env.to_owned()));
+    }
+
+    sql.push_str(
+        r#"
+            LIMIT 1
+        )
+        "#,
+    );
+
+    let found = conn.query_row(&sql, params_from_iter(query_params), |row| {
+        row.get::<_, i64>(0)
+    })?;
+    Ok(found != 0)
 }
 
 fn immediately_excludes_trace(event: &ActivityEvent) -> bool {

--- a/crates/agentenv-events/src/store.rs
+++ b/crates/agentenv-events/src/store.rs
@@ -258,6 +258,7 @@ impl SqliteEventStore {
 
     pub fn query_trace_runs(&self, query: TraceQuery) -> StoreResult<Vec<TraceRun>> {
         let conn = self.connection()?;
+        let limit = query.limit.clamp(1, 10_000);
         let trace_ids = candidate_trace_ids(&conn, &query)?;
         let rows = trace_rows(&conn, &trace_ids, query.env.as_deref())?;
 
@@ -309,15 +310,20 @@ impl SqliteEventStore {
             }
         }
 
-        let mut runs: Vec<_> = traces
-            .into_values()
-            .filter_map(|accumulator| {
-                (accumulator.matches_blueprint
+        let mut runs = Vec::new();
+        for trace_id in trace_ids {
+            if let Some(accumulator) = traces.remove(&trace_id) {
+                if accumulator.matches_blueprint
                     && !accumulator.is_excluded()
-                    && !accumulator.trace.calls.is_empty())
-                .then_some(accumulator.trace)
-            })
-            .collect();
+                    && !accumulator.trace.calls.is_empty()
+                {
+                    runs.push(accumulator.trace);
+                    if runs.len() == limit {
+                        break;
+                    }
+                }
+            }
+        }
         runs.sort_by(|left, right| left.trace_id.cmp(&right.trace_id));
         Ok(runs)
     }
@@ -604,7 +610,6 @@ impl SqliteEventStore {
 }
 
 fn candidate_trace_ids(conn: &Connection, query: &TraceQuery) -> StoreResult<Vec<String>> {
-    let limit = query.limit.clamp(1, 10_000);
     let mut sql = String::from(
         r#"
         SELECT trace_id, MAX(id) AS latest_event_id
@@ -627,7 +632,7 @@ fn candidate_trace_ids(conn: &Connection, query: &TraceQuery) -> StoreResult<Vec
         LIMIT ?
         "#,
     );
-    query_params.push(SqlValue::Integer(limit as i64));
+    query_params.push(SqlValue::Integer(10_000));
 
     let mut stmt = conn.prepare(&sql)?;
     let raw_rows = stmt.query_map(params_from_iter(query_params), |row| {

--- a/crates/agentenv-events/src/store.rs
+++ b/crates/agentenv-events/src/store.rs
@@ -1,4 +1,4 @@
-use std::collections::BTreeMap;
+use std::collections::{BTreeMap, BTreeSet};
 use std::fs::File;
 use std::io::{BufRead, BufReader};
 use std::path::{Path, PathBuf};
@@ -13,7 +13,8 @@ use thiserror::Error;
 
 use crate::activity::{ActivityEvent, ActivityKind, ActivityResult};
 use crate::trace::{
-    event_arguments, event_blueprint_id, event_tool_name, TraceQuery, TraceRun, TraceToolCall,
+    event_arguments, event_blueprint_id, event_request_id, event_tool_name, TraceQuery, TraceRun,
+    TraceToolCall,
 };
 
 pub type StoreResult<T> = Result<T, StoreError>;
@@ -257,50 +258,12 @@ impl SqliteEventStore {
 
     pub fn query_trace_runs(&self, query: TraceQuery) -> StoreResult<Vec<TraceRun>> {
         let conn = self.connection()?;
-        let limit = query.limit.clamp(1, 10_000);
-        let mut sql = String::from(
-            r#"
-            SELECT
-                id,
-                ts,
-                kind,
-                env,
-                actor_json,
-                subject_json,
-                result,
-                latency_ms,
-                trace_id,
-                reason_code,
-                extras_json
-            FROM activity_events
-            WHERE json_type(extras_json, '$.blueprint_id') = 'text'
-              AND json_extract(extras_json, '$.blueprint_id') = ?
-            "#,
-        );
-        let mut query_params = vec![SqlValue::Text(query.blueprint_id.clone())];
-
-        if let Some(env) = &query.env {
-            sql.push_str(" AND env = ?");
-            query_params.push(SqlValue::Text(env.clone()));
-        }
-
-        sql.push_str(" ORDER BY id DESC LIMIT ?");
-        query_params.push(SqlValue::Integer(limit as i64));
-
-        let mut stmt = conn.prepare(&sql)?;
-        let raw_rows = stmt.query_map(params_from_iter(query_params), raw_event_from_row)?;
-        let mut rows = Vec::new();
-        for raw in raw_rows {
-            rows.push(raw?.try_into_stored_event()?);
-        }
-        rows.sort_by_key(|row| row.id);
+        let trace_ids = candidate_trace_ids(&conn, &query)?;
+        let rows = trace_rows(&conn, &trace_ids, query.env.as_deref())?;
 
         let mut traces = BTreeMap::new();
         for row in rows {
             let event = row.event;
-            if event_blueprint_id(&event) != Some(query.blueprint_id.as_str()) {
-                continue;
-            }
 
             let trace_id = event.trace_id.clone();
             let accumulator = traces
@@ -315,12 +278,19 @@ impl SqliteEventStore {
                         terminal_result: event.result,
                         event_ids: Vec::new(),
                     },
+                    matches_blueprint: false,
                     excluded: false,
+                    unresolved_pending_approval: false,
+                    pending_approval_request_ids: BTreeSet::new(),
                 });
 
-            if excludes_trace(&event) {
+            if event_blueprint_id(&event) == Some(query.blueprint_id.as_str()) {
+                accumulator.matches_blueprint = true;
+            }
+            if immediately_excludes_trace(&event) {
                 accumulator.excluded = true;
             }
+            accumulator.record_approval_state(&event);
 
             accumulator.trace.terminal_result = event.result;
             accumulator.trace.event_ids.push(row.id);
@@ -342,8 +312,10 @@ impl SqliteEventStore {
         let mut runs: Vec<_> = traces
             .into_values()
             .filter_map(|accumulator| {
-                (!accumulator.excluded && !accumulator.trace.calls.is_empty())
-                    .then_some(accumulator.trace)
+                (accumulator.matches_blueprint
+                    && !accumulator.is_excluded()
+                    && !accumulator.trace.calls.is_empty())
+                .then_some(accumulator.trace)
             })
             .collect();
         runs.sort_by(|left, right| left.trace_id.cmp(&right.trace_id));
@@ -631,19 +603,133 @@ impl SqliteEventStore {
     }
 }
 
-struct TraceAccumulator {
-    trace: TraceRun,
-    excluded: bool,
+fn candidate_trace_ids(conn: &Connection, query: &TraceQuery) -> StoreResult<Vec<String>> {
+    let limit = query.limit.clamp(1, 10_000);
+    let mut sql = String::from(
+        r#"
+        SELECT trace_id, MAX(id) AS latest_event_id
+        FROM activity_events
+        WHERE json_type(extras_json, '$.blueprint_id') = 'text'
+          AND json_extract(extras_json, '$.blueprint_id') = ?
+        "#,
+    );
+    let mut query_params = vec![SqlValue::Text(query.blueprint_id.clone())];
+
+    if let Some(env) = &query.env {
+        sql.push_str(" AND env = ?");
+        query_params.push(SqlValue::Text(env.clone()));
+    }
+
+    sql.push_str(
+        r#"
+        GROUP BY trace_id
+        ORDER BY latest_event_id DESC
+        LIMIT ?
+        "#,
+    );
+    query_params.push(SqlValue::Integer(limit as i64));
+
+    let mut stmt = conn.prepare(&sql)?;
+    let raw_rows = stmt.query_map(params_from_iter(query_params), |row| {
+        row.get::<_, String>(0)
+    })?;
+
+    let mut trace_ids = Vec::new();
+    for raw in raw_rows {
+        trace_ids.push(raw?);
+    }
+    Ok(trace_ids)
 }
 
-fn excludes_trace(event: &ActivityEvent) -> bool {
+fn trace_rows(
+    conn: &Connection,
+    trace_ids: &[String],
+    env: Option<&str>,
+) -> StoreResult<Vec<StoredEvent>> {
+    if trace_ids.is_empty() {
+        return Ok(Vec::new());
+    }
+
+    let placeholders = std::iter::repeat_n("?", trace_ids.len())
+        .collect::<Vec<_>>()
+        .join(", ");
+    let mut sql = format!(
+        r#"
+        SELECT
+            id,
+            ts,
+            kind,
+            env,
+            actor_json,
+            subject_json,
+            result,
+            latency_ms,
+            trace_id,
+            reason_code,
+            extras_json
+        FROM activity_events
+        WHERE trace_id IN ({placeholders})
+        "#
+    );
+    let mut query_params = trace_ids
+        .iter()
+        .map(|trace_id| SqlValue::Text(trace_id.clone()))
+        .collect::<Vec<_>>();
+
+    if let Some(env) = env {
+        sql.push_str(" AND env = ?");
+        query_params.push(SqlValue::Text(env.to_owned()));
+    }
+
+    sql.push_str(" ORDER BY id ASC");
+
+    let mut stmt = conn.prepare(&sql)?;
+    let raw_rows = stmt.query_map(params_from_iter(query_params), raw_event_from_row)?;
+    let mut rows = Vec::new();
+    for raw in raw_rows {
+        rows.push(raw?.try_into_stored_event()?);
+    }
+    Ok(rows)
+}
+
+struct TraceAccumulator {
+    trace: TraceRun,
+    matches_blueprint: bool,
+    excluded: bool,
+    unresolved_pending_approval: bool,
+    pending_approval_request_ids: BTreeSet<String>,
+}
+
+impl TraceAccumulator {
+    fn record_approval_state(&mut self, event: &ActivityEvent) {
+        if event.result == ActivityResult::PendingApproval {
+            if let Some(request_id) = event_request_id(event) {
+                self.pending_approval_request_ids
+                    .insert(request_id.to_owned());
+            } else {
+                self.unresolved_pending_approval = true;
+            }
+        }
+
+        if event.kind == ActivityKind::ApprovalDecided && event.result == ActivityResult::Ok {
+            if let Some(request_id) = event_request_id(event) {
+                self.pending_approval_request_ids.remove(request_id);
+            }
+        }
+    }
+
+    fn is_excluded(&self) -> bool {
+        self.excluded
+            || self.unresolved_pending_approval
+            || !self.pending_approval_request_ids.is_empty()
+    }
+}
+
+fn immediately_excludes_trace(event: &ActivityEvent) -> bool {
     matches!(
         event.kind,
         ActivityKind::EgressDenied | ActivityKind::SpawnRejected
-    ) || matches!(
-        event.result,
-        ActivityResult::Denied | ActivityResult::PendingApproval | ActivityResult::Error
-    )
+    ) || matches!(event.result, ActivityResult::Denied | ActivityResult::Error)
 }
 
 fn approval_requests_table_exists(conn: &Connection) -> StoreResult<bool> {

--- a/crates/agentenv-events/src/store.rs
+++ b/crates/agentenv-events/src/store.rs
@@ -1,3 +1,4 @@
+use std::collections::BTreeMap;
 use std::fs::File;
 use std::io::{BufRead, BufReader};
 use std::path::{Path, PathBuf};
@@ -11,6 +12,9 @@ use serde_json::Value;
 use thiserror::Error;
 
 use crate::activity::{ActivityEvent, ActivityKind, ActivityResult};
+use crate::trace::{
+    event_arguments, event_blueprint_id, event_tool_name, TraceQuery, TraceRun, TraceToolCall,
+};
 
 pub type StoreResult<T> = Result<T, StoreError>;
 
@@ -249,6 +253,101 @@ impl SqliteEventStore {
             rows.push(raw?.try_into_stored_event()?);
         }
         Ok(rows)
+    }
+
+    pub fn query_trace_runs(&self, query: TraceQuery) -> StoreResult<Vec<TraceRun>> {
+        let conn = self.connection()?;
+        let limit = query.limit.clamp(1, 10_000);
+        let mut sql = String::from(
+            r#"
+            SELECT
+                id,
+                ts,
+                kind,
+                env,
+                actor_json,
+                subject_json,
+                result,
+                latency_ms,
+                trace_id,
+                reason_code,
+                extras_json
+            FROM activity_events
+            WHERE json_type(extras_json, '$.blueprint_id') = 'text'
+              AND json_extract(extras_json, '$.blueprint_id') = ?
+            "#,
+        );
+        let mut query_params = vec![SqlValue::Text(query.blueprint_id.clone())];
+
+        if let Some(env) = &query.env {
+            sql.push_str(" AND env = ?");
+            query_params.push(SqlValue::Text(env.clone()));
+        }
+
+        sql.push_str(" ORDER BY id DESC LIMIT ?");
+        query_params.push(SqlValue::Integer(limit as i64));
+
+        let mut stmt = conn.prepare(&sql)?;
+        let raw_rows = stmt.query_map(params_from_iter(query_params), raw_event_from_row)?;
+        let mut rows = Vec::new();
+        for raw in raw_rows {
+            rows.push(raw?.try_into_stored_event()?);
+        }
+        rows.sort_by_key(|row| row.id);
+
+        let mut traces = BTreeMap::new();
+        for row in rows {
+            let event = row.event;
+            if event_blueprint_id(&event) != Some(query.blueprint_id.as_str()) {
+                continue;
+            }
+
+            let trace_id = event.trace_id.clone();
+            let accumulator = traces
+                .entry(trace_id.clone())
+                .or_insert_with(|| TraceAccumulator {
+                    trace: TraceRun {
+                        trace_id,
+                        env: event.env.clone(),
+                        blueprint_id: query.blueprint_id.clone(),
+                        started_at: event.ts.clone(),
+                        calls: Vec::new(),
+                        terminal_result: event.result,
+                        event_ids: Vec::new(),
+                    },
+                    excluded: false,
+                });
+
+            if excludes_trace(&event) {
+                accumulator.excluded = true;
+            }
+
+            accumulator.trace.terminal_result = event.result;
+            accumulator.trace.event_ids.push(row.id);
+
+            if event.kind == ActivityKind::McpToolCall {
+                if let Some(tool) = event_tool_name(&event) {
+                    accumulator.trace.calls.push(TraceToolCall {
+                        event_id: row.id,
+                        ordinal: accumulator.trace.calls.len() as u32,
+                        tool: tool.to_owned(),
+                        args: event_arguments(&event),
+                        result: event.result,
+                        subject: Value::Object(event.subject.clone().into_iter().collect()),
+                    });
+                }
+            }
+        }
+
+        let mut runs: Vec<_> = traces
+            .into_values()
+            .filter_map(|accumulator| {
+                (!accumulator.excluded && !accumulator.trace.calls.is_empty())
+                    .then_some(accumulator.trace)
+            })
+            .collect();
+        runs.sort_by(|left, right| left.trace_id.cmp(&right.trace_id));
+        Ok(runs)
     }
 
     pub fn has_entries_for_env(&self, env: &str) -> StoreResult<bool> {
@@ -530,6 +629,21 @@ impl SqliteEventStore {
         conn.busy_timeout(Duration::from_secs(5))?;
         Ok(conn)
     }
+}
+
+struct TraceAccumulator {
+    trace: TraceRun,
+    excluded: bool,
+}
+
+fn excludes_trace(event: &ActivityEvent) -> bool {
+    matches!(
+        event.kind,
+        ActivityKind::EgressDenied | ActivityKind::SpawnRejected
+    ) || matches!(
+        event.result,
+        ActivityResult::Denied | ActivityResult::PendingApproval | ActivityResult::Error
+    )
 }
 
 fn approval_requests_table_exists(conn: &Connection) -> StoreResult<bool> {

--- a/crates/agentenv-events/src/trace.rs
+++ b/crates/agentenv-events/src/trace.rs
@@ -39,6 +39,10 @@ pub(crate) fn event_tool_name(event: &crate::ActivityEvent) -> Option<&str> {
     event.subject.get("tool").and_then(Value::as_str)
 }
 
+pub(crate) fn event_request_id(event: &crate::ActivityEvent) -> Option<&str> {
+    event.subject.get("request_id").and_then(Value::as_str)
+}
+
 pub(crate) fn event_arguments(event: &crate::ActivityEvent) -> Value {
     event
         .subject

--- a/crates/agentenv-events/src/trace.rs
+++ b/crates/agentenv-events/src/trace.rs
@@ -1,0 +1,48 @@
+use serde::{Deserialize, Serialize};
+use serde_json::Value;
+
+use crate::ActivityResult;
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct TraceQuery {
+    pub blueprint_id: String,
+    pub env: Option<String>,
+    pub limit: usize,
+}
+
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+pub struct TraceRun {
+    pub trace_id: String,
+    pub env: Option<String>,
+    pub blueprint_id: String,
+    pub started_at: String,
+    pub calls: Vec<TraceToolCall>,
+    pub terminal_result: ActivityResult,
+    pub event_ids: Vec<i64>,
+}
+
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+pub struct TraceToolCall {
+    pub event_id: i64,
+    pub ordinal: u32,
+    pub tool: String,
+    pub args: Value,
+    pub result: ActivityResult,
+    pub subject: Value,
+}
+
+pub(crate) fn event_blueprint_id(event: &crate::ActivityEvent) -> Option<&str> {
+    event.extras.get("blueprint_id").and_then(Value::as_str)
+}
+
+pub(crate) fn event_tool_name(event: &crate::ActivityEvent) -> Option<&str> {
+    event.subject.get("tool").and_then(Value::as_str)
+}
+
+pub(crate) fn event_arguments(event: &crate::ActivityEvent) -> Value {
+    event
+        .subject
+        .get("arguments")
+        .cloned()
+        .unwrap_or(Value::Object(Default::default()))
+}

--- a/crates/agentenv-events/tests/trace_query.rs
+++ b/crates/agentenv-events/tests/trace_query.rs
@@ -331,6 +331,181 @@ fn trace_query_keeps_trace_with_resolved_approval_request() {
     );
 }
 
+#[test]
+fn trace_query_keeps_trace_with_cross_trace_approval_decision() {
+    let temp = tempfile::tempdir().unwrap();
+    let store = SqliteEventStore::open(temp.path().join("events.db")).unwrap();
+    store
+        .append_many(&[
+            event(
+                "approved-trace",
+                1,
+                "demo",
+                "sha256:blueprint-a",
+                "fs_read",
+                ActivityResult::Ok,
+            ),
+            ActivityEvent::new(
+                "2026-05-11T00:00:02Z",
+                ActivityKind::ApprovalRequested,
+                ActivityResult::PendingApproval,
+                "approved-trace",
+            )
+            .with_env("demo")
+            .with_subject_value("request_id", serde_json::json!("approval-1"))
+            .with_extra("blueprint_id", serde_json::json!("sha256:blueprint-a")),
+            ActivityEvent::new(
+                "2026-05-11T00:00:03Z",
+                ActivityKind::ApprovalDecided,
+                ActivityResult::Ok,
+                "approval-decision-trace",
+            )
+            .with_env("demo")
+            .with_subject_value("request_id", serde_json::json!("approval-1")),
+        ])
+        .unwrap();
+
+    let traces = store
+        .query_trace_runs(TraceQuery {
+            blueprint_id: "sha256:blueprint-a".to_owned(),
+            env: Some("demo".to_owned()),
+            limit: 100,
+        })
+        .unwrap();
+
+    assert_eq!(
+        traces
+            .iter()
+            .map(|trace| trace.trace_id.as_str())
+            .collect::<Vec<_>>(),
+        vec!["approved-trace"]
+    );
+}
+
+#[test]
+fn trace_query_excludes_unresolved_pending_approval_with_request_id() {
+    let temp = tempfile::tempdir().unwrap();
+    let store = SqliteEventStore::open(temp.path().join("events.db")).unwrap();
+    store
+        .append_many(&[
+            event(
+                "pending-trace",
+                1,
+                "demo",
+                "sha256:blueprint-a",
+                "fs_read",
+                ActivityResult::Ok,
+            ),
+            ActivityEvent::new(
+                "2026-05-11T00:00:02Z",
+                ActivityKind::ApprovalRequested,
+                ActivityResult::PendingApproval,
+                "pending-trace",
+            )
+            .with_env("demo")
+            .with_subject_value("request_id", serde_json::json!("approval-1"))
+            .with_extra("blueprint_id", serde_json::json!("sha256:blueprint-a")),
+        ])
+        .unwrap();
+
+    let traces = store
+        .query_trace_runs(TraceQuery {
+            blueprint_id: "sha256:blueprint-a".to_owned(),
+            env: Some("demo".to_owned()),
+            limit: 100,
+        })
+        .unwrap();
+
+    assert!(traces.is_empty());
+}
+
+#[test]
+fn trace_query_does_not_resolve_request_with_earlier_approval_decision() {
+    let temp = tempfile::tempdir().unwrap();
+    let store = SqliteEventStore::open(temp.path().join("events.db")).unwrap();
+    store
+        .append_many(&[
+            ActivityEvent::new(
+                "2026-05-11T00:00:01Z",
+                ActivityKind::ApprovalDecided,
+                ActivityResult::Ok,
+                "approval-decision-trace",
+            )
+            .with_env("demo")
+            .with_subject_value("request_id", serde_json::json!("approval-1")),
+            event(
+                "pending-trace",
+                2,
+                "demo",
+                "sha256:blueprint-a",
+                "fs_read",
+                ActivityResult::Ok,
+            ),
+            ActivityEvent::new(
+                "2026-05-11T00:00:03Z",
+                ActivityKind::ApprovalRequested,
+                ActivityResult::PendingApproval,
+                "pending-trace",
+            )
+            .with_env("demo")
+            .with_subject_value("request_id", serde_json::json!("approval-1"))
+            .with_extra("blueprint_id", serde_json::json!("sha256:blueprint-a")),
+        ])
+        .unwrap();
+
+    let traces = store
+        .query_trace_runs(TraceQuery {
+            blueprint_id: "sha256:blueprint-a".to_owned(),
+            env: Some("demo".to_owned()),
+            limit: 100,
+        })
+        .unwrap();
+
+    assert!(traces.is_empty());
+}
+
+#[test]
+fn trace_query_requires_successful_mcp_tool_call() {
+    let temp = tempfile::tempdir().unwrap();
+    let store = SqliteEventStore::open(temp.path().join("events.db")).unwrap();
+    store
+        .append_many(&[
+            ActivityEvent::new(
+                "2026-05-11T00:00:01Z",
+                ActivityKind::McpToolCall,
+                ActivityResult::PendingApproval,
+                "pending-call-trace",
+            )
+            .with_env("demo")
+            .with_subject_value("tool", serde_json::json!("fs_read"))
+            .with_subject_value(
+                "arguments",
+                serde_json::json!({"path": "needs-approval.rs"}),
+            )
+            .with_subject_value("request_id", serde_json::json!("approval-1"))
+            .with_extra("blueprint_id", serde_json::json!("sha256:blueprint-a")),
+            ActivityEvent::new(
+                "2026-05-11T00:00:02Z",
+                ActivityKind::ApprovalDecided,
+                ActivityResult::Ok,
+                "pending-call-trace",
+            )
+            .with_env("demo")
+            .with_subject_value("request_id", serde_json::json!("approval-1")),
+        ])
+        .unwrap();
+
+    let traces = store
+        .query_trace_runs(TraceQuery {
+            blueprint_id: "sha256:blueprint-a".to_owned(),
+            env: Some("demo".to_owned()),
+            limit: 100,
+        })
+        .unwrap();
+
+    assert!(traces.is_empty());
+}
+
 fn event(
     trace_id: &str,
     ordinal: u32,

--- a/crates/agentenv-events/tests/trace_query.rs
+++ b/crates/agentenv-events/tests/trace_query.rs
@@ -125,6 +125,155 @@ fn trace_query_excludes_denied_pending_and_error_traces() {
     );
 }
 
+#[test]
+fn trace_query_excludes_same_trace_disqualifying_event_without_blueprint_id() {
+    let temp = tempfile::tempdir().unwrap();
+    let store = SqliteEventStore::open(temp.path().join("events.db")).unwrap();
+    store
+        .append_many(&[
+            event(
+                "ok-trace",
+                1,
+                "demo",
+                "sha256:blueprint-a",
+                "fs_read",
+                ActivityResult::Ok,
+            ),
+            event(
+                "blocked-trace",
+                2,
+                "demo",
+                "sha256:blueprint-a",
+                "fs_read",
+                ActivityResult::Ok,
+            ),
+            ActivityEvent::new(
+                "2026-05-11T00:00:03Z",
+                ActivityKind::EgressDenied,
+                ActivityResult::Denied,
+                "blocked-trace",
+            )
+            .with_env("demo"),
+        ])
+        .unwrap();
+
+    let traces = store
+        .query_trace_runs(TraceQuery {
+            blueprint_id: "sha256:blueprint-a".to_owned(),
+            env: Some("demo".to_owned()),
+            limit: 100,
+        })
+        .unwrap();
+
+    assert_eq!(
+        traces
+            .iter()
+            .map(|trace| trace.trace_id.as_str())
+            .collect::<Vec<_>>(),
+        vec!["ok-trace"]
+    );
+}
+
+#[test]
+fn trace_query_limit_selects_complete_trace_runs_not_raw_events() {
+    let temp = tempfile::tempdir().unwrap();
+    let store = SqliteEventStore::open(temp.path().join("events.db")).unwrap();
+    store
+        .append_many(&[
+            event(
+                "older-trace",
+                1,
+                "demo",
+                "sha256:blueprint-a",
+                "fs_read",
+                ActivityResult::Ok,
+            ),
+            event(
+                "latest-trace",
+                2,
+                "demo",
+                "sha256:blueprint-a",
+                "fs_read",
+                ActivityResult::Ok,
+            ),
+            event(
+                "latest-trace",
+                3,
+                "demo",
+                "sha256:blueprint-a",
+                "fs_write",
+                ActivityResult::Ok,
+            ),
+        ])
+        .unwrap();
+
+    let traces = store
+        .query_trace_runs(TraceQuery {
+            blueprint_id: "sha256:blueprint-a".to_owned(),
+            env: Some("demo".to_owned()),
+            limit: 1,
+        })
+        .unwrap();
+
+    assert_eq!(traces.len(), 1);
+    assert_eq!(traces[0].trace_id, "latest-trace");
+    assert_eq!(traces[0].calls.len(), 2);
+    assert_eq!(traces[0].calls[0].tool, "fs_read");
+    assert_eq!(traces[0].calls[1].tool, "fs_write");
+}
+
+#[test]
+fn trace_query_keeps_trace_with_resolved_approval_request() {
+    let temp = tempfile::tempdir().unwrap();
+    let store = SqliteEventStore::open(temp.path().join("events.db")).unwrap();
+    store
+        .append_many(&[
+            event(
+                "approved-trace",
+                1,
+                "demo",
+                "sha256:blueprint-a",
+                "fs_read",
+                ActivityResult::Ok,
+            ),
+            ActivityEvent::new(
+                "2026-05-11T00:00:02Z",
+                ActivityKind::ApprovalRequested,
+                ActivityResult::PendingApproval,
+                "approved-trace",
+            )
+            .with_env("demo")
+            .with_subject_value("request_id", serde_json::json!("approval-1"))
+            .with_extra("blueprint_id", serde_json::json!("sha256:blueprint-a")),
+            ActivityEvent::new(
+                "2026-05-11T00:00:03Z",
+                ActivityKind::ApprovalDecided,
+                ActivityResult::Ok,
+                "approved-trace",
+            )
+            .with_env("demo")
+            .with_subject_value("request_id", serde_json::json!("approval-1"))
+            .with_extra("blueprint_id", serde_json::json!("sha256:blueprint-a")),
+        ])
+        .unwrap();
+
+    let traces = store
+        .query_trace_runs(TraceQuery {
+            blueprint_id: "sha256:blueprint-a".to_owned(),
+            env: Some("demo".to_owned()),
+            limit: 100,
+        })
+        .unwrap();
+
+    assert_eq!(
+        traces
+            .iter()
+            .map(|trace| trace.trace_id.as_str())
+            .collect::<Vec<_>>(),
+        vec!["approved-trace"]
+    );
+}
+
 fn event(
     trace_id: &str,
     ordinal: u32,

--- a/crates/agentenv-events/tests/trace_query.rs
+++ b/crates/agentenv-events/tests/trace_query.rs
@@ -1,0 +1,156 @@
+use agentenv_events::{
+    trace::{TraceQuery, TraceRun},
+    ActivityEvent, ActivityKind, ActivityResult, SqliteEventStore,
+};
+
+#[test]
+fn trace_query_groups_successful_mcp_calls_by_trace_id_and_blueprint() {
+    let temp = tempfile::tempdir().unwrap();
+    let store = SqliteEventStore::open(temp.path().join("events.db")).unwrap();
+    store
+        .append_many(&[
+            event(
+                "trace-a",
+                1,
+                "demo",
+                "sha256:blueprint-a",
+                "fs_read",
+                ActivityResult::Ok,
+            ),
+            event(
+                "trace-a",
+                2,
+                "demo",
+                "sha256:blueprint-a",
+                "fs_write",
+                ActivityResult::Ok,
+            ),
+            event(
+                "trace-b",
+                1,
+                "demo",
+                "sha256:blueprint-a",
+                "fs_read",
+                ActivityResult::Ok,
+            ),
+            event(
+                "trace-c",
+                1,
+                "demo",
+                "sha256:blueprint-b",
+                "fs_read",
+                ActivityResult::Ok,
+            ),
+        ])
+        .unwrap();
+
+    let traces = store
+        .query_trace_runs(TraceQuery {
+            blueprint_id: "sha256:blueprint-a".to_owned(),
+            env: Some("demo".to_owned()),
+            limit: 100,
+        })
+        .unwrap();
+
+    assert_eq!(traces.len(), 2);
+    assert_eq!(trace(&traces, "trace-a").calls.len(), 2);
+    assert_eq!(trace(&traces, "trace-a").calls[0].tool, "fs_read");
+    assert_eq!(trace(&traces, "trace-a").calls[1].tool, "fs_write");
+    assert_eq!(trace(&traces, "trace-b").calls.len(), 1);
+}
+
+#[test]
+fn trace_query_excludes_denied_pending_and_error_traces() {
+    let temp = tempfile::tempdir().unwrap();
+    let store = SqliteEventStore::open(temp.path().join("events.db")).unwrap();
+    store
+        .append_many(&[
+            event(
+                "ok-trace",
+                1,
+                "demo",
+                "sha256:blueprint-a",
+                "fs_read",
+                ActivityResult::Ok,
+            ),
+            event(
+                "denied-trace",
+                1,
+                "demo",
+                "sha256:blueprint-a",
+                "fs_read",
+                ActivityResult::Ok,
+            ),
+            ActivityEvent::new(
+                "2026-05-11T00:00:02Z",
+                ActivityKind::EgressDenied,
+                ActivityResult::Denied,
+                "denied-trace",
+            )
+            .with_env("demo")
+            .with_extra("blueprint_id", serde_json::json!("sha256:blueprint-a")),
+            event(
+                "error-trace",
+                1,
+                "demo",
+                "sha256:blueprint-a",
+                "fs_read",
+                ActivityResult::Error,
+            ),
+            ActivityEvent::new(
+                "2026-05-11T00:00:03Z",
+                ActivityKind::ApprovalRequested,
+                ActivityResult::PendingApproval,
+                "pending-trace",
+            )
+            .with_env("demo")
+            .with_extra("blueprint_id", serde_json::json!("sha256:blueprint-a")),
+        ])
+        .unwrap();
+
+    let traces = store
+        .query_trace_runs(TraceQuery {
+            blueprint_id: "sha256:blueprint-a".to_owned(),
+            env: Some("demo".to_owned()),
+            limit: 100,
+        })
+        .unwrap();
+
+    assert_eq!(
+        traces
+            .iter()
+            .map(|trace| trace.trace_id.as_str())
+            .collect::<Vec<_>>(),
+        vec!["ok-trace"]
+    );
+}
+
+fn event(
+    trace_id: &str,
+    ordinal: u32,
+    env: &str,
+    blueprint_id: &str,
+    tool: &str,
+    result: ActivityResult,
+) -> ActivityEvent {
+    ActivityEvent::new(
+        format!("2026-05-11T00:00:{ordinal:02}Z"),
+        ActivityKind::McpToolCall,
+        result,
+        trace_id,
+    )
+    .with_env(env)
+    .with_subject_value("tool", serde_json::json!(tool))
+    .with_subject_value(
+        "arguments",
+        serde_json::json!({"path": format!("file-{ordinal}.rs")}),
+    )
+    .with_extra("blueprint_id", serde_json::json!(blueprint_id))
+}
+
+fn trace<'a>(traces: &'a [TraceRun], trace_id: &str) -> &'a TraceRun {
+    traces
+        .iter()
+        .find(|trace| trace.trace_id == trace_id)
+        .unwrap()
+}

--- a/crates/agentenv-events/tests/trace_query.rs
+++ b/crates/agentenv-events/tests/trace_query.rs
@@ -97,6 +97,14 @@ fn trace_query_excludes_denied_pending_and_error_traces() {
                 "fs_read",
                 ActivityResult::Error,
             ),
+            event(
+                "pending-trace",
+                1,
+                "demo",
+                "sha256:blueprint-a",
+                "fs_read",
+                ActivityResult::Ok,
+            ),
             ActivityEvent::new(
                 "2026-05-11T00:00:03Z",
                 ActivityKind::ApprovalRequested,
@@ -220,6 +228,55 @@ fn trace_query_limit_selects_complete_trace_runs_not_raw_events() {
     assert_eq!(traces[0].calls.len(), 2);
     assert_eq!(traces[0].calls[0].tool, "fs_read");
     assert_eq!(traces[0].calls[1].tool, "fs_write");
+}
+
+#[test]
+fn trace_query_limit_skips_excluded_candidates_to_return_successful_runs() {
+    let temp = tempfile::tempdir().unwrap();
+    let store = SqliteEventStore::open(temp.path().join("events.db")).unwrap();
+    store
+        .append_many(&[
+            event(
+                "older-valid-trace",
+                1,
+                "demo",
+                "sha256:blueprint-a",
+                "fs_read",
+                ActivityResult::Ok,
+            ),
+            event(
+                "newer-blocked-trace",
+                2,
+                "demo",
+                "sha256:blueprint-a",
+                "fs_read",
+                ActivityResult::Ok,
+            ),
+            ActivityEvent::new(
+                "2026-05-11T00:00:03Z",
+                ActivityKind::EgressDenied,
+                ActivityResult::Denied,
+                "newer-blocked-trace",
+            )
+            .with_env("demo"),
+        ])
+        .unwrap();
+
+    let traces = store
+        .query_trace_runs(TraceQuery {
+            blueprint_id: "sha256:blueprint-a".to_owned(),
+            env: Some("demo".to_owned()),
+            limit: 1,
+        })
+        .unwrap();
+
+    assert_eq!(
+        traces
+            .iter()
+            .map(|trace| trace.trace_id.as_str())
+            .collect::<Vec<_>>(),
+        vec!["older-valid-trace"]
+    );
 }
 
 #[test]

--- a/crates/agentenv/Cargo.toml
+++ b/crates/agentenv/Cargo.toml
@@ -39,6 +39,7 @@ inference-ollama = { path = "../drivers/inference-ollama" }
 inference-openai = { path = "../drivers/inference-openai" }
 inference-passthrough = { path = "../drivers/inference-passthrough" }
 rpassword = "7"
+reqwest = { workspace = true, features = ["json"] }
 sandbox-openshell = { path = "../drivers/sandbox-openshell" }
 sandbox-microvm = { path = "../drivers/sandbox-microvm" }
 sandbox-remote-ssh = { path = "../drivers/sandbox-remote-ssh" }

--- a/crates/agentenv/src/main.rs
+++ b/crates/agentenv/src/main.rs
@@ -40,6 +40,7 @@ mod builtin_factory;
 mod bundle_cli;
 mod render;
 mod skills_cli;
+mod skills_propose_cli;
 mod term_backend;
 
 const SELF_ENV_SENTINEL: &str = "__self__";

--- a/crates/agentenv/src/skills_cli.rs
+++ b/crates/agentenv/src/skills_cli.rs
@@ -13,6 +13,8 @@ use anyhow::{bail, Context, Result};
 use clap::{Args, Subcommand};
 use serde::Serialize;
 
+use crate::skills_propose_cli::{run_skills_propose, SkillsProposeArgs};
+
 #[derive(Debug, Args)]
 pub struct SkillsArgs {
     #[command(subcommand)]
@@ -21,6 +23,7 @@ pub struct SkillsArgs {
 
 #[derive(Debug, Subcommand)]
 pub enum SkillsCommand {
+    Propose(SkillsProposeArgs),
     Search(SkillsSearchArgs),
     Add(SkillsAddArgs),
     Install(SkillsInstallArgs),
@@ -138,6 +141,7 @@ pub async fn run_skills(args: SkillsArgs) -> Result<()> {
 
 async fn dispatch(command: SkillsCommand, service: SkillService, root: PathBuf) -> Result<()> {
     match command {
+        SkillsCommand::Propose(args) => run_skills_propose(args).await,
         SkillsCommand::Search(args) => {
             let hits = service.search(&args.query).await?;
             if args.json {
@@ -227,6 +231,7 @@ async fn dispatch(command: SkillsCommand, service: SkillService, root: PathBuf) 
 
 fn registry_override_for_command(command: &SkillsCommand) -> Option<String> {
     match command {
+        SkillsCommand::Propose(_) => None,
         SkillsCommand::Search(args) => args.registry.clone(),
         SkillsCommand::Add(args) => args.registry.clone(),
         SkillsCommand::Publish(args) => args.registry.clone(),

--- a/crates/agentenv/src/skills_cli.rs
+++ b/crates/agentenv/src/skills_cli.rs
@@ -130,6 +130,10 @@ struct SkillsSearchJson {
 }
 
 pub async fn run_skills(args: SkillsArgs) -> Result<()> {
+    if let SkillsCommand::Propose(args) = args.command {
+        return run_skills_propose(args).await;
+    }
+
     let home = dirs::home_dir().context("home directory is unavailable")?;
     let root = home.join(".agentenv");
     let registry_override = registry_override_for_command(&args.command);

--- a/crates/agentenv/src/skills_propose_cli.rs
+++ b/crates/agentenv/src/skills_propose_cli.rs
@@ -58,5 +58,25 @@ pub fn validate_args(args: &SkillsProposeArgs) -> Result<()> {
     if args.open_pr && args.repo.is_none() {
         bail!("--open-pr requires --repo owner/repo");
     }
+    if let Some(repo) = &args.repo {
+        validate_repo(repo)?;
+    }
     Ok(())
+}
+
+fn validate_repo(repo: &str) -> Result<()> {
+    let Some((owner, name)) = repo.split_once('/') else {
+        bail!("--repo must be in owner/repo format");
+    };
+    if owner.is_empty() || name.is_empty() || name.contains('/') {
+        bail!("--repo must be in owner/repo format");
+    }
+    if !owner.chars().all(is_repo_component_char) || !name.chars().all(is_repo_component_char) {
+        bail!("--repo must be in owner/repo format");
+    }
+    Ok(())
+}
+
+fn is_repo_component_char(ch: char) -> bool {
+    ch.is_ascii_alphanumeric() || matches!(ch, '-' | '_' | '.')
 }

--- a/crates/agentenv/src/skills_propose_cli.rs
+++ b/crates/agentenv/src/skills_propose_cli.rs
@@ -31,6 +31,7 @@ use url::Url;
 const DEFAULT_HTTP_TIMEOUT: Duration = Duration::from_secs(60);
 const HTTP_ERROR_BODY_LIMIT: usize = 4096;
 const LOCAL_ENDPOINTS_ENV: &str = "AGENTENV_SKILL_PROPOSER_ALLOW_LOCAL_ENDPOINTS";
+const PRIVATE_ENDPOINTS_ENV: &str = "AGENTENV_SKILL_PROPOSER_ALLOW_PRIVATE_ENDPOINTS";
 const HTTP_TIMEOUT_ENV: &str = "AGENTENV_SKILL_PROPOSER_HTTP_TIMEOUT_MS";
 
 #[derive(Debug, Args, Clone)]
@@ -418,6 +419,8 @@ fn skill_proposer_ssrf_options() -> SsrfOptions {
     let mut options = SsrfOptions::default();
     if env_flag_enabled(LOCAL_ENDPOINTS_ENV) {
         options.allow_loopback = true;
+    }
+    if env_flag_enabled(PRIVATE_ENDPOINTS_ENV) {
         options.allow_private = true;
     }
     options
@@ -435,6 +438,7 @@ fn build_http_client(endpoint: &ValidatedUrl) -> Result<Client> {
     Client::builder()
         .timeout(timeout)
         .connect_timeout(timeout)
+        .redirect(reqwest::redirect::Policy::none())
         .resolve_to_addrs(&endpoint.host, &addrs)
         .build()
         .context("build skill proposal LLM HTTP client")

--- a/crates/agentenv/src/skills_propose_cli.rs
+++ b/crates/agentenv/src/skills_propose_cli.rs
@@ -68,6 +68,16 @@ pub struct SkillsProposeArgs {
 struct SkillsProposeJson {
     proposals: Vec<ProposalEmitOutput>,
     warnings: Vec<String>,
+    #[serde(skip_serializing_if = "Vec::is_empty")]
+    pull_requests: Vec<String>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+struct PullRequestPlan {
+    repo: String,
+    branch: String,
+    title: String,
+    body: String,
 }
 
 struct FixtureGeneralizer {
@@ -169,16 +179,14 @@ pub async fn run_skills_propose(args: SkillsProposeArgs) -> Result<()> {
         })
         .with_context(|| format!("query traces from `{}`", events_db.display()))?;
     if traces.is_empty() {
-        return print_skills_propose_output(
-            args.json,
-            ProposeRunOutput {
-                proposals: Vec::new(),
-                warnings: vec![no_matching_traces_warning(
-                    &blueprint_id,
-                    args.env.as_deref(),
-                )],
-            },
-        );
+        let output = ProposeRunOutput {
+            proposals: Vec::new(),
+            warnings: vec![no_matching_traces_warning(
+                &blueprint_id,
+                args.env.as_deref(),
+            )],
+        };
+        return finish_skills_propose(args.json, args.open_pr, args.repo.clone(), output);
     }
     let output_root = args.out.clone().unwrap_or_else(default_proposed_dir);
     let generalizer = generalizer_for_args(&args, blueprint)?;
@@ -198,14 +206,39 @@ pub async fn run_skills_propose(args: SkillsProposeArgs) -> Result<()> {
         .await
         .context("run skill proposal service")?;
 
-    print_skills_propose_output(args.json, output)
+    finish_skills_propose(args.json, args.open_pr, args.repo.clone(), output)
 }
 
-fn print_skills_propose_output(json: bool, output: ProposeRunOutput) -> Result<()> {
+fn finish_skills_propose(
+    json: bool,
+    open_pr: bool,
+    repo: Option<String>,
+    output: ProposeRunOutput,
+) -> Result<()> {
+    let mut pull_requests = Vec::new();
+    if open_pr {
+        let proposal = output
+            .proposals
+            .first()
+            .context("--open-pr requested but no proposals were emitted")?;
+        let repo = repo.context("--open-pr requires --repo owner/repo")?;
+        let plan = pr_plan_for(repo, proposal);
+        pull_requests.push(publish_pr(&plan, &proposal.path)?);
+    }
+
+    print_skills_propose_output(json, output, pull_requests)
+}
+
+fn print_skills_propose_output(
+    json: bool,
+    output: ProposeRunOutput,
+    pull_requests: Vec<String>,
+) -> Result<()> {
     if json {
         let rendered = serde_json::to_string_pretty(&SkillsProposeJson {
             proposals: output.proposals,
             warnings: output.warnings,
+            pull_requests,
         })
         .context("serialize skill proposal JSON")?;
         println!("{rendered}");
@@ -221,6 +254,74 @@ fn print_skills_propose_output(json: bool, output: ProposeRunOutput) -> Result<(
         for warning in &output.warnings {
             eprintln!("warning: {warning}");
         }
+        for pull_request in &pull_requests {
+            println!("{pull_request}");
+        }
+    }
+    Ok(())
+}
+
+fn pr_plan_for(repo: String, proposal: &ProposalEmitOutput) -> PullRequestPlan {
+    let short_name = proposal.name.replace('_', "-");
+    PullRequestPlan {
+        repo,
+        branch: format!("agentenv/proposed-skill/{short_name}"),
+        title: format!("feat: propose trace-derived skill {}", proposal.name),
+        body: format!(
+            "Trace-derived skill proposal.\n\nNovelty: {}\nSelf-test score: {}\nPath: `{}`\n",
+            proposal.novelty,
+            proposal.self_test_score,
+            proposal.path.display()
+        ),
+    }
+}
+
+fn publish_pr(plan: &PullRequestPlan, proposal_path: &Path) -> Result<String> {
+    run_command("git", &["checkout", "-B", &plan.branch])?;
+    run_command(
+        "git",
+        &[
+            "add",
+            proposal_path
+                .to_str()
+                .context("proposal path is not UTF-8")?,
+        ],
+    )?;
+    run_command("git", &["commit", "-m", &plan.title])?;
+    run_command("git", &["push", "-u", "origin", &plan.branch])?;
+    let output = std::process::Command::new("gh")
+        .args([
+            "pr",
+            "create",
+            "--repo",
+            &plan.repo,
+            "--draft",
+            "--title",
+            &plan.title,
+            "--body",
+            &plan.body,
+        ])
+        .output()
+        .context("run gh pr create")?;
+    if !output.status.success() {
+        bail!(
+            "gh pr create failed: {}",
+            String::from_utf8_lossy(&output.stderr)
+        );
+    }
+    Ok(String::from_utf8_lossy(&output.stdout).trim().to_owned())
+}
+
+fn run_command(program: &str, args: &[&str]) -> Result<()> {
+    let output = std::process::Command::new(program)
+        .args(args)
+        .output()
+        .with_context(|| format!("run {program}"))?;
+    if !output.status.success() {
+        bail!(
+            "{program} failed: {}",
+            String::from_utf8_lossy(&output.stderr)
+        );
     }
     Ok(())
 }

--- a/crates/agentenv/src/skills_propose_cli.rs
+++ b/crates/agentenv/src/skills_propose_cli.rs
@@ -1,7 +1,19 @@
-use std::path::PathBuf;
+use std::{
+    fs,
+    path::{Path, PathBuf},
+};
 
-use anyhow::{bail, Result};
+use agentenv_core::skills::propose::{
+    ProposalEmitOutput, ProposeRunInput, ProposedSkillService, SkillGeneralization,
+    SkillGeneralizationRequest, SkillGeneralizer,
+};
+use agentenv_events::{SqliteEventStore, TraceQuery};
+use anyhow::{bail, Context, Result};
+use async_trait::async_trait;
 use clap::Args;
+use serde::Serialize;
+use sha2::{Digest, Sha256};
+use time::{format_description::well_known::Rfc3339, OffsetDateTime};
 
 #[derive(Debug, Args, Clone)]
 pub struct SkillsProposeArgs {
@@ -33,9 +45,84 @@ pub struct SkillsProposeArgs {
     pub repo: Option<String>,
 }
 
+#[derive(Debug, Serialize)]
+struct SkillsProposeJson {
+    proposals: Vec<ProposalEmitOutput>,
+    warnings: Vec<String>,
+}
+
+struct FixtureGeneralizer {
+    value: SkillGeneralization,
+}
+
+#[async_trait]
+impl SkillGeneralizer for FixtureGeneralizer {
+    async fn generalize(
+        &self,
+        _request: SkillGeneralizationRequest,
+    ) -> Result<SkillGeneralization, agentenv_core::skills::SkillError> {
+        Ok(self.value.clone())
+    }
+}
+
 pub async fn run_skills_propose(args: SkillsProposeArgs) -> Result<()> {
     validate_args(&args)?;
-    println!("no proposals emitted");
+    let blueprint = args
+        .blueprint
+        .as_deref()
+        .context("`agentenv skills propose` requires --blueprint <path>")?;
+    let blueprint_id = blueprint_id_for_path(blueprint)?;
+    let events_db = args
+        .events_db
+        .clone()
+        .unwrap_or_else(default_events_db_path);
+    let store = SqliteEventStore::open(&events_db)
+        .with_context(|| format!("open events database `{}`", events_db.display()))?;
+    let traces = store
+        .query_trace_runs(TraceQuery {
+            blueprint_id: blueprint_id.clone(),
+            env: args.env.clone(),
+            limit: 10_000,
+        })
+        .with_context(|| format!("query traces from `{}`", events_db.display()))?;
+    let output_root = args.out.clone().unwrap_or_else(default_proposed_dir);
+    let generalizer = generalizer_for_args(&args)?;
+    let created_at = now_event_ts();
+    let output = ProposedSkillService::new(generalizer)
+        .run(ProposeRunInput {
+            traces,
+            output_root,
+            blueprint_id,
+            min_occurrences: args.min_occurrences,
+            min_novelty: args.min_novelty,
+            min_self_test_score: args.min_self_test_score,
+            existing_skills: Vec::new(),
+            agentenv_version: env!("CARGO_PKG_VERSION").to_owned(),
+            created_at,
+        })
+        .await
+        .context("run skill proposal service")?;
+
+    if args.json {
+        let rendered = serde_json::to_string_pretty(&SkillsProposeJson {
+            proposals: output.proposals,
+            warnings: output.warnings,
+        })
+        .context("serialize skill proposal JSON")?;
+        println!("{rendered}");
+    } else {
+        for proposal in &output.proposals {
+            println!(
+                "{} {} {}",
+                proposal.name,
+                proposal.novelty,
+                proposal.path.display()
+            );
+        }
+        for warning in &output.warnings {
+            eprintln!("warning: {warning}");
+        }
+    }
     Ok(())
 }
 
@@ -79,4 +166,38 @@ fn validate_repo(repo: &str) -> Result<()> {
 
 fn is_repo_component_char(ch: char) -> bool {
     ch.is_ascii_alphanumeric() || matches!(ch, '-' | '_' | '.')
+}
+
+fn generalizer_for_args(args: &SkillsProposeArgs) -> Result<Box<dyn SkillGeneralizer>> {
+    if args.llm_provider.as_deref() == Some("fixture") {
+        let raw = std::env::var("AGENTENV_SKILL_PROPOSER_FIXTURE_JSON")
+            .context("AGENTENV_SKILL_PROPOSER_FIXTURE_JSON is required for fixture provider")?;
+        let value = serde_json::from_str(&raw).context("parse fixture generalization JSON")?;
+        return Ok(Box::new(FixtureGeneralizer { value }));
+    }
+    bail!("skill proposal LLM provider is not configured")
+}
+
+fn default_events_db_path() -> PathBuf {
+    dirs::home_dir()
+        .unwrap_or_else(|| PathBuf::from("."))
+        .join(".agentenv/events.db")
+}
+
+fn default_proposed_dir() -> PathBuf {
+    dirs::home_dir()
+        .unwrap_or_else(|| PathBuf::from("."))
+        .join(".agentenv/skills/proposed")
+}
+
+fn blueprint_id_for_path(path: &Path) -> Result<String> {
+    let bytes = fs::read(path).with_context(|| format!("read blueprint `{}`", path.display()))?;
+    let digest = Sha256::digest(&bytes);
+    Ok(format!("sha256:{}", hex::encode(digest)))
+}
+
+fn now_event_ts() -> String {
+    OffsetDateTime::now_utc()
+        .format(&Rfc3339)
+        .unwrap_or_else(|_| "1970-01-01T00:00:00Z".to_owned())
 }

--- a/crates/agentenv/src/skills_propose_cli.rs
+++ b/crates/agentenv/src/skills_propose_cli.rs
@@ -1,15 +1,20 @@
 use std::{
     fs,
+    net::SocketAddr,
     path::{Path, PathBuf},
+    time::Duration,
 };
 
-use agentenv_core::skills::{
-    load_project_skills_config, load_user_skills_config, merge_skills_config,
-    propose::{
-        ProposalEmitOutput, ProposeRunInput, ProposeRunOutput, ProposedSkillService,
-        SkillGeneralization, SkillGeneralizationRequest, SkillGeneralizer,
+use agentenv_core::{
+    security::ssrf::{validate_outbound, SsrfOptions, ValidatedUrl},
+    skills::{
+        load_project_skills_config, load_user_skills_config, merge_skills_config,
+        propose::{
+            ProposalEmitOutput, ProposeRunInput, ProposeRunOutput, ProposedSkillService,
+            SkillGeneralization, SkillGeneralizationRequest, SkillGeneralizer,
+        },
+        SkillError, SkillsConfig, SkillsConfigOverride,
     },
-    SkillError, SkillsConfig, SkillsConfigOverride,
 };
 use agentenv_credstore::{CredentialStore, CredentialStoreError};
 use agentenv_events::{SqliteEventStore, TraceQuery};
@@ -21,6 +26,12 @@ use reqwest::Client;
 use serde::Serialize;
 use sha2::{Digest, Sha256};
 use time::{format_description::well_known::Rfc3339, OffsetDateTime};
+use url::Url;
+
+const DEFAULT_HTTP_TIMEOUT: Duration = Duration::from_secs(60);
+const HTTP_ERROR_BODY_LIMIT: usize = 4096;
+const LOCAL_ENDPOINTS_ENV: &str = "AGENTENV_SKILL_PROPOSER_ALLOW_LOCAL_ENDPOINTS";
+const HTTP_TIMEOUT_ENV: &str = "AGENTENV_SKILL_PROPOSER_HTTP_TIMEOUT_MS";
 
 #[derive(Debug, Args, Clone)]
 pub struct SkillsProposeArgs {
@@ -108,7 +119,7 @@ impl SkillGeneralizer for HttpGeneralizer {
             })?;
         let status = response.status();
         if !status.is_success() {
-            let body = http_error_body(response).await;
+            let body = http_error_body(response, &self.bearer).await;
             return Err(SkillError::InvalidConfig {
                 message: format!("skill proposal LLM request failed with status {status}: {body}"),
             });
@@ -169,7 +180,7 @@ pub async fn run_skills_propose(args: SkillsProposeArgs) -> Result<()> {
         );
     }
     let output_root = args.out.clone().unwrap_or_else(default_proposed_dir);
-    let generalizer = generalizer_for_args(&args)?;
+    let generalizer = generalizer_for_args(&args, blueprint)?;
     let created_at = now_event_ts();
     let output = ProposedSkillService::new(generalizer)
         .run(ProposeRunInput {
@@ -264,7 +275,10 @@ fn no_matching_traces_warning(blueprint_id: &str, env: Option<&str>) -> String {
     }
 }
 
-fn generalizer_for_args(args: &SkillsProposeArgs) -> Result<Box<dyn SkillGeneralizer>> {
+fn generalizer_for_args(
+    args: &SkillsProposeArgs,
+    blueprint: &Path,
+) -> Result<Box<dyn SkillGeneralizer>> {
     if args.llm_provider.as_deref() == Some("fixture") {
         let raw = std::env::var("AGENTENV_SKILL_PROPOSER_FIXTURE_JSON")
             .context("AGENTENV_SKILL_PROPOSER_FIXTURE_JSON is required for fixture provider")?;
@@ -272,7 +286,7 @@ fn generalizer_for_args(args: &SkillsProposeArgs) -> Result<Box<dyn SkillGeneral
         return Ok(Box::new(FixtureGeneralizer { value }));
     }
 
-    let config = load_effective_skills_config()?;
+    let config = load_effective_skills_config(blueprint)?;
     let llm = config
         .proposal
         .and_then(|proposal| proposal.llm)
@@ -292,23 +306,51 @@ fn generalizer_for_args(args: &SkillsProposeArgs) -> Result<Box<dyn SkillGeneral
         );
     }
     let bearer = resolve_llm_bearer(&llm.credential)?;
+    let endpoint = validate_llm_endpoint(&llm.endpoint)?;
+    let client = build_http_client(&endpoint)?;
 
     Ok(Box::new(HttpGeneralizer {
-        endpoint: llm.endpoint,
+        endpoint: endpoint.url.to_string(),
         model: llm.model,
         bearer,
-        client: Client::new(),
+        client,
     }))
 }
 
-async fn http_error_body(response: reqwest::Response) -> String {
-    match response.text().await {
-        Ok(body) => body,
-        Err(error) => format!("<failed to read response body: {error}>"),
+async fn http_error_body(mut response: reqwest::Response, bearer: &str) -> String {
+    let mut body = Vec::new();
+    let mut truncated = false;
+    loop {
+        match response.chunk().await {
+            Ok(Some(chunk)) => {
+                let remaining = HTTP_ERROR_BODY_LIMIT.saturating_sub(body.len());
+                if chunk.len() > remaining {
+                    body.extend_from_slice(&chunk[..remaining]);
+                    truncated = true;
+                    break;
+                }
+                body.extend_from_slice(&chunk);
+                if body.len() == HTTP_ERROR_BODY_LIMIT {
+                    truncated = true;
+                    break;
+                }
+            }
+            Ok(None) => break,
+            Err(error) => return format!("<failed to read response body: {error}>"),
+        }
     }
+
+    let mut rendered = String::from_utf8_lossy(&body).into_owned();
+    if !bearer.is_empty() {
+        rendered = rendered.replace(bearer, "[REDACTED]");
+    }
+    if truncated {
+        rendered.push_str("<truncated>");
+    }
+    rendered
 }
 
-fn load_effective_skills_config() -> Result<SkillsConfig> {
+fn load_effective_skills_config(blueprint: &Path) -> Result<SkillsConfig> {
     let user = match dirs::home_dir() {
         Some(home) => {
             let path = home.join(".config/agentenv/config.toml");
@@ -325,20 +367,13 @@ fn load_effective_skills_config() -> Result<SkillsConfig> {
         None => SkillsConfig::default(),
     };
 
-    let project_path = std::env::current_dir()
-        .context("read current directory")?
-        .join("agentenv.yaml");
-    let project = if project_path.is_file() {
-        Some(
-            load_project_skills_config(
-                &fs::read_to_string(&project_path)
-                    .with_context(|| format!("read `{}`", project_path.display()))?,
-            )
-            .with_context(|| format!("load project skills config `{}`", project_path.display()))?,
+    let project = Some(
+        load_project_skills_config(
+            &fs::read_to_string(blueprint)
+                .with_context(|| format!("read `{}`", blueprint.display()))?,
         )
-    } else {
-        None
-    };
+        .with_context(|| format!("load project skills config `{}`", blueprint.display()))?,
+    );
 
     merge_skills_config(user, project, SkillsConfigOverride { registry: None })
         .context("merge skills config")
@@ -362,6 +397,70 @@ fn resolve_llm_bearer(name: &str) -> Result<String> {
             }
             error => anyhow::anyhow!("resolve skill proposal LLM credential `{name}`: {error}"),
         })
+}
+
+fn validate_llm_endpoint(endpoint: &str) -> Result<ValidatedUrl> {
+    let url = Url::parse(endpoint).with_context(|| {
+        format!(
+            "skill proposal LLM endpoint `{}` is invalid",
+            agentenv_core::security::ssrf::sanitize_untrusted_url_text(endpoint)
+        )
+    })?;
+    validate_outbound(&url, skill_proposer_ssrf_options()).map_err(|error| {
+        anyhow::anyhow!(
+            "skill proposal LLM endpoint was blocked by SSRF policy: {}",
+            error
+        )
+    })
+}
+
+fn skill_proposer_ssrf_options() -> SsrfOptions {
+    let mut options = SsrfOptions::default();
+    if env_flag_enabled(LOCAL_ENDPOINTS_ENV) {
+        options.allow_loopback = true;
+        options.allow_private = true;
+    }
+    options
+}
+
+fn build_http_client(endpoint: &ValidatedUrl) -> Result<Client> {
+    let timeout = skill_proposer_http_timeout()?;
+    let port = endpoint.url.port_or_known_default().unwrap_or(80);
+    let addrs: Vec<SocketAddr> = endpoint
+        .pinned_ips
+        .iter()
+        .copied()
+        .map(|ip| SocketAddr::new(ip, port))
+        .collect();
+    Client::builder()
+        .timeout(timeout)
+        .connect_timeout(timeout)
+        .resolve_to_addrs(&endpoint.host, &addrs)
+        .build()
+        .context("build skill proposal LLM HTTP client")
+}
+
+fn skill_proposer_http_timeout() -> Result<Duration> {
+    match std::env::var(HTTP_TIMEOUT_ENV) {
+        Ok(value) => {
+            let millis = value.parse::<u64>().with_context(|| {
+                format!("{HTTP_TIMEOUT_ENV} must be a positive integer number of milliseconds")
+            })?;
+            if millis == 0 {
+                bail!("{HTTP_TIMEOUT_ENV} must be greater than 0");
+            }
+            Ok(Duration::from_millis(millis))
+        }
+        Err(std::env::VarError::NotPresent) => Ok(DEFAULT_HTTP_TIMEOUT),
+        Err(error) => Err(error).context(format!("read {HTTP_TIMEOUT_ENV}")),
+    }
+}
+
+fn env_flag_enabled(name: &str) -> bool {
+    match std::env::var(name) {
+        Ok(value) => matches!(value.as_str(), "1" | "true" | "TRUE" | "yes" | "YES"),
+        Err(_) => false,
+    }
 }
 
 fn default_events_db_path() -> PathBuf {

--- a/crates/agentenv/src/skills_propose_cli.rs
+++ b/crates/agentenv/src/skills_propose_cli.rs
@@ -1,7 +1,8 @@
 use std::{
+    ffi::OsStr,
     fs,
     net::SocketAddr,
-    path::{Path, PathBuf},
+    path::{Component, Path, PathBuf},
     time::Duration,
 };
 
@@ -75,9 +76,16 @@ struct SkillsProposeJson {
 #[derive(Debug, Clone, PartialEq, Eq)]
 struct PullRequestPlan {
     repo: String,
+    repo_root: PathBuf,
     branch: String,
     title: String,
     body: String,
+}
+
+#[derive(Debug, Clone)]
+struct OpenPrContext {
+    repo_root: PathBuf,
+    output_root: PathBuf,
 }
 
 struct FixtureGeneralizer {
@@ -162,6 +170,11 @@ pub async fn run_skills_propose(args: SkillsProposeArgs) -> Result<()> {
         .as_deref()
         .context("`agentenv skills propose` requires --blueprint <path>")?;
     let blueprint_id = blueprint_id_for_path(blueprint)?;
+    let open_pr_context = if args.open_pr {
+        Some(resolve_open_pr_context(args.out.as_deref())?)
+    } else {
+        None
+    };
     let events_db = args
         .events_db
         .clone()
@@ -186,9 +199,13 @@ pub async fn run_skills_propose(args: SkillsProposeArgs) -> Result<()> {
                 args.env.as_deref(),
             )],
         };
-        return finish_skills_propose(args.json, args.open_pr, args.repo.clone(), output);
+        return finish_skills_propose(args.json, open_pr_context, args.repo.clone(), output);
     }
-    let output_root = args.out.clone().unwrap_or_else(default_proposed_dir);
+    let output_root = open_pr_context
+        .as_ref()
+        .map(|context| context.output_root.clone())
+        .or_else(|| args.out.clone())
+        .unwrap_or_else(default_proposed_dir);
     let generalizer = generalizer_for_args(&args, blueprint)?;
     let created_at = now_event_ts();
     let output = ProposedSkillService::new(generalizer)
@@ -206,23 +223,23 @@ pub async fn run_skills_propose(args: SkillsProposeArgs) -> Result<()> {
         .await
         .context("run skill proposal service")?;
 
-    finish_skills_propose(args.json, args.open_pr, args.repo.clone(), output)
+    finish_skills_propose(args.json, open_pr_context, args.repo.clone(), output)
 }
 
 fn finish_skills_propose(
     json: bool,
-    open_pr: bool,
+    open_pr_context: Option<OpenPrContext>,
     repo: Option<String>,
     output: ProposeRunOutput,
 ) -> Result<()> {
     let mut pull_requests = Vec::new();
-    if open_pr {
+    if let Some(context) = open_pr_context {
         let proposal = output
             .proposals
             .first()
             .context("--open-pr requested but no proposals were emitted")?;
         let repo = repo.context("--open-pr requires --repo owner/repo")?;
-        let plan = pr_plan_for(repo, proposal);
+        let plan = pr_plan_for(repo, context.repo_root, proposal);
         pull_requests.push(publish_pr(&plan, &proposal.path)?);
     }
 
@@ -261,10 +278,11 @@ fn print_skills_propose_output(
     Ok(())
 }
 
-fn pr_plan_for(repo: String, proposal: &ProposalEmitOutput) -> PullRequestPlan {
-    let short_name = proposal.name.replace('_', "-");
+fn pr_plan_for(repo: String, repo_root: PathBuf, proposal: &ProposalEmitOutput) -> PullRequestPlan {
+    let short_name = git_ref_safe_slug(&proposal.name);
     PullRequestPlan {
         repo,
+        repo_root,
         branch: format!("agentenv/proposed-skill/{short_name}"),
         title: format!("feat: propose trace-derived skill {}", proposal.name),
         body: format!(
@@ -277,18 +295,49 @@ fn pr_plan_for(repo: String, proposal: &ProposalEmitOutput) -> PullRequestPlan {
 }
 
 fn publish_pr(plan: &PullRequestPlan, proposal_path: &Path) -> Result<String> {
-    run_command("git", &["checkout", "-B", &plan.branch])?;
-    run_command(
-        "git",
+    let relative_proposal_path =
+        proposal_path
+            .strip_prefix(&plan.repo_root)
+            .with_context(|| {
+                format!(
+                    "proposal path `{}` is not inside git worktree `{}`",
+                    proposal_path.display(),
+                    plan.repo_root.display()
+                )
+            })?;
+    run_git_command(
+        &plan.repo_root,
         &[
-            "add",
-            proposal_path
-                .to_str()
-                .context("proposal path is not UTF-8")?,
+            OsStr::new("checkout"),
+            OsStr::new("-B"),
+            OsStr::new(&plan.branch),
         ],
     )?;
-    run_command("git", &["commit", "-m", &plan.title])?;
-    run_command("git", &["push", "-u", "origin", &plan.branch])?;
+    run_git_command(
+        &plan.repo_root,
+        &[
+            OsStr::new("add"),
+            OsStr::new("--"),
+            relative_proposal_path.as_os_str(),
+        ],
+    )?;
+    run_git_command(
+        &plan.repo_root,
+        &[
+            OsStr::new("commit"),
+            OsStr::new("-m"),
+            OsStr::new(&plan.title),
+        ],
+    )?;
+    run_git_command(
+        &plan.repo_root,
+        &[
+            OsStr::new("push"),
+            OsStr::new("-u"),
+            OsStr::new("origin"),
+            OsStr::new(&plan.branch),
+        ],
+    )?;
     let output = std::process::Command::new("gh")
         .args([
             "pr",
@@ -312,18 +361,143 @@ fn publish_pr(plan: &PullRequestPlan, proposal_path: &Path) -> Result<String> {
     Ok(String::from_utf8_lossy(&output.stdout).trim().to_owned())
 }
 
-fn run_command(program: &str, args: &[&str]) -> Result<()> {
-    let output = std::process::Command::new(program)
-        .args(args)
+fn resolve_open_pr_context(out: Option<&Path>) -> Result<OpenPrContext> {
+    let repo_root = git_worktree_root()?;
+    let output_root = match out {
+        Some(path) => {
+            let absolute = absolute_path(path)?;
+            if !absolute.starts_with(&repo_root) {
+                bail!(
+                    "--out must be inside the git worktree when --open-pr is set: `{}` is outside `{}`",
+                    absolute.display(),
+                    repo_root.display()
+                );
+            }
+            absolute
+        }
+        None => repo_root.join(".agentenv/skills/proposed"),
+    };
+    Ok(OpenPrContext {
+        repo_root,
+        output_root,
+    })
+}
+
+fn git_worktree_root() -> Result<PathBuf> {
+    let output = std::process::Command::new("git")
+        .args(["rev-parse", "--show-toplevel"])
         .output()
-        .with_context(|| format!("run {program}"))?;
+        .context("run git rev-parse --show-toplevel")?;
     if !output.status.success() {
         bail!(
-            "{program} failed: {}",
+            "git rev-parse --show-toplevel failed: {}",
             String::from_utf8_lossy(&output.stderr)
         );
     }
+    let rendered = String::from_utf8(output.stdout)
+        .context("git rev-parse --show-toplevel output was not UTF-8")?;
+    let root = rendered.trim();
+    if root.is_empty() {
+        bail!("git rev-parse --show-toplevel returned an empty path");
+    }
+    absolute_path(Path::new(root))
+}
+
+fn run_git_command(repo_root: &Path, args: &[&OsStr]) -> Result<()> {
+    let output = std::process::Command::new("git")
+        .arg("-C")
+        .arg(repo_root)
+        .args(args)
+        .output()
+        .with_context(|| format!("run git -C {}", repo_root.display()))?;
+    if !output.status.success() {
+        bail!("git failed: {}", String::from_utf8_lossy(&output.stderr));
+    }
     Ok(())
+}
+
+fn absolute_path(path: &Path) -> Result<PathBuf> {
+    let absolute = if path.is_absolute() {
+        path.to_path_buf()
+    } else {
+        std::env::current_dir()
+            .context("read current directory")?
+            .join(path)
+    };
+    normalize_absolute_path(&absolute)
+}
+
+fn normalize_absolute_path(path: &Path) -> Result<PathBuf> {
+    let mut normalized = PathBuf::new();
+    for component in path.components() {
+        match component {
+            Component::Prefix(prefix) => normalized.push(prefix.as_os_str()),
+            Component::RootDir => normalized.push(component.as_os_str()),
+            Component::CurDir => {}
+            Component::ParentDir => {
+                if !normalized.pop() {
+                    bail!("path `{}` escapes its root", path.display());
+                }
+            }
+            Component::Normal(part) => normalized.push(part),
+        }
+    }
+    if !normalized.is_absolute() {
+        bail!("path `{}` is not absolute", path.display());
+    }
+    Ok(normalized)
+}
+
+fn git_ref_safe_slug(name: &str) -> String {
+    let mut slug = String::new();
+    let mut previous_dash = false;
+    for byte in name.bytes() {
+        let lowered = byte.to_ascii_lowercase();
+        if lowered.is_ascii_alphanumeric() {
+            slug.push(lowered as char);
+            previous_dash = false;
+        } else if !previous_dash {
+            slug.push('-');
+            previous_dash = true;
+        }
+    }
+    let trimmed = slug.trim_matches('-').to_owned();
+    let mut slug = if trimmed.is_empty() {
+        "skill".to_owned()
+    } else {
+        trimmed
+    };
+    if slug != name {
+        let digest = Sha256::digest(name.as_bytes());
+        let hex = hex::encode(digest);
+        slug.push('-');
+        slug.push_str(&hex[..8]);
+    }
+    while slug.ends_with('.') || slug.ends_with(".lock") || slug.ends_with('-') {
+        slug.pop();
+    }
+    if slug.is_empty() {
+        let digest = Sha256::digest(name.as_bytes());
+        let hex = hex::encode(digest);
+        slug = format!("skill-{}", &hex[..8]);
+    }
+    while slug.contains("..") {
+        slug = slug.replace("..", "-");
+    }
+    if slug.ends_with(".lock") {
+        let digest = Sha256::digest(name.as_bytes());
+        let hex = hex::encode(digest);
+        slug.push('-');
+        slug.push_str(&hex[..8]);
+    }
+    if slug.ends_with('.') {
+        slug.push_str("-ref");
+    }
+    if slug.is_empty() {
+        "skill".to_owned()
+    } else {
+        slug
+    }
 }
 
 pub fn validate_args(args: &SkillsProposeArgs) -> Result<()> {

--- a/crates/agentenv/src/skills_propose_cli.rs
+++ b/crates/agentenv/src/skills_propose_cli.rs
@@ -1,0 +1,62 @@
+use std::path::PathBuf;
+
+use anyhow::{bail, Result};
+use clap::Args;
+
+#[derive(Debug, Args, Clone)]
+pub struct SkillsProposeArgs {
+    #[arg(long)]
+    pub from_traces: bool,
+    #[arg(long, value_name = "FILE")]
+    pub blueprint: Option<PathBuf>,
+    #[arg(long, value_name = "FILE")]
+    pub events_db: Option<PathBuf>,
+    #[arg(long)]
+    pub env: Option<String>,
+    #[arg(long, default_value_t = 3)]
+    pub min_occurrences: usize,
+    #[arg(long, default_value_t = 0.6)]
+    pub min_novelty: f32,
+    #[arg(long, default_value_t = 0.8)]
+    pub min_self_test_score: f32,
+    #[arg(long)]
+    pub llm_provider: Option<String>,
+    #[arg(long, default_value = "local")]
+    pub semantic_backend: String,
+    #[arg(long, value_name = "DIR")]
+    pub out: Option<PathBuf>,
+    #[arg(long)]
+    pub json: bool,
+    #[arg(long)]
+    pub open_pr: bool,
+    #[arg(long)]
+    pub repo: Option<String>,
+}
+
+pub async fn run_skills_propose(args: SkillsProposeArgs) -> Result<()> {
+    validate_args(&args)?;
+    println!("no proposals emitted");
+    Ok(())
+}
+
+pub fn validate_args(args: &SkillsProposeArgs) -> Result<()> {
+    if !args.from_traces {
+        bail!("`agentenv skills propose` requires --from-traces");
+    }
+    if args.blueprint.is_none() {
+        bail!("`agentenv skills propose` requires --blueprint <path>");
+    }
+    if args.min_occurrences < 2 {
+        bail!("--min-occurrences must be at least 2");
+    }
+    if !(0.0..=1.0).contains(&args.min_novelty) {
+        bail!("--min-novelty must be between 0.0 and 1.0");
+    }
+    if !(0.0..=1.0).contains(&args.min_self_test_score) {
+        bail!("--min-self-test-score must be between 0.0 and 1.0");
+    }
+    if args.open_pr && args.repo.is_none() {
+        bail!("--open-pr requires --repo owner/repo");
+    }
+    Ok(())
+}

--- a/crates/agentenv/src/skills_propose_cli.rs
+++ b/crates/agentenv/src/skills_propose_cli.rs
@@ -4,8 +4,8 @@ use std::{
 };
 
 use agentenv_core::skills::propose::{
-    ProposalEmitOutput, ProposeRunInput, ProposedSkillService, SkillGeneralization,
-    SkillGeneralizationRequest, SkillGeneralizer,
+    ProposalEmitOutput, ProposeRunInput, ProposeRunOutput, ProposedSkillService,
+    SkillGeneralization, SkillGeneralizationRequest, SkillGeneralizer,
 };
 use agentenv_events::{SqliteEventStore, TraceQuery};
 use anyhow::{bail, Context, Result};
@@ -76,6 +76,9 @@ pub async fn run_skills_propose(args: SkillsProposeArgs) -> Result<()> {
         .events_db
         .clone()
         .unwrap_or_else(default_events_db_path);
+    if args.events_db.is_some() && !events_db.is_file() {
+        bail!("events DB `{}` does not exist", events_db.display());
+    }
     let store = SqliteEventStore::open(&events_db)
         .with_context(|| format!("open events database `{}`", events_db.display()))?;
     let traces = store
@@ -85,6 +88,18 @@ pub async fn run_skills_propose(args: SkillsProposeArgs) -> Result<()> {
             limit: 10_000,
         })
         .with_context(|| format!("query traces from `{}`", events_db.display()))?;
+    if traces.is_empty() {
+        return print_skills_propose_output(
+            args.json,
+            ProposeRunOutput {
+                proposals: Vec::new(),
+                warnings: vec![no_matching_traces_warning(
+                    &blueprint_id,
+                    args.env.as_deref(),
+                )],
+            },
+        );
+    }
     let output_root = args.out.clone().unwrap_or_else(default_proposed_dir);
     let generalizer = generalizer_for_args(&args)?;
     let created_at = now_event_ts();
@@ -103,7 +118,11 @@ pub async fn run_skills_propose(args: SkillsProposeArgs) -> Result<()> {
         .await
         .context("run skill proposal service")?;
 
-    if args.json {
+    print_skills_propose_output(args.json, output)
+}
+
+fn print_skills_propose_output(json: bool, output: ProposeRunOutput) -> Result<()> {
+    if json {
         let rendered = serde_json::to_string_pretty(&SkillsProposeJson {
             proposals: output.proposals,
             warnings: output.warnings,
@@ -166,6 +185,15 @@ fn validate_repo(repo: &str) -> Result<()> {
 
 fn is_repo_component_char(ch: char) -> bool {
     ch.is_ascii_alphanumeric() || matches!(ch, '-' | '_' | '.')
+}
+
+fn no_matching_traces_warning(blueprint_id: &str, env: Option<&str>) -> String {
+    match env {
+        Some(env) => {
+            format!("No traces matched blueprint `{blueprint_id}` and env `{env}` in the events DB")
+        }
+        None => format!("No traces matched blueprint `{blueprint_id}` in the events DB"),
+    }
 }
 
 fn generalizer_for_args(args: &SkillsProposeArgs) -> Result<Box<dyn SkillGeneralizer>> {

--- a/crates/agentenv/src/skills_propose_cli.rs
+++ b/crates/agentenv/src/skills_propose_cli.rs
@@ -366,16 +366,14 @@ fn resolve_open_pr_context(out: Option<&Path>) -> Result<OpenPrContext> {
     let output_root = match out {
         Some(path) => {
             let absolute = absolute_path(path)?;
-            if !absolute.starts_with(&repo_root) {
-                bail!(
-                    "--out must be inside the git worktree when --open-pr is set: `{}` is outside `{}`",
-                    absolute.display(),
-                    repo_root.display()
-                );
-            }
+            ensure_output_path_inside_worktree(&absolute, &repo_root)?;
             absolute
         }
-        None => repo_root.join(".agentenv/skills/proposed"),
+        None => {
+            let output_root = repo_root.join(".agentenv/skills/proposed");
+            ensure_output_path_inside_worktree(&output_root, &repo_root)?;
+            output_root
+        }
     };
     Ok(OpenPrContext {
         repo_root,
@@ -400,7 +398,9 @@ fn git_worktree_root() -> Result<PathBuf> {
     if root.is_empty() {
         bail!("git rev-parse --show-toplevel returned an empty path");
     }
-    absolute_path(Path::new(root))
+    let absolute = absolute_path(Path::new(root))?;
+    fs::canonicalize(&absolute)
+        .with_context(|| format!("canonicalize git worktree `{}`", absolute.display()))
 }
 
 fn run_git_command(repo_root: &Path, args: &[&OsStr]) -> Result<()> {
@@ -446,6 +446,37 @@ fn normalize_absolute_path(path: &Path) -> Result<PathBuf> {
         bail!("path `{}` is not absolute", path.display());
     }
     Ok(normalized)
+}
+
+fn ensure_output_path_inside_worktree(output_root: &Path, repo_root: &Path) -> Result<()> {
+    let ancestor = deepest_existing_ancestor(output_root)?;
+    let canonical_ancestor = fs::canonicalize(&ancestor).with_context(|| {
+        format!(
+            "canonicalize existing output path ancestor `{}`",
+            ancestor.display()
+        )
+    })?;
+    if !canonical_ancestor.starts_with(repo_root) {
+        bail!(
+            "--out must be inside the git worktree when --open-pr is set: `{}` resolves through `{}` outside `{}`",
+            output_root.display(),
+            canonical_ancestor.display(),
+            repo_root.display()
+        );
+    }
+    Ok(())
+}
+
+fn deepest_existing_ancestor(path: &Path) -> Result<PathBuf> {
+    let mut candidate = path.to_path_buf();
+    loop {
+        if candidate.exists() {
+            return Ok(candidate);
+        }
+        if !candidate.pop() {
+            bail!("no existing ancestor found for `{}`", path.display());
+        }
+    }
 }
 
 fn git_ref_safe_slug(name: &str) -> String {

--- a/crates/agentenv/src/skills_propose_cli.rs
+++ b/crates/agentenv/src/skills_propose_cli.rs
@@ -11,8 +11,9 @@ use agentenv_core::{
     skills::{
         load_project_skills_config, load_user_skills_config, merge_skills_config,
         propose::{
-            ProposalEmitOutput, ProposeRunInput, ProposeRunOutput, ProposedSkillService,
-            SkillGeneralization, SkillGeneralizationRequest, SkillGeneralizer,
+            ExistingSkillSummary, ProposalCandidate, ProposalEmitOutput, ProposeRunInput,
+            ProposeRunOutput, ProposedSkillService, SkillGeneralization,
+            SkillGeneralizationRequest, SkillGeneralizer,
         },
         SkillError, SkillsConfig, SkillsConfigOverride,
     },
@@ -24,7 +25,7 @@ use anyhow::{bail, Context, Result};
 use async_trait::async_trait;
 use clap::Args;
 use reqwest::Client;
-use serde::Serialize;
+use serde::{Deserialize, Serialize};
 use sha2::{Digest, Sha256};
 use time::{format_description::well_known::Rfc3339, OffsetDateTime};
 use url::Url;
@@ -34,6 +35,9 @@ const HTTP_ERROR_BODY_LIMIT: usize = 4096;
 const LOCAL_ENDPOINTS_ENV: &str = "AGENTENV_SKILL_PROPOSER_ALLOW_LOCAL_ENDPOINTS";
 const PRIVATE_ENDPOINTS_ENV: &str = "AGENTENV_SKILL_PROPOSER_ALLOW_PRIVATE_ENDPOINTS";
 const HTTP_TIMEOUT_ENV: &str = "AGENTENV_SKILL_PROPOSER_HTTP_TIMEOUT_MS";
+const SKILL_MANIFEST_FILE: &str = "skill.yaml";
+const INSTALLED_CONTENT_DIR: &str = "content";
+const PROPOSED_SKILLS_DIR_NAME: &str = "proposed";
 
 #[derive(Debug, Args, Clone)]
 pub struct SkillsProposeArgs {
@@ -97,6 +101,14 @@ struct HttpGeneralizer {
     model: String,
     bearer: String,
     client: Client,
+}
+
+#[derive(Debug, Deserialize)]
+struct SkillSummaryManifest {
+    name: String,
+    #[serde(default)]
+    description: Option<String>,
+    entry: PathBuf,
 }
 
 #[async_trait]
@@ -206,6 +218,7 @@ pub async fn run_skills_propose(args: SkillsProposeArgs) -> Result<()> {
         .map(|context| context.output_root.clone())
         .or_else(|| args.out.clone())
         .unwrap_or_else(default_proposed_dir);
+    let existing_skills = load_existing_skill_summaries(&output_root)?;
     let generalizer = generalizer_for_args(&args, blueprint)?;
     let created_at = now_event_ts();
     let output = ProposedSkillService::new(generalizer)
@@ -216,7 +229,7 @@ pub async fn run_skills_propose(args: SkillsProposeArgs) -> Result<()> {
             min_occurrences: args.min_occurrences,
             min_novelty: args.min_novelty,
             min_self_test_score: args.min_self_test_score,
-            existing_skills: Vec::new(),
+            existing_skills,
             agentenv_version: env!("CARGO_PKG_VERSION").to_owned(),
             created_at,
         })
@@ -375,6 +388,7 @@ fn resolve_open_pr_context(out: Option<&Path>) -> Result<OpenPrContext> {
             output_root
         }
     };
+    ensure_clean_git_index(&repo_root)?;
     Ok(OpenPrContext {
         repo_root,
         output_root,
@@ -414,6 +428,200 @@ fn run_git_command(repo_root: &Path, args: &[&OsStr]) -> Result<()> {
         bail!("git failed: {}", String::from_utf8_lossy(&output.stderr));
     }
     Ok(())
+}
+
+fn ensure_clean_git_index(repo_root: &Path) -> Result<()> {
+    let output = std::process::Command::new("git")
+        .arg("-C")
+        .arg(repo_root)
+        .args(["diff", "--cached", "--quiet", "--exit-code"])
+        .output()
+        .with_context(|| format!("run git -C {} diff --cached", repo_root.display()))?;
+    match output.status.code() {
+        Some(0) => Ok(()),
+        Some(1) => bail!(
+            "--open-pr requires a clean git index; commit or unstage staged changes before publishing a proposed skill"
+        ),
+        _ => bail!(
+            "git diff --cached failed: {}",
+            String::from_utf8_lossy(&output.stderr)
+        ),
+    }
+}
+
+fn load_existing_skill_summaries(output_root: &Path) -> Result<Vec<ExistingSkillSummary>> {
+    let mut summaries = load_installed_skill_summaries()?;
+    summaries.extend(load_proposed_skill_summaries(output_root)?);
+    Ok(summaries)
+}
+
+fn load_installed_skill_summaries() -> Result<Vec<ExistingSkillSummary>> {
+    let Some(home) = dirs::home_dir() else {
+        return Ok(Vec::new());
+    };
+    let skills_root = home.join(".agentenv").join("skills");
+    let Some(entries) = read_directory_if_exists(&skills_root)? else {
+        return Ok(Vec::new());
+    };
+
+    let mut summaries = Vec::new();
+    for name_entry in entries {
+        let name_entry = name_entry.with_context(|| format!("read `{}`", skills_root.display()))?;
+        let name_path = name_entry.path();
+        let Some(name) = name_path.file_name().and_then(OsStr::to_str) else {
+            bail!("skill path `{}` is not valid UTF-8", name_path.display());
+        };
+        if name.starts_with('.') || name == PROPOSED_SKILLS_DIR_NAME {
+            continue;
+        }
+        if !entry_file_type(&name_entry)?.is_dir() {
+            continue;
+        }
+        let Some(version_entries) = read_directory_if_exists(&name_path)? else {
+            continue;
+        };
+        for version_entry in version_entries {
+            let version_entry =
+                version_entry.with_context(|| format!("read `{}`", name_path.display()))?;
+            if !entry_file_type(&version_entry)?.is_dir() {
+                continue;
+            }
+            let install_dir = version_entry.path();
+            let content_root = install_dir.join(INSTALLED_CONTENT_DIR);
+            let fingerprint = skill_provenance_fingerprint(&content_root)?;
+            if let Some(summary) =
+                load_skill_summary_from_dir(&install_dir, &content_root, fingerprint)?
+            {
+                summaries.push(summary);
+            }
+        }
+    }
+
+    Ok(summaries)
+}
+
+fn load_proposed_skill_summaries(output_root: &Path) -> Result<Vec<ExistingSkillSummary>> {
+    let Some(entries) = read_directory_if_exists(output_root)? else {
+        return Ok(Vec::new());
+    };
+
+    let mut summaries = Vec::new();
+    for entry in entries {
+        let entry = entry.with_context(|| format!("read `{}`", output_root.display()))?;
+        let path = entry.path();
+        let Some(name) = path.file_name().and_then(OsStr::to_str) else {
+            bail!(
+                "proposed skill path `{}` is not valid UTF-8",
+                path.display()
+            );
+        };
+        if name.starts_with('.') || !entry_file_type(&entry)?.is_dir() {
+            continue;
+        }
+        let fingerprint = skill_provenance_fingerprint(&path)?;
+        if let Some(summary) = load_skill_summary_from_dir(&path, &path, fingerprint)? {
+            summaries.push(summary);
+        }
+    }
+
+    Ok(summaries)
+}
+
+fn load_skill_summary_from_dir(
+    manifest_root: &Path,
+    content_root: &Path,
+    fingerprint: Option<String>,
+) -> Result<Option<ExistingSkillSummary>> {
+    let manifest_path = manifest_root.join(SKILL_MANIFEST_FILE);
+    if !regular_file_exists(&manifest_path)? {
+        return Ok(None);
+    }
+    let manifest_text = read_regular_text_file(&manifest_path)?;
+    let manifest: SkillSummaryManifest = serde_yaml::from_str(&manifest_text)
+        .with_context(|| format!("parse skill manifest `{}`", manifest_path.display()))?;
+    let entry_path = safe_child_path(content_root, &manifest.entry)?;
+    let procedure_text = read_regular_text_file(&entry_path)?;
+
+    Ok(Some(ExistingSkillSummary {
+        name: manifest.name,
+        description: manifest.description.unwrap_or_default(),
+        procedure_text,
+        fingerprint,
+    }))
+}
+
+fn skill_provenance_fingerprint(skill_content_root: &Path) -> Result<Option<String>> {
+    let provenance_path = skill_content_root.join("traces").join("provenance.json");
+    if !regular_file_exists(&provenance_path)? {
+        return Ok(None);
+    }
+    let provenance = read_regular_text_file(&provenance_path)?;
+    let candidate: ProposalCandidate = serde_json::from_str(&provenance)
+        .with_context(|| format!("parse proposal provenance `{}`", provenance_path.display()))?;
+    Ok(Some(candidate.fingerprint))
+}
+
+fn read_directory_if_exists(path: &Path) -> Result<Option<fs::ReadDir>> {
+    match fs::symlink_metadata(path) {
+        Ok(metadata) => {
+            if !metadata.file_type().is_dir() {
+                bail!("skill summary path `{}` is not a directory", path.display());
+            }
+        }
+        Err(source) if source.kind() == std::io::ErrorKind::NotFound => return Ok(None),
+        Err(source) => {
+            return Err(source).with_context(|| format!("read metadata `{}`", path.display()));
+        }
+    }
+    fs::read_dir(path)
+        .map(Some)
+        .with_context(|| format!("read directory `{}`", path.display()))
+}
+
+fn entry_file_type(entry: &fs::DirEntry) -> Result<fs::FileType> {
+    entry
+        .file_type()
+        .with_context(|| format!("read file type `{}`", entry.path().display()))
+}
+
+fn regular_file_exists(path: &Path) -> Result<bool> {
+    match fs::symlink_metadata(path) {
+        Ok(metadata) => {
+            if !metadata.file_type().is_file() {
+                bail!(
+                    "skill summary file `{}` is not a regular file",
+                    path.display()
+                );
+            }
+            Ok(true)
+        }
+        Err(source) if source.kind() == std::io::ErrorKind::NotFound => Ok(false),
+        Err(source) => Err(source).with_context(|| format!("read metadata `{}`", path.display())),
+    }
+}
+
+fn read_regular_text_file(path: &Path) -> Result<String> {
+    if !regular_file_exists(path)? {
+        bail!("skill summary file `{}` does not exist", path.display());
+    }
+    fs::read_to_string(path).with_context(|| format!("read `{}`", path.display()))
+}
+
+fn safe_child_path(root: &Path, relative: &Path) -> Result<PathBuf> {
+    let mut normalized = PathBuf::new();
+    for component in relative.components() {
+        match component {
+            Component::Normal(part) => normalized.push(part),
+            Component::CurDir => {}
+            Component::ParentDir | Component::RootDir | Component::Prefix(_) => {
+                bail!("skill entry path `{}` is not relative", relative.display());
+            }
+        }
+    }
+    if normalized.as_os_str().is_empty() {
+        bail!("skill entry path `{}` is empty", relative.display());
+    }
+    Ok(root.join(normalized))
 }
 
 fn absolute_path(path: &Path) -> Result<PathBuf> {
@@ -546,6 +754,9 @@ pub fn validate_args(args: &SkillsProposeArgs) -> Result<()> {
     }
     if !(0.0..=1.0).contains(&args.min_self_test_score) {
         bail!("--min-self-test-score must be between 0.0 and 1.0");
+    }
+    if args.semantic_backend != "local" {
+        bail!("--semantic-backend currently supports only `local`");
     }
     if args.open_pr && args.repo.is_none() {
         bail!("--open-pr requires --repo owner/repo");

--- a/crates/agentenv/src/skills_propose_cli.rs
+++ b/crates/agentenv/src/skills_propose_cli.rs
@@ -3,14 +3,21 @@ use std::{
     path::{Path, PathBuf},
 };
 
-use agentenv_core::skills::propose::{
-    ProposalEmitOutput, ProposeRunInput, ProposeRunOutput, ProposedSkillService,
-    SkillGeneralization, SkillGeneralizationRequest, SkillGeneralizer,
+use agentenv_core::skills::{
+    load_project_skills_config, load_user_skills_config, merge_skills_config,
+    propose::{
+        ProposalEmitOutput, ProposeRunInput, ProposeRunOutput, ProposedSkillService,
+        SkillGeneralization, SkillGeneralizationRequest, SkillGeneralizer,
+    },
+    SkillError, SkillsConfig, SkillsConfigOverride,
 };
+use agentenv_credstore::{CredentialStore, CredentialStoreError};
 use agentenv_events::{SqliteEventStore, TraceQuery};
+use agentenv_proto::{CredentialKind, CredentialRequirement};
 use anyhow::{bail, Context, Result};
 use async_trait::async_trait;
 use clap::Args;
+use reqwest::Client;
 use serde::Serialize;
 use sha2::{Digest, Sha256};
 use time::{format_description::well_known::Rfc3339, OffsetDateTime};
@@ -55,6 +62,13 @@ struct FixtureGeneralizer {
     value: SkillGeneralization,
 }
 
+struct HttpGeneralizer {
+    endpoint: String,
+    model: String,
+    bearer: String,
+    client: Client,
+}
+
 #[async_trait]
 impl SkillGeneralizer for FixtureGeneralizer {
     async fn generalize(
@@ -62,6 +76,60 @@ impl SkillGeneralizer for FixtureGeneralizer {
         _request: SkillGeneralizationRequest,
     ) -> Result<SkillGeneralization, agentenv_core::skills::SkillError> {
         Ok(self.value.clone())
+    }
+}
+
+#[async_trait]
+impl SkillGeneralizer for HttpGeneralizer {
+    async fn generalize(
+        &self,
+        request: SkillGeneralizationRequest,
+    ) -> Result<SkillGeneralization, SkillError> {
+        let request_json =
+            serde_json::to_string(&request).map_err(|source| SkillError::InvalidConfig {
+                message: format!("skill proposal LLM request failed to serialize: {source}"),
+            })?;
+        let response = self
+            .client
+            .post(&self.endpoint)
+            .bearer_auth(&self.bearer)
+            .json(&serde_json::json!({
+                "model": self.model,
+                "response_format": {"type": "json_object"},
+                "messages": [
+                    {"role": "system", "content": "Return only JSON for an agentenv skill proposal."},
+                    {"role": "user", "content": request_json}
+                ]
+            }))
+            .send()
+            .await
+            .map_err(|source| SkillError::InvalidConfig {
+                message: format!("skill proposal LLM request failed: {source}"),
+            })?;
+        let status = response.status();
+        if !status.is_success() {
+            let body = http_error_body(response).await;
+            return Err(SkillError::InvalidConfig {
+                message: format!("skill proposal LLM request failed with status {status}: {body}"),
+            });
+        }
+        let value: serde_json::Value =
+            response
+                .json()
+                .await
+                .map_err(|source| SkillError::InvalidConfig {
+                    message: format!("skill proposal LLM response was not JSON: {source}"),
+                })?;
+        let content = value
+            .pointer("/choices/0/message/content")
+            .and_then(serde_json::Value::as_str)
+            .ok_or_else(|| SkillError::InvalidConfig {
+                message: "skill proposal LLM response missing choices[0].message.content"
+                    .to_owned(),
+            })?;
+        serde_json::from_str(content).map_err(|source| SkillError::InvalidConfig {
+            message: format!("skill proposal LLM content failed schema validation: {source}"),
+        })
     }
 }
 
@@ -203,7 +271,97 @@ fn generalizer_for_args(args: &SkillsProposeArgs) -> Result<Box<dyn SkillGeneral
         let value = serde_json::from_str(&raw).context("parse fixture generalization JSON")?;
         return Ok(Box::new(FixtureGeneralizer { value }));
     }
-    bail!("skill proposal LLM provider is not configured")
+
+    let config = load_effective_skills_config()?;
+    let llm = config
+        .proposal
+        .and_then(|proposal| proposal.llm)
+        .ok_or_else(|| anyhow::anyhow!("skill proposal LLM provider is not configured"))?;
+    if let Some(provider) = &args.llm_provider {
+        if provider != &llm.provider {
+            bail!(
+                "skill proposal LLM provider `{provider}` does not match configured provider `{}`",
+                llm.provider
+            );
+        }
+    }
+    if llm.provider != "openai-compatible" {
+        bail!(
+            "unsupported skill proposal LLM provider `{}`; expected `openai-compatible`",
+            llm.provider
+        );
+    }
+    let bearer = resolve_llm_bearer(&llm.credential)?;
+
+    Ok(Box::new(HttpGeneralizer {
+        endpoint: llm.endpoint,
+        model: llm.model,
+        bearer,
+        client: Client::new(),
+    }))
+}
+
+async fn http_error_body(response: reqwest::Response) -> String {
+    match response.text().await {
+        Ok(body) => body,
+        Err(error) => format!("<failed to read response body: {error}>"),
+    }
+}
+
+fn load_effective_skills_config() -> Result<SkillsConfig> {
+    let user = match dirs::home_dir() {
+        Some(home) => {
+            let path = home.join(".config/agentenv/config.toml");
+            if path.is_file() {
+                load_user_skills_config(
+                    &fs::read_to_string(&path)
+                        .with_context(|| format!("read `{}`", path.display()))?,
+                )
+                .with_context(|| format!("load skills config `{}`", path.display()))?
+            } else {
+                SkillsConfig::default()
+            }
+        }
+        None => SkillsConfig::default(),
+    };
+
+    let project_path = std::env::current_dir()
+        .context("read current directory")?
+        .join("agentenv.yaml");
+    let project = if project_path.is_file() {
+        Some(
+            load_project_skills_config(
+                &fs::read_to_string(&project_path)
+                    .with_context(|| format!("read `{}`", project_path.display()))?,
+            )
+            .with_context(|| format!("load project skills config `{}`", project_path.display()))?,
+        )
+    } else {
+        None
+    };
+
+    merge_skills_config(user, project, SkillsConfigOverride { registry: None })
+        .context("merge skills config")
+}
+
+fn resolve_llm_bearer(name: &str) -> Result<String> {
+    let store = CredentialStore::from_default_paths().context("initialize credential store")?;
+    let requirement = CredentialRequirement {
+        name: name.to_owned(),
+        kind: CredentialKind::ApiKey,
+        required: true,
+        description: "skill proposal LLM bearer token".to_owned(),
+        validator: None,
+    };
+    store
+        .resolve(name, &requirement)
+        .map(|secret| secret.expose_secret().to_owned())
+        .map_err(|error| match error {
+            CredentialStoreError::MissingCredential { .. } => {
+                anyhow::anyhow!("skill proposal LLM credential `{name}` is not configured")
+            }
+            error => anyhow::anyhow!("resolve skill proposal LLM credential `{name}`: {error}"),
+        })
 }
 
 fn default_events_db_path() -> PathBuf {

--- a/crates/agentenv/src/skills_propose_cli.rs
+++ b/crates/agentenv/src/skills_propose_cli.rs
@@ -103,6 +103,12 @@ struct HttpGeneralizer {
     client: Client,
 }
 
+#[derive(Debug, Default)]
+struct ExistingSkillLoadResult {
+    summaries: Vec<ExistingSkillSummary>,
+    warnings: Vec<String>,
+}
+
 #[derive(Debug, Deserialize)]
 struct SkillSummaryManifest {
     name: String,
@@ -218,10 +224,13 @@ pub async fn run_skills_propose(args: SkillsProposeArgs) -> Result<()> {
         .map(|context| context.output_root.clone())
         .or_else(|| args.out.clone())
         .unwrap_or_else(default_proposed_dir);
-    let existing_skills = load_existing_skill_summaries(&output_root)?;
+    let ExistingSkillLoadResult {
+        summaries: existing_skills,
+        warnings: existing_skill_warnings,
+    } = load_existing_skill_summaries(&output_root)?;
     let generalizer = generalizer_for_args(&args, blueprint)?;
     let created_at = now_event_ts();
-    let output = ProposedSkillService::new(generalizer)
+    let mut output = ProposedSkillService::new(generalizer)
         .run(ProposeRunInput {
             traces,
             output_root,
@@ -235,6 +244,11 @@ pub async fn run_skills_propose(args: SkillsProposeArgs) -> Result<()> {
         })
         .await
         .context("run skill proposal service")?;
+    if !existing_skill_warnings.is_empty() {
+        let mut warnings = existing_skill_warnings;
+        warnings.extend(output.warnings);
+        output.warnings = warnings;
+    }
 
     finish_skills_propose(args.json, open_pr_context, args.repo.clone(), output)
 }
@@ -449,22 +463,24 @@ fn ensure_clean_git_index(repo_root: &Path) -> Result<()> {
     }
 }
 
-fn load_existing_skill_summaries(output_root: &Path) -> Result<Vec<ExistingSkillSummary>> {
-    let mut summaries = load_installed_skill_summaries()?;
-    summaries.extend(load_proposed_skill_summaries(output_root)?);
-    Ok(summaries)
+fn load_existing_skill_summaries(output_root: &Path) -> Result<ExistingSkillLoadResult> {
+    let mut result = load_installed_skill_summaries()?;
+    let proposed = load_proposed_skill_summaries(output_root)?;
+    result.summaries.extend(proposed.summaries);
+    result.warnings.extend(proposed.warnings);
+    Ok(result)
 }
 
-fn load_installed_skill_summaries() -> Result<Vec<ExistingSkillSummary>> {
+fn load_installed_skill_summaries() -> Result<ExistingSkillLoadResult> {
     let Some(home) = dirs::home_dir() else {
-        return Ok(Vec::new());
+        return Ok(ExistingSkillLoadResult::default());
     };
     let skills_root = home.join(".agentenv").join("skills");
     let Some(entries) = read_directory_if_exists(&skills_root)? else {
-        return Ok(Vec::new());
+        return Ok(ExistingSkillLoadResult::default());
     };
 
-    let mut summaries = Vec::new();
+    let mut result = ExistingSkillLoadResult::default();
     for name_entry in entries {
         let name_entry = name_entry.with_context(|| format!("read `{}`", skills_root.display()))?;
         let name_path = name_entry.path();
@@ -488,24 +504,27 @@ fn load_installed_skill_summaries() -> Result<Vec<ExistingSkillSummary>> {
             }
             let install_dir = version_entry.path();
             let content_root = install_dir.join(INSTALLED_CONTENT_DIR);
-            let fingerprint = skill_provenance_fingerprint(&content_root)?;
-            if let Some(summary) =
-                load_skill_summary_from_dir(&install_dir, &content_root, fingerprint)?
-            {
-                summaries.push(summary);
+            let fingerprint =
+                existing_skill_fingerprint_or_warn(&content_root, &mut result.warnings);
+            match load_skill_summary_from_dir(&install_dir, &content_root, fingerprint) {
+                Ok(Some(summary)) => result.summaries.push(summary),
+                Ok(None) => {}
+                Err(error) => {
+                    warn_existing_skill_summary(&install_dir, error, &mut result.warnings)
+                }
             }
         }
     }
 
-    Ok(summaries)
+    Ok(result)
 }
 
-fn load_proposed_skill_summaries(output_root: &Path) -> Result<Vec<ExistingSkillSummary>> {
+fn load_proposed_skill_summaries(output_root: &Path) -> Result<ExistingSkillLoadResult> {
     let Some(entries) = read_directory_if_exists(output_root)? else {
-        return Ok(Vec::new());
+        return Ok(ExistingSkillLoadResult::default());
     };
 
-    let mut summaries = Vec::new();
+    let mut result = ExistingSkillLoadResult::default();
     for entry in entries {
         let entry = entry.with_context(|| format!("read `{}`", output_root.display()))?;
         let path = entry.path();
@@ -518,13 +537,41 @@ fn load_proposed_skill_summaries(output_root: &Path) -> Result<Vec<ExistingSkill
         if name.starts_with('.') || !entry_file_type(&entry)?.is_dir() {
             continue;
         }
-        let fingerprint = skill_provenance_fingerprint(&path)?;
-        if let Some(summary) = load_skill_summary_from_dir(&path, &path, fingerprint)? {
-            summaries.push(summary);
+        let fingerprint = existing_skill_fingerprint_or_warn(&path, &mut result.warnings);
+        match load_skill_summary_from_dir(&path, &path, fingerprint) {
+            Ok(Some(summary)) => result.summaries.push(summary),
+            Ok(None) => {}
+            Err(error) => warn_existing_skill_summary(&path, error, &mut result.warnings),
         }
     }
 
-    Ok(summaries)
+    Ok(result)
+}
+
+fn existing_skill_fingerprint_or_warn(
+    content_root: &Path,
+    warnings: &mut Vec<String>,
+) -> Option<String> {
+    match skill_provenance_fingerprint(content_root) {
+        Ok(fingerprint) => fingerprint,
+        Err(error) => {
+            warnings.push(format!(
+                "ignored existing skill provenance `{}`: {error:#}",
+                content_root
+                    .join("traces")
+                    .join("provenance.json")
+                    .display()
+            ));
+            None
+        }
+    }
+}
+
+fn warn_existing_skill_summary(path: &Path, error: anyhow::Error, warnings: &mut Vec<String>) {
+    warnings.push(format!(
+        "ignored existing skill summary `{}`: {error:#}",
+        path.display()
+    ));
 }
 
 fn load_skill_summary_from_dir(

--- a/crates/agentenv/tests/cli_behavior.rs
+++ b/crates/agentenv/tests/cli_behavior.rs
@@ -1323,6 +1323,69 @@ fn skills_propose_filters_duplicate_installed_skill_by_provenance_fingerprint() 
 }
 
 #[test]
+fn skills_propose_warns_and_continues_past_malformed_existing_proposal_provenance() {
+    let temp_dir = make_temp_dir("skills-propose-malformed-proposed-provenance");
+    let blueprint = temp_dir.join("myapp.yaml");
+    fs::write(
+        &blueprint,
+        "version: 0.1.0\nsandbox: { driver: openshell }\nagent: { driver: codex }\ncontext: { driver: filesystem, mount: . }\n",
+    )
+    .unwrap();
+    let db_path = temp_dir.join(".agentenv/events.db");
+    seed_propose_events(&db_path, &blueprint);
+
+    let out = temp_dir.join("proposed");
+    let existing = out.join("broken-cache");
+    fs::create_dir_all(existing.join("traces")).unwrap();
+    fs::write(
+        existing.join("skill.yaml"),
+        "name: broken-cache\nversion: 0.1.0\ndescription: unrelated cached proposal\nentry: SKILL.md\nfiles:\n  - SKILL.md\n  - traces/provenance.json\n",
+    )
+    .unwrap();
+    fs::write(
+        existing.join("SKILL.md"),
+        "This cached proposal is unrelated to filesystem reads.\n",
+    )
+    .unwrap();
+    fs::write(existing.join("traces/provenance.json"), "{not json").unwrap();
+
+    let output = Command::new(agentenv_bin())
+        .arg("skills")
+        .arg("propose")
+        .arg("--from-traces")
+        .arg("--blueprint")
+        .arg(&blueprint)
+        .arg("--events-db")
+        .arg(&db_path)
+        .arg("--out")
+        .arg(&out)
+        .arg("--llm-provider")
+        .arg("fixture")
+        .arg("--json")
+        .env("HOME", &temp_dir)
+        .env(
+            "AGENTENV_SKILL_PROPOSER_FIXTURE_JSON",
+            fixture_generalization_json(),
+        )
+        .current_dir(&temp_dir)
+        .output()
+        .unwrap();
+
+    assert!(output.status.success(), "{}", output_summary(&output));
+    let json: serde_json::Value = serde_json::from_slice(&output.stdout).unwrap();
+    assert_eq!(json["proposals"][0]["name"], "fs-edit-skill");
+    let warnings = json["warnings"].as_array().unwrap();
+    assert!(
+        warnings.iter().any(|warning| {
+            let warning = warning.as_str().unwrap();
+            warning.contains("broken-cache") && warning.contains("provenance")
+        }),
+        "stdout was: {}",
+        String::from_utf8_lossy(&output.stdout)
+    );
+}
+
+#[test]
 fn skills_propose_rejects_unsupported_semantic_backend() {
     let temp_dir = make_temp_dir("skills-propose-semantic-backend");
     let blueprint = temp_dir.join("myapp.yaml");

--- a/crates/agentenv/tests/cli_behavior.rs
+++ b/crates/agentenv/tests/cli_behavior.rs
@@ -1083,6 +1083,182 @@ fn skills_propose_from_traces_emits_local_proposal_with_fake_llm() {
     assert_eq!(json["proposals"][0]["name"], "fs-edit-skill");
 }
 
+#[test]
+fn skills_propose_filters_duplicate_existing_proposal_by_min_novelty() {
+    let temp_dir = make_temp_dir("skills-propose-existing-proposal");
+    let blueprint = temp_dir.join("myapp.yaml");
+    fs::write(
+        &blueprint,
+        "version: 0.1.0\nsandbox: { driver: openshell }\nagent: { driver: codex }\ncontext: { driver: filesystem, mount: . }\n",
+    )
+    .unwrap();
+    let db_path = temp_dir.join(".agentenv/events.db");
+    seed_propose_events(&db_path, &blueprint);
+
+    let out = temp_dir.join("proposed");
+    let existing = out.join("existing-fs-edit-skill");
+    fs::create_dir_all(&existing).unwrap();
+    fs::write(
+        existing.join("SKILL.md"),
+        "---\nname: existing-fs-edit-skill\ndescription: Edit a repeated filesystem target.\n---\n\nRead {{target_path}}.\n",
+    )
+    .unwrap();
+    fs::write(
+        existing.join("skill.yaml"),
+        "name: existing-fs-edit-skill\nversion: 0.1.0\ndescription: Edit a repeated filesystem target.\nentry: SKILL.md\nfiles:\n  - SKILL.md\n",
+    )
+    .unwrap();
+
+    let output = Command::new(agentenv_bin())
+        .arg("skills")
+        .arg("propose")
+        .arg("--from-traces")
+        .arg("--blueprint")
+        .arg(&blueprint)
+        .arg("--events-db")
+        .arg(&db_path)
+        .arg("--out")
+        .arg(&out)
+        .arg("--llm-provider")
+        .arg("fixture")
+        .arg("--min-novelty")
+        .arg("0.85")
+        .arg("--json")
+        .env("HOME", &temp_dir)
+        .env(
+            "AGENTENV_SKILL_PROPOSER_FIXTURE_JSON",
+            fixture_generalization_json_named("fs-edit-skill-v2"),
+        )
+        .current_dir(&temp_dir)
+        .output()
+        .unwrap();
+
+    assert!(output.status.success(), "{}", output_summary(&output));
+    let json: serde_json::Value = serde_json::from_slice(&output.stdout).unwrap();
+    assert_eq!(json["proposals"].as_array().unwrap().len(), 0);
+    let warnings = json["warnings"].as_array().unwrap();
+    assert!(
+        warnings.iter().any(|warning| warning
+            .as_str()
+            .unwrap()
+            .contains("novelty 0.3 is below 0.85")),
+        "stdout was: {}",
+        String::from_utf8_lossy(&output.stdout)
+    );
+    assert!(
+        !out.join("fs-edit-skill-v2/SKILL.md").exists(),
+        "duplicate-ish proposal should be skipped before emission"
+    );
+}
+
+#[test]
+fn skills_propose_filters_duplicate_installed_skill_by_provenance_fingerprint() {
+    let temp_dir = make_temp_dir("skills-propose-existing-installed");
+    let blueprint = temp_dir.join("myapp.yaml");
+    fs::write(
+        &blueprint,
+        "version: 0.1.0\nsandbox: { driver: openshell }\nagent: { driver: codex }\ncontext: { driver: filesystem, mount: . }\n",
+    )
+    .unwrap();
+    let db_path = temp_dir.join(".agentenv/events.db");
+    seed_propose_events(&db_path, &blueprint);
+
+    let installed = temp_dir.join(".agentenv/skills/existing-installed-skill/0.1.0");
+    fs::create_dir_all(installed.join("content/traces")).unwrap();
+    fs::write(
+        installed.join("skill.yaml"),
+        "name: existing-installed-skill\nversion: 0.1.0\ndescription: unrelated installed skill\nentry: SKILL.md\nfiles:\n  - SKILL.md\n  - traces/provenance.json\n",
+    )
+    .unwrap();
+    fs::write(
+        installed.join("content/SKILL.md"),
+        "This text intentionally does not overlap the generated procedure.\n",
+    )
+    .unwrap();
+    fs::write(
+        installed.join("content/traces/provenance.json"),
+        serde_json::json!({
+            "name_seed": "fs-read",
+            "blueprint_id": blueprint_digest(&blueprint),
+            "fingerprint": fs_read_candidate_fingerprint(),
+            "occurrences": 3,
+            "sequence": [{"tool": "fs_read", "args_shape": {"path": "string:path"}}],
+            "source_trace_ids": ["trace-1", "trace-2", "trace-3"],
+            "redaction_count": 0
+        })
+        .to_string(),
+    )
+    .unwrap();
+
+    let out = temp_dir.join("proposed");
+    let output = Command::new(agentenv_bin())
+        .arg("skills")
+        .arg("propose")
+        .arg("--from-traces")
+        .arg("--blueprint")
+        .arg(&blueprint)
+        .arg("--events-db")
+        .arg(&db_path)
+        .arg("--out")
+        .arg(&out)
+        .arg("--llm-provider")
+        .arg("fixture")
+        .arg("--min-novelty")
+        .arg("0.1")
+        .arg("--json")
+        .env("HOME", &temp_dir)
+        .env(
+            "AGENTENV_SKILL_PROPOSER_FIXTURE_JSON",
+            fixture_generalization_json_named("fs-edit-skill-v3"),
+        )
+        .current_dir(&temp_dir)
+        .output()
+        .unwrap();
+
+    assert!(output.status.success(), "{}", output_summary(&output));
+    let json: serde_json::Value = serde_json::from_slice(&output.stdout).unwrap();
+    assert_eq!(json["proposals"].as_array().unwrap().len(), 0);
+    let warnings = json["warnings"].as_array().unwrap();
+    assert!(
+        warnings
+            .iter()
+            .any(|warning| warning.as_str().unwrap().contains("novelty 0 is below 0.1")),
+        "stdout was: {}",
+        String::from_utf8_lossy(&output.stdout)
+    );
+    assert!(
+        !out.join("fs-edit-skill-v3/SKILL.md").exists(),
+        "exact installed duplicate should be skipped before emission"
+    );
+}
+
+#[test]
+fn skills_propose_rejects_unsupported_semantic_backend() {
+    let temp_dir = make_temp_dir("skills-propose-semantic-backend");
+    let blueprint = temp_dir.join("myapp.yaml");
+    fs::write(&blueprint, "version: 0.1.0\n").unwrap();
+
+    let output = Command::new(agentenv_bin())
+        .arg("skills")
+        .arg("propose")
+        .arg("--from-traces")
+        .arg("--blueprint")
+        .arg(&blueprint)
+        .arg("--semantic-backend")
+        .arg("remote")
+        .env("HOME", &temp_dir)
+        .current_dir(&temp_dir)
+        .output()
+        .unwrap();
+
+    assert!(!output.status.success());
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    assert!(
+        stderr.contains("--semantic-backend") && stderr.contains("local"),
+        "stderr was: {stderr}"
+    );
+}
+
 #[cfg(unix)]
 #[test]
 fn skills_propose_open_pr_publishes_first_proposal_with_fake_git_and_gh() {
@@ -1169,6 +1345,10 @@ fn skills_propose_open_pr_publishes_first_proposal_with_fake_git_and_gh() {
     let expected_commands = [
         "git rev-parse --show-toplevel".to_owned(),
         format!(
+            "git -C {} diff --cached --quiet --exit-code",
+            canonical_repo_root.display()
+        ),
+        format!(
             "git -C {} checkout -B agentenv/proposed-skill/fs-edit-skill",
             canonical_repo_root.display()
         ),
@@ -1193,6 +1373,64 @@ fn skills_propose_open_pr_publishes_first_proposal_with_fake_git_and_gh() {
             .unwrap_or_else(|| panic!("missing ordered command `{expected}`; log was: {log}"));
         cursor += relative + expected.len();
     }
+}
+
+#[cfg(unix)]
+#[test]
+fn skills_propose_open_pr_rejects_staged_changes_before_emitting() {
+    let temp_dir = make_temp_dir("skills-propose-open-pr-staged");
+    let repo_root = temp_dir.join("repo");
+    let home = temp_dir.join("home");
+    fs::create_dir_all(&repo_root).unwrap();
+    fs::create_dir_all(&home).unwrap();
+    run_git(&repo_root, &["init"]);
+
+    let blueprint = repo_root.join("myapp.yaml");
+    fs::write(
+        &blueprint,
+        "version: 0.1.0\nsandbox: { driver: openshell }\nagent: { driver: codex }\ncontext: { driver: filesystem, mount: . }\n",
+    )
+    .unwrap();
+    fs::write(repo_root.join("unrelated.txt"), "user staged change\n").unwrap();
+    run_git(&repo_root, &["add", "unrelated.txt"]);
+
+    let db_path = temp_dir.join(".agentenv/events.db");
+    seed_propose_events(&db_path, &blueprint);
+
+    let output = Command::new(agentenv_bin())
+        .arg("skills")
+        .arg("propose")
+        .arg("--from-traces")
+        .arg("--blueprint")
+        .arg(&blueprint)
+        .arg("--events-db")
+        .arg(&db_path)
+        .arg("--llm-provider")
+        .arg("fixture")
+        .arg("--open-pr")
+        .arg("--repo")
+        .arg("owner/repo")
+        .env("HOME", &home)
+        .env(
+            "AGENTENV_SKILL_PROPOSER_FIXTURE_JSON",
+            fixture_generalization_json(),
+        )
+        .current_dir(&repo_root)
+        .output()
+        .unwrap();
+
+    assert!(!output.status.success(), "{}", output_summary(&output));
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    assert!(
+        stderr.contains("commit or unstage") && stderr.contains("staged"),
+        "stderr was: {stderr}"
+    );
+    assert!(
+        !repo_root
+            .join(".agentenv/skills/proposed/fs-edit-skill/SKILL.md")
+            .exists(),
+        "proposal should not be emitted when the index has unrelated staged changes"
+    );
 }
 
 #[cfg(unix)]
@@ -5817,6 +6055,10 @@ fn fixture_generalization_json_named(name: &str) -> String {
         "skill_md_body": "Read {{target_path}}."
     })
     .to_string()
+}
+
+fn fs_read_candidate_fingerprint() -> &'static str {
+    r#"[{"tool":"fs_read","args_shape":{"path":"string:path"}}]"#
 }
 
 fn seed_activity_db(home: &Path, env: &str, events: &[ActivityEvent]) {

--- a/crates/agentenv/tests/cli_behavior.rs
+++ b/crates/agentenv/tests/cli_behavior.rs
@@ -938,7 +938,31 @@ fn skills_help_lists_propose_subcommand() {
 
     assert!(output.status.success(), "{}", output_summary(&output));
     let stdout = String::from_utf8_lossy(&output.stdout);
-    assert!(stdout.contains("propose"), "stdout was: {stdout}");
+    assert!(
+        stdout
+            .lines()
+            .any(|line| line.trim_start().starts_with("propose")),
+        "stdout was: {stdout}"
+    );
+}
+
+#[test]
+fn skills_propose_help_lists_expected_flags() {
+    let output = Command::new(agentenv_bin())
+        .arg("skills")
+        .arg("propose")
+        .arg("--help")
+        .output()
+        .unwrap();
+
+    assert!(output.status.success(), "{}", output_summary(&output));
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    for flag in ["--from-traces", "--blueprint", "--min-self-test-score"] {
+        assert!(
+            stdout.contains(flag),
+            "missing {flag}; stdout was: {stdout}"
+        );
+    }
 }
 
 #[test]
@@ -955,6 +979,56 @@ fn skills_propose_requires_from_traces_and_blueprint() {
     assert!(!output.status.success());
     let stderr = String::from_utf8_lossy(&output.stderr);
     assert!(stderr.contains("--from-traces"), "stderr was: {stderr}");
+}
+
+#[test]
+fn skills_propose_validation_runs_before_loading_skills_config() {
+    let temp_dir = make_temp_dir("skills-propose-invalid-config");
+    let config_dir = temp_dir.join(".config").join("agentenv");
+    fs::create_dir_all(&config_dir).unwrap();
+    fs::write(config_dir.join("config.toml"), "skills = [").unwrap();
+
+    let output = Command::new(agentenv_bin())
+        .arg("skills")
+        .arg("propose")
+        .env("HOME", &temp_dir)
+        .current_dir(&temp_dir)
+        .output()
+        .unwrap();
+
+    assert!(!output.status.success());
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    assert!(stderr.contains("--from-traces"), "stderr was: {stderr}");
+}
+
+#[test]
+fn skills_propose_open_pr_rejects_invalid_repo() {
+    let temp_dir = make_temp_dir("skills-propose-invalid-repo");
+    let blueprint = temp_dir.join("agentenv.yaml");
+    fs::write(&blueprint, "version: 0.1.0\n").unwrap();
+
+    let output = Command::new(agentenv_bin())
+        .arg("skills")
+        .arg("propose")
+        .arg("--from-traces")
+        .arg("--blueprint")
+        .arg(&blueprint)
+        .arg("--open-pr")
+        .arg("--repo")
+        .arg("bad repo")
+        .env("HOME", &temp_dir)
+        .current_dir(&temp_dir)
+        .output()
+        .unwrap();
+
+    assert!(!output.status.success());
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    assert!(
+        !stdout.contains("no proposals emitted"),
+        "stdout was: {stdout}"
+    );
+    assert!(stderr.contains("owner/repo"), "stderr was: {stderr}");
 }
 
 #[test]

--- a/crates/agentenv/tests/cli_behavior.rs
+++ b/crates/agentenv/tests/cli_behavior.rs
@@ -1083,6 +1083,134 @@ fn skills_propose_from_traces_emits_local_proposal_with_fake_llm() {
     assert_eq!(json["proposals"][0]["name"], "fs-edit-skill");
 }
 
+#[cfg(unix)]
+#[test]
+fn skills_propose_open_pr_publishes_first_proposal_with_fake_git_and_gh() {
+    use std::os::unix::fs::PermissionsExt;
+
+    let temp_dir = make_temp_dir("skills-propose-open-pr");
+    let blueprint = temp_dir.join("myapp.yaml");
+    fs::write(
+        &blueprint,
+        "version: 0.1.0\nsandbox: { driver: openshell }\nagent: { driver: codex }\ncontext: { driver: filesystem, mount: . }\n",
+    )
+    .unwrap();
+    let db_path = temp_dir.join(".agentenv/events.db");
+    let store = SqliteEventStore::open(&db_path).unwrap();
+    let blueprint_id = blueprint_digest(&blueprint);
+    store
+        .append_many(&[
+            propose_event("trace-1", &blueprint_id, "fs_read", "/repo/a.rs"),
+            propose_event("trace-2", &blueprint_id, "fs_read", "/repo/b.rs"),
+            propose_event("trace-3", &blueprint_id, "fs_read", "/repo/c.rs"),
+        ])
+        .unwrap();
+
+    let log_path = temp_dir.join("commands.log");
+    let fake_bin = temp_dir.join("fake-bin");
+    fs::create_dir_all(&fake_bin).unwrap();
+    for program in ["git", "gh"] {
+        let script = fake_bin.join(program);
+        fs::write(
+            &script,
+            format!(
+                "#!/bin/sh\nprintf '%s %s\\n' \"$(basename \"$0\")\" \"$*\" >> '{}'\nif [ \"$(basename \"$0\")\" = gh ]; then\n  printf '%s\\n' 'https://github.com/owner/repo/pull/123'\nfi\n",
+                log_path.display()
+            ),
+        )
+        .unwrap();
+        let mut permissions = fs::metadata(&script).unwrap().permissions();
+        permissions.set_mode(0o755);
+        fs::set_permissions(&script, permissions).unwrap();
+    }
+
+    let out = temp_dir.join("proposed");
+    let path = std::env::var_os("PATH").unwrap_or_default();
+    let mut paths = vec![fake_bin];
+    paths.extend(std::env::split_paths(&path));
+    let output = Command::new(agentenv_bin())
+        .arg("skills")
+        .arg("propose")
+        .arg("--from-traces")
+        .arg("--blueprint")
+        .arg(&blueprint)
+        .arg("--events-db")
+        .arg(&db_path)
+        .arg("--out")
+        .arg(&out)
+        .arg("--llm-provider")
+        .arg("fixture")
+        .arg("--open-pr")
+        .arg("--repo")
+        .arg("owner/repo")
+        .env("HOME", &temp_dir)
+        .env("PATH", std::env::join_paths(paths).unwrap())
+        .env(
+            "AGENTENV_SKILL_PROPOSER_FIXTURE_JSON",
+            fixture_generalization_json(),
+        )
+        .current_dir(&temp_dir)
+        .output()
+        .unwrap();
+
+    assert!(output.status.success(), "{}", output_summary(&output));
+    assert!(out.join("fs-edit-skill/SKILL.md").is_file());
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    assert!(
+        stdout.contains("https://github.com/owner/repo/pull/123"),
+        "stdout was: {stdout}"
+    );
+
+    let log = fs::read_to_string(&log_path).unwrap();
+    let proposal_path = out.join("fs-edit-skill");
+    let expected_commands = [
+        "git checkout -B agentenv/proposed-skill/fs-edit-skill".to_owned(),
+        format!("git add {}", proposal_path.display()),
+        "git commit -m feat: propose trace-derived skill fs-edit-skill".to_owned(),
+        "git push -u origin agentenv/proposed-skill/fs-edit-skill".to_owned(),
+        "gh pr create --repo owner/repo --draft --title feat: propose trace-derived skill fs-edit-skill --body Trace-derived skill proposal.".to_owned(),
+    ];
+    let mut cursor = 0;
+    for expected in expected_commands {
+        let relative = log[cursor..]
+            .find(&expected)
+            .unwrap_or_else(|| panic!("missing ordered command `{expected}`; log was: {log}"));
+        cursor += relative + expected.len();
+    }
+}
+
+#[test]
+fn skills_propose_open_pr_fails_when_no_proposals_are_emitted() {
+    let temp_dir = make_temp_dir("skills-propose-open-pr-empty");
+    let blueprint = temp_dir.join("myapp.yaml");
+    fs::write(&blueprint, "version: 0.1.0\n").unwrap();
+    let db_path = temp_dir.join(".agentenv/events.db");
+    SqliteEventStore::open(&db_path).unwrap();
+
+    let output = Command::new(agentenv_bin())
+        .arg("skills")
+        .arg("propose")
+        .arg("--from-traces")
+        .arg("--blueprint")
+        .arg(&blueprint)
+        .arg("--events-db")
+        .arg(&db_path)
+        .arg("--open-pr")
+        .arg("--repo")
+        .arg("owner/repo")
+        .env("HOME", &temp_dir)
+        .current_dir(&temp_dir)
+        .output()
+        .unwrap();
+
+    assert!(!output.status.success());
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    assert!(
+        stderr.contains("--open-pr requested but no proposals were emitted"),
+        "stderr was: {stderr}"
+    );
+}
+
 #[test]
 fn skills_propose_without_configured_llm_fails_clearly() {
     let temp_dir = make_temp_dir("skills-propose-missing-llm");

--- a/crates/agentenv/tests/cli_behavior.rs
+++ b/crates/agentenv/tests/cli_behavior.rs
@@ -929,6 +929,35 @@ fn skills_help_lists_lifecycle_subcommands() {
 }
 
 #[test]
+fn skills_help_lists_propose_subcommand() {
+    let output = Command::new(agentenv_bin())
+        .arg("skills")
+        .arg("--help")
+        .output()
+        .unwrap();
+
+    assert!(output.status.success(), "{}", output_summary(&output));
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    assert!(stdout.contains("propose"), "stdout was: {stdout}");
+}
+
+#[test]
+fn skills_propose_requires_from_traces_and_blueprint() {
+    let temp_dir = make_temp_dir("skills-propose-required");
+    let output = Command::new(agentenv_bin())
+        .arg("skills")
+        .arg("propose")
+        .env("HOME", &temp_dir)
+        .current_dir(&temp_dir)
+        .output()
+        .unwrap();
+
+    assert!(!output.status.success());
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    assert!(stderr.contains("--from-traces"), "stderr was: {stderr}");
+}
+
+#[test]
 fn skills_verify_all_succeeds_for_valid_local_cache() {
     let temp_dir = make_temp_dir("skills-verify-valid");
     write_cli_cache_skill(

--- a/crates/agentenv/tests/cli_behavior.rs
+++ b/crates/agentenv/tests/cli_behavior.rs
@@ -1032,6 +1032,55 @@ fn skills_propose_open_pr_rejects_invalid_repo() {
 }
 
 #[test]
+fn skills_propose_from_traces_emits_local_proposal_with_fake_llm() {
+    let temp_dir = make_temp_dir("skills-propose-e2e");
+    let blueprint = temp_dir.join("myapp.yaml");
+    fs::write(
+        &blueprint,
+        "version: 0.1.0\nsandbox: { driver: openshell }\nagent: { driver: codex }\ncontext: { driver: filesystem, mount: . }\n",
+    )
+    .unwrap();
+    let db_path = temp_dir.join(".agentenv/events.db");
+    let store = SqliteEventStore::open(&db_path).unwrap();
+    let blueprint_id = blueprint_digest(&blueprint);
+    store
+        .append_many(&[
+            propose_event("trace-1", &blueprint_id, "fs_read", "/repo/a.rs"),
+            propose_event("trace-2", &blueprint_id, "fs_read", "/repo/b.rs"),
+            propose_event("trace-3", &blueprint_id, "fs_read", "/repo/c.rs"),
+        ])
+        .unwrap();
+
+    let out = temp_dir.join("proposed");
+    let output = Command::new(agentenv_bin())
+        .arg("skills")
+        .arg("propose")
+        .arg("--from-traces")
+        .arg("--blueprint")
+        .arg(&blueprint)
+        .arg("--events-db")
+        .arg(&db_path)
+        .arg("--out")
+        .arg(&out)
+        .arg("--llm-provider")
+        .arg("fixture")
+        .arg("--json")
+        .env("HOME", &temp_dir)
+        .env(
+            "AGENTENV_SKILL_PROPOSER_FIXTURE_JSON",
+            fixture_generalization_json(),
+        )
+        .current_dir(&temp_dir)
+        .output()
+        .unwrap();
+
+    assert!(output.status.success(), "{}", output_summary(&output));
+    assert!(out.join("fs-edit-skill/SKILL.md").is_file());
+    let json: serde_json::Value = serde_json::from_slice(&output.stdout).unwrap();
+    assert_eq!(json["proposals"][0]["name"], "fs-edit-skill");
+}
+
+#[test]
 fn skills_verify_all_succeeds_for_valid_local_cache() {
     let temp_dir = make_temp_dir("skills-verify-valid");
     write_cli_cache_skill(
@@ -4827,6 +4876,36 @@ fn activity_event(
     trace_id: &str,
 ) -> ActivityEvent {
     ActivityEvent::new(ts, kind, result, trace_id).with_env("demo")
+}
+
+fn propose_event(trace_id: &str, blueprint_id: &str, tool: &str, path: &str) -> ActivityEvent {
+    ActivityEvent::new(
+        "2026-05-11T00:00:00Z",
+        ActivityKind::McpToolCall,
+        ActivityResult::Ok,
+        trace_id,
+    )
+    .with_env("demo")
+    .with_subject_value("tool", serde_json::json!(tool))
+    .with_subject_value("arguments", serde_json::json!({"path": path}))
+    .with_extra("blueprint_id", serde_json::json!(blueprint_id))
+}
+
+fn blueprint_digest(path: &Path) -> String {
+    let bytes = fs::read(path).unwrap();
+    format!("sha256:{}", hex::encode(Sha256::digest(bytes)))
+}
+
+fn fixture_generalization_json() -> String {
+    serde_json::json!({
+        "name": "fs-edit-skill",
+        "description": "Edit a repeated filesystem target.",
+        "template_variables": [{"name": "target_path", "description": "Target path", "example": "src/lib.rs"}],
+        "procedure_steps": [{"tool": "fs_read", "instruction": "Read {{target_path}}."}],
+        "self_test": {"command": "test -f SKILL.md"},
+        "skill_md_body": "Read {{target_path}}."
+    })
+    .to_string()
 }
 
 fn seed_activity_db(home: &Path, env: &str, events: &[ActivityEvent]) {

--- a/crates/agentenv/tests/cli_behavior.rs
+++ b/crates/agentenv/tests/cli_behavior.rs
@@ -1044,15 +1044,7 @@ fn skills_propose_from_traces_emits_local_proposal_with_fake_llm() {
     )
     .unwrap();
     let db_path = temp_dir.join(".agentenv/events.db");
-    let store = SqliteEventStore::open(&db_path).unwrap();
-    let blueprint_id = blueprint_digest(&blueprint);
-    store
-        .append_many(&[
-            propose_event("trace-1", &blueprint_id, "fs_read", "/repo/a.rs"),
-            propose_event("trace-2", &blueprint_id, "fs_read", "/repo/b.rs"),
-            propose_event("trace-3", &blueprint_id, "fs_read", "/repo/c.rs"),
-        ])
-        .unwrap();
+    seed_propose_events(&db_path, &blueprint);
 
     let out = temp_dir.join("proposed");
     let output = Command::new(agentenv_bin())
@@ -1078,9 +1070,83 @@ fn skills_propose_from_traces_emits_local_proposal_with_fake_llm() {
         .unwrap();
 
     assert!(output.status.success(), "{}", output_summary(&output));
-    assert!(out.join("fs-edit-skill/SKILL.md").is_file());
     let json: serde_json::Value = serde_json::from_slice(&output.stdout).unwrap();
+    assert_eq!(json["warnings"].as_array().unwrap().len(), 0);
     assert_eq!(json["proposals"][0]["name"], "fs-edit-skill");
+    let expected_proposal_path = out.join("fs-edit-skill").to_string_lossy().into_owned();
+    assert_eq!(
+        json["proposals"][0]["path"].as_str(),
+        Some(expected_proposal_path.as_str())
+    );
+    assert_eq!(json["proposals"][0]["novelty"].as_f64(), Some(0.9));
+    assert_eq!(json["proposals"][0]["utility"].as_f64(), Some(0.6));
+    assert_eq!(json["proposals"][0]["self_test_score"].as_f64(), Some(1.0));
+
+    let proposal_dir = out.join("fs-edit-skill");
+    for relative in [
+        "SKILL.md",
+        "skill.yaml",
+        "proposal.yaml",
+        "self-test.json",
+        "traces/provenance.json",
+    ] {
+        assert!(
+            proposal_dir.join(relative).is_file(),
+            "proposal should emit {relative}"
+        );
+    }
+
+    let skill_md = fs::read_to_string(proposal_dir.join("SKILL.md")).unwrap();
+    assert!(skill_md.contains("agentenv-proposal: true"));
+    assert!(skill_md.contains("Read {{target_path}}."));
+
+    let skill_yaml: serde_yaml::Value =
+        serde_yaml::from_str(&fs::read_to_string(proposal_dir.join("skill.yaml")).unwrap())
+            .unwrap();
+    assert_eq!(skill_yaml["name"].as_str(), Some("fs-edit-skill"));
+    assert_eq!(skill_yaml["entry"].as_str(), Some("SKILL.md"));
+    assert_eq!(skill_yaml["agentenv_proposal"].as_bool(), Some(true));
+    let files = skill_yaml["files"].as_sequence().unwrap();
+    for expected in [
+        "SKILL.md",
+        "proposal.yaml",
+        "self-test.json",
+        "traces/provenance.json",
+    ] {
+        assert!(
+            files.iter().any(|file| file.as_str() == Some(expected)),
+            "skill.yaml should declare {expected}: {skill_yaml:?}"
+        );
+    }
+
+    let proposal_yaml: serde_yaml::Value =
+        serde_yaml::from_str(&fs::read_to_string(proposal_dir.join("proposal.yaml")).unwrap())
+            .unwrap();
+    assert_eq!(proposal_yaml["status"].as_str(), Some("proposed"));
+    let expected_blueprint_id = blueprint_digest(&blueprint);
+    assert_eq!(
+        proposal_yaml["blueprint_id"].as_str(),
+        Some(expected_blueprint_id.as_str())
+    );
+    assert_eq!(proposal_yaml["occurrences"].as_u64(), Some(3));
+
+    let self_test: serde_json::Value =
+        serde_json::from_str(&fs::read_to_string(proposal_dir.join("self-test.json")).unwrap())
+            .unwrap();
+    assert_eq!(self_test["passed"].as_bool(), Some(true));
+    assert_eq!(self_test["matched_steps"].as_u64(), Some(1));
+    assert_eq!(self_test["total_steps"].as_u64(), Some(1));
+
+    let provenance: serde_json::Value = serde_json::from_str(
+        &fs::read_to_string(proposal_dir.join("traces/provenance.json")).unwrap(),
+    )
+    .unwrap();
+    assert_eq!(
+        provenance["fingerprint"].as_str(),
+        Some(fs_read_candidate_fingerprint())
+    );
+    assert_eq!(provenance["source_trace_ids"].as_array().unwrap().len(), 3);
+    assert_eq!(provenance["sequence"][0]["tool"].as_str(), Some("fs_read"));
 }
 
 #[test]
@@ -1163,20 +1229,20 @@ fn skills_propose_filters_duplicate_installed_skill_by_provenance_fingerprint() 
     let db_path = temp_dir.join(".agentenv/events.db");
     seed_propose_events(&db_path, &blueprint);
 
-    let installed = temp_dir.join(".agentenv/skills/existing-installed-skill/0.1.0");
-    fs::create_dir_all(installed.join("content/traces")).unwrap();
+    let bundle = temp_dir.join("installed-skill-bundle");
+    fs::create_dir_all(bundle.join("traces")).unwrap();
     fs::write(
-        installed.join("skill.yaml"),
+        bundle.join("skill.yaml"),
         "name: existing-installed-skill\nversion: 0.1.0\ndescription: unrelated installed skill\nentry: SKILL.md\nfiles:\n  - SKILL.md\n  - traces/provenance.json\n",
     )
     .unwrap();
     fs::write(
-        installed.join("content/SKILL.md"),
+        bundle.join("SKILL.md"),
         "This text intentionally does not overlap the generated procedure.\n",
     )
     .unwrap();
     fs::write(
-        installed.join("content/traces/provenance.json"),
+        bundle.join("traces/provenance.json"),
         serde_json::json!({
             "name_seed": "fs-read",
             "blueprint_id": blueprint_digest(&blueprint),
@@ -1189,6 +1255,30 @@ fn skills_propose_filters_duplicate_installed_skill_by_provenance_fingerprint() 
         .to_string(),
     )
     .unwrap();
+
+    let install = Command::new(agentenv_bin())
+        .arg("skills")
+        .arg("install")
+        .arg("--from")
+        .arg(&bundle)
+        .arg("--allow-unsigned")
+        .arg("--json")
+        .env("HOME", &temp_dir)
+        .current_dir(&temp_dir)
+        .output()
+        .unwrap();
+    assert!(install.status.success(), "{}", output_summary(&install));
+    let install_json: serde_json::Value = serde_json::from_slice(&install.stdout).unwrap();
+    assert_eq!(
+        install_json["name"].as_str(),
+        Some("existing-installed-skill")
+    );
+    assert!(
+        temp_dir
+            .join(".agentenv/skills/existing-installed-skill/0.1.0/content/traces/provenance.json")
+            .is_file(),
+        "install command should copy proposal provenance into installed content"
+    );
 
     let out = temp_dir.join("proposed");
     let output = Command::new(agentenv_bin())

--- a/crates/agentenv/tests/cli_behavior.rs
+++ b/crates/agentenv/tests/cli_behavior.rs
@@ -1089,7 +1089,11 @@ fn skills_propose_open_pr_publishes_first_proposal_with_fake_git_and_gh() {
     use std::os::unix::fs::PermissionsExt;
 
     let temp_dir = make_temp_dir("skills-propose-open-pr");
-    let blueprint = temp_dir.join("myapp.yaml");
+    let repo_root = temp_dir.join("repo");
+    let home = temp_dir.join("home");
+    fs::create_dir_all(&repo_root).unwrap();
+    fs::create_dir_all(&home).unwrap();
+    let blueprint = repo_root.join("myapp.yaml");
     fs::write(
         &blueprint,
         "version: 0.1.0\nsandbox: { driver: openshell }\nagent: { driver: codex }\ncontext: { driver: filesystem, mount: . }\n",
@@ -1114,8 +1118,9 @@ fn skills_propose_open_pr_publishes_first_proposal_with_fake_git_and_gh() {
         fs::write(
             &script,
             format!(
-                "#!/bin/sh\nprintf '%s %s\\n' \"$(basename \"$0\")\" \"$*\" >> '{}'\nif [ \"$(basename \"$0\")\" = gh ]; then\n  printf '%s\\n' 'https://github.com/owner/repo/pull/123'\nfi\n",
-                log_path.display()
+                "#!/bin/sh\nprintf '%s %s\\n' \"$(basename \"$0\")\" \"$*\" >> '{}'\nif [ \"$(basename \"$0\")\" = git ] && [ \"$1\" = rev-parse ]; then\n  printf '%s\\n' '{}'\nfi\nif [ \"$(basename \"$0\")\" = gh ]; then\n  printf '%s\\n' 'https://github.com/owner/repo/pull/123'\nfi\n",
+                log_path.display(),
+                repo_root.display()
             ),
         )
         .unwrap();
@@ -1124,7 +1129,115 @@ fn skills_propose_open_pr_publishes_first_proposal_with_fake_git_and_gh() {
         fs::set_permissions(&script, permissions).unwrap();
     }
 
-    let out = temp_dir.join("proposed");
+    let path = std::env::var_os("PATH").unwrap_or_default();
+    let mut paths = vec![fake_bin];
+    paths.extend(std::env::split_paths(&path));
+    let output = Command::new(agentenv_bin())
+        .arg("skills")
+        .arg("propose")
+        .arg("--from-traces")
+        .arg("--blueprint")
+        .arg(&blueprint)
+        .arg("--events-db")
+        .arg(&db_path)
+        .arg("--llm-provider")
+        .arg("fixture")
+        .arg("--open-pr")
+        .arg("--repo")
+        .arg("owner/repo")
+        .env("HOME", &home)
+        .env("PATH", std::env::join_paths(paths).unwrap())
+        .env(
+            "AGENTENV_SKILL_PROPOSER_FIXTURE_JSON",
+            fixture_generalization_json(),
+        )
+        .current_dir(&repo_root)
+        .output()
+        .unwrap();
+
+    assert!(output.status.success(), "{}", output_summary(&output));
+    let out = repo_root.join(".agentenv/skills/proposed");
+    assert!(out.join("fs-edit-skill/SKILL.md").is_file());
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    assert!(
+        stdout.contains("https://github.com/owner/repo/pull/123"),
+        "stdout was: {stdout}"
+    );
+
+    let log = fs::read_to_string(&log_path).unwrap();
+    let expected_commands = [
+        "git rev-parse --show-toplevel".to_owned(),
+        format!(
+            "git -C {} checkout -B agentenv/proposed-skill/fs-edit-skill",
+            repo_root.display()
+        ),
+        format!(
+            "git -C {} add -- .agentenv/skills/proposed/fs-edit-skill",
+            repo_root.display()
+        ),
+        format!(
+            "git -C {} commit -m feat: propose trace-derived skill fs-edit-skill",
+            repo_root.display()
+        ),
+        format!(
+            "git -C {} push -u origin agentenv/proposed-skill/fs-edit-skill",
+            repo_root.display()
+        ),
+        "gh pr create --repo owner/repo --draft --title feat: propose trace-derived skill fs-edit-skill --body Trace-derived skill proposal.".to_owned(),
+    ];
+    let mut cursor = 0;
+    for expected in expected_commands {
+        let relative = log[cursor..]
+            .find(&expected)
+            .unwrap_or_else(|| panic!("missing ordered command `{expected}`; log was: {log}"));
+        cursor += relative + expected.len();
+    }
+}
+
+#[cfg(unix)]
+#[test]
+fn skills_propose_open_pr_rejects_explicit_outside_repo_before_emitting() {
+    use std::os::unix::fs::PermissionsExt;
+
+    let temp_dir = make_temp_dir("skills-propose-open-pr-outside");
+    let repo_root = temp_dir.join("repo");
+    let outside = temp_dir.join("outside");
+    fs::create_dir_all(&repo_root).unwrap();
+    fs::create_dir_all(&outside).unwrap();
+    let blueprint = repo_root.join("myapp.yaml");
+    fs::write(
+        &blueprint,
+        "version: 0.1.0\nsandbox: { driver: openshell }\nagent: { driver: codex }\ncontext: { driver: filesystem, mount: . }\n",
+    )
+    .unwrap();
+    let db_path = temp_dir.join(".agentenv/events.db");
+    let store = SqliteEventStore::open(&db_path).unwrap();
+    let blueprint_id = blueprint_digest(&blueprint);
+    store
+        .append_many(&[
+            propose_event("trace-1", &blueprint_id, "fs_read", "/repo/a.rs"),
+            propose_event("trace-2", &blueprint_id, "fs_read", "/repo/b.rs"),
+            propose_event("trace-3", &blueprint_id, "fs_read", "/repo/c.rs"),
+        ])
+        .unwrap();
+
+    let log_path = temp_dir.join("commands.log");
+    let fake_bin = temp_dir.join("fake-bin");
+    fs::create_dir_all(&fake_bin).unwrap();
+    let git = fake_bin.join("git");
+    fs::write(
+        &git,
+        format!(
+            "#!/bin/sh\nprintf 'git %s\\n' \"$*\" >> '{}'\nif [ \"$1\" = rev-parse ]; then\n  printf '%s\\n' '{}'\nfi\n",
+            log_path.display(),
+            repo_root.display()
+        ),
+    )
+    .unwrap();
+    let mut permissions = fs::metadata(&git).unwrap().permissions();
+    permissions.set_mode(0o755);
+    fs::set_permissions(&git, permissions).unwrap();
+
     let path = std::env::var_os("PATH").unwrap_or_default();
     let mut paths = vec![fake_bin];
     paths.extend(std::env::split_paths(&path));
@@ -1137,55 +1250,150 @@ fn skills_propose_open_pr_publishes_first_proposal_with_fake_git_and_gh() {
         .arg("--events-db")
         .arg(&db_path)
         .arg("--out")
-        .arg(&out)
+        .arg(&outside)
         .arg("--llm-provider")
         .arg("fixture")
         .arg("--open-pr")
         .arg("--repo")
         .arg("owner/repo")
-        .env("HOME", &temp_dir)
+        .env("HOME", temp_dir.join("home"))
         .env("PATH", std::env::join_paths(paths).unwrap())
         .env(
             "AGENTENV_SKILL_PROPOSER_FIXTURE_JSON",
             fixture_generalization_json(),
         )
-        .current_dir(&temp_dir)
+        .current_dir(&repo_root)
+        .output()
+        .unwrap();
+
+    assert!(!output.status.success());
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    assert!(
+        stderr.contains("--out must be inside the git worktree when --open-pr is set"),
+        "stderr was: {stderr}"
+    );
+    assert!(
+        !outside.join("fs-edit-skill/SKILL.md").exists(),
+        "proposal should not be emitted outside the repo"
+    );
+    let log = fs::read_to_string(&log_path).unwrap();
+    assert_eq!(log.trim(), "git rev-parse --show-toplevel");
+}
+
+#[cfg(unix)]
+#[test]
+fn skills_propose_open_pr_sanitizes_git_branch_slug_for_lock_like_names() {
+    use std::os::unix::fs::PermissionsExt;
+
+    let temp_dir = make_temp_dir("skills-propose-open-pr-slug");
+    let repo_root = temp_dir.join("repo");
+    fs::create_dir_all(&repo_root).unwrap();
+    let blueprint = repo_root.join("myapp.yaml");
+    fs::write(
+        &blueprint,
+        "version: 0.1.0\nsandbox: { driver: openshell }\nagent: { driver: codex }\ncontext: { driver: filesystem, mount: . }\n",
+    )
+    .unwrap();
+    let db_path = temp_dir.join(".agentenv/events.db");
+    let store = SqliteEventStore::open(&db_path).unwrap();
+    let blueprint_id = blueprint_digest(&blueprint);
+    store
+        .append_many(&[
+            propose_event("trace-1", &blueprint_id, "fs_read", "/repo/a.rs"),
+            propose_event("trace-2", &blueprint_id, "fs_read", "/repo/b.rs"),
+            propose_event("trace-3", &blueprint_id, "fs_read", "/repo/c.rs"),
+        ])
+        .unwrap();
+
+    let log_path = temp_dir.join("commands.log");
+    let fake_bin = temp_dir.join("fake-bin");
+    fs::create_dir_all(&fake_bin).unwrap();
+    for program in ["git", "gh"] {
+        let script = fake_bin.join(program);
+        fs::write(
+            &script,
+            format!(
+                "#!/bin/sh\nprintf '%s %s\\n' \"$(basename \"$0\")\" \"$*\" >> '{}'\nif [ \"$(basename \"$0\")\" = git ] && [ \"$1\" = rev-parse ]; then\n  printf '%s\\n' '{}'\nfi\nif [ \"$(basename \"$0\")\" = gh ]; then\n  printf '%s\\n' 'https://github.com/owner/repo/pull/456'\nfi\n",
+                log_path.display(),
+                repo_root.display()
+            ),
+        )
+        .unwrap();
+        let mut permissions = fs::metadata(&script).unwrap().permissions();
+        permissions.set_mode(0o755);
+        fs::set_permissions(&script, permissions).unwrap();
+    }
+
+    let path = std::env::var_os("PATH").unwrap_or_default();
+    let mut paths = vec![fake_bin];
+    paths.extend(std::env::split_paths(&path));
+    let output = Command::new(agentenv_bin())
+        .arg("skills")
+        .arg("propose")
+        .arg("--from-traces")
+        .arg("--blueprint")
+        .arg(&blueprint)
+        .arg("--events-db")
+        .arg(&db_path)
+        .arg("--llm-provider")
+        .arg("fixture")
+        .arg("--open-pr")
+        .arg("--repo")
+        .arg("owner/repo")
+        .env("HOME", temp_dir.join("home"))
+        .env("PATH", std::env::join_paths(paths).unwrap())
+        .env(
+            "AGENTENV_SKILL_PROPOSER_FIXTURE_JSON",
+            fixture_generalization_json_named("bad..name.lock"),
+        )
+        .current_dir(&repo_root)
         .output()
         .unwrap();
 
     assert!(output.status.success(), "{}", output_summary(&output));
-    assert!(out.join("fs-edit-skill/SKILL.md").is_file());
-    let stdout = String::from_utf8_lossy(&output.stdout);
-    assert!(
-        stdout.contains("https://github.com/owner/repo/pull/123"),
-        "stdout was: {stdout}"
-    );
-
     let log = fs::read_to_string(&log_path).unwrap();
-    let proposal_path = out.join("fs-edit-skill");
-    let expected_commands = [
-        "git checkout -B agentenv/proposed-skill/fs-edit-skill".to_owned(),
-        format!("git add {}", proposal_path.display()),
-        "git commit -m feat: propose trace-derived skill fs-edit-skill".to_owned(),
-        "git push -u origin agentenv/proposed-skill/fs-edit-skill".to_owned(),
-        "gh pr create --repo owner/repo --draft --title feat: propose trace-derived skill fs-edit-skill --body Trace-derived skill proposal.".to_owned(),
-    ];
-    let mut cursor = 0;
-    for expected in expected_commands {
-        let relative = log[cursor..]
-            .find(&expected)
-            .unwrap_or_else(|| panic!("missing ordered command `{expected}`; log was: {log}"));
-        cursor += relative + expected.len();
-    }
+    let checkout_line = log
+        .lines()
+        .find(|line| line.contains(" checkout -B "))
+        .unwrap();
+    assert!(
+        checkout_line.contains("agentenv/proposed-skill/bad-name-lock-"),
+        "log was: {log}"
+    );
+    assert!(!checkout_line.contains(".."), "log was: {log}");
+    assert!(!checkout_line.contains(".lock"), "log was: {log}");
 }
 
+#[cfg(unix)]
 #[test]
 fn skills_propose_open_pr_fails_when_no_proposals_are_emitted() {
+    use std::os::unix::fs::PermissionsExt;
+
     let temp_dir = make_temp_dir("skills-propose-open-pr-empty");
-    let blueprint = temp_dir.join("myapp.yaml");
+    let repo_root = temp_dir.join("repo");
+    fs::create_dir_all(&repo_root).unwrap();
+    let blueprint = repo_root.join("myapp.yaml");
     fs::write(&blueprint, "version: 0.1.0\n").unwrap();
     let db_path = temp_dir.join(".agentenv/events.db");
     SqliteEventStore::open(&db_path).unwrap();
+
+    let fake_bin = temp_dir.join("fake-bin");
+    fs::create_dir_all(&fake_bin).unwrap();
+    let git = fake_bin.join("git");
+    fs::write(
+        &git,
+        format!(
+            "#!/bin/sh\nif [ \"$1\" = rev-parse ]; then\n  printf '%s\\n' '{}'\nfi\n",
+            repo_root.display()
+        ),
+    )
+    .unwrap();
+    let mut permissions = fs::metadata(&git).unwrap().permissions();
+    permissions.set_mode(0o755);
+    fs::set_permissions(&git, permissions).unwrap();
+    let path = std::env::var_os("PATH").unwrap_or_default();
+    let mut paths = vec![fake_bin];
+    paths.extend(std::env::split_paths(&path));
 
     let output = Command::new(agentenv_bin())
         .arg("skills")
@@ -1199,7 +1407,8 @@ fn skills_propose_open_pr_fails_when_no_proposals_are_emitted() {
         .arg("--repo")
         .arg("owner/repo")
         .env("HOME", &temp_dir)
-        .current_dir(&temp_dir)
+        .env("PATH", std::env::join_paths(paths).unwrap())
+        .current_dir(&repo_root)
         .output()
         .unwrap();
 
@@ -5502,8 +5711,12 @@ fn blueprint_digest(path: &Path) -> String {
 }
 
 fn fixture_generalization_json() -> String {
+    fixture_generalization_json_named("fs-edit-skill")
+}
+
+fn fixture_generalization_json_named(name: &str) -> String {
     serde_json::json!({
-        "name": "fs-edit-skill",
+        "name": name,
         "description": "Edit a repeated filesystem target.",
         "template_variables": [{"name": "target_path", "description": "Target path", "example": "src/lib.rs"}],
         "procedure_steps": [{"tool": "fs_read", "instruction": "Read {{target_path}}."}],

--- a/crates/agentenv/tests/cli_behavior.rs
+++ b/crates/agentenv/tests/cli_behavior.rs
@@ -1120,9 +1120,11 @@ fn skills_propose_without_configured_llm_fails_clearly() {
 #[test]
 fn skills_propose_uses_configured_openai_compatible_provider_and_env_credential() {
     let temp_dir = make_temp_dir("skills-propose-http-provider");
+    let project_dir = temp_dir.join("project");
+    fs::create_dir_all(&project_dir).unwrap();
     let (endpoint, captured_request, server) =
         spawn_openai_compatible_skill_proposer(fixture_generalization_json());
-    let blueprint = temp_dir.join("agentenv.yaml");
+    let blueprint = project_dir.join("agentenv.yaml");
     fs::write(
         &blueprint,
         format!(
@@ -1167,6 +1169,7 @@ skills:
         .arg("--json")
         .env("HOME", &temp_dir)
         .env("AGENTENV_DISABLE_KEYRING", "1")
+        .env("AGENTENV_SKILL_PROPOSER_ALLOW_LOCAL_ENDPOINTS", "1")
         .env("AGENTENV_TEST_SKILL_PROPOSER_TOKEN", "test-token")
         .current_dir(&temp_dir)
         .output()
@@ -1186,6 +1189,145 @@ skills:
     assert!(
         request.contains(r#""model":"test-model""#),
         "request was: {request}"
+    );
+}
+
+#[test]
+fn skills_propose_http_provider_times_out_when_server_never_responds() {
+    let temp_dir = make_temp_dir("skills-propose-http-timeout");
+    let (endpoint, server) = spawn_never_responding_skill_proposer();
+    let blueprint = temp_dir.join("agentenv.yaml");
+    write_skill_proposer_blueprint(
+        &blueprint,
+        &endpoint,
+        "test-model",
+        "AGENTENV_TEST_SKILL_PROPOSER_TIMEOUT_TOKEN",
+    );
+    let db_path = temp_dir.join(".agentenv/events.db");
+    seed_propose_events(&db_path, &blueprint);
+
+    let started_at = Instant::now();
+    let output = Command::new(agentenv_bin())
+        .arg("skills")
+        .arg("propose")
+        .arg("--from-traces")
+        .arg("--blueprint")
+        .arg(&blueprint)
+        .arg("--events-db")
+        .arg(&db_path)
+        .arg("--json")
+        .env("HOME", &temp_dir)
+        .env("AGENTENV_DISABLE_KEYRING", "1")
+        .env("AGENTENV_SKILL_PROPOSER_ALLOW_LOCAL_ENDPOINTS", "1")
+        .env("AGENTENV_SKILL_PROPOSER_HTTP_TIMEOUT_MS", "100")
+        .env(
+            "AGENTENV_TEST_SKILL_PROPOSER_TIMEOUT_TOKEN",
+            "timeout-token",
+        )
+        .current_dir(&temp_dir)
+        .output()
+        .unwrap();
+    let elapsed = started_at.elapsed();
+    server.join().unwrap();
+
+    assert!(!output.status.success(), "{}", output_summary(&output));
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    assert!(
+        stderr.contains("timed out"),
+        "stderr was: {stderr}; elapsed: {elapsed:?}"
+    );
+    assert!(
+        elapsed < Duration::from_secs(3),
+        "request should not wait for the production default timeout, elapsed: {elapsed:?}"
+    );
+    assert!(
+        stderr.contains("skill proposal LLM request failed"),
+        "stderr was: {stderr}"
+    );
+}
+
+#[test]
+fn skills_propose_blocks_metadata_endpoint_before_http_request() {
+    let temp_dir = make_temp_dir("skills-propose-metadata-endpoint");
+    let blueprint = temp_dir.join("agentenv.yaml");
+    write_skill_proposer_blueprint(
+        &blueprint,
+        "http://169.254.169.254/latest/meta-data",
+        "test-model",
+        "AGENTENV_TEST_SKILL_PROPOSER_METADATA_TOKEN",
+    );
+    let db_path = temp_dir.join(".agentenv/events.db");
+    seed_propose_events(&db_path, &blueprint);
+
+    let output = Command::new(agentenv_bin())
+        .arg("skills")
+        .arg("propose")
+        .arg("--from-traces")
+        .arg("--blueprint")
+        .arg(&blueprint)
+        .arg("--events-db")
+        .arg(&db_path)
+        .arg("--json")
+        .env("HOME", &temp_dir)
+        .env("AGENTENV_DISABLE_KEYRING", "1")
+        .env("AGENTENV_SKILL_PROPOSER_HTTP_TIMEOUT_MS", "100")
+        .env(
+            "AGENTENV_TEST_SKILL_PROPOSER_METADATA_TOKEN",
+            "metadata-token",
+        )
+        .current_dir(&temp_dir)
+        .output()
+        .unwrap();
+
+    assert!(!output.status.success(), "{}", output_summary(&output));
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    assert!(
+        stderr.contains("skill proposal LLM endpoint was blocked"),
+        "stderr was: {stderr}"
+    );
+    assert!(stderr.contains("169.254.169.254"), "stderr was: {stderr}");
+}
+
+#[test]
+fn skills_propose_redacts_and_bounds_non_success_provider_body() {
+    let temp_dir = make_temp_dir("skills-propose-http-error-redaction");
+    let (endpoint, server) = spawn_erroring_skill_proposer("test-token", "x".repeat(10_000));
+    let blueprint = temp_dir.join("agentenv.yaml");
+    write_skill_proposer_blueprint(
+        &blueprint,
+        &endpoint,
+        "test-model",
+        "AGENTENV_TEST_SKILL_PROPOSER_ERROR_TOKEN",
+    );
+    let db_path = temp_dir.join(".agentenv/events.db");
+    seed_propose_events(&db_path, &blueprint);
+
+    let output = Command::new(agentenv_bin())
+        .arg("skills")
+        .arg("propose")
+        .arg("--from-traces")
+        .arg("--blueprint")
+        .arg(&blueprint)
+        .arg("--events-db")
+        .arg(&db_path)
+        .arg("--json")
+        .env("HOME", &temp_dir)
+        .env("AGENTENV_DISABLE_KEYRING", "1")
+        .env("AGENTENV_SKILL_PROPOSER_ALLOW_LOCAL_ENDPOINTS", "1")
+        .env("AGENTENV_TEST_SKILL_PROPOSER_ERROR_TOKEN", "test-token")
+        .current_dir(&temp_dir)
+        .output()
+        .unwrap();
+    server.join().unwrap();
+
+    assert!(!output.status.success(), "{}", output_summary(&output));
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    assert!(!stderr.contains("test-token"), "stderr was: {stderr}");
+    assert!(stderr.contains("[REDACTED]"), "stderr was: {stderr}");
+    assert!(
+        stderr.len() < 6_000,
+        "stderr should include a bounded provider body, got {} bytes",
+        stderr.len()
     );
 }
 
@@ -5161,6 +5303,7 @@ fn spawn_openai_compatible_skill_proposer(
                 Err(error) => panic!("accept OpenAI-compatible test request: {error}"),
             }
         };
+        stream.set_nonblocking(false).unwrap();
         stream
             .set_read_timeout(Some(LOCAL_HTTP_TEST_TIMEOUT))
             .unwrap();
@@ -5180,6 +5323,113 @@ fn spawn_openai_compatible_skill_proposer(
     });
 
     (endpoint, captured_request, handle)
+}
+
+fn spawn_never_responding_skill_proposer() -> (String, thread::JoinHandle<()>) {
+    let listener = std::net::TcpListener::bind(("127.0.0.1", 0)).unwrap();
+    listener.set_nonblocking(true).unwrap();
+    let endpoint = format!(
+        "http://{}/v1/chat/completions",
+        listener.local_addr().unwrap()
+    );
+    let handle = thread::spawn(move || {
+        let deadline = Instant::now() + LOCAL_HTTP_TEST_TIMEOUT;
+        let (mut stream, _) = loop {
+            match listener.accept() {
+                Ok(accepted) => break accepted,
+                Err(error) if error.kind() == std::io::ErrorKind::WouldBlock => {
+                    assert!(
+                        Instant::now() < deadline,
+                        "timed out waiting for never-responding test request"
+                    );
+                    thread::sleep(Duration::from_millis(20));
+                }
+                Err(error) => panic!("accept never-responding test request: {error}"),
+            }
+        };
+        stream.set_nonblocking(false).unwrap();
+        stream
+            .set_read_timeout(Some(LOCAL_HTTP_TEST_TIMEOUT))
+            .unwrap();
+        let _request = read_http_request(&mut stream);
+        thread::sleep(Duration::from_secs(2));
+    });
+
+    (endpoint, handle)
+}
+
+fn spawn_erroring_skill_proposer(secret: &str, suffix: String) -> (String, thread::JoinHandle<()>) {
+    let listener = std::net::TcpListener::bind(("127.0.0.1", 0)).unwrap();
+    listener.set_nonblocking(true).unwrap();
+    let endpoint = format!(
+        "http://{}/v1/chat/completions",
+        listener.local_addr().unwrap()
+    );
+    let body = format!("provider failed with token {secret}: {suffix}");
+    let handle = thread::spawn(move || {
+        let deadline = Instant::now() + LOCAL_HTTP_TEST_TIMEOUT;
+        let (mut stream, _) = loop {
+            match listener.accept() {
+                Ok(accepted) => break accepted,
+                Err(error) if error.kind() == std::io::ErrorKind::WouldBlock => {
+                    assert!(
+                        Instant::now() < deadline,
+                        "timed out waiting for erroring test request"
+                    );
+                    thread::sleep(Duration::from_millis(20));
+                }
+                Err(error) => panic!("accept erroring test request: {error}"),
+            }
+        };
+        stream.set_nonblocking(false).unwrap();
+        stream
+            .set_read_timeout(Some(LOCAL_HTTP_TEST_TIMEOUT))
+            .unwrap();
+        let _request = read_http_request(&mut stream);
+        write!(
+            stream,
+            "HTTP/1.1 500 Internal Server Error\r\ncontent-type: text/plain\r\ncontent-length: {}\r\nconnection: close\r\n\r\n{}",
+            body.len(),
+            body
+        )
+        .unwrap();
+    });
+
+    (endpoint, handle)
+}
+
+fn write_skill_proposer_blueprint(blueprint: &Path, endpoint: &str, model: &str, credential: &str) {
+    fs::write(
+        blueprint,
+        format!(
+            r#"
+version: 0.1.0
+sandbox: {{ driver: openshell }}
+agent: {{ driver: codex }}
+context: {{ driver: filesystem, mount: . }}
+skills:
+  proposal:
+    llm:
+      provider: openai-compatible
+      endpoint: {endpoint}
+      model: {model}
+      credential: {credential}
+"#
+        ),
+    )
+    .unwrap();
+}
+
+fn seed_propose_events(db_path: &Path, blueprint: &Path) {
+    let store = SqliteEventStore::open(db_path).unwrap();
+    let blueprint_id = blueprint_digest(blueprint);
+    store
+        .append_many(&[
+            propose_event("trace-1", &blueprint_id, "fs_read", "/repo/a.rs"),
+            propose_event("trace-2", &blueprint_id, "fs_read", "/repo/b.rs"),
+            propose_event("trace-3", &blueprint_id, "fs_read", "/repo/c.rs"),
+        ])
+        .unwrap();
 }
 
 fn read_http_request(stream: &mut std::net::TcpStream) -> String {

--- a/crates/agentenv/tests/cli_behavior.rs
+++ b/crates/agentenv/tests/cli_behavior.rs
@@ -1165,23 +1165,24 @@ fn skills_propose_open_pr_publishes_first_proposal_with_fake_git_and_gh() {
     );
 
     let log = fs::read_to_string(&log_path).unwrap();
+    let canonical_repo_root = fs::canonicalize(&repo_root).unwrap();
     let expected_commands = [
         "git rev-parse --show-toplevel".to_owned(),
         format!(
             "git -C {} checkout -B agentenv/proposed-skill/fs-edit-skill",
-            repo_root.display()
+            canonical_repo_root.display()
         ),
         format!(
             "git -C {} add -- .agentenv/skills/proposed/fs-edit-skill",
-            repo_root.display()
+            canonical_repo_root.display()
         ),
         format!(
             "git -C {} commit -m feat: propose trace-derived skill fs-edit-skill",
-            repo_root.display()
+            canonical_repo_root.display()
         ),
         format!(
             "git -C {} push -u origin agentenv/proposed-skill/fs-edit-skill",
-            repo_root.display()
+            canonical_repo_root.display()
         ),
         "gh pr create --repo owner/repo --draft --title feat: propose trace-derived skill fs-edit-skill --body Trace-derived skill proposal.".to_owned(),
     ];
@@ -1278,6 +1279,98 @@ fn skills_propose_open_pr_rejects_explicit_outside_repo_before_emitting() {
     );
     let log = fs::read_to_string(&log_path).unwrap();
     assert_eq!(log.trim(), "git rev-parse --show-toplevel");
+}
+
+#[cfg(unix)]
+#[test]
+fn skills_propose_open_pr_rejects_default_output_through_symlinked_agentenv() {
+    use std::os::unix::fs::{symlink, PermissionsExt};
+
+    let temp_dir = make_temp_dir("skills-propose-open-pr-symlink-default");
+    let repo_root = temp_dir.join("repo");
+    let outside = temp_dir.join("outside-agentenv");
+    fs::create_dir_all(&repo_root).unwrap();
+    fs::create_dir_all(&outside).unwrap();
+    run_git(&repo_root, &["init"]);
+    symlink(&outside, repo_root.join(".agentenv")).unwrap();
+
+    let blueprint = repo_root.join("myapp.yaml");
+    fs::write(
+        &blueprint,
+        "version: 0.1.0\nsandbox: { driver: openshell }\nagent: { driver: codex }\ncontext: { driver: filesystem, mount: . }\n",
+    )
+    .unwrap();
+    let db_path = temp_dir.join("events.db");
+    let store = SqliteEventStore::open(&db_path).unwrap();
+    let blueprint_id = blueprint_digest(&blueprint);
+    store
+        .append_many(&[
+            propose_event("trace-1", &blueprint_id, "fs_read", "/repo/a.rs"),
+            propose_event("trace-2", &blueprint_id, "fs_read", "/repo/b.rs"),
+            propose_event("trace-3", &blueprint_id, "fs_read", "/repo/c.rs"),
+        ])
+        .unwrap();
+
+    let gh_log = temp_dir.join("gh.log");
+    let fake_bin = temp_dir.join("fake-bin");
+    fs::create_dir_all(&fake_bin).unwrap();
+    let gh = fake_bin.join("gh");
+    fs::write(
+        &gh,
+        format!(
+            "#!/bin/sh\nprintf 'gh %s\\n' \"$*\" >> '{}'\nprintf '%s\\n' 'https://github.com/owner/repo/pull/789'\n",
+            gh_log.display()
+        ),
+    )
+    .unwrap();
+    let mut permissions = fs::metadata(&gh).unwrap().permissions();
+    permissions.set_mode(0o755);
+    fs::set_permissions(&gh, permissions).unwrap();
+    let path = std::env::var_os("PATH").unwrap_or_default();
+    let mut paths = vec![fake_bin];
+    paths.extend(std::env::split_paths(&path));
+
+    let output = Command::new(agentenv_bin())
+        .arg("skills")
+        .arg("propose")
+        .arg("--from-traces")
+        .arg("--blueprint")
+        .arg(&blueprint)
+        .arg("--events-db")
+        .arg(&db_path)
+        .arg("--llm-provider")
+        .arg("fixture")
+        .arg("--open-pr")
+        .arg("--repo")
+        .arg("owner/repo")
+        .env("HOME", temp_dir.join("home"))
+        .env("PATH", std::env::join_paths(paths).unwrap())
+        .env(
+            "AGENTENV_SKILL_PROPOSER_FIXTURE_JSON",
+            fixture_generalization_json(),
+        )
+        .current_dir(&repo_root)
+        .output()
+        .unwrap();
+
+    assert!(!output.status.success(), "{}", output_summary(&output));
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    assert!(
+        stderr.contains("inside the git worktree"),
+        "stderr was: {stderr}"
+    );
+    assert!(
+        !outside
+            .join("skills/proposed/fs-edit-skill/SKILL.md")
+            .exists(),
+        "proposal should not be emitted through the .agentenv symlink"
+    );
+    assert!(
+        !gh_log.exists(),
+        "gh should not be reached when output preflight fails"
+    );
+    let head = git_stdout(&repo_root, &["symbolic-ref", "--short", "HEAD"]);
+    assert_ne!(head, "agentenv/proposed-skill/fs-edit-skill");
 }
 
 #[cfg(unix)]

--- a/crates/agentenv/tests/cli_behavior.rs
+++ b/crates/agentenv/tests/cli_behavior.rs
@@ -4,7 +4,10 @@ use std::{
     io::{Read, Write},
     path::{Path, PathBuf},
     process::{self, Command},
-    sync::{Arc, Mutex, MutexGuard},
+    sync::{
+        atomic::{AtomicUsize, Ordering},
+        Arc, Mutex, MutexGuard,
+    },
     thread,
     time::{Duration, Instant, SystemTime, UNIX_EPOCH},
 };
@@ -1286,6 +1289,145 @@ fn skills_propose_blocks_metadata_endpoint_before_http_request() {
         "stderr was: {stderr}"
     );
     assert!(stderr.contains("169.254.169.254"), "stderr was: {stderr}");
+}
+
+#[test]
+fn skills_propose_does_not_follow_provider_redirect_to_metadata_endpoint() {
+    let temp_dir = make_temp_dir("skills-propose-redirect-ssrf");
+    let (endpoint, request_count, server) =
+        spawn_redirecting_skill_proposer("http://169.254.169.254/latest/meta-data");
+    let blueprint = temp_dir.join("agentenv.yaml");
+    write_skill_proposer_blueprint(
+        &blueprint,
+        &endpoint,
+        "test-model",
+        "AGENTENV_TEST_SKILL_PROPOSER_REDIRECT_TOKEN",
+    );
+    let db_path = temp_dir.join(".agentenv/events.db");
+    seed_propose_events(&db_path, &blueprint);
+
+    let output = Command::new(agentenv_bin())
+        .arg("skills")
+        .arg("propose")
+        .arg("--from-traces")
+        .arg("--blueprint")
+        .arg(&blueprint)
+        .arg("--events-db")
+        .arg(&db_path)
+        .arg("--json")
+        .env("HOME", &temp_dir)
+        .env("AGENTENV_DISABLE_KEYRING", "1")
+        .env("AGENTENV_SKILL_PROPOSER_ALLOW_LOCAL_ENDPOINTS", "1")
+        .env("AGENTENV_SKILL_PROPOSER_HTTP_TIMEOUT_MS", "100")
+        .env(
+            "AGENTENV_TEST_SKILL_PROPOSER_REDIRECT_TOKEN",
+            "redirect-token",
+        )
+        .current_dir(&temp_dir)
+        .output()
+        .unwrap();
+    server.join().unwrap();
+
+    assert!(!output.status.success(), "{}", output_summary(&output));
+    assert_eq!(request_count.load(Ordering::SeqCst), 1);
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    assert!(
+        stderr.contains("307 Temporary Redirect"),
+        "stderr was: {stderr}"
+    );
+    assert!(
+        stderr.contains("redirecting to metadata"),
+        "stderr was: {stderr}"
+    );
+}
+
+#[test]
+fn skills_propose_blocks_private_endpoint_with_only_local_opt_in() {
+    let temp_dir = make_temp_dir("skills-propose-private-local-only");
+    let blueprint = temp_dir.join("agentenv.yaml");
+    write_skill_proposer_blueprint(
+        &blueprint,
+        "http://10.0.0.1/v1/chat/completions",
+        "test-model",
+        "AGENTENV_TEST_SKILL_PROPOSER_PRIVATE_LOCAL_TOKEN",
+    );
+    let db_path = temp_dir.join(".agentenv/events.db");
+    seed_propose_events(&db_path, &blueprint);
+
+    let output = Command::new(agentenv_bin())
+        .arg("skills")
+        .arg("propose")
+        .arg("--from-traces")
+        .arg("--blueprint")
+        .arg(&blueprint)
+        .arg("--events-db")
+        .arg(&db_path)
+        .arg("--json")
+        .env("HOME", &temp_dir)
+        .env("AGENTENV_DISABLE_KEYRING", "1")
+        .env("AGENTENV_SKILL_PROPOSER_ALLOW_LOCAL_ENDPOINTS", "1")
+        .env("AGENTENV_SKILL_PROPOSER_HTTP_TIMEOUT_MS", "100")
+        .env(
+            "AGENTENV_TEST_SKILL_PROPOSER_PRIVATE_LOCAL_TOKEN",
+            "private-local-token",
+        )
+        .current_dir(&temp_dir)
+        .output()
+        .unwrap();
+
+    assert!(!output.status.success(), "{}", output_summary(&output));
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    assert!(
+        stderr.contains("skill proposal LLM endpoint was blocked"),
+        "stderr was: {stderr}"
+    );
+    assert!(stderr.contains("10.0.0.1"), "stderr was: {stderr}");
+}
+
+#[test]
+fn skills_propose_private_endpoint_opt_in_reaches_request_layer() {
+    let temp_dir = make_temp_dir("skills-propose-private-opt-in");
+    let blueprint = temp_dir.join("agentenv.yaml");
+    write_skill_proposer_blueprint(
+        &blueprint,
+        "http://10.0.0.1/v1/chat/completions",
+        "test-model",
+        "AGENTENV_TEST_SKILL_PROPOSER_PRIVATE_TOKEN",
+    );
+    let db_path = temp_dir.join(".agentenv/events.db");
+    seed_propose_events(&db_path, &blueprint);
+
+    let output = Command::new(agentenv_bin())
+        .arg("skills")
+        .arg("propose")
+        .arg("--from-traces")
+        .arg("--blueprint")
+        .arg(&blueprint)
+        .arg("--events-db")
+        .arg(&db_path)
+        .arg("--json")
+        .env("HOME", &temp_dir)
+        .env("AGENTENV_DISABLE_KEYRING", "1")
+        .env("AGENTENV_SKILL_PROPOSER_ALLOW_PRIVATE_ENDPOINTS", "1")
+        .env("AGENTENV_SKILL_PROPOSER_HTTP_TIMEOUT_MS", "100")
+        .env(
+            "AGENTENV_TEST_SKILL_PROPOSER_PRIVATE_TOKEN",
+            "private-token",
+        )
+        .current_dir(&temp_dir)
+        .output()
+        .unwrap();
+
+    assert!(!output.status.success(), "{}", output_summary(&output));
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    assert!(
+        !stderr.contains("skill proposal LLM endpoint was blocked"),
+        "stderr was: {stderr}"
+    );
+    assert!(
+        stderr.contains("skill proposal LLM request failed"),
+        "stderr was: {stderr}"
+    );
 }
 
 #[test]
@@ -5396,6 +5538,52 @@ fn spawn_erroring_skill_proposer(secret: &str, suffix: String) -> (String, threa
     });
 
     (endpoint, handle)
+}
+
+fn spawn_redirecting_skill_proposer(
+    location: &str,
+) -> (String, Arc<AtomicUsize>, thread::JoinHandle<()>) {
+    let listener = std::net::TcpListener::bind(("127.0.0.1", 0)).unwrap();
+    listener.set_nonblocking(true).unwrap();
+    let endpoint = format!(
+        "http://{}/v1/chat/completions",
+        listener.local_addr().unwrap()
+    );
+    let request_count = Arc::new(AtomicUsize::new(0));
+    let request_count_for_thread = Arc::clone(&request_count);
+    let location = location.to_owned();
+    let handle = thread::spawn(move || {
+        let deadline = Instant::now() + LOCAL_HTTP_TEST_TIMEOUT;
+        let (mut stream, _) = loop {
+            match listener.accept() {
+                Ok(accepted) => break accepted,
+                Err(error) if error.kind() == std::io::ErrorKind::WouldBlock => {
+                    assert!(
+                        Instant::now() < deadline,
+                        "timed out waiting for redirecting test request"
+                    );
+                    thread::sleep(Duration::from_millis(20));
+                }
+                Err(error) => panic!("accept redirecting test request: {error}"),
+            }
+        };
+        request_count_for_thread.fetch_add(1, Ordering::SeqCst);
+        stream.set_nonblocking(false).unwrap();
+        stream
+            .set_read_timeout(Some(LOCAL_HTTP_TEST_TIMEOUT))
+            .unwrap();
+        let _request = read_http_request(&mut stream);
+        let body = format!("redirecting to metadata: {location}");
+        write!(
+            stream,
+            "HTTP/1.1 307 Temporary Redirect\r\nlocation: {location}\r\ncontent-type: text/plain\r\ncontent-length: {}\r\nconnection: close\r\n\r\n{}",
+            body.len(),
+            body
+        )
+        .unwrap();
+    });
+
+    (endpoint, request_count, handle)
 }
 
 fn write_skill_proposer_blueprint(blueprint: &Path, endpoint: &str, model: &str, credential: &str) {

--- a/crates/agentenv/tests/cli_behavior.rs
+++ b/crates/agentenv/tests/cli_behavior.rs
@@ -4,7 +4,7 @@ use std::{
     io::{Read, Write},
     path::{Path, PathBuf},
     process::{self, Command},
-    sync::{Mutex, MutexGuard},
+    sync::{Arc, Mutex, MutexGuard},
     thread,
     time::{Duration, Instant, SystemTime, UNIX_EPOCH},
 };
@@ -1078,6 +1078,115 @@ fn skills_propose_from_traces_emits_local_proposal_with_fake_llm() {
     assert!(out.join("fs-edit-skill/SKILL.md").is_file());
     let json: serde_json::Value = serde_json::from_slice(&output.stdout).unwrap();
     assert_eq!(json["proposals"][0]["name"], "fs-edit-skill");
+}
+
+#[test]
+fn skills_propose_without_configured_llm_fails_clearly() {
+    let temp_dir = make_temp_dir("skills-propose-missing-llm");
+    let blueprint = temp_dir.join("myapp.yaml");
+    fs::write(&blueprint, "version: 0.1.0\n").unwrap();
+    let db_path = temp_dir.join(".agentenv/events.db");
+    let store = SqliteEventStore::open(&db_path).unwrap();
+    let blueprint_id = blueprint_digest(&blueprint);
+    store
+        .append_many(&[
+            propose_event("trace-1", &blueprint_id, "fs_read", "/repo/a.rs"),
+            propose_event("trace-2", &blueprint_id, "fs_read", "/repo/b.rs"),
+            propose_event("trace-3", &blueprint_id, "fs_read", "/repo/c.rs"),
+        ])
+        .unwrap();
+
+    let output = Command::new(agentenv_bin())
+        .arg("skills")
+        .arg("propose")
+        .arg("--from-traces")
+        .arg("--blueprint")
+        .arg(&blueprint)
+        .arg("--events-db")
+        .arg(&db_path)
+        .env("HOME", &temp_dir)
+        .current_dir(&temp_dir)
+        .output()
+        .unwrap();
+
+    assert!(!output.status.success());
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    assert!(
+        stderr.contains("skill proposal LLM provider is not configured"),
+        "stderr was: {stderr}"
+    );
+}
+
+#[test]
+fn skills_propose_uses_configured_openai_compatible_provider_and_env_credential() {
+    let temp_dir = make_temp_dir("skills-propose-http-provider");
+    let (endpoint, captured_request, server) =
+        spawn_openai_compatible_skill_proposer(fixture_generalization_json());
+    let blueprint = temp_dir.join("agentenv.yaml");
+    fs::write(
+        &blueprint,
+        format!(
+            r#"
+version: 0.1.0
+sandbox: {{ driver: openshell }}
+agent: {{ driver: codex }}
+context: {{ driver: filesystem, mount: . }}
+skills:
+  proposal:
+    llm:
+      provider: openai-compatible
+      endpoint: {endpoint}
+      model: test-model
+      credential: AGENTENV_TEST_SKILL_PROPOSER_TOKEN
+"#
+        ),
+    )
+    .unwrap();
+    let db_path = temp_dir.join(".agentenv/events.db");
+    let store = SqliteEventStore::open(&db_path).unwrap();
+    let blueprint_id = blueprint_digest(&blueprint);
+    store
+        .append_many(&[
+            propose_event("trace-1", &blueprint_id, "fs_read", "/repo/a.rs"),
+            propose_event("trace-2", &blueprint_id, "fs_read", "/repo/b.rs"),
+            propose_event("trace-3", &blueprint_id, "fs_read", "/repo/c.rs"),
+        ])
+        .unwrap();
+
+    let out = temp_dir.join("proposed");
+    let output = Command::new(agentenv_bin())
+        .arg("skills")
+        .arg("propose")
+        .arg("--from-traces")
+        .arg("--blueprint")
+        .arg(&blueprint)
+        .arg("--events-db")
+        .arg(&db_path)
+        .arg("--out")
+        .arg(&out)
+        .arg("--json")
+        .env("HOME", &temp_dir)
+        .env("AGENTENV_DISABLE_KEYRING", "1")
+        .env("AGENTENV_TEST_SKILL_PROPOSER_TOKEN", "test-token")
+        .current_dir(&temp_dir)
+        .output()
+        .unwrap();
+    server.join().unwrap();
+
+    assert!(output.status.success(), "{}", output_summary(&output));
+    assert!(out.join("fs-edit-skill/SKILL.md").is_file());
+    let json: serde_json::Value = serde_json::from_slice(&output.stdout).unwrap();
+    assert_eq!(json["proposals"][0]["name"], "fs-edit-skill");
+    let request = captured_request.lock().unwrap().clone().unwrap();
+    assert!(
+        request.contains("authorization: Bearer test-token")
+            || request.contains("Authorization: Bearer test-token"),
+        "request was: {request}"
+    );
+    assert!(
+        request.contains(r#""model":"test-model""#),
+        "request was: {request}"
+    );
 }
 
 #[test]
@@ -5024,6 +5133,88 @@ fn reserve_tcp_port() -> u16 {
         .local_addr()
         .unwrap()
         .port()
+}
+
+fn spawn_openai_compatible_skill_proposer(
+    content: String,
+) -> (String, Arc<Mutex<Option<String>>>, thread::JoinHandle<()>) {
+    let listener = std::net::TcpListener::bind(("127.0.0.1", 0)).unwrap();
+    listener.set_nonblocking(true).unwrap();
+    let endpoint = format!(
+        "http://{}/v1/chat/completions",
+        listener.local_addr().unwrap()
+    );
+    let captured_request = Arc::new(Mutex::new(None));
+    let captured_for_thread = Arc::clone(&captured_request);
+    let handle = thread::spawn(move || {
+        let deadline = Instant::now() + LOCAL_HTTP_TEST_TIMEOUT;
+        let (mut stream, _) = loop {
+            match listener.accept() {
+                Ok(accepted) => break accepted,
+                Err(error) if error.kind() == std::io::ErrorKind::WouldBlock => {
+                    assert!(
+                        Instant::now() < deadline,
+                        "timed out waiting for OpenAI-compatible test request"
+                    );
+                    thread::sleep(Duration::from_millis(20));
+                }
+                Err(error) => panic!("accept OpenAI-compatible test request: {error}"),
+            }
+        };
+        stream
+            .set_read_timeout(Some(LOCAL_HTTP_TEST_TIMEOUT))
+            .unwrap();
+        let request = read_http_request(&mut stream);
+        *captured_for_thread.lock().unwrap() = Some(request);
+        let body = serde_json::json!({
+            "choices": [{"message": {"content": content}}],
+        })
+        .to_string();
+        write!(
+            stream,
+            "HTTP/1.1 200 OK\r\ncontent-type: application/json\r\ncontent-length: {}\r\nconnection: close\r\n\r\n{}",
+            body.len(),
+            body
+        )
+        .unwrap();
+    });
+
+    (endpoint, captured_request, handle)
+}
+
+fn read_http_request(stream: &mut std::net::TcpStream) -> String {
+    let mut bytes = Vec::new();
+    let mut buffer = [0; 1024];
+    loop {
+        let count = stream.read(&mut buffer).unwrap();
+        assert!(count != 0, "connection closed before request headers");
+        bytes.extend_from_slice(&buffer[..count]);
+        if let Some(header_end) = find_header_end(&bytes) {
+            let headers = String::from_utf8_lossy(&bytes[..header_end]).to_string();
+            let content_length = headers
+                .lines()
+                .find_map(|line| {
+                    let (name, value) = line.split_once(':')?;
+                    if name.eq_ignore_ascii_case("content-length") {
+                        value.trim().parse::<usize>().ok()
+                    } else {
+                        None
+                    }
+                })
+                .unwrap_or(0);
+            let target_len = header_end + 4 + content_length;
+            while bytes.len() < target_len {
+                let count = stream.read(&mut buffer).unwrap();
+                assert!(count != 0, "connection closed before request body");
+                bytes.extend_from_slice(&buffer[..count]);
+            }
+            return String::from_utf8_lossy(&bytes).to_string();
+        }
+    }
+}
+
+fn find_header_end(bytes: &[u8]) -> Option<usize> {
+    bytes.windows(4).position(|window| window == b"\r\n\r\n")
 }
 
 struct ApprovalsServerChild {

--- a/crates/agentenv/tests/cli_behavior.rs
+++ b/crates/agentenv/tests/cli_behavior.rs
@@ -1081,6 +1081,90 @@ fn skills_propose_from_traces_emits_local_proposal_with_fake_llm() {
 }
 
 #[test]
+fn skills_propose_missing_explicit_events_db_fails_clearly() {
+    let temp_dir = make_temp_dir("skills-propose-missing-events-db");
+    let blueprint = temp_dir.join("myapp.yaml");
+    fs::write(
+        &blueprint,
+        "version: 0.1.0\nsandbox: { driver: openshell }\nagent: { driver: codex }\ncontext: { driver: filesystem, mount: . }\n",
+    )
+    .unwrap();
+    let db_path = temp_dir.join(".agentenv/missing-events.db");
+
+    let output = Command::new(agentenv_bin())
+        .arg("skills")
+        .arg("propose")
+        .arg("--from-traces")
+        .arg("--blueprint")
+        .arg(&blueprint)
+        .arg("--events-db")
+        .arg(&db_path)
+        .arg("--llm-provider")
+        .arg("fixture")
+        .arg("--json")
+        .env("HOME", &temp_dir)
+        .env(
+            "AGENTENV_SKILL_PROPOSER_FIXTURE_JSON",
+            fixture_generalization_json(),
+        )
+        .current_dir(&temp_dir)
+        .output()
+        .unwrap();
+
+    assert!(!output.status.success(), "{}", output_summary(&output));
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    assert!(stdout.trim().is_empty(), "stdout was: {stdout}");
+    assert!(stderr.contains("events DB"), "stderr was: {stderr}");
+    assert!(
+        stderr.contains(&db_path.display().to_string()),
+        "stderr was: {stderr}"
+    );
+}
+
+#[test]
+fn skills_propose_empty_events_db_json_warns_without_stderr_warning() {
+    let temp_dir = make_temp_dir("skills-propose-empty-events-db");
+    let blueprint = temp_dir.join("myapp.yaml");
+    fs::write(
+        &blueprint,
+        "version: 0.1.0\nsandbox: { driver: openshell }\nagent: { driver: codex }\ncontext: { driver: filesystem, mount: . }\n",
+    )
+    .unwrap();
+    let db_path = temp_dir.join(".agentenv/events.db");
+    SqliteEventStore::open(&db_path).unwrap();
+
+    let output = Command::new(agentenv_bin())
+        .arg("skills")
+        .arg("propose")
+        .arg("--from-traces")
+        .arg("--blueprint")
+        .arg(&blueprint)
+        .arg("--events-db")
+        .arg(&db_path)
+        .arg("--llm-provider")
+        .arg("fixture")
+        .arg("--json")
+        .env("HOME", &temp_dir)
+        .env(
+            "AGENTENV_SKILL_PROPOSER_FIXTURE_JSON",
+            fixture_generalization_json(),
+        )
+        .current_dir(&temp_dir)
+        .output()
+        .unwrap();
+
+    assert!(output.status.success(), "{}", output_summary(&output));
+    let json: serde_json::Value = serde_json::from_slice(&output.stdout).unwrap();
+    assert_eq!(json["proposals"].as_array().unwrap().len(), 0);
+    assert!(!json["warnings"].as_array().unwrap().is_empty());
+    let warning = json["warnings"][0].as_str().unwrap();
+    assert!(warning.contains("No traces"), "warning was: {warning}");
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    assert!(!stderr.contains(warning), "stderr was: {stderr}");
+}
+
+#[test]
 fn skills_verify_all_succeeds_for_valid_local_cache() {
     let temp_dir = make_temp_dir("skills-verify-valid");
     write_cli_cache_skill(

--- a/docs/superpowers/plans/2026-05-11-m7-6-trace-skill-proposer.md
+++ b/docs/superpowers/plans/2026-05-11-m7-6-trace-skill-proposer.md
@@ -1,0 +1,2551 @@
+# M7-6 Trace Skill Proposer Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Add `agentenv skills propose --from-traces` so successful activity traces can produce scored, self-tested, PR-ready skill draft proposals.
+
+**Architecture:** Add trace-oriented readers in `agentenv-events`, a focused proposal pipeline under `agentenv-core::skills::propose`, and a thin CLI facade under `agentenv skills propose`. Core owns deterministic extraction, validation, scoring, self-test, and proposal emission; the CLI owns config, credentials, OpenAI-compatible HTTP providers, and optional `git`/`gh` PR publishing.
+
+**Tech Stack:** Rust 2021, `clap`, `serde`, `serde_json`, `serde_yaml`, `rusqlite`, `reqwest` with `rustls`, `time`, existing `agentenv-events`, `agentenv-core::skills`, and `agentenv-credstore`.
+
+---
+
+## File Structure
+
+- Create: `crates/agentenv-events/src/trace.rs`
+- Modify: `crates/agentenv-events/src/lib.rs`
+- Create: `crates/agentenv-events/tests/trace_query.rs`
+- Create: `crates/agentenv-core/src/skills/propose/mod.rs`
+- Create: `crates/agentenv-core/src/skills/propose/model.rs`
+- Create: `crates/agentenv-core/src/skills/propose/extract.rs`
+- Create: `crates/agentenv-core/src/skills/propose/generalize.rs`
+- Create: `crates/agentenv-core/src/skills/propose/score.rs`
+- Create: `crates/agentenv-core/src/skills/propose/self_test.rs`
+- Create: `crates/agentenv-core/src/skills/propose/emit.rs`
+- Create: `crates/agentenv-core/src/skills/propose/service.rs`
+- Modify: `crates/agentenv-core/src/skills/mod.rs`
+- Modify: `crates/agentenv-core/src/skills/config.rs`
+- Modify: `crates/agentenv-core/src/skills/error.rs`
+- Create: `crates/agentenv-core/tests/skill_propose.rs`
+- Create: `crates/agentenv/src/skills_propose_cli.rs`
+- Modify: `crates/agentenv/src/main.rs`
+- Modify: `crates/agentenv/src/skills_cli.rs`
+- Modify: `crates/agentenv/tests/cli_behavior.rs`
+- Reference: `docs/superpowers/specs/2026-05-11-m7-6-trace-skill-proposer-design.md`
+
+## Task 1: Activity Trace Query API
+
+**Files:**
+- Create: `crates/agentenv-events/tests/trace_query.rs`
+- Create: `crates/agentenv-events/src/trace.rs`
+- Modify: `crates/agentenv-events/src/lib.rs`
+
+- [ ] **Step 1: Write failing trace query tests**
+
+Create `crates/agentenv-events/tests/trace_query.rs`:
+
+```rust
+use agentenv_events::{
+    trace::{TraceQuery, TraceRun},
+    ActivityEvent, ActivityKind, ActivityResult, SqliteEventStore,
+};
+
+#[test]
+fn trace_query_groups_successful_mcp_calls_by_trace_id_and_blueprint() {
+    let temp = tempfile::tempdir().unwrap();
+    let store = SqliteEventStore::open(temp.path().join("events.db")).unwrap();
+    store
+        .append_many(&[
+            event("trace-a", 1, "demo", "sha256:blueprint-a", "fs_read", ActivityResult::Ok),
+            event("trace-a", 2, "demo", "sha256:blueprint-a", "fs_write", ActivityResult::Ok),
+            event("trace-b", 1, "demo", "sha256:blueprint-a", "fs_read", ActivityResult::Ok),
+            event("trace-c", 1, "demo", "sha256:blueprint-b", "fs_read", ActivityResult::Ok),
+        ])
+        .unwrap();
+
+    let traces = store
+        .query_trace_runs(TraceQuery {
+            blueprint_id: "sha256:blueprint-a".to_owned(),
+            env: Some("demo".to_owned()),
+            limit: 100,
+        })
+        .unwrap();
+
+    assert_eq!(traces.len(), 2);
+    assert_eq!(trace(&traces, "trace-a").calls.len(), 2);
+    assert_eq!(trace(&traces, "trace-a").calls[0].tool, "fs_read");
+    assert_eq!(trace(&traces, "trace-a").calls[1].tool, "fs_write");
+    assert_eq!(trace(&traces, "trace-b").calls.len(), 1);
+}
+
+#[test]
+fn trace_query_excludes_denied_pending_and_error_traces() {
+    let temp = tempfile::tempdir().unwrap();
+    let store = SqliteEventStore::open(temp.path().join("events.db")).unwrap();
+    store
+        .append_many(&[
+            event("ok-trace", 1, "demo", "sha256:blueprint-a", "fs_read", ActivityResult::Ok),
+            event("denied-trace", 1, "demo", "sha256:blueprint-a", "fs_read", ActivityResult::Ok),
+            ActivityEvent::new(
+                "2026-05-11T00:00:02Z",
+                ActivityKind::EgressDenied,
+                ActivityResult::Denied,
+                "denied-trace",
+            )
+            .with_env("demo")
+            .with_extra("blueprint_id", serde_json::json!("sha256:blueprint-a")),
+            event("error-trace", 1, "demo", "sha256:blueprint-a", "fs_read", ActivityResult::Error),
+            ActivityEvent::new(
+                "2026-05-11T00:00:03Z",
+                ActivityKind::ApprovalRequested,
+                ActivityResult::PendingApproval,
+                "pending-trace",
+            )
+            .with_env("demo")
+            .with_extra("blueprint_id", serde_json::json!("sha256:blueprint-a")),
+        ])
+        .unwrap();
+
+    let traces = store
+        .query_trace_runs(TraceQuery {
+            blueprint_id: "sha256:blueprint-a".to_owned(),
+            env: Some("demo".to_owned()),
+            limit: 100,
+        })
+        .unwrap();
+
+    assert_eq!(traces.iter().map(|trace| trace.trace_id.as_str()).collect::<Vec<_>>(), vec!["ok-trace"]);
+}
+
+fn event(
+    trace_id: &str,
+    ordinal: u32,
+    env: &str,
+    blueprint_id: &str,
+    tool: &str,
+    result: ActivityResult,
+) -> ActivityEvent {
+    ActivityEvent::new(
+        format!("2026-05-11T00:00:{ordinal:02}Z"),
+        ActivityKind::McpToolCall,
+        result,
+        trace_id,
+    )
+    .with_env(env)
+    .with_subject_value("tool", serde_json::json!(tool))
+    .with_subject_value("arguments", serde_json::json!({"path": format!("file-{ordinal}.rs")}))
+    .with_extra("blueprint_id", serde_json::json!(blueprint_id))
+}
+
+fn trace<'a>(traces: &'a [TraceRun], trace_id: &str) -> &'a TraceRun {
+    traces
+        .iter()
+        .find(|trace| trace.trace_id == trace_id)
+        .unwrap()
+}
+```
+
+- [ ] **Step 2: Run tests and verify failure**
+
+Run:
+
+```bash
+cargo test -p agentenv-events --test trace_query
+```
+
+Expected: FAIL because `agentenv_events::trace` and `SqliteEventStore::query_trace_runs` do not exist.
+
+- [ ] **Step 3: Add trace models and query implementation**
+
+Create `crates/agentenv-events/src/trace.rs`:
+
+```rust
+use serde::{Deserialize, Serialize};
+use serde_json::Value;
+
+use crate::{ActivityResult, StoredEvent};
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct TraceQuery {
+    pub blueprint_id: String,
+    pub env: Option<String>,
+    pub limit: usize,
+}
+
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+pub struct TraceRun {
+    pub trace_id: String,
+    pub env: Option<String>,
+    pub blueprint_id: String,
+    pub started_at: String,
+    pub calls: Vec<TraceToolCall>,
+    pub terminal_result: ActivityResult,
+    pub event_ids: Vec<i64>,
+}
+
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+pub struct TraceToolCall {
+    pub event_id: i64,
+    pub ordinal: u32,
+    pub tool: String,
+    pub args: Value,
+    pub result: ActivityResult,
+    pub subject: Value,
+}
+
+pub(crate) fn event_blueprint_id(event: &crate::ActivityEvent) -> Option<&str> {
+    event.extras.get("blueprint_id").and_then(Value::as_str)
+}
+
+pub(crate) fn event_tool_name(event: &crate::ActivityEvent) -> Option<&str> {
+    event.subject.get("tool").and_then(Value::as_str)
+}
+
+pub(crate) fn event_arguments(event: &crate::ActivityEvent) -> Value {
+    event
+        .subject
+        .get("arguments")
+        .cloned()
+        .unwrap_or(Value::Object(Default::default()))
+}
+
+pub(crate) fn stored_event_id(row: &StoredEvent) -> i64 {
+    row.id
+}
+```
+
+Modify `crates/agentenv-events/src/lib.rs`:
+
+```rust
+pub mod trace;
+pub use trace::{TraceQuery, TraceRun, TraceToolCall};
+```
+
+Add `query_trace_runs` to `impl SqliteEventStore` in `crates/agentenv-events/src/store.rs`:
+
+```rust
+pub fn query_trace_runs(&self, query: crate::trace::TraceQuery) -> StoreResult<Vec<crate::trace::TraceRun>> {
+    use crate::trace::{event_arguments, event_blueprint_id, event_tool_name, TraceRun, TraceToolCall};
+    use std::collections::{BTreeMap, BTreeSet};
+
+    let rows = self.query(EventQuery {
+        env: query.env.clone(),
+        limit: query.limit.clamp(1, 10_000),
+        ..EventQuery::default()
+    })?;
+
+    let mut excluded = BTreeSet::new();
+    let mut grouped: BTreeMap<String, Vec<StoredEvent>> = BTreeMap::new();
+
+    for row in rows {
+        if event_blueprint_id(&row.event) != Some(query.blueprint_id.as_str()) {
+            continue;
+        }
+        let trace_id = row.event.trace_id.clone();
+        if row.event.kind == ActivityKind::EgressDenied
+            || row.event.kind == ActivityKind::SpawnRejected
+            || row.event.result == ActivityResult::Denied
+            || row.event.result == ActivityResult::PendingApproval
+            || row.event.result == ActivityResult::Error
+        {
+            excluded.insert(trace_id);
+            continue;
+        }
+        grouped.entry(trace_id).or_default().push(row);
+    }
+
+    let mut runs = Vec::new();
+    for (trace_id, mut rows) in grouped {
+        if excluded.contains(&trace_id) {
+            continue;
+        }
+        rows.sort_by_key(|row| row.id);
+        let mut calls = Vec::new();
+        for row in &rows {
+            if row.event.kind != ActivityKind::McpToolCall {
+                continue;
+            }
+            let Some(tool) = event_tool_name(&row.event) else {
+                continue;
+            };
+            calls.push(TraceToolCall {
+                event_id: row.id,
+                ordinal: calls.len() as u32,
+                tool: tool.to_owned(),
+                args: event_arguments(&row.event),
+                result: row.event.result,
+                subject: serde_json::to_value(&row.event.subject)?,
+            });
+        }
+        if calls.is_empty() {
+            continue;
+        }
+        let started_at = rows
+            .first()
+            .map(|row| row.event.ts.clone())
+            .unwrap_or_default();
+        let env = rows.iter().find_map(|row| row.event.env.clone());
+        let event_ids = rows.iter().map(|row| row.id).collect();
+        runs.push(TraceRun {
+            trace_id,
+            env,
+            blueprint_id: query.blueprint_id.clone(),
+            started_at,
+            calls,
+            terminal_result: ActivityResult::Ok,
+            event_ids,
+        });
+    }
+    runs.sort_by(|left, right| left.trace_id.cmp(&right.trace_id));
+    Ok(runs)
+}
+```
+
+- [ ] **Step 4: Run tests and verify pass**
+
+Run:
+
+```bash
+cargo test -p agentenv-events --test trace_query
+```
+
+Expected: PASS with 2 tests passing.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add crates/agentenv-events/src/lib.rs crates/agentenv-events/src/store.rs crates/agentenv-events/src/trace.rs crates/agentenv-events/tests/trace_query.rs
+git commit -m "feat: add activity trace queries"
+```
+
+## Task 2: Proposal Models And Extraction
+
+**Files:**
+- Create: `crates/agentenv-core/tests/skill_propose.rs`
+- Create: `crates/agentenv-core/src/skills/propose/mod.rs`
+- Create: `crates/agentenv-core/src/skills/propose/model.rs`
+- Create: `crates/agentenv-core/src/skills/propose/extract.rs`
+- Modify: `crates/agentenv-core/src/skills/mod.rs`
+
+- [ ] **Step 1: Write failing extraction tests**
+
+Append to `crates/agentenv-core/tests/skill_propose.rs`:
+
+```rust
+use agentenv_core::skills::propose::{
+    extract_candidates, normalize_args_shape, CandidateExtractionOptions, ProposalCandidate,
+};
+use agentenv_events::{ActivityResult, TraceRun, TraceToolCall};
+
+#[test]
+fn extraction_finds_repeated_tool_sequences_for_distinct_traces() {
+    let traces = vec![
+        trace("trace-1", vec![call("fs_read", "/repo/a.rs"), call("fs_write", "/repo/a.rs")]),
+        trace("trace-2", vec![call("fs_read", "/repo/b.rs"), call("fs_write", "/repo/b.rs")]),
+        trace("trace-3", vec![call("fs_read", "/repo/c.rs"), call("fs_write", "/repo/c.rs")]),
+        trace("trace-4", vec![call("fs_read", "/repo/solo.rs")]),
+    ];
+
+    let candidates = extract_candidates(
+        &traces,
+        CandidateExtractionOptions {
+            blueprint_id: "sha256:blueprint-a".to_owned(),
+            min_occurrences: 3,
+        },
+    )
+    .unwrap();
+
+    assert_eq!(candidates.len(), 1);
+    assert_eq!(candidates[0].occurrences, 3);
+    assert_eq!(candidates[0].sequence.iter().map(|call| call.tool.as_str()).collect::<Vec<_>>(), vec!["fs_read", "fs_write"]);
+    assert_eq!(candidates[0].source_trace_ids, vec!["trace-1", "trace-2", "trace-3"]);
+}
+
+#[test]
+fn argument_shape_redacts_secret_like_values() {
+    let shape = normalize_args_shape(&serde_json::json!({
+        "path": "/repo/src/lib.rs",
+        "token": "sk-secret",
+        "nested": {"authorization": "Bearer secret", "count": 1}
+    }));
+
+    let rendered = serde_json::to_string(&shape).unwrap();
+    assert!(!rendered.contains("sk-secret"));
+    assert!(!rendered.contains("Bearer secret"));
+    assert!(rendered.contains("[redacted]"));
+    assert!(rendered.contains("string:path"));
+}
+
+fn trace(trace_id: &str, calls: Vec<TraceToolCall>) -> TraceRun {
+    TraceRun {
+        trace_id: trace_id.to_owned(),
+        env: Some("demo".to_owned()),
+        blueprint_id: "sha256:blueprint-a".to_owned(),
+        started_at: "2026-05-11T00:00:00Z".to_owned(),
+        calls,
+        terminal_result: ActivityResult::Ok,
+        event_ids: Vec::new(),
+    }
+}
+
+fn call(tool: &str, path: &str) -> TraceToolCall {
+    TraceToolCall {
+        event_id: 0,
+        ordinal: 0,
+        tool: tool.to_owned(),
+        args: serde_json::json!({"path": path}),
+        result: ActivityResult::Ok,
+        subject: serde_json::json!({"tool": tool}),
+    }
+}
+```
+
+- [ ] **Step 2: Run tests and verify failure**
+
+Run:
+
+```bash
+cargo test -p agentenv-core --test skill_propose extraction_
+```
+
+Expected: FAIL because `skills::propose` and extraction functions do not exist.
+
+- [ ] **Step 3: Add proposal model and extraction modules**
+
+Create `crates/agentenv-core/src/skills/propose/model.rs`:
+
+```rust
+use serde::{Deserialize, Serialize};
+use serde_json::Value;
+
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+pub struct ProposalCandidate {
+    pub name_seed: String,
+    pub blueprint_id: String,
+    pub fingerprint: String,
+    pub occurrences: usize,
+    pub sequence: Vec<CandidateToolCall>,
+    pub source_trace_ids: Vec<String>,
+    pub redaction_count: usize,
+}
+
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+pub struct CandidateToolCall {
+    pub tool: String,
+    pub args_shape: Value,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct CandidateExtractionOptions {
+    pub blueprint_id: String,
+    pub min_occurrences: usize,
+}
+```
+
+Create `crates/agentenv-core/src/skills/propose/extract.rs`:
+
+```rust
+use std::collections::{BTreeMap, BTreeSet};
+
+use agentenv_events::TraceRun;
+use serde_json::Value;
+
+use super::model::{CandidateExtractionOptions, CandidateToolCall, ProposalCandidate};
+use crate::skills::SkillError;
+
+pub fn normalize_args_shape(value: &Value) -> Value {
+    normalize_value(value).0
+}
+
+pub fn extract_candidates(
+    traces: &[TraceRun],
+    options: CandidateExtractionOptions,
+) -> Result<Vec<ProposalCandidate>, SkillError> {
+    if options.min_occurrences < 2 {
+        return Err(SkillError::InvalidConfig {
+            message: "min occurrences must be at least 2".to_owned(),
+        });
+    }
+
+    let mut groups: BTreeMap<String, (Vec<CandidateToolCall>, BTreeSet<String>, usize)> = BTreeMap::new();
+    for trace in traces {
+        if trace.blueprint_id != options.blueprint_id || trace.calls.is_empty() {
+            continue;
+        }
+        let mut redactions = 0usize;
+        let sequence = trace
+            .calls
+            .iter()
+            .map(|call| {
+                let (args_shape, count) = normalize_value(&call.args);
+                redactions += count;
+                CandidateToolCall {
+                    tool: call.tool.clone(),
+                    args_shape,
+                }
+            })
+            .collect::<Vec<_>>();
+        let fingerprint = fingerprint_for(&sequence)?;
+        let entry = groups
+            .entry(fingerprint)
+            .or_insert_with(|| (sequence, BTreeSet::new(), 0));
+        entry.1.insert(trace.trace_id.clone());
+        entry.2 += redactions;
+    }
+
+    let mut candidates = Vec::new();
+    for (fingerprint, (sequence, trace_ids, redaction_count)) in groups {
+        if trace_ids.len() < options.min_occurrences {
+            continue;
+        }
+        let source_trace_ids = trace_ids.into_iter().collect::<Vec<_>>();
+        let name_seed = sequence
+            .iter()
+            .map(|call| call.tool.replace('_', "-"))
+            .collect::<Vec<_>>()
+            .join("-");
+        candidates.push(ProposalCandidate {
+            name_seed,
+            blueprint_id: options.blueprint_id.clone(),
+            fingerprint,
+            occurrences: source_trace_ids.len(),
+            sequence,
+            source_trace_ids,
+            redaction_count,
+        });
+    }
+    candidates.sort_by(|left, right| right.occurrences.cmp(&left.occurrences).then(left.fingerprint.cmp(&right.fingerprint)));
+    Ok(candidates)
+}
+
+fn normalize_value(value: &Value) -> (Value, usize) {
+    match value {
+        Value::Object(map) => {
+            let mut out = serde_json::Map::new();
+            let mut redactions = 0usize;
+            for (key, value) in map {
+                if is_secret_key(key) {
+                    out.insert(key.clone(), Value::String("[redacted]".to_owned()));
+                    redactions += 1;
+                } else {
+                    let (normalized, count) = normalize_value(value);
+                    out.insert(key.clone(), normalized);
+                    redactions += count;
+                }
+            }
+            (Value::Object(out), redactions)
+        }
+        Value::Array(values) => {
+            let mut redactions = 0usize;
+            let values = values
+                .iter()
+                .map(|value| {
+                    let (normalized, count) = normalize_value(value);
+                    redactions += count;
+                    normalized
+                })
+                .collect();
+            (Value::Array(values), redactions)
+        }
+        Value::String(text) if looks_like_path(text) => (Value::String("string:path".to_owned()), 0),
+        Value::String(text) if looks_like_url(text) => (Value::String("string:url".to_owned()), 0),
+        Value::String(_) => (Value::String("string".to_owned()), 0),
+        Value::Number(_) => (Value::String("number".to_owned()), 0),
+        Value::Bool(_) => (Value::String("bool".to_owned()), 0),
+        Value::Null => (Value::String("null".to_owned()), 0),
+    }
+}
+
+fn is_secret_key(key: &str) -> bool {
+    let key = key.to_ascii_lowercase();
+    key.contains("token") || key.contains("secret") || key.contains("authorization") || key.contains("password")
+}
+
+fn looks_like_path(text: &str) -> bool {
+    text.starts_with('/') || text.contains(".rs") || text.contains(".md") || text.contains(".toml")
+}
+
+fn looks_like_url(text: &str) -> bool {
+    text.starts_with("http://") || text.starts_with("https://")
+}
+
+fn fingerprint_for(sequence: &[CandidateToolCall]) -> Result<String, SkillError> {
+    serde_json::to_string(sequence).map_err(|source| SkillError::InvalidConfig {
+        message: format!("failed to fingerprint proposal candidate: {source}"),
+    })
+}
+```
+
+Create `crates/agentenv-core/src/skills/propose/mod.rs`:
+
+```rust
+mod extract;
+mod model;
+
+pub use extract::{extract_candidates, normalize_args_shape};
+pub use model::{CandidateExtractionOptions, CandidateToolCall, ProposalCandidate};
+```
+
+Modify `crates/agentenv-core/src/skills/mod.rs`:
+
+```rust
+pub mod propose;
+```
+
+- [ ] **Step 4: Run tests and verify pass**
+
+Run:
+
+```bash
+cargo test -p agentenv-core --test skill_propose extraction_
+```
+
+Expected: PASS for the extraction tests.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add crates/agentenv-core/src/skills/mod.rs crates/agentenv-core/src/skills/propose crates/agentenv-core/tests/skill_propose.rs
+git commit -m "feat: extract skill candidates from traces"
+```
+
+## Task 3: Generalization Schema And Validation
+
+**Files:**
+- Modify: `crates/agentenv-core/src/skills/propose/mod.rs`
+- Create: `crates/agentenv-core/src/skills/propose/generalize.rs`
+- Modify: `crates/agentenv-core/src/skills/propose/model.rs`
+- Modify: `crates/agentenv-core/tests/skill_propose.rs`
+
+- [ ] **Step 1: Write failing generalization validation tests**
+
+Append to `crates/agentenv-core/tests/skill_propose.rs`:
+
+```rust
+use agentenv_core::skills::propose::{
+    validate_generalization, ProcedureStep, ProposedSelfTest, SkillGeneralization,
+    TemplateVariable,
+};
+
+#[test]
+fn generalization_validation_accepts_schema_clean_output() {
+    let generalization = SkillGeneralization {
+        name: "fs-edit-skill".to_owned(),
+        description: "Edit a repeated filesystem target.".to_owned(),
+        template_variables: vec![TemplateVariable {
+            name: "target_path".to_owned(),
+            description: "Path to the file being edited.".to_owned(),
+            example: "src/lib.rs".to_owned(),
+        }],
+        procedure_steps: vec![ProcedureStep {
+            tool: Some("fs_read".to_owned()),
+            instruction: "Read {{target_path}} before editing.".to_owned(),
+        }],
+        self_test: ProposedSelfTest {
+            command: "test -f SKILL.md".to_owned(),
+        },
+        skill_md_body: "Read {{target_path}} before editing.".to_owned(),
+    };
+
+    validate_generalization(&generalization, &["fs_read".to_owned()]).unwrap();
+}
+
+#[test]
+fn generalization_validation_rejects_invalid_names_and_secret_leaks() {
+    let invalid_name = SkillGeneralization {
+        name: "../bad".to_owned(),
+        description: "Bad".to_owned(),
+        template_variables: Vec::new(),
+        procedure_steps: Vec::new(),
+        self_test: ProposedSelfTest {
+            command: "test -f SKILL.md".to_owned(),
+        },
+        skill_md_body: "Body".to_owned(),
+    };
+    assert!(validate_generalization(&invalid_name, &[]).is_err());
+
+    let secret_body = SkillGeneralization {
+        name: "secret-skill".to_owned(),
+        description: "Bad".to_owned(),
+        template_variables: Vec::new(),
+        procedure_steps: vec![ProcedureStep {
+            tool: Some("fs_read".to_owned()),
+            instruction: "Use token sk-secret".to_owned(),
+        }],
+        self_test: ProposedSelfTest {
+            command: "test -f SKILL.md".to_owned(),
+        },
+        skill_md_body: "token sk-secret".to_owned(),
+    };
+    assert!(validate_generalization(&secret_body, &["fs_read".to_owned()]).is_err());
+}
+```
+
+- [ ] **Step 2: Run tests and verify failure**
+
+Run:
+
+```bash
+cargo test -p agentenv-core --test skill_propose generalization_
+```
+
+Expected: FAIL because generalization models and validation are missing.
+
+- [ ] **Step 3: Add generalization models and validation**
+
+Extend `crates/agentenv-core/src/skills/propose/model.rs`:
+
+```rust
+#[derive(Debug, Clone, PartialEq, serde::Serialize, serde::Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct SkillGeneralization {
+    pub name: String,
+    pub description: String,
+    pub template_variables: Vec<TemplateVariable>,
+    pub procedure_steps: Vec<ProcedureStep>,
+    pub self_test: ProposedSelfTest,
+    pub skill_md_body: String,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, serde::Serialize, serde::Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct TemplateVariable {
+    pub name: String,
+    pub description: String,
+    pub example: String,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, serde::Serialize, serde::Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct ProcedureStep {
+    pub tool: Option<String>,
+    pub instruction: String,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, serde::Serialize, serde::Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct ProposedSelfTest {
+    pub command: String,
+}
+```
+
+Create `crates/agentenv-core/src/skills/propose/generalize.rs`:
+
+```rust
+use std::collections::BTreeSet;
+
+use async_trait::async_trait;
+
+use super::model::SkillGeneralization;
+use crate::skills::{validate_skill_name, SkillError};
+
+#[async_trait]
+pub trait SkillGeneralizer: Send + Sync {
+    async fn generalize(&self, request: SkillGeneralizationRequest) -> Result<SkillGeneralization, SkillError>;
+}
+
+#[derive(Debug, Clone, PartialEq, serde::Serialize, serde::Deserialize)]
+pub struct SkillGeneralizationRequest {
+    pub schema_version: String,
+    pub candidate_json: serde_json::Value,
+    pub existing_skill_summaries: Vec<String>,
+}
+
+pub fn validate_generalization(
+    generalization: &SkillGeneralization,
+    allowed_tools: &[String],
+) -> Result<(), SkillError> {
+    validate_skill_name(&generalization.name)?;
+    require_non_empty("description", &generalization.description)?;
+    require_non_empty("skill_md_body", &generalization.skill_md_body)?;
+    reject_secret_text(&generalization.skill_md_body)?;
+
+    let allowed_tools = allowed_tools.iter().cloned().collect::<BTreeSet<_>>();
+    let variables = generalization
+        .template_variables
+        .iter()
+        .map(|variable| variable.name.clone())
+        .collect::<BTreeSet<_>>();
+    for variable in &generalization.template_variables {
+        validate_skill_name(&variable.name)?;
+        require_non_empty("template variable description", &variable.description)?;
+    }
+    for step in &generalization.procedure_steps {
+        require_non_empty("procedure step instruction", &step.instruction)?;
+        reject_secret_text(&step.instruction)?;
+        if let Some(tool) = &step.tool {
+            if !allowed_tools.contains(tool) {
+                return Err(SkillError::InvalidConfig {
+                    message: format!("generalized step references unknown tool `{tool}`"),
+                });
+            }
+        }
+    }
+    for variable in variables {
+        let marker = format!("{{{{{variable}}}}}");
+        let referenced = generalization.skill_md_body.contains(&marker)
+            || generalization
+                .procedure_steps
+                .iter()
+                .any(|step| step.instruction.contains(&marker));
+        if !referenced {
+            return Err(SkillError::InvalidConfig {
+                message: format!("template variable `{variable}` is not referenced"),
+            });
+        }
+    }
+    require_non_empty("self-test command", &generalization.self_test.command)?;
+    Ok(())
+}
+
+fn require_non_empty(field: &str, value: &str) -> Result<(), SkillError> {
+    if value.trim().is_empty() {
+        return Err(SkillError::InvalidConfig {
+            message: format!("{field} must not be empty"),
+        });
+    }
+    Ok(())
+}
+
+fn reject_secret_text(value: &str) -> Result<(), SkillError> {
+    let lowered = value.to_ascii_lowercase();
+    if lowered.contains("sk-") || lowered.contains("bearer ") || lowered.contains("token ") {
+        return Err(SkillError::InvalidConfig {
+            message: "generalized skill text contains secret-like content".to_owned(),
+        });
+    }
+    Ok(())
+}
+```
+
+Modify `crates/agentenv-core/src/skills/propose/mod.rs`:
+
+```rust
+mod generalize;
+pub use generalize::{validate_generalization, SkillGeneralizationRequest, SkillGeneralizer};
+pub use model::{ProcedureStep, ProposedSelfTest, SkillGeneralization, TemplateVariable};
+```
+
+- [ ] **Step 4: Run tests and verify pass**
+
+Run:
+
+```bash
+cargo test -p agentenv-core --test skill_propose generalization_
+```
+
+Expected: PASS for generalization tests.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add crates/agentenv-core/src/skills/propose crates/agentenv-core/tests/skill_propose.rs
+git commit -m "feat: validate skill proposal generalization"
+```
+
+## Task 4: Novelty And Utility Scoring
+
+**Files:**
+- Create: `crates/agentenv-core/src/skills/propose/score.rs`
+- Modify: `crates/agentenv-core/src/skills/propose/mod.rs`
+- Modify: `crates/agentenv-core/src/skills/propose/model.rs`
+- Modify: `crates/agentenv-core/tests/skill_propose.rs`
+
+- [ ] **Step 1: Write failing scoring tests**
+
+Append to `crates/agentenv-core/tests/skill_propose.rs`:
+
+```rust
+use agentenv_core::skills::propose::{
+    score_proposal, ExistingSkillSummary, NoveltyBackend, ProposalScoreInput,
+};
+
+#[test]
+fn scoring_maps_duplicate_minor_variant_and_new_capability_to_ladder() {
+    let duplicate = score_proposal(ProposalScoreInput {
+        name: "review-skill".to_owned(),
+        description: "Review code changes".to_owned(),
+        procedure_text: "read diff write review".to_owned(),
+        fingerprint: "same".to_owned(),
+        occurrences: 3,
+        existing_skills: vec![ExistingSkillSummary {
+            name: "review-skill".to_owned(),
+            description: "Review code changes".to_owned(),
+            procedure_text: "read diff write review".to_owned(),
+            fingerprint: Some("same".to_owned()),
+        }],
+        backend: NoveltyBackend::Local,
+    })
+    .unwrap();
+    assert_eq!(duplicate.novelty, 0.0);
+
+    let new_capability = score_proposal(ProposalScoreInput {
+        name: "snapshot-skill".to_owned(),
+        description: "Create and verify snapshots".to_owned(),
+        procedure_text: "snapshot verify restore".to_owned(),
+        fingerprint: "new".to_owned(),
+        occurrences: 5,
+        existing_skills: Vec::new(),
+        backend: NoveltyBackend::Local,
+    })
+    .unwrap();
+    assert_eq!(new_capability.novelty, 0.9);
+    assert!(new_capability.utility > 0.5);
+}
+```
+
+- [ ] **Step 2: Run tests and verify failure**
+
+Run:
+
+```bash
+cargo test -p agentenv-core --test skill_propose scoring_
+```
+
+Expected: FAIL because score types and functions are missing.
+
+- [ ] **Step 3: Implement local scoring**
+
+Extend `model.rs`:
+
+```rust
+#[derive(Debug, Clone, PartialEq, serde::Serialize, serde::Deserialize)]
+pub struct ProposalScore {
+    pub novelty: f32,
+    pub utility: f32,
+    pub final_score: f32,
+    pub nearest_matches: Vec<SkillMatch>,
+    pub reasons: Vec<String>,
+}
+
+#[derive(Debug, Clone, PartialEq, serde::Serialize, serde::Deserialize)]
+pub struct SkillMatch {
+    pub name: String,
+    pub similarity: f32,
+    pub reason: String,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct ExistingSkillSummary {
+    pub name: String,
+    pub description: String,
+    pub procedure_text: String,
+    pub fingerprint: Option<String>,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum NoveltyBackend {
+    Local,
+}
+
+#[derive(Debug, Clone, PartialEq)]
+pub struct ProposalScoreInput {
+    pub name: String,
+    pub description: String,
+    pub procedure_text: String,
+    pub fingerprint: String,
+    pub occurrences: usize,
+    pub existing_skills: Vec<ExistingSkillSummary>,
+    pub backend: NoveltyBackend,
+}
+```
+
+Create `score.rs`:
+
+```rust
+use std::collections::BTreeSet;
+
+use super::model::{ProposalScore, ProposalScoreInput, SkillMatch};
+use crate::skills::SkillError;
+
+pub fn score_proposal(input: ProposalScoreInput) -> Result<ProposalScore, SkillError> {
+    let mut best: Option<SkillMatch> = None;
+    let mut novelty = 0.9f32;
+    let mut reasons = Vec::new();
+
+    for existing in &input.existing_skills {
+        if existing.fingerprint.as_deref() == Some(input.fingerprint.as_str()) {
+            novelty = 0.0;
+            best = Some(SkillMatch {
+                name: existing.name.clone(),
+                similarity: 1.0,
+                reason: "exact fingerprint match".to_owned(),
+            });
+            reasons.push("duplicate of existing skill".to_owned());
+            break;
+        }
+        let similarity = jaccard(&input.procedure_text, &existing.procedure_text)
+            .max(jaccard(&input.description, &existing.description));
+        if best.as_ref().is_none_or(|current| similarity > current.similarity) {
+            best = Some(SkillMatch {
+                name: existing.name.clone(),
+                similarity,
+                reason: "local semantic similarity".to_owned(),
+            });
+        }
+    }
+
+    if novelty != 0.0 {
+        if let Some(best) = &best {
+            novelty = if best.similarity >= 0.85 {
+                reasons.push("minor variation of existing skill".to_owned());
+                0.3
+            } else if best.similarity >= 0.45 {
+                reasons.push("distinct variant of existing skill family".to_owned());
+                0.6
+            } else {
+                reasons.push("new capability category".to_owned());
+                0.9
+            };
+        } else {
+            reasons.push("no existing skill matches".to_owned());
+        }
+    }
+
+    let utility = ((input.occurrences as f32) / 5.0).clamp(0.0, 1.0);
+    let final_score = (novelty * 0.7) + (utility * 0.3);
+    Ok(ProposalScore {
+        novelty,
+        utility,
+        final_score,
+        nearest_matches: best.into_iter().collect(),
+        reasons,
+    })
+}
+
+fn jaccard(left: &str, right: &str) -> f32 {
+    let left = tokens(left);
+    let right = tokens(right);
+    if left.is_empty() && right.is_empty() {
+        return 1.0;
+    }
+    let intersection = left.intersection(&right).count() as f32;
+    let union = left.union(&right).count() as f32;
+    if union == 0.0 { 0.0 } else { intersection / union }
+}
+
+fn tokens(value: &str) -> BTreeSet<String> {
+    value
+        .split(|character: char| !character.is_ascii_alphanumeric())
+        .filter(|token| !token.is_empty())
+        .map(|token| token.to_ascii_lowercase())
+        .collect()
+}
+```
+
+Modify `mod.rs` exports:
+
+```rust
+mod score;
+pub use model::{ExistingSkillSummary, NoveltyBackend, ProposalScore, ProposalScoreInput, SkillMatch};
+pub use score::score_proposal;
+```
+
+- [ ] **Step 4: Run tests and verify pass**
+
+Run:
+
+```bash
+cargo test -p agentenv-core --test skill_propose scoring_
+```
+
+Expected: PASS for scoring tests.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add crates/agentenv-core/src/skills/propose crates/agentenv-core/tests/skill_propose.rs
+git commit -m "feat: score proposed skills"
+```
+
+## Task 5: Self-Test Gate
+
+**Files:**
+- Create: `crates/agentenv-core/src/skills/propose/self_test.rs`
+- Modify: `crates/agentenv-core/src/skills/propose/mod.rs`
+- Modify: `crates/agentenv-core/src/skills/propose/model.rs`
+- Modify: `crates/agentenv-core/tests/skill_propose.rs`
+
+- [ ] **Step 1: Write failing self-test tests**
+
+Append to `crates/agentenv-core/tests/skill_propose.rs`:
+
+```rust
+use agentenv_core::skills::propose::{
+    evaluate_self_test, ProposalSelfTestInput,
+};
+
+#[test]
+fn self_test_scores_step_and_variable_coverage() {
+    let report = evaluate_self_test(ProposalSelfTestInput {
+        source_tools: vec!["fs_read".to_owned(), "fs_write".to_owned()],
+        procedure_steps: vec![
+            ProcedureStep {
+                tool: Some("fs_read".to_owned()),
+                instruction: "Read {{target_path}}".to_owned(),
+            },
+            ProcedureStep {
+                tool: Some("fs_write".to_owned()),
+                instruction: "Write {{target_path}}".to_owned(),
+            },
+        ],
+        template_variables: vec![TemplateVariable {
+            name: "target_path".to_owned(),
+            description: "Target path".to_owned(),
+            example: "src/lib.rs".to_owned(),
+        }],
+        min_score: 0.8,
+    })
+    .unwrap();
+
+    assert!(report.passed);
+    assert!(report.score >= 0.8);
+    assert_eq!(report.matched_steps, 2);
+    assert_eq!(report.matched_variables, 1);
+}
+```
+
+- [ ] **Step 2: Run tests and verify failure**
+
+Run:
+
+```bash
+cargo test -p agentenv-core --test skill_propose self_test_
+```
+
+Expected: FAIL because self-test types and evaluator are missing.
+
+- [ ] **Step 3: Implement self-test evaluator**
+
+Extend `model.rs`:
+
+```rust
+#[derive(Debug, Clone, PartialEq)]
+pub struct ProposalSelfTestInput {
+    pub source_tools: Vec<String>,
+    pub procedure_steps: Vec<ProcedureStep>,
+    pub template_variables: Vec<TemplateVariable>,
+    pub min_score: f32,
+}
+
+#[derive(Debug, Clone, PartialEq, serde::Serialize, serde::Deserialize)]
+pub struct ProposalSelfTestReport {
+    pub score: f32,
+    pub passed: bool,
+    pub matched_steps: u32,
+    pub total_steps: u32,
+    pub matched_variables: u32,
+    pub total_variables: u32,
+    pub failures: Vec<String>,
+}
+```
+
+Create `self_test.rs`:
+
+```rust
+use std::collections::BTreeSet;
+
+use super::model::{ProposalSelfTestInput, ProposalSelfTestReport};
+use crate::skills::SkillError;
+
+pub fn evaluate_self_test(input: ProposalSelfTestInput) -> Result<ProposalSelfTestReport, SkillError> {
+    if !(0.0..=1.0).contains(&input.min_score) {
+        return Err(SkillError::InvalidConfig {
+            message: "min self-test score must be between 0.0 and 1.0".to_owned(),
+        });
+    }
+    let source_tools = input.source_tools.iter().cloned().collect::<BTreeSet<_>>();
+    let total_steps = input.procedure_steps.len() as u32;
+    let matched_steps = input
+        .procedure_steps
+        .iter()
+        .filter(|step| step.tool.as_ref().is_some_and(|tool| source_tools.contains(tool)))
+        .count() as u32;
+
+    let all_text = input
+        .procedure_steps
+        .iter()
+        .map(|step| step.instruction.as_str())
+        .collect::<Vec<_>>()
+        .join("\n");
+    let total_variables = input.template_variables.len() as u32;
+    let matched_variables = input
+        .template_variables
+        .iter()
+        .filter(|variable| all_text.contains(&format!("{{{{{}}}}}", variable.name)))
+        .count() as u32;
+
+    let step_score = ratio(matched_steps, total_steps);
+    let variable_score = ratio(matched_variables, total_variables);
+    let score = ((step_score * 0.7) + (variable_score * 0.3)).clamp(0.0, 1.0);
+    let mut failures = Vec::new();
+    if matched_steps != total_steps {
+        failures.push("not every procedure step maps to a source tool".to_owned());
+    }
+    if matched_variables != total_variables {
+        failures.push("not every template variable is referenced by a step".to_owned());
+    }
+
+    Ok(ProposalSelfTestReport {
+        score,
+        passed: score >= input.min_score,
+        matched_steps,
+        total_steps,
+        matched_variables,
+        total_variables,
+        failures,
+    })
+}
+
+fn ratio(matched: u32, total: u32) -> f32 {
+    if total == 0 { 1.0 } else { matched as f32 / total as f32 }
+}
+```
+
+Modify `mod.rs` exports:
+
+```rust
+mod self_test;
+pub use model::{ProposalSelfTestInput, ProposalSelfTestReport};
+pub use self_test::evaluate_self_test;
+```
+
+- [ ] **Step 4: Run tests and verify pass**
+
+Run:
+
+```bash
+cargo test -p agentenv-core --test skill_propose self_test_
+```
+
+Expected: PASS for self-test tests.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add crates/agentenv-core/src/skills/propose crates/agentenv-core/tests/skill_propose.rs
+git commit -m "feat: gate proposals with trace self tests"
+```
+
+## Task 6: Proposal Emission
+
+**Files:**
+- Create: `crates/agentenv-core/src/skills/propose/emit.rs`
+- Modify: `crates/agentenv-core/src/skills/propose/mod.rs`
+- Modify: `crates/agentenv-core/src/skills/propose/model.rs`
+- Modify: `crates/agentenv-core/tests/skill_propose.rs`
+
+- [ ] **Step 1: Write failing proposal writer tests**
+
+Append to `crates/agentenv-core/tests/skill_propose.rs`:
+
+```rust
+use agentenv_core::skills::{
+    load_skill_manifest,
+    propose::{emit_proposal, ProposalEmitInput},
+};
+
+#[test]
+fn proposal_writer_emits_skill_manifest_and_reports() {
+    let temp = tempfile::tempdir().unwrap();
+    let output_root = temp.path().join("proposed");
+    let generalization = valid_generalization();
+    let report = evaluate_self_test(ProposalSelfTestInput {
+        source_tools: vec!["fs_read".to_owned()],
+        procedure_steps: generalization.procedure_steps.clone(),
+        template_variables: generalization.template_variables.clone(),
+        min_score: 0.8,
+    })
+    .unwrap();
+
+    let output = emit_proposal(ProposalEmitInput {
+        output_root: output_root.clone(),
+        candidate: ProposalCandidate {
+            name_seed: "fs-read".to_owned(),
+            blueprint_id: "sha256:blueprint-a".to_owned(),
+            fingerprint: "fingerprint-a".to_owned(),
+            occurrences: 3,
+            sequence: vec![CandidateToolCall {
+                tool: "fs_read".to_owned(),
+                args_shape: serde_json::json!({"path": "string:path"}),
+            }],
+            source_trace_ids: vec!["trace-1".to_owned(), "trace-2".to_owned(), "trace-3".to_owned()],
+            redaction_count: 0,
+        },
+        generalization,
+        score: ProposalScore {
+            novelty: 0.9,
+            utility: 0.6,
+            final_score: 0.81,
+            nearest_matches: Vec::new(),
+            reasons: vec!["no existing skill matches".to_owned()],
+        },
+        self_test: report,
+        agentenv_version: "0.0.1-alpha0".to_owned(),
+        created_at: "2026-05-11T00:00:00Z".to_owned(),
+    })
+    .unwrap();
+
+    assert_eq!(output.name, "fs-edit-skill");
+    assert!(output.path.join("SKILL.md").is_file());
+    assert!(output.path.join("skill.yaml").is_file());
+    assert!(output.path.join("proposal.yaml").is_file());
+    assert!(output.path.join("self-test.json").is_file());
+    assert!(output.path.join("traces/provenance.json").is_file());
+    let manifest = load_skill_manifest(&output.path).unwrap();
+    assert_eq!(manifest.name, "fs-edit-skill");
+    assert_eq!(manifest.entry, std::path::PathBuf::from("SKILL.md"));
+}
+
+fn valid_generalization() -> SkillGeneralization {
+    SkillGeneralization {
+        name: "fs-edit-skill".to_owned(),
+        description: "Edit a repeated filesystem target.".to_owned(),
+        template_variables: vec![TemplateVariable {
+            name: "target_path".to_owned(),
+            description: "Target path".to_owned(),
+            example: "src/lib.rs".to_owned(),
+        }],
+        procedure_steps: vec![ProcedureStep {
+            tool: Some("fs_read".to_owned()),
+            instruction: "Read {{target_path}}.".to_owned(),
+        }],
+        self_test: ProposedSelfTest {
+            command: "test -f SKILL.md".to_owned(),
+        },
+        skill_md_body: "Read {{target_path}}.".to_owned(),
+    }
+}
+```
+
+- [ ] **Step 2: Run tests and verify failure**
+
+Run:
+
+```bash
+cargo test -p agentenv-core --test skill_propose proposal_writer_
+```
+
+Expected: FAIL because `emit_proposal` and writer types are missing.
+
+- [ ] **Step 3: Implement proposal writer**
+
+Extend `model.rs`:
+
+```rust
+#[derive(Debug, Clone)]
+pub struct ProposalEmitInput {
+    pub output_root: std::path::PathBuf,
+    pub candidate: ProposalCandidate,
+    pub generalization: SkillGeneralization,
+    pub score: ProposalScore,
+    pub self_test: ProposalSelfTestReport,
+    pub agentenv_version: String,
+    pub created_at: String,
+}
+
+#[derive(Debug, Clone, PartialEq, serde::Serialize, serde::Deserialize)]
+pub struct ProposalEmitOutput {
+    pub name: String,
+    pub path: std::path::PathBuf,
+    pub novelty: f32,
+    pub self_test_score: f32,
+}
+```
+
+Create `emit.rs` with a staging directory, explicit files, and no overwrite:
+
+```rust
+use std::{fs, path::Path};
+
+use serde::Serialize;
+
+use super::model::{ProposalEmitInput, ProposalEmitOutput};
+use crate::skills::{load_skill_manifest, validate_skill_name, SkillError};
+
+#[derive(Serialize)]
+struct ProposalYaml<'a> {
+    schema_version: &'static str,
+    status: &'static str,
+    blueprint_id: &'a str,
+    occurrences: usize,
+    novelty: f32,
+    utility: f32,
+    self_test_score: f32,
+    generated_by: GeneratedBy<'a>,
+}
+
+#[derive(Serialize)]
+struct GeneratedBy<'a> {
+    agentenv_version: &'a str,
+}
+
+pub fn emit_proposal(input: ProposalEmitInput) -> Result<ProposalEmitOutput, SkillError> {
+    validate_skill_name(&input.generalization.name)?;
+    let output = input.output_root.join(&input.generalization.name);
+    if output.exists() {
+        return Err(SkillError::InvalidConfig {
+            message: format!("proposal output `{}` already exists", output.display()),
+        });
+    }
+    let staging = input.output_root.join(format!(".{}.staging", input.generalization.name));
+    if staging.exists() {
+        fs::remove_dir_all(&staging).map_err(|source| SkillError::Io { path: staging.clone(), source })?;
+    }
+    fs::create_dir_all(staging.join("traces")).map_err(|source| SkillError::Io { path: staging.clone(), source })?;
+
+    write_file(&staging.join("SKILL.md"), render_skill_md(&input))?;
+    write_file(&staging.join("skill.yaml"), render_skill_yaml(&input)?)?;
+    write_file(&staging.join("proposal.yaml"), render_proposal_yaml(&input)?)?;
+    write_file(&staging.join("self-test.json"), json_pretty(&input.self_test, &staging.join("self-test.json"))?)?;
+    write_file(&staging.join("traces/provenance.json"), json_pretty(&input.candidate, &staging.join("traces/provenance.json"))?)?;
+    load_skill_manifest(&staging)?;
+    fs::rename(&staging, &output).map_err(|source| SkillError::Io { path: output.clone(), source })?;
+    Ok(ProposalEmitOutput {
+        name: input.generalization.name,
+        path: output,
+        novelty: input.score.novelty,
+        self_test_score: input.self_test.score,
+    })
+}
+
+fn render_skill_md(input: &ProposalEmitInput) -> String {
+    format!(
+        "---\nname: {}\ndescription: {}\nversion: 0.1.0\ntags: [agentenv-proposed, trace-derived]\nagentenv-proposal: true\nagentenv-schema: \"0.1\"\n---\n\n# {}\n\n{}\n",
+        input.generalization.name,
+        input.generalization.description,
+        input.generalization.name,
+        input.generalization.skill_md_body
+    )
+}
+
+fn render_skill_yaml(input: &ProposalEmitInput) -> Result<String, SkillError> {
+    serde_yaml::to_string(&serde_json::json!({
+        "name": input.generalization.name,
+        "version": "0.1.0",
+        "description": input.generalization.description,
+        "entry": "SKILL.md",
+        "files": ["SKILL.md", "proposal.yaml", "self-test.json", "traces/provenance.json"],
+        "self_test": {"command": input.generalization.self_test.command},
+        "agentenv_proposal": true,
+        "agentenv_schema": "0.1"
+    }))
+    .map_err(|source| SkillError::Serde { path: input.output_root.join("skill.yaml"), source })
+}
+
+fn render_proposal_yaml(input: &ProposalEmitInput) -> Result<String, SkillError> {
+    let value = ProposalYaml {
+        schema_version: "0.1",
+        status: "proposed",
+        blueprint_id: &input.candidate.blueprint_id,
+        occurrences: input.candidate.occurrences,
+        novelty: input.score.novelty,
+        utility: input.score.utility,
+        self_test_score: input.self_test.score,
+        generated_by: GeneratedBy {
+            agentenv_version: &input.agentenv_version,
+        },
+    };
+    serde_yaml::to_string(&value).map_err(|source| SkillError::Serde { path: input.output_root.join("proposal.yaml"), source })
+}
+
+fn write_file(path: &Path, content: String) -> Result<(), SkillError> {
+    if let Some(parent) = path.parent() {
+        fs::create_dir_all(parent).map_err(|source| SkillError::Io { path: parent.to_path_buf(), source })?;
+    }
+    fs::write(path, content).map_err(|source| SkillError::Io { path: path.to_path_buf(), source })
+}
+
+fn json_pretty<T: serde::Serialize>(value: &T, path: &Path) -> Result<String, SkillError> {
+    serde_json::to_string_pretty(value).map_err(|source| SkillError::InvalidConfig {
+        message: format!("failed to serialize `{}`: {source}", path.display()),
+    })
+}
+```
+
+Modify `mod.rs` exports:
+
+```rust
+mod emit;
+pub use emit::emit_proposal;
+pub use model::{ProposalEmitInput, ProposalEmitOutput};
+```
+
+- [ ] **Step 4: Run tests and verify pass**
+
+Run:
+
+```bash
+cargo test -p agentenv-core --test skill_propose proposal_writer_
+```
+
+Expected: PASS for proposal writer tests.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add crates/agentenv-core/src/skills/propose crates/agentenv-core/tests/skill_propose.rs
+git commit -m "feat: emit proposed skill drafts"
+```
+
+## Task 7: Proposal Config Parsing
+
+**Files:**
+- Modify: `crates/agentenv-core/src/skills/config.rs`
+- Modify: `crates/agentenv-core/src/skills/mod.rs`
+- Modify: `crates/agentenv-core/tests/skills.rs`
+
+- [ ] **Step 1: Write failing config tests**
+
+Append to `crates/agentenv-core/tests/skills.rs`:
+
+```rust
+#[test]
+fn skills_config_loads_proposal_provider_settings() {
+    let yaml = r#"
+skills:
+  proposal:
+    llm:
+      provider: default
+      endpoint: https://llm.example.test/v1
+      model: proposal-generalizer
+      credential: AGENTENV_SKILL_PROPOSER_TOKEN
+    semantic:
+      backend: local
+    pr:
+      default_repo: owner/skills
+"#;
+
+    let config = load_project_skills_config(yaml).unwrap();
+    let proposal = config.proposal.unwrap();
+    assert_eq!(proposal.llm.unwrap().provider, "default");
+    assert_eq!(proposal.semantic.unwrap().backend, "local");
+    assert_eq!(proposal.pr.unwrap().default_repo.unwrap(), "owner/skills");
+}
+```
+
+- [ ] **Step 2: Run tests and verify failure**
+
+Run:
+
+```bash
+cargo test -p agentenv-core --test skills skills_config_loads_proposal_provider_settings
+```
+
+Expected: FAIL because `SkillsConfig::proposal` does not exist.
+
+- [ ] **Step 3: Add proposal config types**
+
+Modify `SkillsConfig` in `config.rs`:
+
+```rust
+#[derive(Debug, Clone, Default, serde::Serialize, serde::Deserialize, PartialEq, Eq)]
+pub struct SkillsConfig {
+    #[serde(default)]
+    pub registries: Vec<RegistryConfig>,
+    #[serde(default)]
+    pub registry_order: Vec<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub proposal: Option<ProposalConfig>,
+}
+
+#[derive(Debug, Clone, Default, serde::Serialize, serde::Deserialize, PartialEq, Eq)]
+pub struct ProposalConfig {
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub llm: Option<ProposalLlmConfig>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub semantic: Option<ProposalSemanticConfig>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub pr: Option<ProposalPrConfig>,
+}
+
+#[derive(Debug, Clone, serde::Serialize, serde::Deserialize, PartialEq, Eq)]
+pub struct ProposalLlmConfig {
+    pub provider: String,
+    pub endpoint: String,
+    pub model: String,
+    pub credential: String,
+}
+
+#[derive(Debug, Clone, serde::Serialize, serde::Deserialize, PartialEq, Eq)]
+pub struct ProposalSemanticConfig {
+    pub backend: String,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub endpoint: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub credential: Option<String>,
+}
+
+#[derive(Debug, Clone, Default, serde::Serialize, serde::Deserialize, PartialEq, Eq)]
+pub struct ProposalPrConfig {
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub default_repo: Option<String>,
+}
+```
+
+Update `merge_project_over_user` so project proposal config overrides user proposal config when present and preserves the user value when absent:
+
+```rust
+let proposal = project.proposal.or(user.proposal);
+```
+
+Export the new config types from `skills/mod.rs`:
+
+```rust
+pub use config::{ProposalConfig, ProposalLlmConfig, ProposalPrConfig, ProposalSemanticConfig};
+```
+
+- [ ] **Step 4: Run tests and verify pass**
+
+Run:
+
+```bash
+cargo test -p agentenv-core --test skills skills_config_loads_proposal_provider_settings
+```
+
+Expected: PASS for proposal config parsing.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add crates/agentenv-core/src/skills/config.rs crates/agentenv-core/src/skills/mod.rs crates/agentenv-core/tests/skills.rs
+git commit -m "feat: parse skill proposal config"
+```
+
+## Task 8: Proposal Service Orchestration
+
+**Files:**
+- Create: `crates/agentenv-core/src/skills/propose/service.rs`
+- Modify: `crates/agentenv-core/src/skills/propose/mod.rs`
+- Modify: `crates/agentenv-core/src/skills/propose/model.rs`
+- Modify: `crates/agentenv-core/tests/skill_propose.rs`
+
+- [ ] **Step 1: Write failing service test with fake generalizer**
+
+Append to `crates/agentenv-core/tests/skill_propose.rs`:
+
+```rust
+use async_trait::async_trait;
+use agentenv_core::skills::propose::{
+    ProposedSkillService, ProposeRunInput, SkillGeneralizationRequest, SkillGeneralizer,
+};
+
+#[tokio::test]
+async fn proposal_service_runs_full_pipeline_with_fake_generalizer() {
+    let temp = tempfile::tempdir().unwrap();
+    let traces = vec![
+        trace("trace-1", vec![call("fs_read", "/repo/a.rs")]),
+        trace("trace-2", vec![call("fs_read", "/repo/b.rs")]),
+        trace("trace-3", vec![call("fs_read", "/repo/c.rs")]),
+    ];
+    let service = ProposedSkillService::new(Box::new(FakeGeneralizer));
+
+    let output = service
+        .run(ProposeRunInput {
+            traces,
+            output_root: temp.path().join("proposed"),
+            blueprint_id: "sha256:blueprint-a".to_owned(),
+            min_occurrences: 3,
+            min_novelty: 0.6,
+            min_self_test_score: 0.8,
+            existing_skills: Vec::new(),
+            agentenv_version: "0.0.1-alpha0".to_owned(),
+            created_at: "2026-05-11T00:00:00Z".to_owned(),
+        })
+        .await
+        .unwrap();
+
+    assert_eq!(output.proposals.len(), 1);
+    assert_eq!(output.proposals[0].name, "fs-edit-skill");
+    assert!(output.proposals[0].path.join("SKILL.md").is_file());
+}
+
+struct FakeGeneralizer;
+
+#[async_trait]
+impl SkillGeneralizer for FakeGeneralizer {
+    async fn generalize(
+        &self,
+        _request: SkillGeneralizationRequest,
+    ) -> Result<SkillGeneralization, agentenv_core::skills::SkillError> {
+        Ok(valid_generalization())
+    }
+}
+```
+
+- [ ] **Step 2: Run tests and verify failure**
+
+Run:
+
+```bash
+cargo test -p agentenv-core --test skill_propose proposal_service_
+```
+
+Expected: FAIL because `ProposedSkillService` and orchestration models are missing.
+
+- [ ] **Step 3: Implement service orchestration**
+
+Extend `model.rs`:
+
+```rust
+#[derive(Debug, Clone)]
+pub struct ProposeRunInput {
+    pub traces: Vec<agentenv_events::TraceRun>,
+    pub output_root: std::path::PathBuf,
+    pub blueprint_id: String,
+    pub min_occurrences: usize,
+    pub min_novelty: f32,
+    pub min_self_test_score: f32,
+    pub existing_skills: Vec<ExistingSkillSummary>,
+    pub agentenv_version: String,
+    pub created_at: String,
+}
+
+#[derive(Debug, Clone, PartialEq, serde::Serialize, serde::Deserialize)]
+pub struct ProposeRunOutput {
+    pub proposals: Vec<ProposalEmitOutput>,
+    pub warnings: Vec<String>,
+}
+```
+
+Create `service.rs`:
+
+```rust
+use super::{
+    emit_proposal, evaluate_self_test, extract_candidates, score_proposal, validate_generalization,
+    CandidateExtractionOptions, ProposalEmitInput, ProposalScoreInput, ProposalSelfTestInput,
+    ProposeRunInput, ProposeRunOutput, SkillGeneralizationRequest, SkillGeneralizer,
+};
+use crate::skills::SkillError;
+
+pub struct ProposedSkillService {
+    generalizer: Box<dyn SkillGeneralizer>,
+}
+
+impl ProposedSkillService {
+    pub fn new(generalizer: Box<dyn SkillGeneralizer>) -> Self {
+        Self { generalizer }
+    }
+
+    pub async fn run(&self, input: ProposeRunInput) -> Result<ProposeRunOutput, SkillError> {
+        let candidates = extract_candidates(
+            &input.traces,
+            CandidateExtractionOptions {
+                blueprint_id: input.blueprint_id.clone(),
+                min_occurrences: input.min_occurrences,
+            },
+        )?;
+        let mut proposals = Vec::new();
+        let mut warnings = Vec::new();
+        for candidate in candidates {
+            let request = SkillGeneralizationRequest {
+                schema_version: "0.1".to_owned(),
+                candidate_json: serde_json::to_value(&candidate).map_err(|source| SkillError::InvalidConfig {
+                    message: format!("failed to encode proposal candidate: {source}"),
+                })?,
+                existing_skill_summaries: input.existing_skills.iter().map(|skill| skill.name.clone()).collect(),
+            };
+            let generalization = self.generalizer.generalize(request).await?;
+            let allowed_tools = candidate.sequence.iter().map(|call| call.tool.clone()).collect::<Vec<_>>();
+            validate_generalization(&generalization, &allowed_tools)?;
+            let score = score_proposal(ProposalScoreInput {
+                name: generalization.name.clone(),
+                description: generalization.description.clone(),
+                procedure_text: generalization.skill_md_body.clone(),
+                fingerprint: candidate.fingerprint.clone(),
+                occurrences: candidate.occurrences,
+                existing_skills: input.existing_skills.clone(),
+                backend: super::NoveltyBackend::Local,
+            })?;
+            if score.novelty < input.min_novelty {
+                warnings.push(format!("skipped `{}` because novelty {} is below {}", generalization.name, score.novelty, input.min_novelty));
+                continue;
+            }
+            let self_test = evaluate_self_test(ProposalSelfTestInput {
+                source_tools: allowed_tools,
+                procedure_steps: generalization.procedure_steps.clone(),
+                template_variables: generalization.template_variables.clone(),
+                min_score: input.min_self_test_score,
+            })?;
+            if !self_test.passed {
+                warnings.push(format!("skipped `{}` because self-test score {} is below {}", generalization.name, self_test.score, input.min_self_test_score));
+                continue;
+            }
+            proposals.push(emit_proposal(ProposalEmitInput {
+                output_root: input.output_root.clone(),
+                candidate,
+                generalization,
+                score,
+                self_test,
+                agentenv_version: input.agentenv_version.clone(),
+                created_at: input.created_at.clone(),
+            })?);
+        }
+        Ok(ProposeRunOutput { proposals, warnings })
+    }
+}
+```
+
+Modify `mod.rs` exports:
+
+```rust
+mod service;
+pub use model::{ProposeRunInput, ProposeRunOutput};
+pub use service::ProposedSkillService;
+```
+
+- [ ] **Step 4: Run tests and verify pass**
+
+Run:
+
+```bash
+cargo test -p agentenv-core --test skill_propose proposal_service_
+```
+
+Expected: PASS for service orchestration.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add crates/agentenv-core/src/skills/propose crates/agentenv-core/tests/skill_propose.rs
+git commit -m "feat: orchestrate skill proposal pipeline"
+```
+
+## Task 9: CLI Subcommand And Fake Provider Path
+
+**Files:**
+- Create: `crates/agentenv/src/skills_propose_cli.rs`
+- Modify: `crates/agentenv/src/main.rs`
+- Modify: `crates/agentenv/src/skills_cli.rs`
+- Modify: `crates/agentenv/tests/cli_behavior.rs`
+
+- [ ] **Step 1: Write failing CLI tests**
+
+Append to `crates/agentenv/tests/cli_behavior.rs`:
+
+```rust
+#[test]
+fn skills_help_lists_propose_subcommand() {
+    let output = Command::new(agentenv_bin())
+        .arg("skills")
+        .arg("--help")
+        .output()
+        .unwrap();
+
+    assert!(output.status.success(), "{}", output_summary(&output));
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    assert!(stdout.contains("propose"), "stdout was: {stdout}");
+}
+
+#[test]
+fn skills_propose_requires_from_traces_and_blueprint() {
+    let temp_dir = make_temp_dir("skills-propose-required");
+    let output = Command::new(agentenv_bin())
+        .arg("skills")
+        .arg("propose")
+        .env("HOME", &temp_dir)
+        .current_dir(&temp_dir)
+        .output()
+        .unwrap();
+
+    assert!(!output.status.success());
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    assert!(stderr.contains("--from-traces"), "stderr was: {stderr}");
+}
+```
+
+- [ ] **Step 2: Run tests and verify failure**
+
+Run:
+
+```bash
+cargo test -p agentenv --test cli_behavior skills_help_lists_propose_subcommand skills_propose_requires_from_traces_and_blueprint
+```
+
+Expected: FAIL because the `propose` subcommand does not exist.
+
+- [ ] **Step 3: Add CLI args and dispatch stub**
+
+Create `crates/agentenv/src/skills_propose_cli.rs`:
+
+```rust
+use std::path::PathBuf;
+
+use anyhow::{bail, Result};
+use clap::Args;
+
+#[derive(Debug, Args, Clone)]
+pub struct SkillsProposeArgs {
+    #[arg(long)]
+    pub from_traces: bool,
+    #[arg(long, value_name = "FILE")]
+    pub blueprint: Option<PathBuf>,
+    #[arg(long, value_name = "FILE")]
+    pub events_db: Option<PathBuf>,
+    #[arg(long)]
+    pub env: Option<String>,
+    #[arg(long, default_value_t = 3)]
+    pub min_occurrences: usize,
+    #[arg(long, default_value_t = 0.6)]
+    pub min_novelty: f32,
+    #[arg(long, default_value_t = 0.8)]
+    pub min_self_test_score: f32,
+    #[arg(long)]
+    pub llm_provider: Option<String>,
+    #[arg(long, default_value = "local")]
+    pub semantic_backend: String,
+    #[arg(long, value_name = "DIR")]
+    pub out: Option<PathBuf>,
+    #[arg(long)]
+    pub json: bool,
+    #[arg(long)]
+    pub open_pr: bool,
+    #[arg(long)]
+    pub repo: Option<String>,
+}
+
+pub async fn run_skills_propose(args: SkillsProposeArgs) -> Result<()> {
+    validate_args(&args)?;
+    println!("no proposals emitted");
+    Ok(())
+}
+
+pub fn validate_args(args: &SkillsProposeArgs) -> Result<()> {
+    if !args.from_traces {
+        bail!("`agentenv skills propose` requires --from-traces");
+    }
+    if args.blueprint.is_none() {
+        bail!("`agentenv skills propose` requires --blueprint <path>");
+    }
+    if args.min_occurrences < 2 {
+        bail!("--min-occurrences must be at least 2");
+    }
+    if !(0.0..=1.0).contains(&args.min_novelty) {
+        bail!("--min-novelty must be between 0.0 and 1.0");
+    }
+    if !(0.0..=1.0).contains(&args.min_self_test_score) {
+        bail!("--min-self-test-score must be between 0.0 and 1.0");
+    }
+    if args.open_pr && args.repo.is_none() {
+        bail!("--open-pr requires --repo owner/repo");
+    }
+    Ok(())
+}
+```
+
+Modify `crates/agentenv/src/main.rs`:
+
+```rust
+mod skills_propose_cli;
+```
+
+Modify `crates/agentenv/src/skills_cli.rs`:
+
+```rust
+use crate::skills_propose_cli::{run_skills_propose, SkillsProposeArgs};
+
+#[derive(Debug, Subcommand)]
+pub enum SkillsCommand {
+    Propose(SkillsProposeArgs),
+    Search(SkillsSearchArgs),
+    Add(SkillsAddArgs),
+    Install(SkillsInstallArgs),
+    List(SkillsListArgs),
+    Info(SkillsInfoArgs),
+    Remove(SkillsRemoveArgs),
+    Publish(SkillsPublishArgs),
+    Verify(SkillsVerifyArgs),
+    Prune(SkillsPruneArgs),
+}
+```
+
+Add dispatch branch:
+
+```rust
+SkillsCommand::Propose(args) => run_skills_propose(args).await,
+```
+
+Update `registry_override_for_command` to return `None` for `SkillsCommand::Propose(_)`.
+
+- [ ] **Step 4: Run tests and verify pass**
+
+Run:
+
+```bash
+cargo test -p agentenv --test cli_behavior skills_help_lists_propose_subcommand skills_propose_requires_from_traces_and_blueprint
+```
+
+Expected: PASS for CLI command shape tests.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add crates/agentenv/src/main.rs crates/agentenv/src/skills_cli.rs crates/agentenv/src/skills_propose_cli.rs crates/agentenv/tests/cli_behavior.rs
+git commit -m "feat: add skills propose command"
+```
+
+## Task 10: CLI Full Pipeline With Fake LLM
+
+**Files:**
+- Modify: `crates/agentenv/src/skills_propose_cli.rs`
+- Modify: `crates/agentenv/tests/cli_behavior.rs`
+
+- [ ] **Step 1: Write failing end-to-end CLI proposal test**
+
+Append to `crates/agentenv/tests/cli_behavior.rs`:
+
+```rust
+#[test]
+fn skills_propose_from_traces_emits_local_proposal_with_fake_llm() {
+    let temp_dir = make_temp_dir("skills-propose-e2e");
+    let blueprint = temp_dir.join("myapp.yaml");
+    fs::write(&blueprint, "version: 0.1.0\nsandbox: { driver: openshell }\nagent: { driver: codex }\ncontext: { driver: filesystem, mount: . }\n").unwrap();
+    let db_path = temp_dir.join(".agentenv/events.db");
+    let store = SqliteEventStore::open(&db_path).unwrap();
+    let blueprint_id = blueprint_digest(&blueprint);
+    store
+        .append_many(&[
+            propose_event("trace-1", &blueprint_id, "fs_read", "/repo/a.rs"),
+            propose_event("trace-2", &blueprint_id, "fs_read", "/repo/b.rs"),
+            propose_event("trace-3", &blueprint_id, "fs_read", "/repo/c.rs"),
+        ])
+        .unwrap();
+
+    let out = temp_dir.join("proposed");
+    let output = Command::new(agentenv_bin())
+        .arg("skills")
+        .arg("propose")
+        .arg("--from-traces")
+        .arg("--blueprint")
+        .arg(&blueprint)
+        .arg("--events-db")
+        .arg(&db_path)
+        .arg("--out")
+        .arg(&out)
+        .arg("--llm-provider")
+        .arg("fixture")
+        .arg("--json")
+        .env("HOME", &temp_dir)
+        .env("AGENTENV_SKILL_PROPOSER_FIXTURE_JSON", fixture_generalization_json())
+        .current_dir(&temp_dir)
+        .output()
+        .unwrap();
+
+    assert!(output.status.success(), "{}", output_summary(&output));
+    assert!(out.join("fs-edit-skill/SKILL.md").is_file());
+    let json: serde_json::Value = serde_json::from_slice(&output.stdout).unwrap();
+    assert_eq!(json["proposals"][0]["name"], "fs-edit-skill");
+}
+
+fn propose_event(trace_id: &str, blueprint_id: &str, tool: &str, path: &str) -> ActivityEvent {
+    ActivityEvent::new(
+        "2026-05-11T00:00:00Z",
+        ActivityKind::McpToolCall,
+        ActivityResult::Ok,
+        trace_id,
+    )
+    .with_env("demo")
+    .with_subject_value("tool", serde_json::json!(tool))
+    .with_subject_value("arguments", serde_json::json!({"path": path}))
+    .with_extra("blueprint_id", serde_json::json!(blueprint_id))
+}
+
+fn blueprint_digest(path: &Path) -> String {
+    let bytes = fs::read(path).unwrap();
+    format!("sha256:{}", hex::encode(Sha256::digest(bytes)))
+}
+
+fn fixture_generalization_json() -> String {
+    serde_json::json!({
+        "name": "fs-edit-skill",
+        "description": "Edit a repeated filesystem target.",
+        "template_variables": [{"name": "target_path", "description": "Target path", "example": "src/lib.rs"}],
+        "procedure_steps": [{"tool": "fs_read", "instruction": "Read {{target_path}}."}],
+        "self_test": {"command": "test -f SKILL.md"},
+        "skill_md_body": "Read {{target_path}}."
+    })
+    .to_string()
+}
+```
+
+- [ ] **Step 2: Run test and verify failure**
+
+Run:
+
+```bash
+cargo test -p agentenv --test cli_behavior skills_propose_from_traces_emits_local_proposal_with_fake_llm
+```
+
+Expected: FAIL because `run_skills_propose` does not read traces or run the core service.
+
+- [ ] **Step 3: Implement fake and HTTP generalizers plus CLI orchestration**
+
+In `skills_propose_cli.rs`, add:
+
+```rust
+use agentenv_core::skills::{
+    propose::{ProposeRunInput, ProposedSkillService, SkillGeneralization, SkillGeneralizationRequest, SkillGeneralizer},
+    ProposalConfig,
+};
+use agentenv_events::{SqliteEventStore, TraceQuery};
+use async_trait::async_trait;
+use serde::Serialize;
+
+#[derive(Debug, Serialize)]
+struct SkillsProposeJson {
+    proposals: Vec<agentenv_core::skills::propose::ProposalEmitOutput>,
+    warnings: Vec<String>,
+}
+
+struct FixtureGeneralizer {
+    value: SkillGeneralization,
+}
+
+#[async_trait]
+impl SkillGeneralizer for FixtureGeneralizer {
+    async fn generalize(
+        &self,
+        _request: SkillGeneralizationRequest,
+    ) -> Result<SkillGeneralization, agentenv_core::skills::SkillError> {
+        Ok(self.value.clone())
+    }
+}
+```
+
+Update `run_skills_propose`:
+
+```rust
+pub async fn run_skills_propose(args: SkillsProposeArgs) -> Result<()> {
+    validate_args(&args)?;
+    let blueprint = args.blueprint.as_ref().unwrap();
+    let blueprint_id = blueprint_id_for_path(blueprint)?;
+    let events_db = args.events_db.clone().unwrap_or_else(default_events_db_path);
+    let store = SqliteEventStore::open(&events_db)
+        .with_context(|| format!("open activity database `{}`", events_db.display()))?;
+    let traces = store.query_trace_runs(TraceQuery {
+        blueprint_id: blueprint_id.clone(),
+        env: args.env.clone(),
+        limit: 10_000,
+    })?;
+    let output_root = args.out.clone().unwrap_or_else(default_proposed_dir);
+    let generalizer = generalizer_for_args(&args)?;
+    let service = ProposedSkillService::new(generalizer);
+    let output = service
+        .run(ProposeRunInput {
+            traces,
+            output_root,
+            blueprint_id,
+            min_occurrences: args.min_occurrences,
+            min_novelty: args.min_novelty,
+            min_self_test_score: args.min_self_test_score,
+            existing_skills: Vec::new(),
+            agentenv_version: env!("CARGO_PKG_VERSION").to_owned(),
+            created_at: now_event_ts(),
+        })
+        .await?;
+    if args.json {
+        println!("{}", serde_json::to_string_pretty(&SkillsProposeJson {
+            proposals: output.proposals,
+            warnings: output.warnings,
+        })?);
+    } else {
+        for proposal in output.proposals {
+            println!("{} {} {}", proposal.name, proposal.novelty, proposal.path.display());
+        }
+        for warning in output.warnings {
+            eprintln!("warning: {warning}");
+        }
+    }
+    Ok(())
+}
+```
+
+Add helpers:
+
+```rust
+fn generalizer_for_args(args: &SkillsProposeArgs) -> Result<Box<dyn SkillGeneralizer>> {
+    if args.llm_provider.as_deref() == Some("fixture") {
+        let raw = std::env::var("AGENTENV_SKILL_PROPOSER_FIXTURE_JSON")
+            .context("AGENTENV_SKILL_PROPOSER_FIXTURE_JSON is required for fixture provider")?;
+        let value = serde_json::from_str(&raw).context("parse fixture generalization JSON")?;
+        return Ok(Box::new(FixtureGeneralizer { value }));
+    }
+    bail!("skill proposal LLM provider is not configured")
+}
+
+fn default_events_db_path() -> PathBuf {
+    dirs::home_dir()
+        .unwrap_or_else(|| PathBuf::from("."))
+        .join(".agentenv/events.db")
+}
+
+fn default_proposed_dir() -> PathBuf {
+    dirs::home_dir()
+        .unwrap_or_else(|| PathBuf::from("."))
+        .join(".agentenv/skills/proposed")
+}
+
+fn blueprint_id_for_path(path: &std::path::Path) -> Result<String> {
+    let bytes = std::fs::read(path).with_context(|| format!("read blueprint `{}`", path.display()))?;
+    let digest = sha2::Sha256::digest(&bytes);
+    Ok(format!("sha256:{}", hex::encode(digest)))
+}
+```
+
+- [ ] **Step 4: Run test and verify pass**
+
+Run:
+
+```bash
+cargo test -p agentenv --test cli_behavior skills_propose_from_traces_emits_local_proposal_with_fake_llm
+```
+
+Expected: PASS for fake-provider end-to-end proposal emission.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add crates/agentenv/src/skills_propose_cli.rs crates/agentenv/tests/cli_behavior.rs
+git commit -m "feat: run skills propose from traces"
+```
+
+## Task 11: OpenAI-Compatible Provider And Credential Resolution
+
+**Files:**
+- Modify: `crates/agentenv/src/skills_propose_cli.rs`
+- Modify: `crates/agentenv/tests/cli_behavior.rs`
+
+- [ ] **Step 1: Write failing missing-provider test**
+
+Append to `crates/agentenv/tests/cli_behavior.rs`:
+
+```rust
+#[test]
+fn skills_propose_without_configured_llm_fails_clearly() {
+    let temp_dir = make_temp_dir("skills-propose-missing-llm");
+    let blueprint = temp_dir.join("myapp.yaml");
+    fs::write(&blueprint, "version: 0.1.0\n").unwrap();
+    let db_path = temp_dir.join(".agentenv/events.db");
+    SqliteEventStore::open(&db_path).unwrap();
+
+    let output = Command::new(agentenv_bin())
+        .arg("skills")
+        .arg("propose")
+        .arg("--from-traces")
+        .arg("--blueprint")
+        .arg(&blueprint)
+        .arg("--events-db")
+        .arg(&db_path)
+        .env("HOME", &temp_dir)
+        .current_dir(&temp_dir)
+        .output()
+        .unwrap();
+
+    assert!(!output.status.success());
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    assert!(stderr.contains("skill proposal LLM provider is not configured"), "stderr was: {stderr}");
+}
+```
+
+- [ ] **Step 2: Run test and verify failure**
+
+Run:
+
+```bash
+cargo test -p agentenv --test cli_behavior skills_propose_without_configured_llm_fails_clearly
+```
+
+Expected: FAIL until error text and config path are implemented.
+
+- [ ] **Step 3: Add HTTP provider adapter**
+
+In `skills_propose_cli.rs`, add an OpenAI-compatible adapter:
+
+```rust
+struct HttpGeneralizer {
+    endpoint: String,
+    model: String,
+    bearer: String,
+    client: reqwest::Client,
+}
+
+#[async_trait]
+impl SkillGeneralizer for HttpGeneralizer {
+    async fn generalize(
+        &self,
+        request: SkillGeneralizationRequest,
+    ) -> Result<SkillGeneralization, agentenv_core::skills::SkillError> {
+        let response = self.client
+            .post(&self.endpoint)
+            .bearer_auth(&self.bearer)
+            .json(&serde_json::json!({
+                "model": self.model,
+                "response_format": {"type": "json_object"},
+                "messages": [
+                    {"role": "system", "content": "Return only JSON for an agentenv skill proposal."},
+                    {"role": "user", "content": serde_json::to_string(&request).unwrap_or_default()}
+                ]
+            }))
+            .send()
+            .await
+            .map_err(|source| agentenv_core::skills::SkillError::InvalidConfig {
+                message: format!("skill proposal LLM request failed: {source}"),
+            })?;
+        let value: serde_json::Value = response.json().await.map_err(|source| agentenv_core::skills::SkillError::InvalidConfig {
+            message: format!("skill proposal LLM response was not JSON: {source}"),
+        })?;
+        let content = value
+            .pointer("/choices/0/message/content")
+            .and_then(serde_json::Value::as_str)
+            .ok_or_else(|| agentenv_core::skills::SkillError::InvalidConfig {
+                message: "skill proposal LLM response missing choices[0].message.content".to_owned(),
+            })?;
+        serde_json::from_str(content).map_err(|source| agentenv_core::skills::SkillError::InvalidConfig {
+            message: format!("skill proposal LLM content failed schema validation: {source}"),
+        })
+    }
+}
+```
+
+Update `generalizer_for_args` to:
+
+1. Use fixture when `--llm-provider fixture`.
+2. Load proposal config through existing `load_effective_config`.
+3. Resolve `ProposalLlmConfig.credential` through `CredentialStore`.
+4. Construct `HttpGeneralizer`.
+5. Return the exact missing-config error when no provider exists.
+
+- [ ] **Step 4: Run tests and verify pass**
+
+Run:
+
+```bash
+cargo test -p agentenv --test cli_behavior skills_propose_without_configured_llm_fails_clearly
+cargo test -p agentenv --test cli_behavior skills_propose_from_traces_emits_local_proposal_with_fake_llm
+```
+
+Expected: both tests pass.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add crates/agentenv/src/skills_propose_cli.rs crates/agentenv/tests/cli_behavior.rs
+git commit -m "feat: configure skill proposal llm provider"
+```
+
+## Task 12: Optional PR Publishing
+
+**Files:**
+- Modify: `crates/agentenv/src/skills_propose_cli.rs`
+- Modify: `crates/agentenv/tests/cli_behavior.rs`
+
+- [ ] **Step 1: Write failing PR validation and command construction tests**
+
+Append to `crates/agentenv/tests/cli_behavior.rs`:
+
+```rust
+#[test]
+fn skills_propose_open_pr_requires_valid_repo() {
+    let temp_dir = make_temp_dir("skills-propose-bad-repo");
+    let blueprint = temp_dir.join("agentenv.yaml");
+    fs::write(&blueprint, "version: 0.1.0\n").unwrap();
+
+    let output = Command::new(agentenv_bin())
+        .arg("skills")
+        .arg("propose")
+        .arg("--from-traces")
+        .arg("--blueprint")
+        .arg(&blueprint)
+        .arg("--open-pr")
+        .arg("--repo")
+        .arg("bad repo")
+        .env("HOME", &temp_dir)
+        .current_dir(&temp_dir)
+        .output()
+        .unwrap();
+
+    assert!(!output.status.success());
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    assert!(stderr.contains("--repo must be owner/repo"), "stderr was: {stderr}");
+}
+```
+
+- [ ] **Step 2: Run test and verify failure**
+
+Run:
+
+```bash
+cargo test -p agentenv --test cli_behavior skills_propose_open_pr_requires_valid_repo
+```
+
+Expected: FAIL until repo validation is implemented.
+
+- [ ] **Step 3: Implement PR validation and publisher interface**
+
+In `skills_propose_cli.rs`, add:
+
+```rust
+#[derive(Debug, Clone, PartialEq, Eq)]
+struct PullRequestPlan {
+    repo: String,
+    branch: String,
+    title: String,
+    body: String,
+}
+
+fn validate_repo(repo: &str) -> Result<()> {
+    let Some((owner, name)) = repo.split_once('/') else {
+        bail!("--repo must be owner/repo");
+    };
+    let valid = |value: &str| {
+        !value.is_empty()
+            && value
+                .bytes()
+                .all(|byte| byte.is_ascii_alphanumeric() || matches!(byte, b'-' | b'_' | b'.'))
+    };
+    if !valid(owner) || !valid(name) {
+        bail!("--repo must be owner/repo with conservative characters");
+    }
+    Ok(())
+}
+
+fn pr_plan_for(repo: String, proposal: &agentenv_core::skills::propose::ProposalEmitOutput) -> PullRequestPlan {
+    let short_name = proposal.name.replace('_', "-");
+    PullRequestPlan {
+        repo,
+        branch: format!("agentenv/proposed-skill/{short_name}"),
+        title: format!("feat: propose trace-derived skill {}", proposal.name),
+        body: format!(
+            "Trace-derived skill proposal.\n\nNovelty: {}\nSelf-test score: {}\nPath: `{}`\n",
+            proposal.novelty,
+            proposal.self_test_score,
+            proposal.path.display()
+        ),
+    }
+}
+```
+
+Update `validate_args` to call `validate_repo` when `repo` is present.
+
+Add a publisher function that runs non-interactive commands:
+
+```rust
+fn publish_pr(plan: &PullRequestPlan, proposal_path: &std::path::Path) -> Result<String> {
+    run_command("git", &["checkout", "-B", &plan.branch])?;
+    run_command("git", &["add", proposal_path.to_str().context("proposal path is not UTF-8")?])?;
+    run_command("git", &["commit", "-m", &plan.title])?;
+    run_command("git", &["push", "-u", "origin", &plan.branch])?;
+    let output = std::process::Command::new("gh")
+        .args(["pr", "create", "--repo", &plan.repo, "--draft", "--title", &plan.title, "--body", &plan.body])
+        .output()
+        .context("run gh pr create")?;
+    if !output.status.success() {
+        bail!("gh pr create failed: {}", String::from_utf8_lossy(&output.stderr));
+    }
+    Ok(String::from_utf8_lossy(&output.stdout).trim().to_owned())
+}
+
+fn run_command(program: &str, args: &[&str]) -> Result<()> {
+    let output = std::process::Command::new(program)
+        .args(args)
+        .output()
+        .with_context(|| format!("run {program}"))?;
+    if !output.status.success() {
+        bail!(
+            "{program} failed: {}",
+            String::from_utf8_lossy(&output.stderr)
+        );
+    }
+    Ok(())
+}
+```
+
+Use the publisher only after proposal emission succeeds and only when
+`--open-pr` is set.
+
+- [ ] **Step 4: Run PR tests and existing propose tests**
+
+Run:
+
+```bash
+cargo test -p agentenv --test cli_behavior skills_propose_open_pr_requires_valid_repo
+cargo test -p agentenv --test cli_behavior skills_propose_from_traces_emits_local_proposal_with_fake_llm
+```
+
+Expected: both tests pass.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add crates/agentenv/src/skills_propose_cli.rs crates/agentenv/tests/cli_behavior.rs
+git commit -m "feat: support skill proposal pull requests"
+```
+
+## Task 13: End-To-End Verification And Polish
+
+**Files:**
+- Review/modify: `crates/agentenv-events/src/trace.rs`
+- Review/modify: `crates/agentenv-events/src/store.rs`
+- Review/modify: `crates/agentenv-core/src/skills/propose/*.rs`
+- Review/modify: `crates/agentenv-core/src/skills/config.rs`
+- Review/modify: `crates/agentenv/src/skills_propose_cli.rs`
+- Review/modify: `crates/agentenv/src/skills_cli.rs`
+- Review/modify: `crates/agentenv/tests/cli_behavior.rs`
+- Review: `docs/superpowers/specs/2026-05-11-m7-6-trace-skill-proposer-design.md`
+
+- [ ] **Step 1: Run formatting**
+
+Run:
+
+```bash
+cargo fmt
+```
+
+Expected: command exits 0.
+
+- [ ] **Step 2: Run clippy**
+
+Run:
+
+```bash
+cargo clippy --workspace -- -D warnings
+```
+
+Expected: command exits 0. Fix each warning in the smallest owning module, then rerun this exact command.
+
+- [ ] **Step 3: Run workspace tests**
+
+Run:
+
+```bash
+cargo test --workspace
+```
+
+Expected: command exits 0 with all non-ignored tests passing.
+
+- [ ] **Step 4: Confirm requirement coverage**
+
+Check the implementation against this list and update code when any item is missing:
+
+```text
+- CLI: agentenv skills propose --from-traces --blueprint <path>
+- Trace filtering by blueprint_id
+- Repeated sequence extraction with min occurrences
+- Redaction before prompt/proposal emission
+- LLM generalization with strict JSON validation
+- Novelty ladder 0.0, 0.3, 0.6, 0.9
+- Self-test gate default score >= 0.8
+- Emission under ~/.agentenv/skills/proposed/<name>/
+- Optional --open-pr --repo owner/repo path
+- No driver protocol/schema version changes
+```
+
+- [ ] **Step 5: Commit final fixes**
+
+```bash
+git status --short
+git add crates/agentenv-events crates/agentenv-core crates/agentenv
+git commit -m "test: verify trace skill proposer"
+```
+
+Skip this commit if `git status --short` is empty after verification.

--- a/docs/superpowers/specs/2026-05-11-m7-6-trace-skill-proposer-design.md
+++ b/docs/superpowers/specs/2026-05-11-m7-6-trace-skill-proposer-design.md
@@ -1,0 +1,612 @@
+# M7-6 Design: Trace To Skill Proposer
+
+- Date: 2026-05-11
+- Issue: https://github.com/windoliver/agentenv/issues/32
+- Milestone: M7 Skills axis and registry
+- Depends on: https://github.com/windoliver/agentenv/issues/27, https://github.com/windoliver/agentenv/issues/23, https://github.com/windoliver/agentenv/issues/28
+- Affected crates: `agentenv`, `agentenv-core`, `agentenv-events`
+- Protocol impact: no driver protocol or schema-version change
+
+## 1. Context And Goals
+
+Issue #32 adds a trace-to-skill flywheel:
+
+```text
+agentenv skills propose --from-traces --blueprint myapp.yaml --min-occurrences 3 --min-novelty 0.6
+```
+
+Successful agent runs are already represented by the M6 activity stream.
+M7 has also established that skills are core-managed static artifacts, not a
+new driver kind and not a fifth pluggable axis. This issue should connect
+those two surfaces: read successful activity traces, detect repeated
+procedures, generalize them into reusable skill drafts, score novelty, run a
+regression self-test, and emit proposals that an operator can curate.
+
+The requested scope is the full pipeline:
+
+1. Consume activity traces.
+2. Extract repeated tool-call sequences by `blueprint_id`.
+3. Generalize concrete arguments into template variables with an LLM provider.
+4. Score novelty and utility, including semantic dedup.
+5. Gate proposals with a self-test score of at least `0.8` by default.
+6. Emit PR-ready skill drafts under `~/.agentenv/skills/proposed/<name>/`.
+7. Optionally open a draft PR to a user's skills repository.
+
+The implementation should still degrade clearly. Local deterministic trace
+mining should work without network access. LLM generalization, semantic vector
+dedup, and PR publishing require explicit configuration and fail with actionable
+messages when requested but unavailable.
+
+## 2. Scope And Non-Goals
+
+In scope:
+
+1. Add `agentenv skills propose` with the issue command shape.
+2. Add trace-oriented activity-store queries in `agentenv-events`.
+3. Add an `agentenv-core::skills::propose` module for trace extraction,
+   candidate modeling, generalization schemas, scoring, self-test evaluation,
+   and proposal emission.
+4. Support grouping successful `mcp_tool_call` traces by `blueprint_id`.
+5. Detect repeated normalized tool-call sequences across at least
+   `--min-occurrences` traces.
+6. Redact secret-like data before any candidate, prompt, or proposal reaches
+   disk or a model provider.
+7. Use a configured LLM provider for full-scope generalization.
+8. Validate LLM output through strict serde models before writing files.
+9. Deduplicate against installed and already proposed skills with exact,
+   structural, and semantic scoring.
+10. Support a local semantic fallback and a pluggable vector-search adapter
+    for deployments that use pgvector, Milvus, or another embedding backend.
+11. Implement the novelty ladder required by the issue:
+    - `0.0`: duplicate of an existing skill
+    - `0.3`: minor variation or parameter difference
+    - `0.6`: distinct variant or new target
+    - `0.9`: genuinely new capability
+12. Implement a self-test gate against the source trace abstraction.
+13. Emit proposed skill directories under
+    `~/.agentenv/skills/proposed/<name>/`.
+14. Support optional draft PR creation with explicit `--open-pr --repo owner/repo`.
+15. Add tests for trace reads, extraction, redaction, LLM output validation,
+    novelty scoring, self-test scoring, proposal layout, CLI behavior, and PR
+    publishing command construction.
+
+Out of scope:
+
+1. A driver protocol change or schema bump.
+2. A new registry adapter kind for proposed skills.
+3. Installing proposed skills automatically. Operators still curate and merge.
+4. Rerunning arbitrary agent tools during self-test. The first self-test
+   replays against the trace abstraction.
+5. Sending raw event rows, credentials, or unredacted command arguments to an
+   LLM or vector backend.
+6. Adding Python, Node, OpenSSL, Docker, or another runtime dependency to the
+   core binary.
+7. Creating a new CLI vocabulary outside the established `skills` lifecycle.
+
+Note: the repo workflow asks for an approach comment on architectural issues
+before code. The GitHub app returned `403 Resource not accessible by
+integration` when attempting to post that comment for issue #32 in this
+session. This design document records the approved approach instead.
+
+## 3. Architecture
+
+Keep the pipeline core-managed and modular:
+
+```text
+agentenv skills propose
+  -> read activity events from SQLite
+  -> filter successful traces by blueprint_id
+  -> normalize ordered MCP/tool-call sequences
+  -> extract repeated candidates
+  -> generalize candidates through a configured LLM provider
+  -> score exact, structural, semantic, and utility signals
+  -> run regression self-test against source traces
+  -> write proposed skill draft
+  -> optionally open draft PR
+```
+
+`agentenv-events` should expose trace-oriented read APIs over the existing
+SQLite store. The CLI should not hand-write SQL against `activity_events`.
+
+`agentenv-core` should own the deterministic pipeline and data models:
+
+1. `trace`: raw trace records, normalized tool calls, blueprint filtering.
+2. `extract`: repeated sequence detection and candidate formation.
+3. `generalize`: strict request/response models and provider trait.
+4. `score`: novelty, utility, and semantic dedup abstractions.
+5. `self_test`: regression scoring against trace abstractions.
+6. `emit`: proposed-skill directory rendering.
+
+`agentenv` should remain CLI glue:
+
+1. Parse flags.
+2. Load skills config and credential references.
+3. Resolve the activity database path.
+4. Construct concrete LLM, embedding, vector-search, and PR publisher adapters.
+5. Render JSON or table output.
+
+This boundary keeps core logic testable without network access while still
+supporting full-scope integrations through traits.
+
+## 4. Command Shape
+
+Add a `Propose(SkillsProposeArgs)` subcommand under `agentenv skills`:
+
+```text
+agentenv skills propose --from-traces --blueprint <path> \
+  [--events-db <path>] [--env <name>] \
+  [--min-occurrences <n>] [--min-novelty <score>] \
+  [--min-self-test-score <score>] \
+  [--llm-provider <name>] [--semantic-backend <name>] \
+  [--out <dir>] [--json] \
+  [--open-pr --repo <owner/repo>]
+```
+
+Required:
+
+1. `--from-traces` is required for the first implementation. It leaves room for
+   additional sources without creating a new top-level verb.
+2. `--blueprint <path>` identifies the blueprint scope.
+
+Defaults:
+
+1. `--min-occurrences 3`
+2. `--min-novelty 0.6`
+3. `--min-self-test-score 0.8`
+4. `--out ~/.agentenv/skills/proposed`
+5. `--events-db` defaults to the global activity database, with env-scoped
+   reads merged when `--env` is provided and the env store exists.
+6. `--llm-provider` defaults to the configured skills proposal provider.
+7. `--semantic-backend local` unless config chooses an external backend.
+
+Validation:
+
+1. `--min-occurrences` must be at least `2`.
+2. `--min-novelty` and `--min-self-test-score` must be between `0.0` and `1.0`.
+3. `--open-pr` requires `--repo`.
+4. `--repo` must be `owner/name` with conservative characters.
+5. `--events-db` must pass the same no-symlink final-component safety used by
+   the activity store.
+
+Human output should list proposed names, novelty score, self-test score,
+occurrence count, output path, and PR URL when present. JSON output should use a
+stable response model with the same fields plus warnings.
+
+## 5. Configuration And Credentials
+
+Add optional proposal config to the existing skills config surface:
+
+```yaml
+skills:
+  proposal:
+    llm:
+      provider: default
+      endpoint: https://llm.example.test/v1
+      model: proposal-generalizer
+      credential: AGENTENV_SKILL_PROPOSER_TOKEN
+    semantic:
+      backend: local
+      embedding_provider: default
+      embedding_model: proposal-embedding
+      credential: AGENTENV_SKILL_PROPOSER_EMBEDDING_TOKEN
+    pr:
+      default_repo: owner/skills
+```
+
+The same shape should be accepted in `~/.config/agentenv/config.toml`.
+Project config overrides user config for project-local proposals, and CLI flags
+override both.
+
+Credential handling:
+
+1. Credential names are resolved through the existing CLI credential store.
+2. Credential values are never stored in proposal files.
+3. Credential values are injected only into concrete HTTP or GitHub adapters.
+4. Generalization prompts include redacted trace summaries, not raw event rows.
+5. External semantic requests include only redacted candidate text and
+   generated proposal summaries.
+
+If full-scope generalization is requested and no LLM provider is configured,
+the command should fail with a message that names the missing config and
+credential. A deterministic-only mode would be a separate opt-in path and is
+not the full-scope default requested for this issue.
+
+## 6. Trace Selection
+
+The proposer reads `ActivityEvent` rows and builds `TraceRun` values:
+
+```rust
+pub struct TraceRun {
+    pub trace_id: String,
+    pub env: Option<String>,
+    pub blueprint_id: String,
+    pub started_at: String,
+    pub calls: Vec<TraceToolCall>,
+    pub terminal_result: ActivityResult,
+}
+
+pub struct TraceToolCall {
+    pub ordinal: u32,
+    pub tool: String,
+    pub args: serde_json::Value,
+    pub args_shape: serde_json::Value,
+    pub result: ActivityResult,
+    pub subject: serde_json::Value,
+}
+```
+
+Blueprint scope:
+
+1. Resolve `--blueprint` and compute a stable `blueprint_id`.
+2. Prefer explicit `extras.blueprint_id` values in activity events.
+3. If older events lack `blueprint_id`, support an env-scoped fallback only
+   when the persisted env state can be tied unambiguously to the same
+   blueprint digest.
+4. If neither path can establish scope, skip the trace and record a warning.
+
+Successful traces:
+
+1. Include only traces with at least one successful `mcp_tool_call`.
+2. Exclude traces that contain `egress_denied`, `spawn_rejected`,
+   `approval_requested` without a matching successful `approval_decided`, or
+   any terminal `error` result for the same `trace_id`.
+3. Exclude tool calls whose subject lacks a textual `tool` name.
+4. Apply event redaction before normalization.
+
+Ordering:
+
+1. Within a trace, order calls by event id.
+2. Preserve repeated calls to the same tool.
+3. Use `trace_id` as the run boundary.
+
+## 7. Candidate Extraction
+
+Normalize each tool call into a fingerprint:
+
+```text
+tool + normalized_arg_shape + selected_subject_keys + result
+```
+
+Argument normalization:
+
+1. Preserve JSON types and object keys.
+2. Replace scalar values with shape markers for sequence matching.
+3. Preserve small enumerations when every occurrence shares the same value.
+4. Redact values for secret-like keys and URLs before computing candidate
+   material.
+5. Treat paths, URLs, branch names, package names, and env names as potential
+   template variables.
+
+Candidate formation:
+
+1. Group exact normalized sequences.
+2. Allow argument variation inside the same sequence if tool order and shape
+   remain stable.
+3. Require at least `--min-occurrences` distinct trace ids.
+4. Prefer shorter maximal repeated sequences when a larger sequence has
+   unrelated setup or cleanup calls around the repeatable procedure.
+5. Generate a draft name from blueprint context and dominant tools, then
+   validate it with `validate_skill_name`.
+
+Candidate provenance should include:
+
+1. Source `blueprint_id`.
+2. Source event database path.
+3. Trace ids.
+4. Event id ranges.
+5. Normalized sequence fingerprint.
+6. Redaction counts.
+
+## 8. LLM Generalization
+
+Core should define the provider trait and validated schema:
+
+```rust
+#[async_trait]
+pub trait SkillGeneralizer: Send + Sync {
+    async fn generalize(
+        &self,
+        request: SkillGeneralizationRequest,
+    ) -> Result<SkillGeneralization, ProposeError>;
+}
+```
+
+Request contents:
+
+1. Candidate summary.
+2. Redacted representative traces.
+3. Argument variation summary.
+4. Blueprint metadata.
+5. Existing installed and proposed skill summaries.
+6. Required output schema version.
+
+Response contents:
+
+```rust
+pub struct SkillGeneralization {
+    pub name: String,
+    pub description: String,
+    pub template_variables: Vec<TemplateVariable>,
+    pub procedure_steps: Vec<ProcedureStep>,
+    pub self_test: ProposedSelfTest,
+    pub skill_md_body: String,
+}
+```
+
+Validation:
+
+1. Name must pass `validate_skill_name`.
+2. Description must be present and concise.
+3. Template variables must be referenced by at least one procedure step.
+4. Procedure steps must refer only to tools present in the source candidate or
+   to clear human-instruction steps.
+5. `SKILL.md` body must not include secrets, raw trace ids, absolute home paths,
+   or provider-specific credentials.
+6. Output must be rejected if it is not valid JSON, has unknown top-level
+   fields, or references files outside the proposal bundle.
+
+The concrete provider in the CLI can call an OpenAI-compatible or other
+configured HTTP endpoint through `reqwest` and `rustls`. The provider should
+request JSON-only output and then parse locally. The core should not trust the
+model to enforce security or schema rules.
+
+## 9. Novelty And Utility Scoring
+
+Compute a score report rather than a single opaque number:
+
+```rust
+pub struct ProposalScore {
+    pub novelty: f32,
+    pub utility: f32,
+    pub final_score: f32,
+    pub nearest_matches: Vec<SkillMatch>,
+    pub reasons: Vec<String>,
+}
+```
+
+Novelty steps:
+
+1. Exact duplicate: compare generated `SKILL.md`, `skill.yaml`, procedure
+   steps, and normalized fingerprints against installed and proposed skills.
+2. Structural duplicate: compare ordered tools, variable names, and step
+   structure.
+3. Semantic duplicate: query the selected semantic backend with the generated
+   description and procedure summary.
+
+Semantic backends:
+
+1. `local`: token/Jaccard similarity over existing skill names, descriptions,
+   tags, and procedure text. This gives deterministic offline behavior.
+2. `embedding-local-cache`: use a configured embedding provider and store
+   vectors in a local SQLite table under `~/.agentenv/skills/proposed/index.db`.
+3. `external`: call a configured HTTP adapter for Milvus, pgvector, or an
+   organization-specific vector service. The adapter contract uses JSON over
+   HTTPS and SSRF validation. Direct database or gRPC clients are unnecessary
+   for this issue because the HTTP adapter keeps core dependencies narrow.
+
+Ladder mapping:
+
+1. `0.0`: exact duplicate or semantic similarity above the duplicate threshold.
+2. `0.3`: same sequence with only parameter/target variation.
+3. `0.6`: distinct sequence variant or new target family.
+4. `0.9`: no close match and a new capability category.
+
+Utility scoring:
+
+1. Higher occurrence count increases utility.
+2. More distinct trace ids and timestamps increase confidence.
+3. Failed or noisy nearby events reduce utility.
+4. Candidates with too many template variables are penalized.
+
+The CLI enforces `--min-novelty` against the novelty score. The self-test gate
+is separate.
+
+## 10. Self-Test Gate
+
+The self-test does not rerun arbitrary tools. It evaluates the generated skill
+against the trace abstraction:
+
+1. Each generated procedure step must map to one or more source tool calls or a
+   clear human instruction.
+2. Template variables must explain observed argument variation.
+3. Constant values must match the source traces.
+4. The generated self-test command must be syntactically valid metadata but is
+   not executed during proposal generation unless it is a safe local file check.
+5. The generated `SKILL.md` must contain enough procedure detail to reproduce
+   the source sequence at a high level.
+
+Self-test report:
+
+```rust
+pub struct ProposalSelfTestReport {
+    pub score: f32,
+    pub matched_steps: u32,
+    pub total_steps: u32,
+    pub matched_variables: u32,
+    pub total_variables: u32,
+    pub failures: Vec<String>,
+}
+```
+
+Default gate: `score >= 0.8`.
+
+Rejected proposals are not emitted by default. Diagnostic emission of rejected
+proposals is out of scope for this issue so the proposal output remains clean.
+
+## 11. Proposal Emission
+
+Emit each accepted proposal to:
+
+```text
+~/.agentenv/skills/proposed/<name>/
+|-- SKILL.md
+|-- skill.yaml
+|-- proposal.yaml
+|-- self-test.json
+`-- traces/
+    `-- provenance.json
+```
+
+`SKILL.md` should include frontmatter compatible with the existing skill
+ecosystem:
+
+```yaml
+---
+name: proposed-skill
+description: Short generated description
+version: 0.1.0
+tags: [agentenv-proposed, trace-derived]
+agentenv-proposal: true
+agentenv-schema: "0.1"
+---
+```
+
+`skill.yaml` remains the package manifest used by existing skills code:
+
+```yaml
+name: proposed-skill
+version: 0.1.0
+description: Short generated description
+entry: SKILL.md
+files:
+  - SKILL.md
+  - proposal.yaml
+  - self-test.json
+  - traces/provenance.json
+self_test:
+  command: test -f SKILL.md
+agentenv_proposal: true
+agentenv_schema: "0.1"
+```
+
+`proposal.yaml` should include candidate metadata, scores, provider metadata,
+source blueprint id, and curation status:
+
+```yaml
+schema_version: "0.1"
+status: proposed
+blueprint_id: sha256:...
+occurrences: 3
+novelty: 0.6
+utility: 0.8
+self_test_score: 0.91
+generated_by:
+  agentenv_version: 0.0.1-alpha0
+  llm_provider: default
+```
+
+Safety:
+
+1. Refuse to overwrite an existing proposal directory unless the content is
+   byte-identical. Replacement behavior is out of scope for this issue.
+2. Use staging plus atomic rename where possible.
+3. Validate the emitted bundle with `load_skill_manifest`.
+4. Compute a bundle digest and include it in CLI output.
+5. Keep trace provenance redacted and bounded. Store summaries, not full raw
+   event rows.
+
+## 12. Optional PR Publishing
+
+When `--open-pr --repo owner/repo` is provided:
+
+1. Create a branch name such as
+   `agentenv/proposed-skill/<proposal-name>-<short-digest>`.
+2. Add only the emitted proposal directory to the target skills repository.
+3. Commit with a message such as
+   `feat: propose trace-derived skill <name>`.
+4. Push the branch.
+5. Open a draft PR with summary, scores, source blueprint id, and self-test
+   report.
+
+Implementation options:
+
+1. Prefer the GitHub app connector when available for PR creation.
+2. Use local `git` and `gh` only when the connector cannot operate on the
+   target repo from the current checkout.
+3. If neither path is configured, leave the proposal on disk and fail only the
+   publishing step with a clear message.
+
+Publishing must never include credential values, raw event databases, or
+unredacted traces.
+
+## 13. Error Handling
+
+Use `thiserror` in core and `anyhow` in CLI glue.
+
+Representative errors:
+
+1. Missing activity database.
+2. Blueprint file cannot be read or verified.
+3. No matching traces for `blueprint_id`.
+4. Not enough repeated traces for `--min-occurrences`.
+5. Missing LLM provider config or credential.
+6. LLM response failed schema validation.
+7. Semantic backend unavailable.
+8. Novelty below threshold.
+9. Self-test below threshold.
+10. Proposal output path exists.
+11. PR publishing unavailable or failed after local proposal emission.
+
+Partial success should be explicit. If proposal emission succeeds but PR
+publishing fails, return a non-zero exit only for the publishing command path
+and print the local proposal path so the user can recover.
+
+## 14. Testing
+
+Core tests:
+
+1. Trace query helper groups rows by `trace_id` and filters by `blueprint_id`.
+2. Trace selection excludes denied, rejected, and error traces.
+3. Extraction finds repeated sequences and ignores singletons.
+4. Normalization redacts secrets, URLs with credentials, and token-like values.
+5. LLM response parsing rejects malformed JSON, unknown fields, invalid names,
+   unsafe paths, and leaked secrets.
+6. Novelty scoring maps exact, structural, semantic, and new-capability cases
+   to the required ladder.
+7. Self-test scoring accepts well-mapped proposals and rejects under-specified
+   proposals.
+8. Proposal writer emits the expected layout and validates with
+   `load_skill_manifest`.
+9. Proposal writer rejects existing output paths and unsafe proposal names.
+
+CLI tests:
+
+1. `agentenv skills --help` lists `propose`.
+2. Missing `--from-traces` or `--blueprint` fails cleanly.
+3. A fixture activity database produces a proposed skill under a temp
+   `AGENTENV_HOME`.
+4. `--json` emits stable proposal metadata.
+5. Missing LLM config in full mode fails with a precise message.
+6. A fake LLM provider can drive a deterministic accepted proposal.
+7. A low novelty proposal is skipped.
+8. A low self-test score is skipped.
+9. `--open-pr` validates `--repo` and constructs a draft PR request without
+   touching unrelated files.
+
+Verification before PR:
+
+```bash
+cargo fmt
+cargo clippy --workspace -- -D warnings
+cargo test --workspace
+```
+
+## 15. Rollout Notes
+
+This issue touches architectural surface but does not require a driver schema
+bump because it only reads the existing activity store and writes core-managed
+skill artifacts.
+
+The PR description should list the affected crates:
+
+1. `agentenv-events`
+2. `agentenv-core`
+3. `agentenv`
+
+It should also call out:
+
+1. No driver protocol impact.
+2. Which semantic backends are implemented in the PR.
+3. How LLM and embedding credentials are configured.
+4. That proposed skills are emitted locally by default and are not installed
+   automatically.


### PR DESCRIPTION
Closes #32.

## Summary
- Add trace-run querying and candidate extraction for repeated successful MCP tool-call patterns.
- Add the proposed-skill pipeline: fixture/OpenAI-compatible generalization, schema and secret validation, novelty scoring, source-coverage self-tests, and atomic proposal emission.
- Expose `agentenv skills propose --from-traces`, including config-driven LLM provider setup, SSRF/timeout hardening, JSON output, existing skill dedup, and optional draft PR publishing for emitted proposals.

## Affected crates
- `agentenv`
- `agentenv-core`
- `agentenv-events`

## Notes
- Exact novelty dedup for proposed/installed trace-derived skills uses proposal provenance fingerprints when present; otherwise local semantic similarity is used.
- `--semantic-backend` is currently restricted to `local` instead of silently ignoring unsupported values.
- `--open-pr` now preflights output paths and requires a clean git index before emitting/publishing proposal files.

## Test Plan
- `cargo fmt`
- `cargo clippy --workspace -- -D warnings`
- `cargo test --workspace`

## Review status
- Draft PR: broad feature surface with focused final review already run locally.