### PR TITLE
[codex] M7-7 skill self-test gate

### DIFF
--- a/crates/agentenv-core/Cargo.toml
+++ b/crates/agentenv-core/Cargo.toml
@@ -29,7 +29,7 @@ rustix = { version = "1.1", features = ["fs"] }
 sha2.workspace = true
 ed25519-dalek.workspace = true
 hex.workspace = true
-rand_core.workspace = true
+rand_core = { workspace = true, features = ["getrandom"] }
 dirs.workspace = true
 libc.workspace = true
 windows-sys.workspace = true

--- a/crates/agentenv-core/src/bundle/render.rs
+++ b/crates/agentenv-core/src/bundle/render.rs
@@ -29,8 +29,23 @@ struct SkillYaml<'a> {
     files: Vec<&'static str>,
     #[serde(skip_serializing_if = "Vec::is_empty")]
     tags: Vec<&'a str>,
+    self_test: SkillYamlSelfTest,
     agentenv_bundle: bool,
     agentenv_schema: &'static str,
+}
+
+#[derive(Debug, Serialize)]
+struct SkillYamlSelfTest {
+    runner: &'static str,
+    assertions: Vec<SkillYamlSelfTestAssertion>,
+    timeout_seconds: u64,
+}
+
+#[derive(Debug, Serialize)]
+struct SkillYamlSelfTestAssertion {
+    #[serde(rename = "type")]
+    assertion_type: &'static str,
+    path: &'static str,
 }
 
 pub(crate) fn render_skill_md(
@@ -107,6 +122,20 @@ pub(crate) fn render_skill_yaml(
         entry: "SKILL.md",
         files,
         tags: metadata.tags.iter().map(String::as_str).collect(),
+        self_test: SkillYamlSelfTest {
+            runner: "agentenv",
+            assertions: vec![
+                SkillYamlSelfTestAssertion {
+                    assertion_type: "file_exists",
+                    path: "agentenv.lock",
+                },
+                SkillYamlSelfTestAssertion {
+                    assertion_type: "file_exists",
+                    path: "scripts/bootstrap.sh",
+                },
+            ],
+            timeout_seconds: 30,
+        },
         agentenv_bundle: true,
         agentenv_schema: AGENTENV_BUNDLE_SCHEMA,
     };

--- a/crates/agentenv-core/src/runtime.rs
+++ b/crates/agentenv-core/src/runtime.rs
@@ -2984,6 +2984,29 @@ pub async fn exec_env_observed(
     }
 }
 
+pub async fn run_agent_prompt_once(
+    options: &RuntimeOptions,
+    factory: &dyn DriverFactory,
+    name: &str,
+    prompt: &str,
+) -> RuntimeResult<agentenv_proto::ExecResult> {
+    let state = describe_env(options, name)?.state;
+    let selection = selection_from_state(&state);
+    let handle = required_sandbox_handle(&state, name)?;
+    let mut set = factory.build(&selection)?;
+    initialize_sandbox_driver(options, set.sandbox.as_mut()).await?;
+    let cmd = format!("{} {}", AGENT_ENTRYPOINT_PATH, shell_quote(prompt));
+    set.sandbox
+        .exec(agentenv_proto::ExecParams {
+            handle,
+            cmd,
+            tty: false,
+            env: BTreeMap::new(),
+        })
+        .await
+        .map_err(RuntimeError::Driver)
+}
+
 pub async fn enter_env(
     options: &RuntimeOptions,
     factory: &dyn DriverFactory,
@@ -10286,6 +10309,55 @@ policy:
                 .join("agent")
                 .exists(),
             "rendered agent files can contain credentials and must not persist in the registry"
+        );
+    }
+
+    #[tokio::test]
+    async fn run_agent_prompt_once_uses_entrypoint_with_quoted_prompt() {
+        let root = unique_root("agentenv-agent-prompt-once");
+        let options = RuntimeOptions {
+            root,
+            log_level: LogLevel::Info,
+            non_interactive: true,
+        };
+        let yaml = r#"
+version: 0.1.0
+min_agentenv_version: 0.0.1-alpha0
+sandbox:
+  driver: openshell
+agent:
+  driver: codex
+context:
+  driver: filesystem
+  mount: .
+policy:
+  tier: restricted
+  presets: []
+"#;
+        let tracker = Arc::new(AgentSetupTracker::default());
+        let factory = AgentSetupFactory {
+            tracker: Arc::clone(&tracker),
+        };
+        let mut credentials = super::tests_support::EmptyCredentialProvider;
+
+        super::create_env(&options, &factory, &mut credentials, "demo", yaml)
+            .await
+            .unwrap();
+        tracker.exec_cmds.lock().expect("exec tracker").clear();
+
+        let result = super::run_agent_prompt_once(&options, &factory, "demo", "summarize 'quotes'")
+            .await
+            .unwrap();
+
+        assert_eq!(result.status, 0);
+        let exec_cmds = tracker.exec_cmds.lock().expect("exec tracker").clone();
+        assert_eq!(
+            exec_cmds,
+            vec![format!(
+                "{} {}",
+                super::AGENT_ENTRYPOINT_PATH,
+                super::shell_quote("summarize 'quotes'")
+            )]
         );
     }
 

--- a/crates/agentenv-core/src/skills/attestation.rs
+++ b/crates/agentenv-core/src/skills/attestation.rs
@@ -1,0 +1,416 @@
+use std::{fs, io::Write, path::Path};
+
+use ed25519_dalek::{
+    Signature, Signer, SigningKey, Verifier, VerifyingKey, PUBLIC_KEY_LENGTH, SIGNATURE_LENGTH,
+};
+use rand_core::{OsRng, RngCore};
+use serde::{Deserialize, Serialize};
+use time::{format_description::well_known::Rfc3339, OffsetDateTime};
+
+use super::{SkillAssertionResult, SkillError, SkillSelfTestReport, SELF_TEST_PUBLISH_THRESHOLD};
+
+const SELF_TEST_ATTESTATION_SCHEMA_VERSION: &str = "0.1";
+const SELF_TEST_ATTESTATION_PREDICATE_TYPE: &str =
+    "https://agentenv.dev/attestations/skill-self-test/v1";
+const SELF_TEST_ATTESTATION_PAYLOAD_HEADER: &[u8] = b"agentenv-skill-self-test-attestation-v1\n";
+
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct SkillSelfTestAttestation {
+    pub schema_version: String,
+    pub predicate_type: String,
+    pub subject: SkillSelfTestSubject,
+    pub self_test_digest: String,
+    pub runner: String,
+    pub score: f64,
+    pub publishable: bool,
+    pub started_at: OffsetDateTime,
+    pub completed_at: OffsetDateTime,
+    pub assertions: Vec<SkillAssertionResult>,
+    pub signature: SkillSelfTestAttestationSignature,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct SkillSelfTestSubject {
+    pub name: String,
+    pub version: String,
+    pub digest: String,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct SkillSelfTestAttestationSignature {
+    pub key_id: String,
+    pub algorithm: String,
+    pub public_key_ed25519: String,
+    pub value: String,
+}
+
+#[derive(Debug, Clone)]
+pub struct SkillSelfTestSigningKey {
+    signing_key: SigningKey,
+}
+
+#[derive(Debug, Clone)]
+pub struct SkillAttestationValidationOptions {
+    pub trusted_public_keys: Vec<String>,
+    pub now: OffsetDateTime,
+    pub max_age_seconds: u64,
+    pub threshold: f64,
+}
+
+impl Default for SkillAttestationValidationOptions {
+    fn default() -> Self {
+        Self {
+            trusted_public_keys: Vec::new(),
+            now: OffsetDateTime::now_utc(),
+            max_age_seconds: 86_400,
+            threshold: SELF_TEST_PUBLISH_THRESHOLD,
+        }
+    }
+}
+
+impl SkillSelfTestSigningKey {
+    pub fn from_secret_bytes(secret: [u8; 32]) -> Self {
+        Self {
+            signing_key: SigningKey::from_bytes(&secret),
+        }
+    }
+
+    pub fn public_key_hex(&self) -> String {
+        hex::encode(self.signing_key.verifying_key().to_bytes())
+    }
+
+    pub fn load_or_create(path: &Path) -> Result<Self, SkillError> {
+        #[cfg(unix)]
+        match fs::symlink_metadata(path) {
+            Ok(_) => {
+                ensure_unix_key_file_hygiene(path)?;
+                return read_existing_key(path);
+            }
+            Err(source) if source.kind() == std::io::ErrorKind::NotFound => {}
+            Err(source) => {
+                return Err(SkillError::Io {
+                    path: path.to_path_buf(),
+                    source,
+                });
+            }
+        }
+
+        #[cfg(not(unix))]
+        {
+            if path.exists() {
+                return read_existing_key(path);
+            }
+        }
+
+        if let Some(parent) = path.parent() {
+            fs::create_dir_all(parent).map_err(|source| SkillError::Io {
+                path: parent.to_path_buf(),
+                source,
+            })?;
+        }
+
+        let mut secret = [0_u8; 32];
+        OsRng.fill_bytes(&mut secret);
+        write_new_key_file(path, &secret)?;
+        Ok(Self::from_secret_bytes(secret))
+    }
+}
+
+fn read_existing_key(path: &Path) -> Result<SkillSelfTestSigningKey, SkillError> {
+    let bytes = fs::read(path).map_err(|source| SkillError::Io {
+        path: path.to_path_buf(),
+        source,
+    })?;
+    let secret = secret_bytes_from_slice(path, &bytes)?;
+    Ok(SkillSelfTestSigningKey::from_secret_bytes(secret))
+}
+
+pub fn sign_skill_self_test_attestation(
+    report: &SkillSelfTestReport,
+    key: &SkillSelfTestSigningKey,
+) -> Result<SkillSelfTestAttestation, SkillError> {
+    let public_key = key.public_key_hex();
+    let mut attestation = SkillSelfTestAttestation {
+        schema_version: SELF_TEST_ATTESTATION_SCHEMA_VERSION.to_owned(),
+        predicate_type: SELF_TEST_ATTESTATION_PREDICATE_TYPE.to_owned(),
+        subject: SkillSelfTestSubject {
+            name: report.name.clone(),
+            version: report.version.clone(),
+            digest: report.digest.clone(),
+        },
+        self_test_digest: report.self_test_digest.clone(),
+        runner: "agentenv".to_owned(),
+        score: report.score,
+        publishable: report.publishable,
+        started_at: report.started_at,
+        completed_at: report.completed_at,
+        assertions: report.assertions.clone(),
+        signature: SkillSelfTestAttestationSignature {
+            key_id: "local-agentenv".to_owned(),
+            algorithm: "ed25519".to_owned(),
+            public_key_ed25519: public_key,
+            value: String::new(),
+        },
+    };
+    let payload = attestation_payload(&attestation)?;
+    let signature = key.signing_key.sign(&payload);
+    attestation.signature.value = hex::encode(signature.to_bytes());
+    Ok(attestation)
+}
+
+pub fn validate_skill_publish_attestation(
+    name: &str,
+    version: &str,
+    digest: &str,
+    self_test_digest: &str,
+    attestation: &SkillSelfTestAttestation,
+    options: SkillAttestationValidationOptions,
+) -> Result<(), SkillError> {
+    if attestation.schema_version != SELF_TEST_ATTESTATION_SCHEMA_VERSION {
+        return Err(invalid_attestation(format!(
+            "unsupported schema version `{}`",
+            attestation.schema_version
+        )));
+    }
+    if attestation.predicate_type != SELF_TEST_ATTESTATION_PREDICATE_TYPE {
+        return Err(invalid_attestation(format!(
+            "unsupported predicate type `{}`",
+            attestation.predicate_type
+        )));
+    }
+    if attestation.subject.name != name
+        || attestation.subject.version != version
+        || attestation.subject.digest != digest
+    {
+        return Err(SkillError::SelfTestAttestationSubjectMismatch);
+    }
+    if attestation.self_test_digest != self_test_digest {
+        return Err(SkillError::SelfTestAttestationDigestMismatch);
+    }
+    validate_attestation_fields(attestation, &options)?;
+    if attestation.score < options.threshold || !attestation.publishable {
+        return Err(SkillError::SelfTestScoreBelowThreshold {
+            score: attestation.score,
+            threshold: options.threshold,
+        });
+    }
+    validate_attestation_recency(attestation.completed_at, &options)?;
+    verify_attestation_signature(attestation, &options)
+}
+
+fn attestation_payload(attestation: &SkillSelfTestAttestation) -> Result<Vec<u8>, SkillError> {
+    #[derive(Serialize)]
+    struct SignaturePayload<'a> {
+        key_id: &'a str,
+        algorithm: &'a str,
+        public_key_ed25519: &'a str,
+    }
+
+    #[derive(Serialize)]
+    struct CanonicalAttestationPayload<'a> {
+        schema_version: &'a str,
+        predicate_type: &'a str,
+        subject: &'a SkillSelfTestSubject,
+        self_test_digest: &'a str,
+        runner: &'a str,
+        score: f64,
+        publishable: bool,
+        started_at: OffsetDateTime,
+        completed_at: OffsetDateTime,
+        assertions: &'a [SkillAssertionResult],
+        signature: SignaturePayload<'a>,
+    }
+
+    let normalized = CanonicalAttestationPayload {
+        schema_version: &attestation.schema_version,
+        predicate_type: &attestation.predicate_type,
+        subject: &attestation.subject,
+        self_test_digest: &attestation.self_test_digest,
+        runner: &attestation.runner,
+        score: attestation.score,
+        publishable: attestation.publishable,
+        started_at: attestation.started_at,
+        completed_at: attestation.completed_at,
+        assertions: &attestation.assertions,
+        signature: SignaturePayload {
+            key_id: &attestation.signature.key_id,
+            algorithm: &attestation.signature.algorithm,
+            public_key_ed25519: &attestation.signature.public_key_ed25519,
+        },
+    };
+    let json = serde_json::to_vec(&normalized).map_err(|source| {
+        invalid_attestation(format!("failed to serialize canonical payload: {source}"))
+    })?;
+
+    let mut payload = SELF_TEST_ATTESTATION_PAYLOAD_HEADER.to_vec();
+    payload.extend(json);
+    Ok(payload)
+}
+
+fn verify_attestation_signature(
+    attestation: &SkillSelfTestAttestation,
+    options: &SkillAttestationValidationOptions,
+) -> Result<(), SkillError> {
+    if attestation.signature.algorithm != "ed25519" {
+        return Err(invalid_attestation(format!(
+            "unsupported signature algorithm `{}`",
+            attestation.signature.algorithm
+        )));
+    }
+    if !options
+        .trusted_public_keys
+        .iter()
+        .any(|trusted| trusted == &attestation.signature.public_key_ed25519)
+    {
+        return Err(invalid_attestation(
+            "self-test attestation public key is not trusted",
+        ));
+    }
+
+    let public_key_bytes = decode_hex_exact(
+        "public key",
+        &attestation.signature.public_key_ed25519,
+        PUBLIC_KEY_LENGTH,
+    )?;
+    let signature_bytes =
+        decode_hex_exact("signature", &attestation.signature.value, SIGNATURE_LENGTH)?;
+    let public_key = public_key_from_bytes(&public_key_bytes)?;
+    let signature = Signature::try_from(signature_bytes.as_slice()).map_err(|source| {
+        invalid_attestation(format!("invalid self-test attestation signature: {source}"))
+    })?;
+    let payload = attestation_payload(attestation)?;
+
+    public_key
+        .verify(&payload, &signature)
+        .map_err(|source| invalid_attestation(format!("signature verification failed: {source}")))
+}
+
+fn validate_attestation_fields(
+    attestation: &SkillSelfTestAttestation,
+    options: &SkillAttestationValidationOptions,
+) -> Result<(), SkillError> {
+    if attestation.runner != "agentenv" {
+        return Err(invalid_attestation(format!(
+            "unsupported self-test runner `{}`",
+            attestation.runner
+        )));
+    }
+    if !attestation.score.is_finite() || !(0.0..=1.0).contains(&attestation.score) {
+        return Err(invalid_attestation(
+            "self-test score must be between 0.0 and 1.0",
+        ));
+    }
+    if !options.threshold.is_finite() || !(0.0..=1.0).contains(&options.threshold) {
+        return Err(invalid_attestation(
+            "self-test attestation threshold must be between 0.0 and 1.0",
+        ));
+    }
+    if attestation.started_at > attestation.completed_at {
+        return Err(invalid_attestation(
+            "self-test attestation started_at is after completed_at",
+        ));
+    }
+    Ok(())
+}
+
+fn validate_attestation_recency(
+    completed_at: OffsetDateTime,
+    options: &SkillAttestationValidationOptions,
+) -> Result<(), SkillError> {
+    let age = options.now - completed_at;
+    let max_age_seconds = i64::try_from(options.max_age_seconds).unwrap_or(i64::MAX);
+    if age.is_negative() || age.whole_seconds() > max_age_seconds {
+        return Err(SkillError::StaleSelfTestAttestation {
+            completed_at: completed_at
+                .format(&Rfc3339)
+                .unwrap_or_else(|_| completed_at.to_string()),
+        });
+    }
+    Ok(())
+}
+
+fn decode_hex_exact(label: &str, value: &str, expected_len: usize) -> Result<Vec<u8>, SkillError> {
+    let bytes = hex::decode(value)
+        .map_err(|source| invalid_attestation(format!("invalid {label} hex: {source}")))?;
+    if bytes.len() != expected_len {
+        return Err(invalid_attestation(format!(
+            "{label} must be {expected_len} bytes"
+        )));
+    }
+    Ok(bytes)
+}
+
+fn public_key_from_bytes(bytes: &[u8]) -> Result<VerifyingKey, SkillError> {
+    let public_key: [u8; PUBLIC_KEY_LENGTH] = bytes.try_into().map_err(|_| {
+        invalid_attestation(format!("public key must be {PUBLIC_KEY_LENGTH} bytes"))
+    })?;
+    VerifyingKey::from_bytes(&public_key)
+        .map_err(|source| invalid_attestation(format!("invalid public key: {source}")))
+}
+
+fn secret_bytes_from_slice(path: &Path, bytes: &[u8]) -> Result<[u8; 32], SkillError> {
+    let secret: [u8; 32] = bytes
+        .try_into()
+        .map_err(|_| SkillError::InvalidSelfTestSigningKey {
+            path: path.to_path_buf(),
+        })?;
+    Ok(secret)
+}
+
+#[cfg(unix)]
+fn ensure_unix_key_file_hygiene(path: &Path) -> Result<(), SkillError> {
+    use std::os::unix::fs::PermissionsExt;
+
+    let metadata = fs::symlink_metadata(path).map_err(|source| SkillError::Io {
+        path: path.to_path_buf(),
+        source,
+    })?;
+    if metadata.file_type().is_symlink() || !metadata.file_type().is_file() {
+        return Err(SkillError::InvalidSelfTestSigningKey {
+            path: path.to_path_buf(),
+        });
+    }
+    if metadata.permissions().mode() & 0o077 != 0 {
+        return Err(SkillError::InvalidSelfTestSigningKey {
+            path: path.to_path_buf(),
+        });
+    }
+    Ok(())
+}
+
+#[cfg(unix)]
+fn write_new_key_file(path: &Path, secret: &[u8; 32]) -> Result<(), SkillError> {
+    use std::os::unix::fs::OpenOptionsExt;
+
+    let mut file = fs::OpenOptions::new()
+        .create_new(true)
+        .write(true)
+        .mode(0o600)
+        .open(path)
+        .map_err(|source| SkillError::Io {
+            path: path.to_path_buf(),
+            source,
+        })?;
+    file.write_all(secret).map_err(|source| SkillError::Io {
+        path: path.to_path_buf(),
+        source,
+    })?;
+    Ok(())
+}
+
+#[cfg(not(unix))]
+fn write_new_key_file(path: &Path, secret: &[u8; 32]) -> Result<(), SkillError> {
+    fs::write(path, secret).map_err(|source| SkillError::Io {
+        path: path.to_path_buf(),
+        source,
+    })
+}
+
+fn invalid_attestation(message: impl Into<String>) -> SkillError {
+    SkillError::InvalidSelfTestAttestation {
+        message: message.into(),
+    }
+}

--- a/crates/agentenv-core/src/skills/cache.rs
+++ b/crates/agentenv-core/src/skills/cache.rs
@@ -17,6 +17,8 @@ use thiserror::Error;
 
 use crate::digest::{parse_sha256_digest, parse_sha256_hex, DigestError};
 
+pub use super::self_test::SkillSelfTestAssertion;
+
 pub const SKILL_METADATA_SCHEMA_VERSION: &str = "0.1";
 
 #[derive(Debug, Error)]
@@ -108,7 +110,7 @@ impl SkillCacheLayout {
     }
 }
 
-#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
 #[serde(deny_unknown_fields)]
 pub struct SkillManifest {
     pub schema_version: String,
@@ -131,20 +133,13 @@ pub struct SkillArchive {
     pub cache_key: String,
 }
 
-#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
 #[serde(deny_unknown_fields)]
 pub struct SkillSelfTest {
     #[serde(default = "default_self_test_timeout_seconds")]
     pub timeout_seconds: u64,
     #[serde(default, skip_serializing_if = "Vec::is_empty")]
     pub assertions: Vec<SkillSelfTestAssertion>,
-}
-
-#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
-#[serde(tag = "type", rename_all = "snake_case", deny_unknown_fields)]
-pub enum SkillSelfTestAssertion {
-    FileExists { path: String },
-    CommandExitsZero { cmd: String },
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
@@ -1113,11 +1108,16 @@ fn verify_self_tests(skill_dir: &Path, manifest: &SkillManifest, errors: &mut Ve
                     errors.push(error);
                 }
             }
+            SkillSelfTestAssertion::AgentProduces { .. } => {
+                errors.push(
+                    "agent_produces self-test assertions require the self-test runner".to_owned(),
+                );
+            }
         }
     }
 }
 
-fn verify_self_test_file_exists(skill_dir: &Path, path: &str, errors: &mut Vec<String>) {
+fn verify_self_test_file_exists(skill_dir: &Path, path: &Path, errors: &mut Vec<String>) {
     let relative_path = match safe_relative_path(path) {
         Ok(path) => path,
         Err(error) => {
@@ -1126,12 +1126,14 @@ fn verify_self_test_file_exists(skill_dir: &Path, path: &str, errors: &mut Vec<S
         }
     };
     if !skill_dir.join(&relative_path).is_file() {
-        errors.push(format!("self-test file does not exist `{path}`"));
+        errors.push(format!(
+            "self-test file does not exist `{}`",
+            path.display()
+        ));
     }
 }
 
-fn safe_relative_path(path: &str) -> Result<PathBuf, String> {
-    let source = Path::new(path);
+fn safe_relative_path(source: &Path) -> Result<PathBuf, String> {
     if source.as_os_str().is_empty() {
         return Err("self-test path must not be empty".to_owned());
     }
@@ -1142,7 +1144,8 @@ fn safe_relative_path(path: &str) -> Result<PathBuf, String> {
             Component::Normal(segment) => relative.push(segment),
             _ => {
                 return Err(format!(
-                    "self-test path must be a safe relative path `{path}`"
+                    "self-test path must be a safe relative path `{}`",
+                    source.display()
                 ))
             }
         }

--- a/crates/agentenv-core/src/skills/error.rs
+++ b/crates/agentenv-core/src/skills/error.rs
@@ -70,6 +70,12 @@ pub enum SkillError {
     MissingManifestField { path: PathBuf, field: &'static str },
     #[error("skill digest mismatch: expected `{expected}`, found `{actual}`")]
     DigestMismatch { expected: String, actual: String },
+    #[error("skill self-test is missing")]
+    MissingSelfTest,
+    #[error("invalid skill self-test: {message}")]
+    InvalidSelfTest { message: String },
+    #[error("conflicting skill self-test declaration in `{declaration_source}`")]
+    ConflictingSelfTestDeclarations { declaration_source: String },
     #[error("missing Ed25519 signature for skill `{name}` version `{version}`")]
     MissingSignature { name: String, version: String },
     #[error("invalid Ed25519 signature for skill `{name}` version `{version}`: {message}")]

--- a/crates/agentenv-core/src/skills/error.rs
+++ b/crates/agentenv-core/src/skills/error.rs
@@ -80,6 +80,8 @@ pub enum SkillError {
     SelfTestTimeout { timeout_seconds: u64 },
     #[error("skill self-test score {score:.3} is below required threshold {threshold:.3}")]
     SelfTestScoreBelowThreshold { score: f64, threshold: f64 },
+    #[error("missing signed self-test attestation for skill publish")]
+    MissingSelfTestAttestation,
     #[error("invalid skill self-test signing key at `{path}`")]
     InvalidSelfTestSigningKey { path: PathBuf },
     #[error("invalid skill self-test attestation: {message}")]

--- a/crates/agentenv-core/src/skills/error.rs
+++ b/crates/agentenv-core/src/skills/error.rs
@@ -76,6 +76,12 @@ pub enum SkillError {
     InvalidSelfTest { message: String },
     #[error("conflicting skill self-test declaration in `{declaration_source}`")]
     ConflictingSelfTestDeclarations { declaration_source: String },
+    #[error("skill self-test timed out after {timeout_seconds}s")]
+    SelfTestTimeout { timeout_seconds: u64 },
+    #[error("skill self-test score {score:.3} is below required threshold {threshold:.3}")]
+    SelfTestScoreBelowThreshold { score: f64, threshold: f64 },
+    #[error("agent_produces self-test assertions are unavailable in this execution context")]
+    UnsupportedAgentProduces,
     #[error("missing Ed25519 signature for skill `{name}` version `{version}`")]
     MissingSignature { name: String, version: String },
     #[error("invalid Ed25519 signature for skill `{name}` version `{version}`: {message}")]

--- a/crates/agentenv-core/src/skills/error.rs
+++ b/crates/agentenv-core/src/skills/error.rs
@@ -80,6 +80,18 @@ pub enum SkillError {
     SelfTestTimeout { timeout_seconds: u64 },
     #[error("skill self-test score {score:.3} is below required threshold {threshold:.3}")]
     SelfTestScoreBelowThreshold { score: f64, threshold: f64 },
+    #[error("invalid skill self-test signing key at `{path}`")]
+    InvalidSelfTestSigningKey { path: PathBuf },
+    #[error("invalid skill self-test attestation: {message}")]
+    InvalidSelfTestAttestation { message: String },
+    #[error("skill self-test attestation subject does not match published skill")]
+    SelfTestAttestationSubjectMismatch,
+    #[error("skill self-test attestation digest does not match published self-test")]
+    SelfTestAttestationDigestMismatch,
+    #[error(
+        "skill self-test attestation completed at `{completed_at}` is outside the allowed window"
+    )]
+    StaleSelfTestAttestation { completed_at: String },
     #[error("agent_produces self-test assertions are unavailable in this execution context")]
     UnsupportedAgentProduces,
     #[error("missing Ed25519 signature for skill `{name}` version `{version}`")]

--- a/crates/agentenv-core/src/skills/mod.rs
+++ b/crates/agentenv-core/src/skills/mod.rs
@@ -30,8 +30,10 @@ pub use error::SkillError;
 pub use manifest::{load_skill_manifest, validate_skill_name, SkillManifest};
 pub use registry::{FetchedSkill, RegistryAdapter, RegistryConfig, RegistryKind, SkillSearchHit};
 pub use self_test::{
-    load_skill_self_test_spec, normalized_self_test_digest, SkillSelfTestAssertion,
-    SkillSelfTestRunner, SkillSelfTestSpec,
+    load_skill_self_test_spec, normalized_self_test_digest, run_skill_self_test,
+    AgentProduceRequest, AgentProduceRunner, SkillAssertionResult, SkillAssertionStatus,
+    SkillSelfTestAssertion, SkillSelfTestOptions, SkillSelfTestReport, SkillSelfTestRunner,
+    SkillSelfTestSpec, UnsupportedAgentProduceRunner, SELF_TEST_PUBLISH_THRESHOLD,
 };
 pub use service::{SkillAddRequest, SkillCredentialResolver, SkillPublishRequest, SkillService};
 pub use signature::{signature_payload, verify_ed25519_signature};

--- a/crates/agentenv-core/src/skills/mod.rs
+++ b/crates/agentenv-core/src/skills/mod.rs
@@ -9,6 +9,7 @@ mod registry_filesystem;
 mod registry_git;
 mod registry_http;
 mod registry_oci;
+pub mod self_test;
 mod service;
 mod signature;
 mod store;
@@ -17,8 +18,8 @@ pub use cache::{
     execute_skill_prune, load_skill_trust_keys, plan_skill_prune, rebuild_skill_index,
     verify_all_installed_skills, verify_skill_pins, SkillArchive, SkillCacheError,
     SkillCacheLayout, SkillIndex, SkillIndexEntry, SkillProvenance, SkillProvenanceSubject,
-    SkillPrunePlan, SkillSelfTest, SkillSelfTestAssertion, SkillTrustKey, SkillVerifyEntry,
-    SkillVerifyOptions, SkillVerifyReport, SkillVerifyStatus, SKILL_METADATA_SCHEMA_VERSION,
+    SkillPrunePlan, SkillSelfTest, SkillTrustKey, SkillVerifyEntry, SkillVerifyOptions,
+    SkillVerifyReport, SkillVerifyStatus, SKILL_METADATA_SCHEMA_VERSION,
 };
 pub use config::{
     load_project_skills_config, load_user_skills_config, merge_skills_config, SkillsConfig,
@@ -28,6 +29,10 @@ pub use digest::compute_bundle_digest;
 pub use error::SkillError;
 pub use manifest::{load_skill_manifest, validate_skill_name, SkillManifest};
 pub use registry::{FetchedSkill, RegistryAdapter, RegistryConfig, RegistryKind, SkillSearchHit};
+pub use self_test::{
+    load_skill_self_test_spec, normalized_self_test_digest, SkillSelfTestAssertion,
+    SkillSelfTestRunner, SkillSelfTestSpec,
+};
 pub use service::{SkillAddRequest, SkillCredentialResolver, SkillPublishRequest, SkillService};
 pub use signature::{signature_payload, verify_ed25519_signature};
 pub use store::{

--- a/crates/agentenv-core/src/skills/mod.rs
+++ b/crates/agentenv-core/src/skills/mod.rs
@@ -44,6 +44,7 @@ pub use self_test::{
 pub use service::{SkillAddRequest, SkillCredentialResolver, SkillPublishRequest, SkillService};
 pub use signature::{signature_payload, verify_ed25519_signature};
 pub use store::{
-    info_installed_skill, install_local_skill, list_installed_skills, remove_installed_skill,
-    verify_installed_skill, InstalledSkill, InstalledSkillSelector, SkillInstallOptions,
+    info_installed_skill, install_local_skill, list_installed_skills, read_self_test_attestation,
+    remove_installed_skill, self_test_signing_key_path, verify_installed_skill,
+    write_self_test_attestation, InstalledSkill, InstalledSkillSelector, SkillInstallOptions,
 };

--- a/crates/agentenv-core/src/skills/mod.rs
+++ b/crates/agentenv-core/src/skills/mod.rs
@@ -1,3 +1,4 @@
+mod attestation;
 pub mod cache;
 mod config;
 mod digest;
@@ -14,6 +15,11 @@ mod service;
 mod signature;
 mod store;
 
+pub use attestation::{
+    sign_skill_self_test_attestation, validate_skill_publish_attestation,
+    SkillAttestationValidationOptions, SkillSelfTestAttestation, SkillSelfTestAttestationSignature,
+    SkillSelfTestSigningKey, SkillSelfTestSubject,
+};
 pub use cache::{
     execute_skill_prune, load_skill_trust_keys, plan_skill_prune, rebuild_skill_index,
     verify_all_installed_skills, verify_skill_pins, SkillArchive, SkillCacheError,

--- a/crates/agentenv-core/src/skills/registry.rs
+++ b/crates/agentenv-core/src/skills/registry.rs
@@ -1,6 +1,6 @@
 use std::path::{Path, PathBuf};
 
-use super::SkillError;
+use super::{SkillError, SkillSelfTestAttestation};
 
 #[derive(Debug, Clone, serde::Serialize, serde::Deserialize, PartialEq, Eq)]
 pub struct RegistryConfig {
@@ -70,7 +70,7 @@ pub enum RegistryKind {
     Git,
 }
 
-#[derive(Debug, Clone, serde::Serialize, serde::Deserialize, PartialEq, Eq)]
+#[derive(Debug, Clone, serde::Serialize, serde::Deserialize, PartialEq)]
 pub struct SkillSearchHit {
     pub name: String,
     pub version: String,
@@ -79,6 +79,22 @@ pub struct SkillSearchHit {
     pub digest: Option<String>,
     pub signature_ed25519: Option<String>,
     pub public_key_ed25519: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub self_test_score: Option<f64>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub self_test_attestation_digest: Option<String>,
+}
+
+impl SkillSearchHit {
+    pub(crate) fn apply_self_test_attestation(
+        &mut self,
+        attestation: Option<&SkillSelfTestAttestation>,
+    ) {
+        if let Some(attestation) = attestation {
+            self.self_test_score = Some(attestation.score);
+            self.self_test_attestation_digest = Some(attestation.self_test_digest.clone());
+        }
+    }
 }
 
 #[derive(Debug, Clone)]
@@ -98,5 +114,6 @@ pub trait RegistryAdapter {
         &self,
         bundle_path: &Path,
         allow_unsigned: bool,
+        attestation: Option<&SkillSelfTestAttestation>,
     ) -> Result<SkillSearchHit, SkillError>;
 }

--- a/crates/agentenv-core/src/skills/registry_filesystem.rs
+++ b/crates/agentenv-core/src/skills/registry_filesystem.rs
@@ -8,15 +8,16 @@ use std::{
 use semver::Version;
 use serde::{Deserialize, Serialize};
 
+use super::signature::verify_skill_package_signature;
 use super::{
-    compute_bundle_digest, manifest::validated_bundle_file, validate_skill_name,
-    verify_ed25519_signature, FetchedSkill, RegistryAdapter, SkillError, SkillManifest,
-    SkillSearchHit,
+    compute_bundle_digest, manifest::validated_bundle_file, validate_skill_name, FetchedSkill,
+    RegistryAdapter, SkillError, SkillManifest, SkillSearchHit, SkillSelfTestAttestation,
 };
 
 const BUNDLES_DIR: &str = "bundles";
 const INDEX_FILE: &str = "index.yaml";
 const MANIFEST_FILE: &str = "skill.yaml";
+const SKILL_TEST_FILE: &str = "skill-test.yaml";
 const SOURCE_TYPE: &str = "filesystem";
 
 #[derive(Debug, Clone)]
@@ -166,6 +167,8 @@ impl FilesystemRegistryAdapter {
             digest: Some(digest),
             signature_ed25519: manifest.signature_ed25519.clone(),
             public_key_ed25519: manifest.signature_public_key_ed25519.clone(),
+            self_test_score: None,
+            self_test_attestation_digest: None,
         }
     }
 
@@ -373,14 +376,17 @@ impl RegistryAdapter for FilesystemRegistryAdapter {
         &self,
         bundle_path: &Path,
         allow_unsigned: bool,
+        attestation: Option<&SkillSelfTestAttestation>,
     ) -> Result<SkillSearchHit, SkillError> {
         ensure_directory(&self.root)?;
         ensure_directory(&self.root.join(BUNDLES_DIR))?;
         let manifest = super::load_skill_manifest(bundle_path)?;
         let digest = compute_bundle_digest(bundle_path, &manifest)?;
         verify_publish_signature(&manifest, &digest, allow_unsigned)?;
+        let attestation = attestation.ok_or(SkillError::MissingSelfTestAttestation)?;
         let version = manifest.version.to_string();
-        let hit = self.hit_for_manifest(&manifest, digest.clone());
+        let mut hit = self.hit_for_manifest(&manifest, digest.clone());
+        hit.apply_self_test_attestation(Some(attestation));
 
         if let Some(existing_digest) = self.existing_bundle_digest(&manifest.name, &version)? {
             if existing_digest != digest {
@@ -390,6 +396,21 @@ impl RegistryAdapter for FilesystemRegistryAdapter {
                     existing: existing_digest,
                 });
             }
+            let destination =
+                existing_child_directory(&self.root, &[BUNDLES_DIR, &manifest.name, &version])?
+                    .ok_or_else(|| SkillError::SkillNotInstalled {
+                        name: manifest.name.clone(),
+                    })?;
+            copy_bundle_contents(bundle_path, &destination, &manifest)?;
+            write_json_atomic(
+                &self
+                    .root
+                    .join(BUNDLES_DIR)
+                    .join(&manifest.name)
+                    .join(&version)
+                    .join("self-test-attestation.json"),
+                attestation,
+            )?;
             self.upsert_hit(hit.clone())?;
             return Ok(hit);
         }
@@ -399,6 +420,7 @@ impl RegistryAdapter for FilesystemRegistryAdapter {
         let staging = staging_publish_path(&bundle_parent, &version)?;
         remove_directory_if_exists(&staging)?;
         copy_bundle_contents(bundle_path, &staging, &manifest)?;
+        write_json_atomic(&staging.join("self-test-attestation.json"), attestation)?;
         rename_directory(&staging, &destination)?;
         self.upsert_hit(hit.clone())?;
         Ok(hit)
@@ -410,27 +432,7 @@ fn verify_publish_signature(
     digest: &str,
     allow_unsigned: bool,
 ) -> Result<(), SkillError> {
-    if allow_unsigned {
-        return Ok(());
-    }
-
-    let signature =
-        manifest
-            .signature_ed25519
-            .as_deref()
-            .ok_or_else(|| SkillError::MissingSignature {
-                name: manifest.name.clone(),
-                version: manifest.version.to_string(),
-            })?;
-    let public_key = manifest
-        .signature_public_key_ed25519
-        .as_deref()
-        .ok_or_else(|| SkillError::MissingSignature {
-            name: manifest.name.clone(),
-            version: manifest.version.to_string(),
-        })?;
-
-    verify_ed25519_signature(manifest, digest, signature, public_key)
+    verify_skill_package_signature(manifest, digest, allow_unsigned).map(|_| ())
 }
 
 fn contains_hit(hits: &[SkillSearchHit], needle: &SkillSearchHit) -> bool {
@@ -452,7 +454,46 @@ fn copy_bundle_contents(
         let source = validated_bundle_file(source_root, declared_file)?;
         copy_regular_file(&source, &destination_root.join(declared_file))?;
     }
+    copy_optional_self_test_file(source_root, destination_root)?;
     Ok(())
+}
+
+fn copy_optional_self_test_file(
+    source_root: &Path,
+    destination_root: &Path,
+) -> Result<(), SkillError> {
+    let source = source_root.join(SKILL_TEST_FILE);
+    let destination = destination_root.join(SKILL_TEST_FILE);
+    match fs::symlink_metadata(&source) {
+        Ok(metadata) if metadata.file_type().is_file() => copy_regular_file(&source, &destination),
+        Ok(_) => Err(SkillError::UnsafeBundlePath { path: source }),
+        Err(source_error) if source_error.kind() == std::io::ErrorKind::NotFound => {
+            remove_optional_file(&destination)
+        }
+        Err(source_error) => Err(SkillError::Io {
+            path: source,
+            source: source_error,
+        }),
+    }
+}
+
+fn remove_optional_file(path: &Path) -> Result<(), SkillError> {
+    match fs::symlink_metadata(path) {
+        Ok(metadata) if metadata.file_type().is_file() => {
+            fs::remove_file(path).map_err(|source| SkillError::Io {
+                path: path.to_path_buf(),
+                source,
+            })
+        }
+        Ok(_) => Err(SkillError::UnsafeBundlePath {
+            path: path.to_path_buf(),
+        }),
+        Err(source) if source.kind() == std::io::ErrorKind::NotFound => Ok(()),
+        Err(source) => Err(SkillError::Io {
+            path: path.to_path_buf(),
+            source,
+        }),
+    }
 }
 
 fn ensure_directory(path: &Path) -> Result<(), SkillError> {
@@ -685,6 +726,34 @@ where
     })?;
     let tmp_path = temporary_path(path);
     fs::write(&tmp_path, yaml).map_err(|source| SkillError::Io {
+        path: tmp_path.clone(),
+        source,
+    })?;
+    replace_file(&tmp_path, path).map_err(|source| {
+        let _ = fs::remove_file(&tmp_path);
+        SkillError::Io {
+            path: path.to_path_buf(),
+            source,
+        }
+    })
+}
+
+fn write_json_atomic<T>(path: &Path, value: &T) -> Result<(), SkillError>
+where
+    T: Serialize,
+{
+    let parent = path.parent().ok_or_else(|| SkillError::UnsafeBundlePath {
+        path: path.to_path_buf(),
+    })?;
+    ensure_directory(parent)?;
+
+    let json = serde_json::to_vec_pretty(value).map_err(|source| {
+        SkillError::InvalidSelfTestAttestation {
+            message: format!("failed to serialize self-test attestation: {source}"),
+        }
+    })?;
+    let tmp_path = temporary_path(path);
+    fs::write(&tmp_path, json).map_err(|source| SkillError::Io {
         path: tmp_path.clone(),
         source,
     })?;

--- a/crates/agentenv-core/src/skills/registry_git.rs
+++ b/crates/agentenv-core/src/skills/registry_git.rs
@@ -20,6 +20,7 @@ use super::{
 };
 
 const MANIFEST_FILE: &str = "skill.yaml";
+const SKILL_TEST_FILE: &str = "skill-test.yaml";
 const SOURCE_TYPE: &str = "git";
 const GIT_COMMAND_TIMEOUT: Duration = Duration::from_secs(120);
 
@@ -235,6 +236,8 @@ impl GitRegistryAdapter {
             digest: Some(digest),
             signature_ed25519: manifest.signature_ed25519.clone(),
             public_key_ed25519: manifest.signature_public_key_ed25519.clone(),
+            self_test_score: None,
+            self_test_attestation_digest: None,
         }
     }
 }
@@ -310,6 +313,7 @@ impl RegistryAdapter for GitRegistryAdapter {
         &self,
         _bundle_path: &Path,
         _allow_unsigned: bool,
+        _attestation: Option<&super::SkillSelfTestAttestation>,
     ) -> Result<SkillSearchHit, SkillError> {
         Err(SkillError::UnsupportedRegistryPublish {
             registry: self.name.clone(),
@@ -816,7 +820,28 @@ fn copy_bundle_contents(
             &destination_root.join(declared_file),
         )?;
     }
+    copy_optional_self_test_file(source_root, destination_root)?;
     Ok(())
+}
+
+fn copy_optional_self_test_file(
+    source_root: &Path,
+    destination_root: &Path,
+) -> Result<(), SkillError> {
+    let source = source_root.join(SKILL_TEST_FILE);
+    match fs::symlink_metadata(&source) {
+        Ok(metadata) if metadata.file_type().is_file() => copy_regular_file(
+            source_root,
+            Path::new(SKILL_TEST_FILE),
+            &destination_root.join(SKILL_TEST_FILE),
+        ),
+        Ok(_) => Err(SkillError::UnsafeBundlePath { path: source }),
+        Err(source_error) if source_error.kind() == std::io::ErrorKind::NotFound => Ok(()),
+        Err(source_error) => Err(SkillError::Io {
+            path: source,
+            source: source_error,
+        }),
+    }
 }
 
 fn sort_hits(hits: &mut [SkillSearchHit]) {

--- a/crates/agentenv-core/src/skills/registry_http.rs
+++ b/crates/agentenv-core/src/skills/registry_http.rs
@@ -12,11 +12,12 @@ use url::Url;
 
 use crate::security::ssrf::{validate_outbound, SsrfOptions};
 
+use super::signature::verify_skill_package_signature;
 use super::{
     compute_bundle_digest,
     manifest::{load_remote_skill_manifest, normalize_bundle_path, validated_bundle_file},
     validate_skill_name, verify_ed25519_signature, FetchedSkill, RegistryAdapter, SkillError,
-    SkillManifest, SkillSearchHit,
+    SkillManifest, SkillSearchHit, SkillSelfTestAttestation,
 };
 
 const BUNDLES_DIR: &str = "bundles";
@@ -24,6 +25,7 @@ const CONTENT_DIR: &str = "content";
 const INDEX_JSON_FILE: &str = "index.json";
 const INDEX_YAML_FILE: &str = "index.yaml";
 const MANIFEST_FILE: &str = "skill.yaml";
+const SKILL_TEST_FILE: &str = "skill-test.yaml";
 const SOURCE_TYPE: &str = "http";
 
 #[derive(Debug, Clone)]
@@ -86,6 +88,14 @@ impl HttpRegistryAdapter {
 
     fn manifest_url(&self, name: &str, version: &str) -> Result<Url, SkillError> {
         self.url_for(&[BUNDLES_DIR, name, version, MANIFEST_FILE])
+    }
+
+    fn skill_test_url(&self, name: &str, version: &str) -> Result<Url, SkillError> {
+        self.url_for(&[BUNDLES_DIR, name, version, SKILL_TEST_FILE])
+    }
+
+    fn attestation_url(&self, name: &str, version: &str) -> Result<Url, SkillError> {
+        self.url_for(&[BUNDLES_DIR, name, version, "self-test-attestation.json"])
     }
 
     fn tarball_url(&self, name: &str, version: &str) -> Result<Url, SkillError> {
@@ -225,6 +235,8 @@ impl HttpRegistryAdapter {
             digest: Some(digest),
             signature_ed25519: manifest.signature_ed25519.clone(),
             public_key_ed25519: manifest.signature_public_key_ed25519.clone(),
+            self_test_score: None,
+            self_test_attestation_digest: None,
         }
     }
 
@@ -356,6 +368,12 @@ impl HttpRegistryAdapter {
                 .get_bytes(self.content_url(&hit.name, &hit.version, declared_file)?)
                 .await?;
             write_file(&staging_path.join(declared_file), &content)?;
+        }
+        if let Some(content) = self
+            .get_optional_bytes(self.skill_test_url(&hit.name, &hit.version)?)
+            .await?
+        {
+            write_file(&staging_path.join(SKILL_TEST_FILE), &content)?;
         }
 
         Ok(())
@@ -511,12 +529,15 @@ impl RegistryAdapter for HttpRegistryAdapter {
         &self,
         bundle_path: &Path,
         allow_unsigned: bool,
+        attestation: Option<&SkillSelfTestAttestation>,
     ) -> Result<SkillSearchHit, SkillError> {
         let manifest = super::load_skill_manifest(bundle_path)?;
         let digest = compute_bundle_digest(bundle_path, &manifest)?;
         verify_publish_signature(&manifest, &digest, allow_unsigned)?;
+        let attestation = attestation.ok_or(SkillError::MissingSelfTestAttestation)?;
         let version = manifest.version.to_string();
-        let hit = self.hit_for_manifest(&manifest, digest.clone());
+        let mut hit = self.hit_for_manifest(&manifest, digest.clone());
+        hit.apply_self_test_attestation(Some(attestation));
         let (mut index, index_format) = self.read_index_with_format().await?;
 
         if let Some(existing) = index
@@ -539,6 +560,10 @@ impl RegistryAdapter for HttpRegistryAdapter {
         let manifest_bytes = read_regular_file(&bundle_path.join(MANIFEST_FILE))?;
         self.put_bytes(self.manifest_url(&manifest.name, &version)?, manifest_bytes)
             .await?;
+        if let Some(bytes) = read_optional_regular_file(&bundle_path.join(SKILL_TEST_FILE))? {
+            self.put_bytes(self.skill_test_url(&manifest.name, &version)?, bytes)
+                .await?;
+        }
         for declared_file in &manifest.declared_files {
             let source = validated_bundle_file(bundle_path, declared_file)?;
             let bytes = read_regular_file(&source)?;
@@ -548,6 +573,13 @@ impl RegistryAdapter for HttpRegistryAdapter {
             )
             .await?;
         }
+        let bytes = serde_json::to_vec_pretty(attestation).map_err(|source| {
+            SkillError::InvalidSelfTestAttestation {
+                message: format!("failed to serialize self-test attestation: {source}"),
+            }
+        })?;
+        self.put_bytes(self.attestation_url(&manifest.name, &version)?, bytes)
+            .await?;
 
         index
             .skills
@@ -640,27 +672,7 @@ fn verify_publish_signature(
     digest: &str,
     allow_unsigned: bool,
 ) -> Result<(), SkillError> {
-    if allow_unsigned {
-        return Ok(());
-    }
-
-    let signature =
-        manifest
-            .signature_ed25519
-            .as_deref()
-            .ok_or_else(|| SkillError::MissingSignature {
-                name: manifest.name.clone(),
-                version: manifest.version.to_string(),
-            })?;
-    let public_key = manifest
-        .signature_public_key_ed25519
-        .as_deref()
-        .ok_or_else(|| SkillError::MissingSignature {
-            name: manifest.name.clone(),
-            version: manifest.version.to_string(),
-        })?;
-
-    verify_ed25519_signature(manifest, digest, signature, public_key)
+    verify_skill_package_signature(manifest, digest, allow_unsigned).map(|_| ())
 }
 
 fn remove_directory_if_exists(path: &Path) -> Result<(), SkillError> {
@@ -693,6 +705,20 @@ fn write_file(path: &Path, content: &[u8]) -> Result<(), SkillError> {
         path: path.to_path_buf(),
         source,
     })
+}
+
+fn read_optional_regular_file(path: &Path) -> Result<Option<Vec<u8>>, SkillError> {
+    match fs::symlink_metadata(path) {
+        Ok(metadata) if metadata.file_type().is_file() => read_regular_file(path).map(Some),
+        Ok(_) => Err(SkillError::UnsafeBundlePath {
+            path: path.to_path_buf(),
+        }),
+        Err(source) if source.kind() == std::io::ErrorKind::NotFound => Ok(None),
+        Err(source) => Err(SkillError::Io {
+            path: path.to_path_buf(),
+            source,
+        }),
+    }
 }
 
 #[cfg(unix)]

--- a/crates/agentenv-core/src/skills/registry_oci.rs
+++ b/crates/agentenv-core/src/skills/registry_oci.rs
@@ -14,21 +14,28 @@ use url::Url;
 
 use crate::security::ssrf::{validate_outbound, SsrfOptions};
 
+use super::signature::verify_skill_package_signature;
 use super::{
     compute_bundle_digest,
     manifest::{normalize_bundle_path, validated_bundle_file},
-    validate_skill_name, verify_ed25519_signature, FetchedSkill, RegistryAdapter, SkillError,
-    SkillManifest, SkillSearchHit,
+    validate_skill_name, FetchedSkill, RegistryAdapter, SkillError, SkillManifest, SkillSearchHit,
+    SkillSelfTestAttestation,
 };
 
 const OCI_IMAGE_MANIFEST: &str = "application/vnd.oci.image.manifest.v1+json";
 const AGENTENV_SKILL_CONFIG: &str = "application/vnd.agentenv.skill.config.v1+json";
 const AGENTENV_SKILL_MANIFEST: &str = "application/vnd.agentenv.skill.manifest.v1+yaml";
 const AGENTENV_SKILL_FILE: &str = "application/vnd.agentenv.skill.file.v1";
+const AGENTENV_SKILL_SELF_TEST_ATTESTATION: &str =
+    "application/vnd.agentenv.skill.self-test-attestation.v1+json";
 const AGENTENV_SKILLS_INDEX: &str = "application/vnd.agentenv.skills.index.v1+yaml";
 const SKILL_PATH_ANNOTATION: &str = "io.agentenv.skill.path";
+const OCI_ANNOTATION_SELF_TEST_SCORE: &str = "dev.agentenv.skill.self-test.score";
+const OCI_ANNOTATION_SELF_TEST_DIGEST: &str = "dev.agentenv.skill.self-test.digest";
+const OCI_ANNOTATION_SELF_TEST_COMPLETED_AT: &str = "dev.agentenv.skill.self-test.completed-at";
 const INDEX_TAG: &str = "skills-index";
 const MANIFEST_FILE: &str = "skill.yaml";
+const SKILL_TEST_FILE: &str = "skill-test.yaml";
 const SOURCE_TYPE: &str = "oci";
 
 #[derive(Debug, Clone)]
@@ -204,6 +211,8 @@ impl OciRegistryAdapter {
             digest: Some(digest),
             signature_ed25519: manifest.signature_ed25519.clone(),
             public_key_ed25519: manifest.signature_public_key_ed25519.clone(),
+            self_test_score: None,
+            self_test_attestation_digest: None,
         }
     }
 
@@ -490,12 +499,15 @@ impl RegistryAdapter for OciRegistryAdapter {
         &self,
         bundle_path: &Path,
         allow_unsigned: bool,
+        attestation: Option<&SkillSelfTestAttestation>,
     ) -> Result<SkillSearchHit, SkillError> {
         let manifest = super::load_skill_manifest(bundle_path)?;
         let digest = compute_bundle_digest(bundle_path, &manifest)?;
         verify_publish_signature(&manifest, &digest, allow_unsigned)?;
+        let attestation = attestation.ok_or(SkillError::MissingSelfTestAttestation)?;
         let version = manifest.version.to_string();
-        let hit = self.hit_for_manifest(&manifest, digest.clone());
+        let mut hit = self.hit_for_manifest(&manifest, digest.clone());
+        hit.apply_self_test_attestation(Some(attestation));
         let mut index = self.read_index().await?;
 
         if let Some(existing) = index
@@ -528,6 +540,13 @@ impl RegistryAdapter for OciRegistryAdapter {
             .upload_blob(AGENTENV_SKILL_MANIFEST, manifest_bytes)
             .await?;
         let mut layers = vec![manifest_layer];
+        if let Some(bytes) = read_optional_regular_file(&bundle_path.join(SKILL_TEST_FILE))? {
+            let mut descriptor = self.upload_blob(AGENTENV_SKILL_FILE, bytes).await?;
+            descriptor
+                .annotations
+                .insert(SKILL_PATH_ANNOTATION.to_owned(), SKILL_TEST_FILE.to_owned());
+            layers.push(descriptor);
+        }
         for declared_file in &manifest.declared_files {
             let source = validated_bundle_file(bundle_path, declared_file)?;
             let bytes = read_regular_file(&source)?;
@@ -538,6 +557,29 @@ impl RegistryAdapter for OciRegistryAdapter {
             );
             layers.push(descriptor);
         }
+        let mut descriptor = self
+            .upload_blob(
+                AGENTENV_SKILL_SELF_TEST_ATTESTATION,
+                serde_json::to_vec_pretty(attestation).map_err(|source| {
+                    SkillError::InvalidSelfTestAttestation {
+                        message: format!("failed to serialize self-test attestation: {source}"),
+                    }
+                })?,
+            )
+            .await?;
+        descriptor.annotations.insert(
+            OCI_ANNOTATION_SELF_TEST_SCORE.to_owned(),
+            attestation.score.to_string(),
+        );
+        descriptor.annotations.insert(
+            OCI_ANNOTATION_SELF_TEST_DIGEST.to_owned(),
+            attestation.self_test_digest.clone(),
+        );
+        descriptor.annotations.insert(
+            OCI_ANNOTATION_SELF_TEST_COMPLETED_AT.to_owned(),
+            attestation.completed_at.to_string(),
+        );
+        layers.push(descriptor);
         self.put_manifest(
             &skill_tag(&manifest.name, &version),
             OciImageManifest {
@@ -632,27 +674,7 @@ fn verify_publish_signature(
     digest: &str,
     allow_unsigned: bool,
 ) -> Result<(), SkillError> {
-    if allow_unsigned {
-        return Ok(());
-    }
-
-    let signature =
-        manifest
-            .signature_ed25519
-            .as_deref()
-            .ok_or_else(|| SkillError::MissingSignature {
-                name: manifest.name.clone(),
-                version: manifest.version.to_string(),
-            })?;
-    let public_key = manifest
-        .signature_public_key_ed25519
-        .as_deref()
-        .ok_or_else(|| SkillError::MissingSignature {
-            name: manifest.name.clone(),
-            version: manifest.version.to_string(),
-        })?;
-
-    verify_ed25519_signature(manifest, digest, signature, public_key)
+    verify_skill_package_signature(manifest, digest, allow_unsigned).map(|_| ())
 }
 
 fn sha256_digest(content: &[u8]) -> String {
@@ -713,6 +735,20 @@ fn write_file(path: &Path, content: &[u8]) -> Result<(), SkillError> {
         path: path.to_path_buf(),
         source,
     })
+}
+
+fn read_optional_regular_file(path: &Path) -> Result<Option<Vec<u8>>, SkillError> {
+    match fs::symlink_metadata(path) {
+        Ok(metadata) if metadata.file_type().is_file() => read_regular_file(path).map(Some),
+        Ok(_) => Err(SkillError::UnsafeBundlePath {
+            path: path.to_path_buf(),
+        }),
+        Err(source) if source.kind() == std::io::ErrorKind::NotFound => Ok(None),
+        Err(source) => Err(SkillError::Io {
+            path: path.to_path_buf(),
+            source,
+        }),
+    }
 }
 
 #[cfg(unix)]

--- a/crates/agentenv-core/src/skills/self_test.rs
+++ b/crates/agentenv-core/src/skills/self_test.rs
@@ -1,0 +1,314 @@
+use std::{
+    collections::BTreeMap,
+    fs,
+    path::{Path, PathBuf},
+};
+
+use serde::{Deserialize, Serialize};
+use serde_yaml::Value;
+use sha2::{Digest, Sha256};
+
+use super::{manifest::normalize_bundle_path, SkillError};
+
+const SKILL_TEST_FILE: &str = "skill-test.yaml";
+const SKILL_MD_FILE: &str = "SKILL.md";
+const SKILL_YAML_FILE: &str = "skill.yaml";
+const DEFAULT_TIMEOUT_SECONDS: u64 = 120;
+const LEGACY_TIMEOUT_SECONDS: u64 = 30;
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "kebab-case")]
+pub enum SkillSelfTestRunner {
+    Agentenv,
+}
+
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+pub struct SkillSelfTestSpec {
+    pub runner: SkillSelfTestRunner,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub blueprint: Option<PathBuf>,
+    pub assertions: Vec<SkillSelfTestAssertion>,
+    pub timeout_seconds: u64,
+}
+
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+#[serde(tag = "type", rename_all = "snake_case", deny_unknown_fields)]
+pub enum SkillSelfTestAssertion {
+    CommandExitsZero {
+        cmd: String,
+    },
+    FileExists {
+        path: PathBuf,
+    },
+    AgentProduces {
+        prompt: String,
+        expect_tokens_matching: Vec<String>,
+        min_match_ratio: f64,
+    },
+}
+
+#[derive(Debug, Deserialize)]
+#[serde(deny_unknown_fields)]
+struct SelfTestDocument {
+    self_test: RawSelfTestSpec,
+}
+
+#[derive(Debug, Deserialize)]
+struct FrontmatterSelfTestDocument {
+    self_test: RawSelfTestSpec,
+    #[serde(flatten)]
+    _extra: BTreeMap<String, Value>,
+}
+
+#[derive(Debug, Deserialize)]
+#[serde(deny_unknown_fields)]
+struct RawSelfTestSpec {
+    runner: Option<String>,
+    blueprint: Option<String>,
+    assertions: Option<Vec<SkillSelfTestAssertion>>,
+    timeout_seconds: Option<u64>,
+    command: Option<String>,
+}
+
+#[derive(Debug, Deserialize)]
+struct RawSkillYaml {
+    self_test: Option<RawSelfTestSpec>,
+    #[serde(flatten)]
+    _extra: BTreeMap<String, Value>,
+}
+
+pub fn load_skill_self_test_spec(root: impl AsRef<Path>) -> Result<SkillSelfTestSpec, SkillError> {
+    let root = root.as_ref();
+    let mut specs = Vec::new();
+
+    if let Some(spec) = load_from_skill_test_yaml(root)? {
+        specs.push(("skill-test.yaml", spec));
+    }
+    if let Some(spec) = load_from_skill_md_frontmatter(root)? {
+        specs.push(("SKILL.md", spec));
+    }
+    if let Some(spec) = load_from_skill_yaml(root)? {
+        specs.push(("skill.yaml", spec));
+    }
+
+    let Some((_, first)) = specs.first().cloned() else {
+        return Err(SkillError::MissingSelfTest);
+    };
+    let first_digest = normalized_self_test_digest(&first)?;
+    for (source, spec) in specs.iter().skip(1) {
+        if first_digest != normalized_self_test_digest(spec)? {
+            return Err(SkillError::ConflictingSelfTestDeclarations {
+                declaration_source: (*source).to_owned(),
+            });
+        }
+    }
+    Ok(first)
+}
+
+pub fn normalized_self_test_digest(spec: &SkillSelfTestSpec) -> Result<String, SkillError> {
+    let bytes = serde_json::to_vec(spec).map_err(|source| SkillError::InvalidSelfTest {
+        message: format!("failed to serialize normalized self-test: {source}"),
+    })?;
+    let digest = Sha256::digest(bytes);
+    Ok(format!("sha256:{}", hex::encode(digest)))
+}
+
+fn load_from_skill_test_yaml(root: &Path) -> Result<Option<SkillSelfTestSpec>, SkillError> {
+    let path = root.join(SKILL_TEST_FILE);
+    let Some(content) = read_optional_file(&path)? else {
+        return Ok(None);
+    };
+    let document =
+        serde_yaml::from_str::<SelfTestDocument>(&content).map_err(|source| SkillError::Yaml {
+            path: path.clone(),
+            source,
+        })?;
+    normalize_raw_self_test(document.self_test, false).map(Some)
+}
+
+fn load_from_skill_yaml(root: &Path) -> Result<Option<SkillSelfTestSpec>, SkillError> {
+    let path = root.join(SKILL_YAML_FILE);
+    let Some(content) = read_optional_file(&path)? else {
+        return Ok(None);
+    };
+    let document =
+        serde_yaml::from_str::<RawSkillYaml>(&content).map_err(|source| SkillError::Yaml {
+            path: path.clone(),
+            source,
+        })?;
+    document
+        .self_test
+        .map(|raw| normalize_raw_self_test(raw, true))
+        .transpose()
+}
+
+fn load_from_skill_md_frontmatter(root: &Path) -> Result<Option<SkillSelfTestSpec>, SkillError> {
+    let path = root.join(SKILL_MD_FILE);
+    let Some(content) = read_optional_file(&path)? else {
+        return Ok(None);
+    };
+    let Some(frontmatter) = yaml_frontmatter(&content) else {
+        return Ok(None);
+    };
+    if !frontmatter_contains_self_test_key(frontmatter) {
+        return Ok(None);
+    }
+    let document =
+        serde_yaml::from_str::<FrontmatterSelfTestDocument>(frontmatter).map_err(|source| {
+            SkillError::Yaml {
+                path: path.clone(),
+                source,
+            }
+        })?;
+    normalize_raw_self_test(document.self_test, false).map(Some)
+}
+
+fn yaml_frontmatter(content: &str) -> Option<&str> {
+    let content = content.strip_prefix("---")?;
+    let content = content
+        .strip_prefix("\r\n")
+        .or_else(|| content.strip_prefix('\n'))?;
+    let marker = content.find("\n---")?;
+    Some(&content[..marker])
+}
+
+fn frontmatter_contains_self_test_key(frontmatter: &str) -> bool {
+    frontmatter.lines().any(|line| {
+        if line.starts_with(char::is_whitespace) {
+            return false;
+        }
+        let Some((key, _)) = line.split_once(':') else {
+            return false;
+        };
+        let key = key.trim();
+        matches!(key, "self_test" | "'self_test'" | "\"self_test\"")
+    })
+}
+
+fn normalize_raw_self_test(
+    raw: RawSelfTestSpec,
+    allow_legacy_command: bool,
+) -> Result<SkillSelfTestSpec, SkillError> {
+    if raw.command.is_some() && !allow_legacy_command {
+        return Err(SkillError::InvalidSelfTest {
+            message: "`command` self-test shorthand is only supported in skill.yaml".to_owned(),
+        });
+    }
+    if raw.command.is_some() && raw.assertions.is_some() {
+        return Err(SkillError::InvalidSelfTest {
+            message: "`command` self-test shorthand cannot be combined with assertions".to_owned(),
+        });
+    }
+    if raw.command.is_some() && raw.blueprint.is_some() {
+        return Err(SkillError::InvalidSelfTest {
+            message: "`command` self-test shorthand cannot be combined with blueprint".to_owned(),
+        });
+    }
+
+    let legacy_command = raw.command;
+    let is_legacy_command = legacy_command.is_some();
+    let runner = match raw.runner.as_deref().unwrap_or("agentenv") {
+        "agentenv" => SkillSelfTestRunner::Agentenv,
+        runner => {
+            return Err(SkillError::InvalidSelfTest {
+                message: format!("unsupported self-test runner `{runner}`"),
+            });
+        }
+    };
+    let blueprint = raw
+        .blueprint
+        .map(|blueprint| normalize_bundle_path(Path::new(&blueprint)))
+        .transpose()?;
+    let mut assertions = if let Some(command) = legacy_command {
+        vec![SkillSelfTestAssertion::CommandExitsZero { cmd: command }]
+    } else {
+        raw.assertions.ok_or_else(|| SkillError::InvalidSelfTest {
+            message: "self-test assertions are required".to_owned(),
+        })?
+    };
+
+    if assertions.is_empty() {
+        return Err(SkillError::InvalidSelfTest {
+            message: "self-test assertions must not be empty".to_owned(),
+        });
+    }
+    for assertion in &mut assertions {
+        validate_assertion(assertion)?;
+    }
+
+    let timeout_seconds = if is_legacy_command {
+        LEGACY_TIMEOUT_SECONDS
+    } else {
+        raw.timeout_seconds.unwrap_or(DEFAULT_TIMEOUT_SECONDS)
+    };
+    if timeout_seconds == 0 {
+        return Err(SkillError::InvalidSelfTest {
+            message: "self-test timeout_seconds must be greater than 0".to_owned(),
+        });
+    }
+
+    Ok(SkillSelfTestSpec {
+        runner,
+        blueprint,
+        assertions,
+        timeout_seconds,
+    })
+}
+
+fn validate_assertion(assertion: &mut SkillSelfTestAssertion) -> Result<(), SkillError> {
+    match assertion {
+        SkillSelfTestAssertion::CommandExitsZero { cmd } => {
+            if cmd.trim().is_empty() {
+                return Err(SkillError::InvalidSelfTest {
+                    message: "command_exits_zero assertion requires a non-empty cmd".to_owned(),
+                });
+            }
+        }
+        SkillSelfTestAssertion::FileExists { path } => {
+            *path = normalize_bundle_path(path)?;
+        }
+        SkillSelfTestAssertion::AgentProduces {
+            prompt,
+            expect_tokens_matching,
+            min_match_ratio,
+        } => {
+            if prompt.trim().is_empty() {
+                return Err(SkillError::InvalidSelfTest {
+                    message: "agent_produces assertion requires a non-empty prompt".to_owned(),
+                });
+            }
+            if expect_tokens_matching.is_empty() {
+                return Err(SkillError::InvalidSelfTest {
+                    message: "agent_produces assertion requires expected tokens".to_owned(),
+                });
+            }
+            if expect_tokens_matching
+                .iter()
+                .any(|token| token.trim().is_empty())
+            {
+                return Err(SkillError::InvalidSelfTest {
+                    message: "agent_produces expected tokens must not be empty".to_owned(),
+                });
+            }
+            if !min_match_ratio.is_finite() || *min_match_ratio < 0.0 || *min_match_ratio > 1.0 {
+                return Err(SkillError::InvalidSelfTest {
+                    message: "agent_produces min_match_ratio must be between 0.0 and 1.0"
+                        .to_owned(),
+                });
+            }
+        }
+    }
+
+    Ok(())
+}
+
+fn read_optional_file(path: &Path) -> Result<Option<String>, SkillError> {
+    match fs::read_to_string(path) {
+        Ok(content) => Ok(Some(content)),
+        Err(source) if source.kind() == std::io::ErrorKind::NotFound => Ok(None),
+        Err(source) => Err(SkillError::Io {
+            path: path.to_path_buf(),
+            source,
+        }),
+    }
+}

--- a/crates/agentenv-core/src/skills/self_test.rs
+++ b/crates/agentenv-core/src/skills/self_test.rs
@@ -2,11 +2,22 @@ use std::{
     collections::BTreeMap,
     fs,
     path::{Path, PathBuf},
+    process::{Child, Command, Stdio},
+    sync::{
+        atomic::{AtomicBool, Ordering},
+        mpsc, Arc,
+    },
+    thread,
+    time::{Duration, Instant},
 };
+
+#[cfg(unix)]
+use std::os::unix::process::CommandExt;
 
 use serde::{Deserialize, Serialize};
 use serde_yaml::Value;
 use sha2::{Digest, Sha256};
+use time::OffsetDateTime;
 
 use super::{manifest::normalize_bundle_path, SkillError};
 
@@ -15,6 +26,7 @@ const SKILL_MD_FILE: &str = "SKILL.md";
 const SKILL_YAML_FILE: &str = "skill.yaml";
 const DEFAULT_TIMEOUT_SECONDS: u64 = 120;
 const LEGACY_TIMEOUT_SECONDS: u64 = 30;
+pub const SELF_TEST_PUBLISH_THRESHOLD: f64 = 0.8;
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
 #[serde(rename_all = "kebab-case")]
@@ -45,6 +57,164 @@ pub enum SkillSelfTestAssertion {
         expect_tokens_matching: Vec<String>,
         min_match_ratio: f64,
     },
+}
+
+impl SkillSelfTestAssertion {
+    pub fn kind(&self) -> &'static str {
+        match self {
+            SkillSelfTestAssertion::CommandExitsZero { .. } => "command_exits_zero",
+            SkillSelfTestAssertion::FileExists { .. } => "file_exists",
+            SkillSelfTestAssertion::AgentProduces { .. } => "agent_produces",
+        }
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+pub struct SkillSelfTestReport {
+    pub name: String,
+    pub version: String,
+    pub digest: String,
+    pub self_test_digest: String,
+    pub score: f64,
+    pub passed: usize,
+    pub total: usize,
+    pub publishable: bool,
+    pub assertions: Vec<SkillAssertionResult>,
+    pub started_at: OffsetDateTime,
+    pub completed_at: OffsetDateTime,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct SkillAssertionResult {
+    #[serde(rename = "type")]
+    pub assertion_type: String,
+    pub status: SkillAssertionStatus,
+    pub message: String,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum SkillAssertionStatus {
+    Passed,
+    Failed,
+    Skipped,
+}
+
+#[derive(Debug, Clone, Copy)]
+pub struct SkillSelfTestOptions {
+    pub threshold: f64,
+}
+
+impl Default for SkillSelfTestOptions {
+    fn default() -> Self {
+        Self {
+            threshold: SELF_TEST_PUBLISH_THRESHOLD,
+        }
+    }
+}
+
+#[derive(Debug, Clone)]
+pub struct AgentProduceRequest<'a> {
+    pub skill_root: &'a Path,
+    pub blueprint: &'a Path,
+    pub prompt: &'a str,
+    pub timeout: Duration,
+    pub cancelled: Arc<AtomicBool>,
+}
+
+/// Runs an `agent_produces` prompt for the self-test engine.
+///
+/// Implementations must honor `AgentProduceRequest::timeout` and return promptly
+/// when `AgentProduceRequest::cancelled` is set. The core runner also bounds its
+/// wait on this call, but Rust cannot safely stop an arbitrary blocked thread.
+pub trait AgentProduceRunner: Send + Sync + 'static {
+    fn run_agent_prompt(&self, request: AgentProduceRequest<'_>) -> Result<String, SkillError>;
+}
+
+#[derive(Debug, Default, Clone, Copy)]
+pub struct UnsupportedAgentProduceRunner;
+
+impl AgentProduceRunner for UnsupportedAgentProduceRunner {
+    fn run_agent_prompt(&self, _request: AgentProduceRequest<'_>) -> Result<String, SkillError> {
+        Err(SkillError::UnsupportedAgentProduces)
+    }
+}
+
+pub fn run_skill_self_test(
+    skill_root: impl AsRef<Path>,
+    name: impl Into<String>,
+    version: impl Into<String>,
+    digest: impl Into<String>,
+    spec: &SkillSelfTestSpec,
+    options: SkillSelfTestOptions,
+    agent_runner: Arc<dyn AgentProduceRunner>,
+) -> Result<SkillSelfTestReport, SkillError> {
+    let skill_root = skill_root.as_ref();
+    if !options.threshold.is_finite() || !(0.0..=1.0).contains(&options.threshold) {
+        return Err(SkillError::InvalidSelfTest {
+            message: "self-test threshold must be between 0.0 and 1.0".to_owned(),
+        });
+    }
+    if spec.timeout_seconds == 0 {
+        return Err(SkillError::InvalidSelfTest {
+            message: "self-test timeout_seconds must be greater than 0".to_owned(),
+        });
+    }
+
+    let started_at = OffsetDateTime::now_utc();
+    let started = Instant::now();
+    let timeout = Duration::from_secs(spec.timeout_seconds);
+    let deadline = started
+        .checked_add(timeout)
+        .ok_or_else(|| SkillError::InvalidSelfTest {
+            message: "self-test timeout_seconds is too large".to_owned(),
+        })?;
+    let mut assertions = Vec::with_capacity(spec.assertions.len());
+
+    for assertion in &spec.assertions {
+        if Instant::now() >= deadline {
+            assertions.push(SkillAssertionResult {
+                assertion_type: assertion.kind().to_owned(),
+                status: SkillAssertionStatus::Skipped,
+                message: "self-test deadline was reached before assertion ran".to_owned(),
+            });
+            continue;
+        }
+
+        let remaining = deadline.saturating_duration_since(Instant::now());
+        assertions.push(run_assertion(
+            skill_root,
+            spec,
+            assertion,
+            Arc::clone(&agent_runner),
+            remaining,
+        ));
+    }
+
+    let passed = assertions
+        .iter()
+        .filter(|assertion| assertion.status == SkillAssertionStatus::Passed)
+        .count();
+    let total = spec.assertions.len();
+    let score = if total == 0 {
+        0.0
+    } else {
+        passed as f64 / total as f64
+    };
+    let threshold = options.threshold;
+    Ok(SkillSelfTestReport {
+        name: name.into(),
+        version: version.into(),
+        digest: digest.into(),
+        self_test_digest: normalized_self_test_digest(spec)?,
+        score,
+        passed,
+        total,
+        publishable: score >= threshold,
+        assertions,
+        started_at,
+        completed_at: OffsetDateTime::now_utc(),
+    })
 }
 
 #[derive(Debug, Deserialize)]
@@ -111,6 +281,441 @@ pub fn normalized_self_test_digest(spec: &SkillSelfTestSpec) -> Result<String, S
     })?;
     let digest = Sha256::digest(bytes);
     Ok(format!("sha256:{}", hex::encode(digest)))
+}
+
+fn run_assertion(
+    skill_root: &Path,
+    spec: &SkillSelfTestSpec,
+    assertion: &SkillSelfTestAssertion,
+    agent_runner: Arc<dyn AgentProduceRunner>,
+    remaining_timeout: Duration,
+) -> SkillAssertionResult {
+    match assertion {
+        SkillSelfTestAssertion::FileExists { path } => run_file_exists(skill_root, assertion, path),
+        SkillSelfTestAssertion::CommandExitsZero { cmd } => {
+            run_command_exits_zero(skill_root, assertion, cmd, remaining_timeout)
+        }
+        SkillSelfTestAssertion::AgentProduces { .. } => {
+            run_agent_produces(skill_root, spec, assertion, agent_runner, remaining_timeout)
+        }
+    }
+}
+
+fn passed(assertion: &SkillSelfTestAssertion, message: impl Into<String>) -> SkillAssertionResult {
+    SkillAssertionResult {
+        assertion_type: assertion.kind().to_owned(),
+        status: SkillAssertionStatus::Passed,
+        message: message.into(),
+    }
+}
+
+fn failed(assertion: &SkillSelfTestAssertion, message: impl Into<String>) -> SkillAssertionResult {
+    SkillAssertionResult {
+        assertion_type: assertion.kind().to_owned(),
+        status: SkillAssertionStatus::Failed,
+        message: message.into(),
+    }
+}
+
+fn run_file_exists(
+    skill_root: &Path,
+    assertion: &SkillSelfTestAssertion,
+    path: &Path,
+) -> SkillAssertionResult {
+    let normalized = match normalize_bundle_path(path) {
+        Ok(path) => path,
+        Err(error) => return failed(assertion, error.to_string()),
+    };
+    let full_path = skill_root.join(&normalized);
+    if full_path.is_file() {
+        passed(assertion, format!("file exists `{}`", normalized.display()))
+    } else {
+        failed(
+            assertion,
+            format!("file does not exist `{}`", normalized.display()),
+        )
+    }
+}
+
+fn run_command_exits_zero(
+    skill_root: &Path,
+    assertion: &SkillSelfTestAssertion,
+    cmd: &str,
+    timeout: Duration,
+) -> SkillAssertionResult {
+    let mut command = shell_command(cmd);
+    let mut child = match command
+        .current_dir(skill_root)
+        .stdout(Stdio::null())
+        .stderr(Stdio::null())
+        .env_clear()
+        .spawn()
+    {
+        Ok(child) => child,
+        Err(source) => {
+            return failed(
+                assertion,
+                format!("command failed to start `{cmd}`: {source}"),
+            );
+        }
+    };
+    let started = Instant::now();
+
+    loop {
+        match child.try_wait() {
+            Ok(Some(status)) => {
+                if status.success() {
+                    return passed(assertion, format!("command exited zero `{cmd}`"));
+                }
+                return failed(
+                    assertion,
+                    format!("command exited nonzero `{cmd}` with status {status}"),
+                );
+            }
+            Ok(None) => {
+                if started.elapsed() >= timeout {
+                    let cleanup_message = terminate_timed_out_self_test(&mut child)
+                        .err()
+                        .map(|error| format!("; cleanup failed: {error}"))
+                        .unwrap_or_default();
+                    return failed(
+                        assertion,
+                        format!(
+                            "command timed out after {}s `{cmd}`{cleanup_message}",
+                            timeout.as_secs()
+                        ),
+                    );
+                }
+                thread::sleep(Duration::from_millis(25));
+            }
+            Err(source) => {
+                let _ = terminate_timed_out_self_test(&mut child);
+                return failed(assertion, format!("command poll failed `{cmd}`: {source}"));
+            }
+        }
+    }
+}
+
+fn run_agent_produces(
+    skill_root: &Path,
+    spec: &SkillSelfTestSpec,
+    assertion: &SkillSelfTestAssertion,
+    agent_runner: Arc<dyn AgentProduceRunner>,
+    timeout: Duration,
+) -> SkillAssertionResult {
+    let SkillSelfTestAssertion::AgentProduces {
+        prompt,
+        expect_tokens_matching,
+        min_match_ratio,
+    } = assertion
+    else {
+        return failed(assertion, "internal assertion type mismatch");
+    };
+
+    let Some(blueprint) = &spec.blueprint else {
+        return failed(assertion, "agent_produces requires self-test blueprint");
+    };
+    let normalized_blueprint = match normalize_bundle_path(blueprint) {
+        Ok(path) => path,
+        Err(error) => return failed(assertion, error.to_string()),
+    };
+    let blueprint = skill_root.join(normalized_blueprint);
+    if expect_tokens_matching.is_empty() {
+        return failed(
+            assertion,
+            "agent_produces requires at least one expected token",
+        );
+    }
+    if !min_match_ratio.is_finite() || !(0.0..=1.0).contains(min_match_ratio) {
+        return failed(
+            assertion,
+            "agent_produces min_match_ratio must be between 0.0 and 1.0",
+        );
+    }
+    let output = match run_agent_prompt_with_timeout(
+        agent_runner,
+        skill_root.to_path_buf(),
+        blueprint,
+        prompt.to_owned(),
+        timeout,
+    ) {
+        Ok(output) => output,
+        Err(error) => return failed(assertion, error.to_string()),
+    };
+    let matched = expect_tokens_matching
+        .iter()
+        .filter(|token| output.contains(token.as_str()))
+        .count();
+    let ratio = matched as f64 / expect_tokens_matching.len() as f64;
+    if ratio >= *min_match_ratio {
+        passed(
+            assertion,
+            format!(
+                "matched {matched}/{} expected tokens ({ratio:.3})",
+                expect_tokens_matching.len()
+            ),
+        )
+    } else {
+        failed(
+            assertion,
+            format!(
+                "matched {matched}/{} expected tokens ({ratio:.3}), below required {min_match_ratio:.3}",
+                expect_tokens_matching.len()
+            ),
+        )
+    }
+}
+
+fn run_agent_prompt_with_timeout(
+    agent_runner: Arc<dyn AgentProduceRunner>,
+    skill_root: PathBuf,
+    blueprint: PathBuf,
+    prompt: String,
+    timeout: Duration,
+) -> Result<String, SkillError> {
+    let (sender, receiver) = mpsc::channel();
+    let cancelled = Arc::new(AtomicBool::new(false));
+    let request_cancelled = Arc::clone(&cancelled);
+    thread::spawn(move || {
+        let request = AgentProduceRequest {
+            skill_root: &skill_root,
+            blueprint: &blueprint,
+            prompt: &prompt,
+            timeout,
+            cancelled: request_cancelled,
+        };
+        let _ = sender.send(agent_runner.run_agent_prompt(request));
+    });
+
+    match receiver.recv_timeout(timeout) {
+        Ok(result) => result,
+        Err(mpsc::RecvTimeoutError::Timeout) => {
+            cancelled.store(true, Ordering::Relaxed);
+            Err(SkillError::SelfTestTimeout {
+                timeout_seconds: timeout.as_secs(),
+            })
+        }
+        Err(mpsc::RecvTimeoutError::Disconnected) => Err(SkillError::InvalidSelfTest {
+            message: "agent_produces runner stopped before returning a result".to_owned(),
+        }),
+    }
+}
+
+#[cfg(unix)]
+fn shell_command(command: &str) -> Command {
+    let mut shell = Command::new("/bin/sh");
+    shell.args([
+        "-c",
+        &format!("trap 'jobs -p | xargs kill -KILL 2>/dev/null || true' EXIT\n{command}"),
+    ]);
+    shell.process_group(0);
+    shell
+}
+
+#[cfg(windows)]
+fn shell_command(command: &str) -> Command {
+    let mut shell = Command::new("cmd.exe");
+    shell.args(["/C", command]);
+    shell
+}
+
+#[cfg(not(any(unix, windows)))]
+fn shell_command(command: &str) -> Command {
+    let mut shell = Command::new("sh");
+    shell.args(["-c", command]);
+    shell
+}
+
+#[cfg(unix)]
+fn terminate_timed_out_self_test(child: &mut Child) -> Result<(), String> {
+    let process_group_id = child.id() as i32;
+    let mut descendant_pids = unix_descendant_pids(process_group_id).unwrap_or_default();
+    let _ = unix_signal_process_group(process_group_id, "STOP");
+    unix_signal_pids(&descendant_pids, "STOP");
+    thread::sleep(Duration::from_millis(25));
+
+    if let Ok(mut discovered_pids) = unix_descendant_pids(process_group_id) {
+        descendant_pids.append(&mut discovered_pids);
+        descendant_pids.sort_unstable();
+        descendant_pids.dedup();
+    }
+
+    let group_signal_error = unix_kill_process_group(process_group_id).err();
+    unix_kill_pids(&descendant_pids);
+
+    let _ = Command::new("pkill")
+        .arg("-KILL")
+        .arg("-g")
+        .arg(process_group_id.to_string())
+        .stdout(Stdio::null())
+        .stderr(Stdio::null())
+        .status();
+
+    child
+        .wait()
+        .map_err(|source| format!("wait failed: {source}"))?;
+
+    let started_at = Instant::now();
+    loop {
+        let survivor_pids = unix_process_group_pids(process_group_id)?;
+        if survivor_pids.is_empty() {
+            return Ok(());
+        }
+
+        unix_kill_pids(&survivor_pids);
+        if started_at.elapsed() >= Duration::from_secs(2) {
+            let group_signal_error = group_signal_error
+                .as_deref()
+                .unwrap_or("process-group signal started successfully");
+            return Err(format!(
+                "process group {process_group_id} still has survivor pids {survivor_pids:?}; {group_signal_error}"
+            ));
+        }
+        thread::sleep(Duration::from_millis(25));
+    }
+}
+
+#[cfg(unix)]
+fn unix_kill_process_group(process_group_id: i32) -> Result<(), String> {
+    unix_signal_process_group(process_group_id, "KILL")
+}
+
+#[cfg(unix)]
+fn unix_signal_process_group(process_group_id: i32, signal: &str) -> Result<(), String> {
+    let status = Command::new("kill")
+        .arg(format!("-{signal}"))
+        .arg("--")
+        .arg(format!("-{process_group_id}"))
+        .stdout(Stdio::null())
+        .stderr(Stdio::null())
+        .status()
+        .map_err(|source| format!("could not start process-group signal: {source}"))?;
+    if status.success() {
+        Ok(())
+    } else {
+        Err(format!(
+            "process-group signal {signal} exited with {status}"
+        ))
+    }
+}
+
+#[cfg(unix)]
+fn unix_kill_pids(pids: &[i32]) {
+    unix_signal_pids(pids, "KILL");
+}
+
+#[cfg(unix)]
+fn unix_signal_pids(pids: &[i32], signal: &str) {
+    for pid in pids {
+        let _ = Command::new("kill")
+            .arg(format!("-{signal}"))
+            .arg("--")
+            .arg(pid.to_string())
+            .stdout(Stdio::null())
+            .stderr(Stdio::null())
+            .status();
+    }
+}
+
+#[cfg(unix)]
+fn unix_process_group_pids(process_group_id: i32) -> Result<Vec<i32>, String> {
+    let output = Command::new("pgrep")
+        .arg("-g")
+        .arg(process_group_id.to_string())
+        .output()
+        .map_err(|source| format!("could not list process group {process_group_id}: {source}"))?;
+    if !output.status.success() {
+        return Ok(Vec::new());
+    }
+    parse_pid_lines(&String::from_utf8_lossy(&output.stdout))
+}
+
+#[cfg(unix)]
+fn unix_descendant_pids(root_pid: i32) -> Result<Vec<i32>, String> {
+    let output = Command::new("ps")
+        .arg("-axo")
+        .arg("pid=,ppid=")
+        .output()
+        .map_err(|source| format!("could not list processes: {source}"))?;
+    if !output.status.success() {
+        return Err(format!("process listing exited with {}", output.status));
+    }
+
+    let mut processes = Vec::new();
+    for line in String::from_utf8_lossy(&output.stdout).lines() {
+        let mut parts = line.split_whitespace();
+        let (Some(pid), Some(parent_pid)) = (parts.next(), parts.next()) else {
+            continue;
+        };
+        let (Ok(pid), Ok(parent_pid)) = (pid.parse::<i32>(), parent_pid.parse::<i32>()) else {
+            continue;
+        };
+        processes.push((pid, parent_pid));
+    }
+
+    let mut descendants = Vec::new();
+    let mut stack = vec![root_pid];
+    while let Some(parent_pid) = stack.pop() {
+        for (pid, candidate_parent_pid) in &processes {
+            if *candidate_parent_pid == parent_pid {
+                descendants.push(*pid);
+                stack.push(*pid);
+            }
+        }
+    }
+
+    descendants.sort_unstable();
+    descendants.dedup();
+    Ok(descendants)
+}
+
+#[cfg(unix)]
+fn parse_pid_lines(stdout: &str) -> Result<Vec<i32>, String> {
+    let mut pids = Vec::new();
+    for line in stdout.lines() {
+        let trimmed = line.trim();
+        if trimmed.is_empty() {
+            continue;
+        }
+        let pid = trimmed
+            .parse::<i32>()
+            .map_err(|source| format!("failed to parse pid `{trimmed}`: {source}"))?;
+        pids.push(pid);
+    }
+    pids.sort_unstable();
+    pids.dedup();
+    Ok(pids)
+}
+
+#[cfg(windows)]
+fn terminate_timed_out_self_test(child: &mut Child) -> Result<(), String> {
+    let status = Command::new("taskkill")
+        .arg("/PID")
+        .arg(child.id().to_string())
+        .arg("/T")
+        .arg("/F")
+        .status()
+        .map_err(|source| format!("could not start taskkill: {source}"))?;
+    if !status.success() {
+        child.kill().map_err(|source| {
+            format!("taskkill failed with {status}; direct kill failed: {source}")
+        })?;
+    }
+    child
+        .wait()
+        .map_err(|source| format!("wait failed: {source}"))?;
+    Ok(())
+}
+
+#[cfg(not(any(unix, windows)))]
+fn terminate_timed_out_self_test(child: &mut Child) -> Result<(), String> {
+    child
+        .kill()
+        .map_err(|source| format!("could not kill child: {source}"))?;
+    child
+        .wait()
+        .map_err(|source| format!("wait failed: {source}"))?;
+    Ok(())
 }
 
 fn load_from_skill_test_yaml(root: &Path) -> Result<Option<SkillSelfTestSpec>, SkillError> {

--- a/crates/agentenv-core/src/skills/service.rs
+++ b/crates/agentenv-core/src/skills/service.rs
@@ -9,13 +9,21 @@ use sha2::{Digest, Sha256};
 
 use crate::security::ssrf::SsrfOptions;
 
-use super::store::{install_local_skill_with_runner, verify_installed_skill_with_runner};
+use super::signature::verify_skill_package_signature;
+use super::store::{
+    install_local_skill_with_attestation, install_local_skill_with_runner,
+    verify_installed_skill_with_runner,
+};
 use super::{
-    info_installed_skill, install_local_skill, list_installed_skills, registry_filesystem,
-    registry_git, registry_http, registry_oci, remove_installed_skill, validate_skill_name,
-    AgentProduceRunner, FetchedSkill, InstalledSkill, InstalledSkillSelector, RegistryAdapter,
-    RegistryConfig, RegistryKind, SkillError, SkillInstallOptions, SkillSearchHit, SkillsConfig,
-    UnsupportedAgentProduceRunner,
+    compute_bundle_digest, info_installed_skill, list_installed_skills, load_skill_manifest,
+    load_skill_self_test_spec, normalized_self_test_digest, read_self_test_attestation,
+    registry_filesystem, registry_git, registry_http, registry_oci, remove_installed_skill,
+    run_skill_self_test, self_test_signing_key_path, sign_skill_self_test_attestation,
+    validate_skill_name, validate_skill_publish_attestation, AgentProduceRunner, FetchedSkill,
+    InstalledSkill, InstalledSkillSelector, RegistryAdapter, RegistryConfig, RegistryKind,
+    SkillAttestationValidationOptions, SkillError, SkillInstallOptions, SkillSearchHit,
+    SkillSelfTestAttestation, SkillSelfTestOptions, SkillSelfTestSigningKey, SkillsConfig,
+    UnsupportedAgentProduceRunner, SELF_TEST_PUBLISH_THRESHOLD,
 };
 
 pub type SkillCredentialResolver =
@@ -35,6 +43,7 @@ pub struct SkillAddRequest {
     pub handle: String,
     pub registry: Option<String>,
     pub allow_unsigned: bool,
+    pub self_test_attestation: Option<PathBuf>,
 }
 
 #[derive(Debug, Clone)]
@@ -42,6 +51,8 @@ pub struct SkillPublishRequest {
     pub bundle_path: PathBuf,
     pub registry: Option<String>,
     pub allow_unsigned: bool,
+    pub self_test_attestation: Option<PathBuf>,
+    pub no_self_test_run: bool,
 }
 
 impl SkillService {
@@ -91,7 +102,23 @@ impl SkillService {
             let adapter = self.adapter_for(registry)?;
             match adapter.fetch(&parsed.name, parsed.version.as_deref()).await {
                 Ok(fetched) => {
-                    return self.install_fetched_skill(fetched, request.allow_unsigned);
+                    let attestation = match self.self_test_attestation_for_bundle(
+                        &fetched.staging_path,
+                        request.allow_unsigned,
+                        request.self_test_attestation.as_deref(),
+                        false,
+                    ) {
+                        Ok(attestation) => attestation,
+                        Err(error) => {
+                            cleanup_staging_path(&fetched.staging_path);
+                            return Err(error);
+                        }
+                    };
+                    return self.install_fetched_skill(
+                        fetched,
+                        request.allow_unsigned,
+                        Some(&attestation),
+                    );
                 }
                 Err(SkillError::SkillNotInstalled { .. }) => {
                     continue;
@@ -118,8 +145,24 @@ impl SkillService {
                 })?,
         };
         let adapter = self.adapter_for(registry)?;
+        if matches!(registry.kind, RegistryKind::Git) {
+            return Err(SkillError::UnsupportedRegistryPublish {
+                registry: registry.name.clone(),
+                kind: "git".to_owned(),
+            });
+        }
+        let attestation = self.self_test_attestation_for_bundle(
+            &request.bundle_path,
+            request.allow_unsigned,
+            request.self_test_attestation.as_deref(),
+            request.no_self_test_run,
+        )?;
         adapter
-            .publish(&request.bundle_path, request.allow_unsigned)
+            .publish(
+                &request.bundle_path,
+                request.allow_unsigned,
+                Some(&attestation),
+            )
             .await
     }
 
@@ -128,7 +171,29 @@ impl SkillService {
         bundle_path: impl AsRef<Path>,
         allow_unsigned: bool,
         source_label: impl Into<String>,
+        self_test_attestation: Option<&Path>,
     ) -> Result<InstalledSkill, SkillError> {
+        let bundle_path = bundle_path.as_ref();
+        if let Some(attestation_path) = self_test_attestation {
+            let attestation = self.self_test_attestation_for_bundle(
+                bundle_path,
+                allow_unsigned,
+                Some(attestation_path),
+                true,
+            )?;
+            return install_local_skill_with_attestation(
+                &self.root,
+                bundle_path,
+                SkillInstallOptions {
+                    allow_unsigned,
+                    source_type: "local".to_owned(),
+                    source_label: source_label.into(),
+                    unsafe_skip_self_test_gate: true,
+                },
+                &attestation,
+            );
+        }
+
         install_local_skill_with_runner(
             &self.root,
             bundle_path,
@@ -287,20 +352,104 @@ impl SkillService {
         &self,
         fetched: FetchedSkill,
         allow_unsigned: bool,
+        self_test_attestation: Option<&SkillSelfTestAttestation>,
     ) -> Result<InstalledSkill, SkillError> {
         let source_label = source_label_for_fetched(&fetched);
-        let installed = install_local_skill(
-            &self.root,
-            &fetched.staging_path,
-            SkillInstallOptions {
-                allow_unsigned,
-                source_type: fetched.source_type.clone(),
-                source_label,
-                unsafe_skip_self_test_gate: true,
-            },
-        );
+        let options = SkillInstallOptions {
+            allow_unsigned,
+            source_type: fetched.source_type.clone(),
+            source_label,
+            unsafe_skip_self_test_gate: true,
+        };
+        let installed = match self_test_attestation {
+            Some(attestation) => install_local_skill_with_attestation(
+                &self.root,
+                &fetched.staging_path,
+                options,
+                attestation,
+            ),
+            None => install_local_skill_with_runner(
+                &self.root,
+                &fetched.staging_path,
+                options,
+                Arc::clone(&self.agent_produce_runner),
+            ),
+        };
         cleanup_staging_path(&fetched.staging_path);
         installed
+    }
+
+    fn self_test_attestation_for_bundle(
+        &self,
+        bundle_path: &Path,
+        allow_unsigned: bool,
+        attestation_path: Option<&Path>,
+        no_self_test_run: bool,
+    ) -> Result<SkillSelfTestAttestation, SkillError> {
+        let manifest = load_skill_manifest(bundle_path)?;
+        let digest = compute_bundle_digest(bundle_path, &manifest)?;
+        verify_skill_package_signature(&manifest, &digest, allow_unsigned)?;
+        let spec = load_skill_self_test_spec(bundle_path)?;
+        let self_test_digest = normalized_self_test_digest(&spec)?;
+        let version = manifest.version.to_string();
+
+        if let Some(attestation_path) = attestation_path {
+            let attestation = read_self_test_attestation(attestation_path)?;
+            self.validate_self_test_attestation(
+                &manifest.name,
+                &version,
+                &digest,
+                &self_test_digest,
+                &attestation,
+            )?;
+            return Ok(attestation);
+        }
+
+        if no_self_test_run {
+            return Err(SkillError::MissingSelfTestAttestation);
+        }
+
+        let report = run_skill_self_test(
+            bundle_path,
+            manifest.name.clone(),
+            version,
+            digest,
+            &spec,
+            SkillSelfTestOptions::default(),
+            Arc::clone(&self.agent_produce_runner),
+        )?;
+        if !report.publishable {
+            return Err(SkillError::SelfTestScoreBelowThreshold {
+                score: report.score,
+                threshold: SELF_TEST_PUBLISH_THRESHOLD,
+            });
+        }
+        let signing_key =
+            SkillSelfTestSigningKey::load_or_create(&self_test_signing_key_path(&self.root))?;
+        sign_skill_self_test_attestation(&report, &signing_key)
+    }
+
+    fn validate_self_test_attestation(
+        &self,
+        name: &str,
+        version: &str,
+        digest: &str,
+        self_test_digest: &str,
+        attestation: &SkillSelfTestAttestation,
+    ) -> Result<(), SkillError> {
+        let signing_key =
+            SkillSelfTestSigningKey::load_or_create(&self_test_signing_key_path(&self.root))?;
+        validate_skill_publish_attestation(
+            name,
+            version,
+            digest,
+            self_test_digest,
+            attestation,
+            SkillAttestationValidationOptions {
+                trusted_public_keys: vec![signing_key.public_key_hex()],
+                ..SkillAttestationValidationOptions::default()
+            },
+        )
     }
 }
 
@@ -477,7 +626,7 @@ mod tests {
         };
 
         let installed = service
-            .install_fetched_skill(fetched, true)
+            .install_fetched_skill(fetched, true, None)
             .expect("fetched git skill should install");
 
         assert_eq!(installed.name, "provenance-git");

--- a/crates/agentenv-core/src/skills/service.rs
+++ b/crates/agentenv-core/src/skills/service.rs
@@ -9,11 +9,13 @@ use sha2::{Digest, Sha256};
 
 use crate::security::ssrf::SsrfOptions;
 
+use super::store::{install_local_skill_with_runner, verify_installed_skill_with_runner};
 use super::{
     info_installed_skill, install_local_skill, list_installed_skills, registry_filesystem,
     registry_git, registry_http, registry_oci, remove_installed_skill, validate_skill_name,
-    verify_installed_skill, FetchedSkill, InstalledSkill, InstalledSkillSelector, RegistryAdapter,
+    AgentProduceRunner, FetchedSkill, InstalledSkill, InstalledSkillSelector, RegistryAdapter,
     RegistryConfig, RegistryKind, SkillError, SkillInstallOptions, SkillSearchHit, SkillsConfig,
+    UnsupportedAgentProduceRunner,
 };
 
 pub type SkillCredentialResolver =
@@ -25,6 +27,7 @@ pub struct SkillService {
     config: SkillsConfig,
     credential_resolver: SkillCredentialResolver,
     ssrf_options: SsrfOptions,
+    agent_produce_runner: Arc<dyn AgentProduceRunner>,
 }
 
 #[derive(Debug, Clone)]
@@ -48,6 +51,7 @@ impl SkillService {
             config,
             credential_resolver: Arc::new(|_| Ok(None)),
             ssrf_options: SsrfOptions::default(),
+            agent_produce_runner: Arc::new(UnsupportedAgentProduceRunner),
         }
     }
 
@@ -58,6 +62,11 @@ impl SkillService {
 
     pub fn with_ssrf_options(mut self, options: SsrfOptions) -> Self {
         self.ssrf_options = options;
+        self
+    }
+
+    pub fn with_agent_produce_runner(mut self, runner: Arc<dyn AgentProduceRunner>) -> Self {
+        self.agent_produce_runner = runner;
         self
     }
 
@@ -120,7 +129,7 @@ impl SkillService {
         allow_unsigned: bool,
         source_label: impl Into<String>,
     ) -> Result<InstalledSkill, SkillError> {
-        install_local_skill(
+        install_local_skill_with_runner(
             &self.root,
             bundle_path,
             SkillInstallOptions {
@@ -129,6 +138,7 @@ impl SkillService {
                 source_label: source_label.into(),
                 unsafe_skip_self_test_gate: false,
             },
+            Arc::clone(&self.agent_produce_runner),
         )
     }
 
@@ -145,7 +155,11 @@ impl SkillService {
     }
 
     pub fn verify(&self, selector: InstalledSkillSelector) -> Result<InstalledSkill, SkillError> {
-        verify_installed_skill(&self.root, selector)
+        verify_installed_skill_with_runner(
+            &self.root,
+            selector,
+            Arc::clone(&self.agent_produce_runner),
+        )
     }
 
     fn ordered_registries(&self) -> Result<Vec<&RegistryConfig>, SkillError> {

--- a/crates/agentenv-core/src/skills/service.rs
+++ b/crates/agentenv-core/src/skills/service.rs
@@ -127,6 +127,7 @@ impl SkillService {
                 allow_unsigned,
                 source_type: "local".to_owned(),
                 source_label: source_label.into(),
+                unsafe_skip_self_test_gate: false,
             },
         )
     }
@@ -281,6 +282,7 @@ impl SkillService {
                 allow_unsigned,
                 source_type: fetched.source_type.clone(),
                 source_label,
+                unsafe_skip_self_test_gate: true,
             },
         );
         cleanup_staging_path(&fetched.staging_path);

--- a/crates/agentenv-core/src/skills/signature.rs
+++ b/crates/agentenv-core/src/skills/signature.rs
@@ -92,6 +92,35 @@ pub fn verify_ed25519_signature(
         })
 }
 
+pub(crate) fn verify_skill_package_signature(
+    manifest: &SkillManifest,
+    digest: &str,
+    allow_unsigned: bool,
+) -> Result<Option<String>, SkillError> {
+    if allow_unsigned {
+        return Ok(None);
+    }
+
+    let signature =
+        manifest
+            .signature_ed25519
+            .as_deref()
+            .ok_or_else(|| SkillError::MissingSignature {
+                name: manifest.name.clone(),
+                version: manifest.version.to_string(),
+            })?;
+    let public_key = manifest
+        .signature_public_key_ed25519
+        .as_deref()
+        .ok_or_else(|| SkillError::MissingSignature {
+            name: manifest.name.clone(),
+            version: manifest.version.to_string(),
+        })?;
+
+    verify_ed25519_signature(manifest, digest, signature, public_key)?;
+    Ok(Some(public_key.to_owned()))
+}
+
 fn invalid_signature(manifest: &SkillManifest, source: impl std::fmt::Display) -> SkillError {
     SkillError::InvalidSignature {
         name: manifest.name.clone(),

--- a/crates/agentenv-core/src/skills/store.rs
+++ b/crates/agentenv-core/src/skills/store.rs
@@ -462,7 +462,10 @@ fn cache_can_be_repaired(error: &SkillError) -> bool {
         | SkillError::MissingManifestField { .. }
         | SkillError::MissingSelfTest
         | SkillError::InvalidSelfTest { .. }
-        | SkillError::ConflictingSelfTestDeclarations { .. } => true,
+        | SkillError::ConflictingSelfTestDeclarations { .. }
+        | SkillError::SelfTestTimeout { .. }
+        | SkillError::SelfTestScoreBelowThreshold { .. }
+        | SkillError::UnsupportedAgentProduces => true,
         SkillError::UnsafeBundlePath { .. }
         | SkillError::DigestMismatch { .. }
         | SkillError::MissingSignature { .. }

--- a/crates/agentenv-core/src/skills/store.rs
+++ b/crates/agentenv-core/src/skills/store.rs
@@ -10,6 +10,7 @@ use serde::Deserialize;
 use serde_yaml::Value;
 use time::{format_description::well_known::Rfc3339, OffsetDateTime};
 
+use super::signature::verify_skill_package_signature;
 use super::{
     compute_bundle_digest, index, load_skill_self_test_spec,
     manifest::{normalize_bundle_path, validated_bundle_file},
@@ -23,6 +24,7 @@ const MANIFEST_FILE: &str = "skill.yaml";
 const SKILL_TEST_FILE: &str = "skill-test.yaml";
 const CONTENT_DIR: &str = "content";
 const SIGNATURE_STATUS_UNSIGNED: &str = "unsigned";
+const SIGNATURE_STATUS_SIGNED: &str = "signed";
 const SELF_TEST_KEY_FILE: &str = "self-test-signing-key.ed25519";
 const SELF_TEST_ATTESTATIONS_DIR: &str = ".self-test-attestations";
 
@@ -108,13 +110,12 @@ pub(crate) fn install_local_skill_with_runner(
     let manifest = super::load_skill_manifest(bundle)?;
     let digest = compute_bundle_digest(bundle, &manifest)?;
 
-    let signature_status = if options.allow_unsigned {
-        SIGNATURE_STATUS_UNSIGNED.to_owned()
+    let signature_public_key_ed25519 =
+        verify_skill_package_signature(&manifest, &digest, options.allow_unsigned)?;
+    let signature_status = if signature_public_key_ed25519.is_some() {
+        SIGNATURE_STATUS_SIGNED.to_owned()
     } else {
-        return Err(SkillError::MissingSignature {
-            name: manifest.name,
-            version: manifest.version.to_string(),
-        });
+        SIGNATURE_STATUS_UNSIGNED.to_owned()
     };
 
     let version = manifest.version.to_string();
@@ -154,7 +155,7 @@ pub(crate) fn install_local_skill_with_runner(
         source_label: options.source_label,
         digest,
         signature_status,
-        signature_public_key_ed25519: None,
+        signature_public_key_ed25519,
         entry: PathBuf::from(CONTENT_DIR).join(&manifest.entry),
         installed_at: installed_at_now(),
         path: install_dir.clone(),
@@ -189,6 +190,18 @@ pub(crate) fn install_local_skill_with_runner(
     index::rebuild(root)?;
 
     Ok(installed)
+}
+
+pub(crate) fn install_local_skill_with_attestation(
+    root: impl AsRef<Path>,
+    bundle: impl AsRef<Path>,
+    mut options: SkillInstallOptions,
+    attestation: &SkillSelfTestAttestation,
+) -> Result<InstalledSkill, SkillError> {
+    options.unsafe_skip_self_test_gate = true;
+    let root = root.as_ref();
+    let installed = install_local_skill(root, bundle, options)?;
+    record_self_test_attestation(root, installed, attestation)
 }
 
 pub fn list_installed_skills(root: impl AsRef<Path>) -> Result<Vec<InstalledSkill>, SkillError> {
@@ -369,6 +382,28 @@ pub fn read_self_test_attestation(path: &Path) -> Result<SkillSelfTestAttestatio
     serde_json::from_str(&content).map_err(|source| SkillError::InvalidSelfTestAttestation {
         message: format!("failed to parse `{}`: {source}", path.display()),
     })
+}
+
+fn record_self_test_attestation(
+    root: &Path,
+    mut installed: InstalledSkill,
+    attestation: &SkillSelfTestAttestation,
+) -> Result<InstalledSkill, SkillError> {
+    if attestation.subject.name != installed.name
+        || attestation.subject.version != installed.version
+    {
+        return Err(SkillError::SelfTestAttestationSubjectMismatch);
+    }
+    if attestation.subject.digest != installed.digest {
+        return Err(SkillError::SelfTestAttestationDigestMismatch);
+    }
+
+    let attestation_path = write_self_test_attestation(root, attestation)?;
+    installed.self_test_score = Some(attestation.score);
+    installed.self_test_attestation = Some(attestation_path);
+    index::write_record(&index::installed_record_path(&installed.path), &installed)?;
+    index::rebuild(root)?;
+    Ok(installed)
 }
 
 fn verify_signature_if_required(
@@ -562,6 +597,7 @@ fn cache_can_be_repaired(error: &SkillError) -> bool {
         | SkillError::ConflictingSelfTestDeclarations { .. }
         | SkillError::SelfTestTimeout { .. }
         | SkillError::SelfTestScoreBelowThreshold { .. }
+        | SkillError::MissingSelfTestAttestation
         | SkillError::InvalidSelfTestSigningKey { .. }
         | SkillError::InvalidSelfTestAttestation { .. }
         | SkillError::SelfTestAttestationSubjectMismatch

--- a/crates/agentenv-core/src/skills/store.rs
+++ b/crates/agentenv-core/src/skills/store.rs
@@ -465,6 +465,11 @@ fn cache_can_be_repaired(error: &SkillError) -> bool {
         | SkillError::ConflictingSelfTestDeclarations { .. }
         | SkillError::SelfTestTimeout { .. }
         | SkillError::SelfTestScoreBelowThreshold { .. }
+        | SkillError::InvalidSelfTestSigningKey { .. }
+        | SkillError::InvalidSelfTestAttestation { .. }
+        | SkillError::SelfTestAttestationSubjectMismatch
+        | SkillError::SelfTestAttestationDigestMismatch
+        | SkillError::StaleSelfTestAttestation { .. }
         | SkillError::UnsupportedAgentProduces => true,
         SkillError::UnsafeBundlePath { .. }
         | SkillError::DigestMismatch { .. }

--- a/crates/agentenv-core/src/skills/store.rs
+++ b/crates/agentenv-core/src/skills/store.rs
@@ -2,9 +2,7 @@ use std::{
     collections::{BTreeMap, BTreeSet},
     fs,
     path::{Component, Path, PathBuf},
-    process::Command,
-    thread,
-    time::{Duration, Instant},
+    sync::Arc,
 };
 
 use semver::Version;
@@ -13,17 +11,22 @@ use serde_yaml::Value;
 use time::{format_description::well_known::Rfc3339, OffsetDateTime};
 
 use super::{
-    compute_bundle_digest, index,
+    compute_bundle_digest, index, load_skill_self_test_spec,
     manifest::{normalize_bundle_path, validated_bundle_file},
-    validate_skill_name, verify_ed25519_signature, SkillError, SkillManifest,
+    run_skill_self_test, sign_skill_self_test_attestation, validate_skill_name,
+    verify_ed25519_signature, SkillError, SkillManifest, SkillSelfTestAttestation,
+    SkillSelfTestOptions, SkillSelfTestSigningKey, UnsupportedAgentProduceRunner,
+    SELF_TEST_PUBLISH_THRESHOLD,
 };
 
 const MANIFEST_FILE: &str = "skill.yaml";
+const SKILL_TEST_FILE: &str = "skill-test.yaml";
 const CONTENT_DIR: &str = "content";
 const SIGNATURE_STATUS_UNSIGNED: &str = "unsigned";
-const SELF_TEST_TIMEOUT: Duration = Duration::from_secs(30);
+const SELF_TEST_KEY_FILE: &str = "self-test-signing-key.ed25519";
+const SELF_TEST_ATTESTATIONS_DIR: &str = ".self-test-attestations";
 
-#[derive(Debug, Clone, serde::Serialize, serde::Deserialize, PartialEq, Eq)]
+#[derive(Debug, Clone, serde::Serialize, serde::Deserialize, PartialEq)]
 pub struct InstalledSkill {
     pub name: String,
     pub version: String,
@@ -36,6 +39,10 @@ pub struct InstalledSkill {
     pub entry: PathBuf,
     pub installed_at: String,
     pub path: PathBuf,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub self_test_score: Option<f64>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub self_test_attestation: Option<PathBuf>,
 }
 
 #[derive(Debug, Clone)]
@@ -43,6 +50,7 @@ pub struct SkillInstallOptions {
     pub allow_unsigned: bool,
     pub source_type: String,
     pub source_label: String,
+    pub unsafe_skip_self_test_gate: bool,
 }
 
 #[derive(Debug, Clone)]
@@ -105,10 +113,19 @@ pub fn install_local_skill(
                 existing: existing.digest,
             });
         }
-        if cached_install_matches_record(&existing)? {
+        let cache_matches = cached_install_matches_record(&existing)?;
+        if options.unsafe_skip_self_test_gate && cache_matches {
             return Ok(existing);
         }
     }
+
+    let (self_test_score, self_test_attestation) = if options.unsafe_skip_self_test_gate {
+        (None, None)
+    } else {
+        let (score, attestation_path) =
+            run_self_test_gate(root, bundle, &manifest.name, &version, &digest)?;
+        (Some(score), Some(attestation_path))
+    };
 
     let installed = InstalledSkill {
         name: manifest.name.clone(),
@@ -121,6 +138,8 @@ pub fn install_local_skill(
         entry: PathBuf::from(CONTENT_DIR).join(&manifest.entry),
         installed_at: installed_at_now(),
         path: install_dir.clone(),
+        self_test_score,
+        self_test_attestation,
     };
 
     let staging_dir = staging_install_dir(&install_dir)?;
@@ -144,6 +163,7 @@ pub fn install_local_skill(
         let destination = staging_dir.join(CONTENT_DIR).join(declared_file);
         copy_regular_file(&source, &destination)?;
     }
+    copy_structured_self_test_file_if_present(bundle, &staging_dir.join(CONTENT_DIR))?;
     index::write_record(&index::installed_record_path(&staging_dir), &installed)?;
     replace_install_dir(&staging_dir, &install_dir)?;
     index::rebuild(root)?;
@@ -200,7 +220,8 @@ pub fn verify_installed_skill(
     root: impl AsRef<Path>,
     selector: InstalledSkillSelector,
 ) -> Result<InstalledSkill, SkillError> {
-    let installed = info_installed_skill(root, selector)?;
+    let root = root.as_ref();
+    let mut installed = info_installed_skill(root, selector)?;
     ensure_content_directory(&installed.path)?;
     let manifest = load_cached_manifest(&installed.path)?;
     validate_installed_record(&installed, &manifest)?;
@@ -214,11 +235,109 @@ pub fn verify_installed_skill(
     }
 
     verify_signature_if_required(&installed, &manifest)?;
-    if let Some(command) = manifest.self_test_command.as_deref() {
-        run_self_test(&installed, command)?;
-    }
+    let (score, attestation_path) = run_installed_self_test_gate(root, &installed, &actual_digest)?;
+    installed.self_test_score = Some(score);
+    installed.self_test_attestation = Some(attestation_path);
+    index::write_record(&index::installed_record_path(&installed.path), &installed)?;
+    index::rebuild(root)?;
 
     Ok(installed)
+}
+
+fn run_self_test_gate(
+    root: &Path,
+    skill_root: &Path,
+    name: &str,
+    version: &str,
+    digest: &str,
+) -> Result<(f64, PathBuf), SkillError> {
+    let spec = load_skill_self_test_spec(skill_root)?;
+    let report = run_skill_self_test(
+        skill_root,
+        name,
+        version,
+        digest,
+        &spec,
+        SkillSelfTestOptions::default(),
+        Arc::new(UnsupportedAgentProduceRunner),
+    )?;
+    if !report.publishable {
+        return Err(SkillError::SelfTestScoreBelowThreshold {
+            score: report.score,
+            threshold: SELF_TEST_PUBLISH_THRESHOLD,
+        });
+    }
+    let signing_key = SkillSelfTestSigningKey::load_or_create(&self_test_signing_key_path(root))?;
+    let attestation = sign_skill_self_test_attestation(&report, &signing_key)?;
+    let attestation_path = write_self_test_attestation(root, &attestation)?;
+    Ok((report.score, attestation_path))
+}
+
+fn run_installed_self_test_gate(
+    root: &Path,
+    installed: &InstalledSkill,
+    digest: &str,
+) -> Result<(f64, PathBuf), SkillError> {
+    let content_root = installed.path.join(CONTENT_DIR);
+    let spec = match load_skill_self_test_spec(&content_root) {
+        Ok(spec) => spec,
+        Err(SkillError::MissingSelfTest) => load_skill_self_test_spec(&installed.path)?,
+        Err(error) => return Err(error),
+    };
+    let report = run_skill_self_test(
+        &content_root,
+        &installed.name,
+        &installed.version,
+        digest,
+        &spec,
+        SkillSelfTestOptions::default(),
+        Arc::new(UnsupportedAgentProduceRunner),
+    )?;
+    if !report.publishable {
+        return Err(SkillError::SelfTestScoreBelowThreshold {
+            score: report.score,
+            threshold: SELF_TEST_PUBLISH_THRESHOLD,
+        });
+    }
+    let signing_key = SkillSelfTestSigningKey::load_or_create(&self_test_signing_key_path(root))?;
+    let attestation = sign_skill_self_test_attestation(&report, &signing_key)?;
+    let attestation_path = write_self_test_attestation(root, &attestation)?;
+    Ok((report.score, attestation_path))
+}
+
+pub fn self_test_signing_key_path(root: &Path) -> PathBuf {
+    index::skills_root(root).join(SELF_TEST_KEY_FILE)
+}
+
+pub fn write_self_test_attestation(
+    root: &Path,
+    attestation: &SkillSelfTestAttestation,
+) -> Result<PathBuf, SkillError> {
+    validate_skill_name(&attestation.subject.name)?;
+    attestation
+        .subject
+        .version
+        .parse::<Version>()
+        .map_err(|source| SkillError::InvalidVersion {
+            version: attestation.subject.version.clone(),
+            source,
+        })?;
+    let path = index::skills_root(root)
+        .join(SELF_TEST_ATTESTATIONS_DIR)
+        .join(&attestation.subject.name)
+        .join(format!("{}.json", attestation.subject.version));
+    write_self_test_attestation_json_atomic(&path, attestation)?;
+    Ok(path)
+}
+
+pub fn read_self_test_attestation(path: &Path) -> Result<SkillSelfTestAttestation, SkillError> {
+    let content = fs::read_to_string(path).map_err(|source| SkillError::Io {
+        path: path.to_path_buf(),
+        source,
+    })?;
+    serde_json::from_str(&content).map_err(|source| SkillError::InvalidSelfTestAttestation {
+        message: format!("failed to parse `{}`: {source}", path.display()),
+    })
 }
 
 fn verify_signature_if_required(
@@ -249,59 +368,6 @@ fn verify_signature_if_required(
     verify_ed25519_signature(manifest, &installed.digest, signature, public_key)?;
 
     Ok(())
-}
-
-fn run_self_test(installed: &InstalledSkill, command: &str) -> Result<(), SkillError> {
-    let content_root = installed.path.join(CONTENT_DIR);
-    let mut command = shell_command(command);
-    command.current_dir(&content_root).env_clear();
-    let mut child = command.spawn().map_err(|source| SkillError::Io {
-        path: content_root.clone(),
-        source,
-    })?;
-    let deadline = Instant::now() + SELF_TEST_TIMEOUT;
-
-    loop {
-        if let Some(status) = child.try_wait().map_err(|source| SkillError::Io {
-            path: content_root.clone(),
-            source,
-        })? {
-            if status.success() {
-                return Ok(());
-            }
-            return Err(SkillError::SelfTestFailed {
-                name: installed.name.clone(),
-                version: installed.version.clone(),
-                status: status.code().map_or(-1, |code| code),
-            });
-        }
-
-        if Instant::now() >= deadline {
-            let _ = child.kill();
-            let _ = child.wait();
-            return Err(SkillError::SelfTestFailed {
-                name: installed.name.clone(),
-                version: installed.version.clone(),
-                status: -1,
-            });
-        }
-
-        thread::sleep(Duration::from_millis(50));
-    }
-}
-
-#[cfg(windows)]
-fn shell_command(command: &str) -> Command {
-    let mut shell = Command::new("cmd.exe");
-    shell.args(["/C", command]);
-    shell
-}
-
-#[cfg(not(windows))]
-fn shell_command(command: &str) -> Command {
-    let mut shell = Command::new("/bin/sh");
-    shell.args(["-c", command]);
-    shell
 }
 
 fn resolve_installed(
@@ -592,6 +658,55 @@ fn copy_regular_file(source: &Path, destination: &Path) -> Result<(), SkillError
         source,
     })?;
     Ok(())
+}
+
+fn copy_structured_self_test_file_if_present(
+    bundle: &Path,
+    content_root: &Path,
+) -> Result<(), SkillError> {
+    let source = bundle.join(SKILL_TEST_FILE);
+    match fs::symlink_metadata(&source) {
+        Ok(metadata) if metadata.file_type().is_file() => {
+            copy_regular_file(&source, &content_root.join(SKILL_TEST_FILE))
+        }
+        Ok(_) => Err(SkillError::UnsafeBundlePath { path: source }),
+        Err(source_error) if source_error.kind() == std::io::ErrorKind::NotFound => Ok(()),
+        Err(source_error) => Err(SkillError::Io {
+            path: source,
+            source: source_error,
+        }),
+    }
+}
+
+fn write_self_test_attestation_json_atomic(
+    path: &Path,
+    attestation: &SkillSelfTestAttestation,
+) -> Result<(), SkillError> {
+    let parent = path.parent().ok_or_else(|| SkillError::UnsafeBundlePath {
+        path: path.to_path_buf(),
+    })?;
+    fs::create_dir_all(parent).map_err(|source| SkillError::Io {
+        path: parent.to_path_buf(),
+        source,
+    })?;
+    let json = serde_json::to_vec_pretty(attestation).map_err(|source| {
+        SkillError::InvalidSelfTestAttestation {
+            message: format!("failed to serialize self-test attestation: {source}"),
+        }
+    })?;
+    let tmp_path = path.with_extension(format!(
+        "json.tmp-{}-{}",
+        std::process::id(),
+        temporary_suffix()
+    ));
+    fs::write(&tmp_path, json).map_err(|source| SkillError::Io {
+        path: tmp_path.clone(),
+        source,
+    })?;
+    fs::rename(&tmp_path, path).map_err(|source| SkillError::Io {
+        path: path.to_path_buf(),
+        source,
+    })
 }
 
 #[cfg(unix)]

--- a/crates/agentenv-core/src/skills/store.rs
+++ b/crates/agentenv-core/src/skills/store.rs
@@ -14,9 +14,9 @@ use super::{
     compute_bundle_digest, index, load_skill_self_test_spec,
     manifest::{normalize_bundle_path, validated_bundle_file},
     run_skill_self_test, sign_skill_self_test_attestation, validate_skill_name,
-    verify_ed25519_signature, SkillError, SkillManifest, SkillSelfTestAttestation,
-    SkillSelfTestOptions, SkillSelfTestSigningKey, UnsupportedAgentProduceRunner,
-    SELF_TEST_PUBLISH_THRESHOLD,
+    verify_ed25519_signature, AgentProduceRunner, SkillError, SkillManifest,
+    SkillSelfTestAttestation, SkillSelfTestOptions, SkillSelfTestSigningKey,
+    UnsupportedAgentProduceRunner, SELF_TEST_PUBLISH_THRESHOLD,
 };
 
 const MANIFEST_FILE: &str = "skill.yaml";
@@ -89,6 +89,20 @@ pub fn install_local_skill(
     bundle: impl AsRef<Path>,
     options: SkillInstallOptions,
 ) -> Result<InstalledSkill, SkillError> {
+    install_local_skill_with_runner(
+        root,
+        bundle,
+        options,
+        Arc::new(UnsupportedAgentProduceRunner),
+    )
+}
+
+pub(crate) fn install_local_skill_with_runner(
+    root: impl AsRef<Path>,
+    bundle: impl AsRef<Path>,
+    options: SkillInstallOptions,
+    agent_runner: Arc<dyn AgentProduceRunner>,
+) -> Result<InstalledSkill, SkillError> {
     let root = root.as_ref();
     let bundle = bundle.as_ref();
     let manifest = super::load_skill_manifest(bundle)?;
@@ -122,8 +136,14 @@ pub fn install_local_skill(
     let (self_test_score, self_test_attestation) = if options.unsafe_skip_self_test_gate {
         (None, None)
     } else {
-        let (score, attestation_path) =
-            run_self_test_gate(root, bundle, &manifest.name, &version, &digest)?;
+        let (score, attestation_path) = run_self_test_gate(
+            root,
+            bundle,
+            &manifest.name,
+            &version,
+            &digest,
+            agent_runner,
+        )?;
         (Some(score), Some(attestation_path))
     };
 
@@ -220,6 +240,14 @@ pub fn verify_installed_skill(
     root: impl AsRef<Path>,
     selector: InstalledSkillSelector,
 ) -> Result<InstalledSkill, SkillError> {
+    verify_installed_skill_with_runner(root, selector, Arc::new(UnsupportedAgentProduceRunner))
+}
+
+pub(crate) fn verify_installed_skill_with_runner(
+    root: impl AsRef<Path>,
+    selector: InstalledSkillSelector,
+    agent_runner: Arc<dyn AgentProduceRunner>,
+) -> Result<InstalledSkill, SkillError> {
     let root = root.as_ref();
     let mut installed = info_installed_skill(root, selector)?;
     ensure_content_directory(&installed.path)?;
@@ -235,7 +263,8 @@ pub fn verify_installed_skill(
     }
 
     verify_signature_if_required(&installed, &manifest)?;
-    let (score, attestation_path) = run_installed_self_test_gate(root, &installed, &actual_digest)?;
+    let (score, attestation_path) =
+        run_installed_self_test_gate(root, &installed, &actual_digest, agent_runner)?;
     installed.self_test_score = Some(score);
     installed.self_test_attestation = Some(attestation_path);
     index::write_record(&index::installed_record_path(&installed.path), &installed)?;
@@ -250,6 +279,7 @@ fn run_self_test_gate(
     name: &str,
     version: &str,
     digest: &str,
+    agent_runner: Arc<dyn AgentProduceRunner>,
 ) -> Result<(f64, PathBuf), SkillError> {
     let spec = load_skill_self_test_spec(skill_root)?;
     let report = run_skill_self_test(
@@ -259,7 +289,7 @@ fn run_self_test_gate(
         digest,
         &spec,
         SkillSelfTestOptions::default(),
-        Arc::new(UnsupportedAgentProduceRunner),
+        agent_runner,
     )?;
     if !report.publishable {
         return Err(SkillError::SelfTestScoreBelowThreshold {
@@ -277,6 +307,7 @@ fn run_installed_self_test_gate(
     root: &Path,
     installed: &InstalledSkill,
     digest: &str,
+    agent_runner: Arc<dyn AgentProduceRunner>,
 ) -> Result<(f64, PathBuf), SkillError> {
     let content_root = installed.path.join(CONTENT_DIR);
     let spec = match load_skill_self_test_spec(&content_root) {
@@ -291,7 +322,7 @@ fn run_installed_self_test_gate(
         digest,
         &spec,
         SkillSelfTestOptions::default(),
-        Arc::new(UnsupportedAgentProduceRunner),
+        agent_runner,
     )?;
     if !report.publishable {
         return Err(SkillError::SelfTestScoreBelowThreshold {

--- a/crates/agentenv-core/src/skills/store.rs
+++ b/crates/agentenv-core/src/skills/store.rs
@@ -459,7 +459,10 @@ fn cache_can_be_repaired(error: &SkillError) -> bool {
         | SkillError::InvalidVersion { .. }
         | SkillError::MissingDeclaredFile { .. }
         | SkillError::EmptyFilePattern { .. }
-        | SkillError::MissingManifestField { .. } => true,
+        | SkillError::MissingManifestField { .. }
+        | SkillError::MissingSelfTest
+        | SkillError::InvalidSelfTest { .. }
+        | SkillError::ConflictingSelfTestDeclarations { .. } => true,
         SkillError::UnsafeBundlePath { .. }
         | SkillError::DigestMismatch { .. }
         | SkillError::MissingSignature { .. }

--- a/crates/agentenv-core/tests/skills.rs
+++ b/crates/agentenv-core/tests/skills.rs
@@ -9,9 +9,10 @@ use std::{
 use agentenv_core::security::ssrf::SsrfOptions;
 use agentenv_core::skills::{
     compute_bundle_digest, install_local_skill, list_installed_skills, load_project_skills_config,
-    load_skill_manifest, load_user_skills_config, merge_skills_config, validate_skill_name,
-    verify_installed_skill, InstalledSkillSelector, RegistryKind, SkillAddRequest, SkillError,
-    SkillInstallOptions, SkillPublishRequest, SkillService, SkillsConfig, SkillsConfigOverride,
+    load_skill_manifest, load_user_skills_config, merge_skills_config, read_self_test_attestation,
+    validate_skill_name, verify_installed_skill, InstalledSkillSelector, RegistryKind,
+    SkillAddRequest, SkillError, SkillInstallOptions, SkillPublishRequest, SkillService,
+    SkillsConfig, SkillsConfigOverride,
 };
 use ed25519_dalek::{Signer, SigningKey};
 
@@ -1429,12 +1430,7 @@ fn skills_config_rejects_oci_reference_with_invalid_parts() {
 async fn filesystem_registry_search_add_and_publish_work() {
     let home = temp_dir("skill-fs-home");
     let registry = temp_dir("skill-fs-registry");
-    let bundle = temp_dir("skill-fs-bundle");
-    write_file(&bundle.join("SKILL.md"), "# Searchable Skill\n");
-    write_file(
-        &bundle.join("skill.yaml"),
-        "name: searchable-skill\nversion: 0.1.0\ndescription: Searchable demo\nentry: SKILL.md\nfiles:\n  - SKILL.md\n",
-    );
+    let bundle = skill_bundle("searchable-skill", "0.1.0", "Searchable demo");
     let service = SkillService::new(
         home.join(".agentenv"),
         SkillsConfig {
@@ -1451,6 +1447,8 @@ async fn filesystem_registry_search_add_and_publish_work() {
             bundle_path: bundle,
             registry: Some("local-dev".to_owned()),
             allow_unsigned: true,
+            self_test_attestation: None,
+            no_self_test_run: false,
         })
         .await
         .expect("publish should succeed");
@@ -1466,11 +1464,233 @@ async fn filesystem_registry_search_add_and_publish_work() {
             handle: "searchable-skill@0.1.0".to_owned(),
             registry: None,
             allow_unsigned: true,
+            self_test_attestation: None,
         })
         .await
         .expect("add should install");
 
     assert_eq!(installed.name, "searchable-skill");
+}
+
+#[tokio::test]
+async fn skill_service_publish_rejects_missing_self_test() {
+    let home = temp_dir("skill-fs-publish-missing-self-test-home");
+    let registry = temp_dir("skill-fs-publish-missing-self-test-registry");
+    let bundle = temp_dir("skill-fs-publish-missing-self-test-bundle");
+    write_file(&bundle.join("SKILL.md"), "# Missing self-test\n");
+    write_file(
+        &bundle.join("skill.yaml"),
+        "name: missing-self-test\nversion: 0.1.0\nentry: SKILL.md\nfiles:\n  - SKILL.md\n",
+    );
+    let service = filesystem_skill_service(&home, &registry);
+
+    let error = service
+        .publish(SkillPublishRequest {
+            bundle_path: bundle,
+            registry: Some("local-dev".to_owned()),
+            allow_unsigned: true,
+            self_test_attestation: None,
+            no_self_test_run: false,
+        })
+        .await
+        .expect_err("publish must reject bundles without a self-test");
+
+    assert!(matches!(error, SkillError::MissingSelfTest));
+    assert!(service
+        .search("missing-self-test")
+        .await
+        .unwrap()
+        .is_empty());
+}
+
+#[tokio::test]
+async fn skill_service_publish_checks_signature_before_self_test() {
+    let home = temp_dir("skill-fs-publish-signature-before-self-test-home");
+    let registry = temp_dir("skill-fs-publish-signature-before-self-test-registry");
+    let bundle = temp_dir("skill-fs-publish-signature-before-self-test-bundle");
+    write_file(&bundle.join("SKILL.md"), "# Unsigned publish\n");
+    write_file(
+        &bundle.join("skill.yaml"),
+        "name: unsigned-publish-order\nversion: 0.1.0\nentry: SKILL.md\nfiles:\n  - SKILL.md\nself_test:\n  command: touch self-test-ran\n",
+    );
+    let service = filesystem_skill_service(&home, &registry);
+
+    let error = service
+        .publish(SkillPublishRequest {
+            bundle_path: bundle.clone(),
+            registry: Some("local-dev".to_owned()),
+            allow_unsigned: false,
+            self_test_attestation: None,
+            no_self_test_run: false,
+        })
+        .await
+        .expect_err("publish must reject unsigned bundles before running self-tests");
+
+    assert!(matches!(error, SkillError::MissingSignature { .. }));
+    assert!(!bundle.join("self-test-ran").exists());
+}
+
+#[tokio::test]
+async fn skill_service_add_checks_signature_before_self_test() {
+    let home = temp_dir("skill-fs-add-signature-before-self-test-home");
+    let registry = temp_dir("skill-fs-add-signature-before-self-test-registry");
+    write_file(
+        &registry.join("unsigned-add-order/skill.yaml"),
+        "name: unsigned-add-order\nversion: 0.1.0\nentry: SKILL.md\nfiles:\n  - SKILL.md\nself_test:\n  command: false\n",
+    );
+    write_file(
+        &registry.join("unsigned-add-order/SKILL.md"),
+        "# Unsigned add\n",
+    );
+    let service = filesystem_skill_service(&home, &registry);
+
+    let error = service
+        .add(SkillAddRequest {
+            handle: "unsigned-add-order@0.1.0".to_owned(),
+            registry: Some("local-dev".to_owned()),
+            allow_unsigned: false,
+            self_test_attestation: None,
+        })
+        .await
+        .expect_err("add must reject unsigned bundles before running self-tests");
+
+    assert!(matches!(error, SkillError::MissingSignature { .. }));
+    assert!(service.list().unwrap().is_empty());
+}
+
+#[tokio::test]
+async fn skill_service_publish_rejects_low_self_test_score() {
+    let home = temp_dir("skill-fs-publish-low-score-home");
+    let registry = temp_dir("skill-fs-publish-low-score-registry");
+    let bundle = temp_dir("skill-fs-publish-low-score-bundle");
+    write_file(&bundle.join("SKILL.md"), "# Low score\n");
+    write_file(
+        &bundle.join("skill.yaml"),
+        "name: low-score-skill\nversion: 0.1.0\nentry: SKILL.md\nfiles:\n  - SKILL.md\nself_test:\n  runner: agentenv\n  assertions:\n    - type: file_exists\n      path: SKILL.md\n    - type: file_exists\n      path: missing.txt\n  timeout_seconds: 5\n",
+    );
+    let service = filesystem_skill_service(&home, &registry);
+
+    let error = service
+        .publish(SkillPublishRequest {
+            bundle_path: bundle,
+            registry: Some("local-dev".to_owned()),
+            allow_unsigned: true,
+            self_test_attestation: None,
+            no_self_test_run: false,
+        })
+        .await
+        .expect_err("publish must reject scores below the threshold");
+
+    assert!(matches!(
+        error,
+        SkillError::SelfTestScoreBelowThreshold {
+            score,
+            threshold
+        } if (score - 0.5).abs() < f64::EPSILON && (threshold - 0.8).abs() < f64::EPSILON
+    ));
+    assert!(service.search("low-score-skill").await.unwrap().is_empty());
+}
+
+#[tokio::test]
+async fn skill_service_publish_no_self_test_run_requires_attestation() {
+    let home = temp_dir("skill-fs-publish-attestation-required-home");
+    let registry = temp_dir("skill-fs-publish-attestation-required-registry");
+    let service = filesystem_skill_service(&home, &registry);
+
+    let error = service
+        .publish(SkillPublishRequest {
+            bundle_path: skill_bundle("attestation-required", "0.1.0", "Attestation required"),
+            registry: Some("local-dev".to_owned()),
+            allow_unsigned: true,
+            self_test_attestation: None,
+            no_self_test_run: true,
+        })
+        .await
+        .expect_err("publish without running a self-test must require an attestation");
+
+    assert!(matches!(error, SkillError::MissingSelfTestAttestation));
+}
+
+#[tokio::test]
+async fn filesystem_registry_publish_stores_self_test_attestation() {
+    let home = temp_dir("skill-fs-publish-attestation-home");
+    let registry = temp_dir("skill-fs-publish-attestation-registry");
+    let service = filesystem_skill_service(&home, &registry);
+
+    let hit = service
+        .publish(SkillPublishRequest {
+            bundle_path: skill_bundle("attested-skill", "0.1.0", "Attested"),
+            registry: Some("local-dev".to_owned()),
+            allow_unsigned: true,
+            self_test_attestation: None,
+            no_self_test_run: false,
+        })
+        .await
+        .expect("publish should store the generated self-test attestation");
+
+    assert_eq!(hit.self_test_score, Some(1.0));
+    assert!(hit.self_test_attestation_digest.is_some());
+    let attestation_path = registry.join("bundles/attested-skill/0.1.0/self-test-attestation.json");
+    let attestation = read_self_test_attestation(&attestation_path).unwrap();
+    assert_eq!(attestation.subject.name, "attested-skill");
+    assert_eq!(attestation.subject.version, "0.1.0");
+    assert_eq!(
+        hit.self_test_attestation_digest.as_deref(),
+        Some(attestation.self_test_digest.as_str())
+    );
+}
+
+#[tokio::test]
+async fn filesystem_registry_publish_and_add_preserves_skill_test_yaml() {
+    let home = temp_dir("skill-fs-publish-skill-test-file-home");
+    let registry = temp_dir("skill-fs-publish-skill-test-file-registry");
+    let service = filesystem_skill_service(&home, &registry);
+    let bundle = skill_test_file_bundle("file-backed-self-test", "0.1.0", "File-backed self-test");
+
+    service
+        .publish(SkillPublishRequest {
+            bundle_path: bundle.clone(),
+            registry: Some("local-dev".to_owned()),
+            allow_unsigned: true,
+            self_test_attestation: None,
+            no_self_test_run: false,
+        })
+        .await
+        .expect("publish should accept skill-test.yaml backed self-tests");
+
+    assert!(registry
+        .join("bundles/file-backed-self-test/0.1.0/skill-test.yaml")
+        .is_file());
+
+    let updated_skill_test = "self_test:\n  runner: agentenv\n  assertions:\n    - type: file_exists\n      path: SKILL.md\n  timeout_seconds: 5\n";
+    write_file(&bundle.join("skill-test.yaml"), updated_skill_test);
+    service
+        .publish(SkillPublishRequest {
+            bundle_path: bundle,
+            registry: Some("local-dev".to_owned()),
+            allow_unsigned: true,
+            self_test_attestation: None,
+            no_self_test_run: false,
+        })
+        .await
+        .expect("republishing the same digest should refresh undeclared self-test files");
+    let stored_skill_test =
+        fs::read_to_string(registry.join("bundles/file-backed-self-test/0.1.0/skill-test.yaml"))
+            .unwrap();
+    assert_eq!(stored_skill_test, updated_skill_test);
+
+    let installed = service
+        .add(SkillAddRequest {
+            handle: "file-backed-self-test@0.1.0".to_owned(),
+            registry: Some("local-dev".to_owned()),
+            allow_unsigned: true,
+            self_test_attestation: None,
+        })
+        .await
+        .expect("add should rerun the preserved skill-test.yaml");
+
+    assert_eq!(installed.self_test_score, Some(1.0));
+    assert!(installed.path.join("content/skill-test.yaml").is_file());
 }
 
 #[tokio::test]
@@ -1525,7 +1745,7 @@ async fn filesystem_registry_add_uses_scanned_subdirectory_without_index() {
     let registry = temp_dir("skill-fs-scan-add-registry");
     write_file(
         &registry.join("scan-add/skill.yaml"),
-        "name: scan-add\nversion: 0.1.0\nentry: SKILL.md\nfiles:\n  - SKILL.md\n",
+        "name: scan-add\nversion: 0.1.0\nentry: SKILL.md\nfiles:\n  - SKILL.md\nself_test:\n  command: test -f SKILL.md\n",
     );
     write_file(&registry.join("scan-add/SKILL.md"), "# Scan add\n");
     let service = filesystem_skill_service(&home, &registry);
@@ -1535,6 +1755,7 @@ async fn filesystem_registry_add_uses_scanned_subdirectory_without_index() {
             handle: "scan-add".to_owned(),
             registry: None,
             allow_unsigned: true,
+            self_test_attestation: None,
         })
         .await
         .expect("add should use scanned directory");
@@ -1562,6 +1783,8 @@ async fn filesystem_registry_publish_keeps_scanned_subdirectories_ephemeral() {
             bundle_path: skill_bundle("published-skill", "0.1.0", "Published"),
             registry: Some("local-dev".to_owned()),
             allow_unsigned: true,
+            self_test_attestation: None,
+            no_self_test_run: false,
         })
         .await
         .expect("publish should succeed");
@@ -1630,6 +1853,7 @@ async fn filesystem_registry_fetch_does_not_fallback_to_shadowed_scanned_directo
             handle: "shadowed-skill@0.1.0".to_owned(),
             registry: None,
             allow_unsigned: true,
+            self_test_attestation: None,
         })
         .await
         .expect_err("indexed hit with missing bundle must not fall back to scanned directory");
@@ -1653,6 +1877,7 @@ async fn skill_service_add_without_version_installs_highest_semver() {
             handle: "versioned-skill".to_owned(),
             registry: None,
             allow_unsigned: true,
+            self_test_attestation: None,
         })
         .await
         .expect("add without version should install highest semver");
@@ -1671,6 +1896,7 @@ async fn skill_service_rejects_invalid_handle_before_registry_access() {
             handle: "../bad@0.1.0".to_owned(),
             registry: None,
             allow_unsigned: true,
+            self_test_attestation: None,
         })
         .await
         .expect_err("invalid handles must fail before registry access");
@@ -1691,6 +1917,8 @@ async fn filesystem_registry_refuses_same_version_with_different_digest() {
             bundle_path: changed,
             registry: Some("local-dev".to_owned()),
             allow_unsigned: true,
+            self_test_attestation: None,
+            no_self_test_run: false,
         })
         .await
         .expect_err("publishing a different digest over the same version must fail");
@@ -1716,6 +1944,8 @@ async fn skill_service_publish_uses_first_ordered_registry_when_unspecified() {
             bundle_path: skill_bundle("default-registry-skill", "0.1.0", "Default registry"),
             registry: None,
             allow_unsigned: true,
+            self_test_attestation: None,
+            no_self_test_run: false,
         })
         .await
         .expect("publish without registry should use configured registry order");
@@ -1749,6 +1979,7 @@ async fn filesystem_registry_rejects_index_hit_with_mismatched_manifest_identity
             handle: "requested-skill@0.1.0".to_owned(),
             registry: None,
             allow_unsigned: true,
+            self_test_attestation: None,
         })
         .await
         .expect_err("index identity must match fetched manifest identity");
@@ -1786,6 +2017,7 @@ async fn filesystem_registry_rejects_symlinked_bundles_directory() {
             handle: "symlinked-skill@0.1.0".to_owned(),
             registry: None,
             allow_unsigned: true,
+            self_test_attestation: None,
         })
         .await
         .expect_err("symlinked registry bundle parents must be rejected");
@@ -1813,6 +2045,8 @@ async fn filesystem_registry_publish_repairs_stale_index_without_bundle() {
             bundle_path: bundle,
             registry: Some("local-dev".to_owned()),
             allow_unsigned: true,
+            self_test_attestation: None,
+            no_self_test_run: false,
         })
         .await
         .expect("publish should repair stale index entries whose bundle is missing");
@@ -1835,6 +2069,7 @@ async fn skill_service_add_records_registry_source_with_resolved_version() {
             handle: "provenance-skill".to_owned(),
             registry: None,
             allow_unsigned: true,
+            self_test_attestation: None,
         })
         .await
         .expect("add should install from registry");
@@ -1933,9 +2168,11 @@ async fn http_registry_publish_and_add_round_trip() {
 
     service
         .publish(SkillPublishRequest {
-            bundle_path: skill_bundle("http-skill", "0.1.0", "HTTP skill"),
+            bundle_path: skill_test_file_bundle("http-skill", "0.1.0", "HTTP skill"),
             registry: Some("http-dev".to_owned()),
             allow_unsigned: true,
+            self_test_attestation: None,
+            no_self_test_run: false,
         })
         .await
         .expect("publish should upload files");
@@ -1945,6 +2182,7 @@ async fn http_registry_publish_and_add_round_trip() {
             handle: "http-skill@0.1.0".to_owned(),
             registry: Some("http-dev".to_owned()),
             allow_unsigned: true,
+            self_test_attestation: None,
         })
         .await
         .expect("add should download uploaded files");
@@ -1952,6 +2190,8 @@ async fn http_registry_publish_and_add_round_trip() {
     assert_eq!(installed.name, "http-skill");
     assert_eq!(installed.source_type, "http");
     assert_eq!(installed.source_label, "http:http-dev:http-skill@0.1.0");
+    assert_eq!(installed.self_test_score, Some(1.0));
+    assert!(installed.path.join("content/skill-test.yaml").is_file());
 }
 
 #[tokio::test]
@@ -1969,6 +2209,8 @@ async fn http_registry_publish_updates_existing_index_json() {
             bundle_path: skill_bundle("json-published", "0.1.0", "JSON publish"),
             registry: Some("http-dev".to_owned()),
             allow_unsigned: true,
+            self_test_attestation: None,
+            no_self_test_run: false,
         })
         .await
         .expect("publish should update existing JSON index");
@@ -1978,6 +2220,7 @@ async fn http_registry_publish_updates_existing_index_json() {
             handle: "json-published@0.1.0".to_owned(),
             registry: Some("http-dev".to_owned()),
             allow_unsigned: true,
+            self_test_attestation: None,
         })
         .await
         .expect("add should read updated JSON index");
@@ -1997,6 +2240,8 @@ async fn http_registry_publish_defaults_missing_index_to_json() {
             bundle_path: skill_bundle("json-default", "0.1.0", "JSON default"),
             registry: Some("http-dev".to_owned()),
             allow_unsigned: true,
+            self_test_attestation: None,
+            no_self_test_run: false,
         })
         .await
         .expect("publish should create a new JSON index");
@@ -2036,6 +2281,7 @@ async fn http_registry_add_downloads_tar_zst_skill_artifact() {
             handle: "tarball-skill@0.1.0".to_owned(),
             registry: Some("http-dev".to_owned()),
             allow_unsigned: true,
+            self_test_attestation: None,
         })
         .await
         .expect("add should unpack tar.zst artifact");
@@ -2081,6 +2327,7 @@ async fn http_registry_add_verifies_tar_zst_signature_sidecar() {
             handle: "signed-tarball-skill@0.1.0".to_owned(),
             registry: Some("http-dev".to_owned()),
             allow_unsigned: true,
+            self_test_attestation: None,
         })
         .await
         .expect("add should verify the tar.zst signature sidecar");
@@ -2123,6 +2370,7 @@ async fn http_registry_add_rejects_invalid_tar_zst_signature_sidecar() {
             handle: "bad-signature-tarball@0.1.0".to_owned(),
             registry: Some("http-dev".to_owned()),
             allow_unsigned: true,
+            self_test_attestation: None,
         })
         .await
         .expect_err("add should reject an invalid tar.zst signature sidecar");
@@ -2158,6 +2406,7 @@ async fn http_registry_add_rejects_tar_zst_parent_traversal_entry() {
             handle: "unsafe-tarball-skill@0.1.0".to_owned(),
             registry: Some("http-dev".to_owned()),
             allow_unsigned: true,
+            self_test_attestation: None,
         })
         .await
         .expect_err("add should reject unsafe tar path");
@@ -2196,6 +2445,7 @@ async fn http_registry_add_rejects_tar_zst_symlink_entry() {
             handle: "symlink-tarball-skill@0.1.0".to_owned(),
             registry: Some("http-dev".to_owned()),
             allow_unsigned: true,
+            self_test_attestation: None,
         })
         .await
         .expect_err("add should reject tar symlink");
@@ -2230,6 +2480,7 @@ async fn http_registry_rejects_tarball_hardlink_entries() {
             handle: "hardlink-skill@0.1.0".to_owned(),
             registry: Some("http-dev".to_owned()),
             allow_unsigned: true,
+            self_test_attestation: None,
         })
         .await
         .expect_err("hardlink tar entries must be rejected");
@@ -2302,9 +2553,11 @@ async fn oci_registry_search_add_and_publish_use_distribution_api() {
 
     service
         .publish(SkillPublishRequest {
-            bundle_path: skill_bundle("oci-skill", "0.1.0", "OCI skill"),
+            bundle_path: skill_test_file_bundle("oci-skill", "0.1.0", "OCI skill"),
             registry: Some("oci-dev".to_owned()),
             allow_unsigned: true,
+            self_test_attestation: None,
+            no_self_test_run: false,
         })
         .await
         .expect("OCI publish should work against fixture");
@@ -2317,6 +2570,7 @@ async fn oci_registry_search_add_and_publish_use_distribution_api() {
             handle: "oci-skill@0.1.0".to_owned(),
             registry: Some("oci-dev".to_owned()),
             allow_unsigned: true,
+            self_test_attestation: None,
         })
         .await
         .expect("OCI add should install");
@@ -2324,6 +2578,8 @@ async fn oci_registry_search_add_and_publish_use_distribution_api() {
     assert_eq!(installed.name, "oci-skill");
     assert_eq!(installed.source_type, "oci");
     assert_eq!(installed.source_label, "oci:oci-dev:oci-skill@0.1.0");
+    assert_eq!(installed.self_test_score, Some(1.0));
+    assert!(installed.path.join("content/skill-test.yaml").is_file());
 }
 
 #[tokio::test]
@@ -2345,6 +2601,8 @@ async fn git_registry_publish_is_reported_as_unsupported() {
             bundle_path: skill_bundle("git-publish", "0.1.0", "Git publish"),
             registry: Some("git-dev".to_owned()),
             allow_unsigned: true,
+            self_test_attestation: None,
+            no_self_test_run: false,
         })
         .await
         .expect_err("git publish should be read-only");
@@ -2375,6 +2633,8 @@ async fn git_registry_rejects_invalid_registry_name_before_cache_path_use() {
             bundle_path: skill_bundle("git-name-reject", "0.1.0", "Git name reject"),
             registry: Some("../../outside".to_owned()),
             allow_unsigned: true,
+            self_test_attestation: None,
+            no_self_test_run: false,
         })
         .await
         .expect_err("invalid registry names must be rejected before adapter construction");
@@ -2432,6 +2692,8 @@ async fn publish_test_skill(service: &SkillService, name: &str, version: &str, c
             bundle_path: skill_bundle(name, version, content),
             registry: Some("local-dev".to_owned()),
             allow_unsigned: true,
+            self_test_attestation: None,
+            no_self_test_run: false,
         })
         .await
         .expect("publish should succeed");
@@ -2465,8 +2727,24 @@ fn skill_bundle(name: &str, version: &str, content: &str) -> PathBuf {
     write_file(
         &bundle.join("skill.yaml"),
         &format!(
+            "name: {name}\nversion: {version}\ndescription: {content}\nentry: SKILL.md\nfiles:\n  - SKILL.md\nself_test:\n  command: test -f SKILL.md\n"
+        ),
+    );
+    bundle
+}
+
+fn skill_test_file_bundle(name: &str, version: &str, content: &str) -> PathBuf {
+    let bundle = temp_dir(&format!("skill-test-file-bundle-{name}-{version}"));
+    write_file(&bundle.join("SKILL.md"), &format!("# {content}\n"));
+    write_file(
+        &bundle.join("skill.yaml"),
+        &format!(
             "name: {name}\nversion: {version}\ndescription: {content}\nentry: SKILL.md\nfiles:\n  - SKILL.md\n"
         ),
+    );
+    write_file(
+        &bundle.join("skill-test.yaml"),
+        "self_test:\n  runner: agentenv\n  assertions:\n    - type: file_exists\n      path: SKILL.md\n",
     );
     bundle
 }
@@ -2548,6 +2826,12 @@ fn append_bundle_minimal_files<W: io::Write>(builder: &mut tar::Builder<W>, bund
     builder
         .append_path_with_name(bundle_path.join("SKILL.md"), "SKILL.md")
         .unwrap();
+    let skill_test_path = bundle_path.join("skill-test.yaml");
+    if skill_test_path.is_file() {
+        builder
+            .append_path_with_name(skill_test_path, "skill-test.yaml")
+            .unwrap();
+    }
 }
 
 async fn add_binary_response(server: &TestHttpRegistry, method: &str, path: &str, body: Vec<u8>) {

--- a/crates/agentenv-core/tests/skills.rs
+++ b/crates/agentenv-core/tests/skills.rs
@@ -385,6 +385,7 @@ fn local_install_writes_cache_and_index() {
             allow_unsigned: true,
             source_type: "local".to_owned(),
             source_label: "local-dev".to_owned(),
+            unsafe_skip_self_test_gate: true,
         },
     )
     .expect("install should succeed");
@@ -393,6 +394,65 @@ fn local_install_writes_cache_and_index() {
     assert_eq!(installed.version, "0.1.0");
     assert!(installed.path.join("content/SKILL.md").is_file());
     assert!(home.join(".agentenv/skills/index.yaml").is_file());
+}
+
+#[test]
+fn local_install_rejects_missing_self_test() {
+    let home = temp_dir("skill-install-missing-self-test-home");
+    let bundle = temp_dir("skill-install-missing-self-test-bundle");
+    write_file(&bundle.join("SKILL.md"), "# Demo\n");
+    write_file(
+        &bundle.join("skill.yaml"),
+        "name: missing-self-test-demo\nversion: 0.1.0\nentry: SKILL.md\nfiles:\n  - SKILL.md\n",
+    );
+
+    let error = install_local_skill(
+        home.join(".agentenv"),
+        &bundle,
+        SkillInstallOptions {
+            allow_unsigned: true,
+            source_type: "local".to_owned(),
+            source_label: "local-dev".to_owned(),
+            unsafe_skip_self_test_gate: false,
+        },
+    )
+    .expect_err("install without a self-test must fail");
+
+    assert!(matches!(error, SkillError::MissingSelfTest));
+    assert!(!home
+        .join(".agentenv/skills/missing-self-test-demo/0.1.0")
+        .exists());
+}
+
+#[test]
+fn local_install_accepts_passing_self_test_and_records_score() {
+    let home = temp_dir("skill-install-passing-self-test-home");
+    let bundle = temp_dir("skill-install-passing-self-test-bundle");
+    write_file(&bundle.join("SKILL.md"), "# Demo\n");
+    write_file(
+        &bundle.join("skill.yaml"),
+        "name: passing-self-test-demo\nversion: 0.1.0\nentry: SKILL.md\nfiles:\n  - SKILL.md\n",
+    );
+    write_file(
+        &bundle.join("skill-test.yaml"),
+        "self_test:\n  runner: agentenv\n  assertions:\n    - type: file_exists\n      path: SKILL.md\n",
+    );
+
+    let installed = install_local_skill(
+        home.join(".agentenv"),
+        &bundle,
+        SkillInstallOptions {
+            allow_unsigned: true,
+            source_type: "local".to_owned(),
+            source_label: "local-dev".to_owned(),
+            unsafe_skip_self_test_gate: false,
+        },
+    )
+    .expect("passing self-test should install");
+
+    assert_eq!(installed.self_test_score, Some(1.0));
+    assert!(installed.self_test_attestation.is_some());
+    assert!(installed.self_test_attestation.as_ref().unwrap().is_file());
 }
 
 #[test]
@@ -411,6 +471,7 @@ fn local_reinstall_same_digest_keeps_existing_record() {
             allow_unsigned: true,
             source_type: "local".to_owned(),
             source_label: "first-source".to_owned(),
+            unsafe_skip_self_test_gate: true,
         },
     )
     .unwrap();
@@ -422,6 +483,7 @@ fn local_reinstall_same_digest_keeps_existing_record() {
             allow_unsigned: true,
             source_type: "local".to_owned(),
             source_label: "second-source".to_owned(),
+            unsafe_skip_self_test_gate: true,
         },
     )
     .unwrap();
@@ -431,10 +493,62 @@ fn local_reinstall_same_digest_keeps_existing_record() {
 }
 
 #[test]
+fn local_reinstall_reruns_self_test_when_digest_matches() {
+    let home = temp_dir("skill-install-rerun-self-test-home");
+    let bundle = temp_dir("skill-install-rerun-self-test-bundle");
+    write_file(&bundle.join("SKILL.md"), "# Demo\n");
+    write_file(
+        &bundle.join("skill-test.yaml"),
+        "self_test:\n  runner: agentenv\n  assertions:\n    - type: file_exists\n      path: SKILL.md\n",
+    );
+    write_file(
+        &bundle.join("skill.yaml"),
+        "name: rerun-self-test-demo\nversion: 0.1.0\nentry: SKILL.md\nfiles:\n  - SKILL.md\n",
+    );
+
+    install_local_skill(
+        home.join(".agentenv"),
+        &bundle,
+        SkillInstallOptions {
+            allow_unsigned: true,
+            source_type: "local".to_owned(),
+            source_label: "local-dev".to_owned(),
+            unsafe_skip_self_test_gate: false,
+        },
+    )
+    .expect("initial passing self-test should install");
+    write_file(
+        &bundle.join("skill-test.yaml"),
+        "self_test:\n  runner: agentenv\n  assertions:\n    - type: file_exists\n      path: missing.md\n",
+    );
+
+    let error = install_local_skill(
+        home.join(".agentenv"),
+        &bundle,
+        SkillInstallOptions {
+            allow_unsigned: true,
+            source_type: "local".to_owned(),
+            source_label: "local-dev".to_owned(),
+            unsafe_skip_self_test_gate: false,
+        },
+    )
+    .expect_err("same-digest reinstall must rerun the current self-test");
+
+    assert!(matches!(
+        error,
+        SkillError::SelfTestScoreBelowThreshold { .. }
+    ));
+}
+
+#[test]
 fn local_reinstall_repairs_tampered_cached_content() {
     let home = temp_dir("skill-install-repair-home");
     let bundle = temp_dir("skill-install-repair-bundle");
     write_file(&bundle.join("SKILL.md"), "# Demo\n");
+    write_file(
+        &bundle.join("skill-test.yaml"),
+        "self_test:\n  runner: agentenv\n  assertions:\n    - type: file_exists\n      path: SKILL.md\n",
+    );
     write_file(
         &bundle.join("skill.yaml"),
         "name: repair-demo\nversion: 0.1.0\nentry: SKILL.md\nfiles:\n  - SKILL.md\n",
@@ -446,6 +560,7 @@ fn local_reinstall_repairs_tampered_cached_content() {
             allow_unsigned: true,
             source_type: "local".to_owned(),
             source_label: "local-dev".to_owned(),
+            unsafe_skip_self_test_gate: true,
         },
     )
     .unwrap();
@@ -458,6 +573,7 @@ fn local_reinstall_repairs_tampered_cached_content() {
             allow_unsigned: true,
             source_type: "local".to_owned(),
             source_label: "local-dev".to_owned(),
+            unsafe_skip_self_test_gate: true,
         },
     )
     .expect("reinstall should repair tampered same-digest cache");
@@ -500,6 +616,7 @@ fn local_reinstall_rejects_symlinked_existing_version_directory() {
             allow_unsigned: true,
             source_type: "local".to_owned(),
             source_label: "local-dev".to_owned(),
+            unsafe_skip_self_test_gate: true,
         },
     )
     .expect_err("reinstall must reject symlinked existing install dirs");
@@ -525,6 +642,7 @@ fn local_reinstall_rejects_symlinked_cached_content_directory() {
             allow_unsigned: true,
             source_type: "local".to_owned(),
             source_label: "local-dev".to_owned(),
+            unsafe_skip_self_test_gate: true,
         },
     )
     .unwrap();
@@ -539,6 +657,7 @@ fn local_reinstall_rejects_symlinked_cached_content_directory() {
             allow_unsigned: true,
             source_type: "local".to_owned(),
             source_label: "local-dev".to_owned(),
+            unsafe_skip_self_test_gate: true,
         },
     )
     .expect_err("reinstall must reject symlinked cached content dirs");
@@ -564,6 +683,7 @@ fn local_reinstall_rejects_symlinked_cached_content_with_missing_files() {
             allow_unsigned: true,
             source_type: "local".to_owned(),
             source_label: "local-dev".to_owned(),
+            unsafe_skip_self_test_gate: true,
         },
     )
     .unwrap();
@@ -577,6 +697,7 @@ fn local_reinstall_rejects_symlinked_cached_content_with_missing_files() {
             allow_unsigned: true,
             source_type: "local".to_owned(),
             source_label: "local-dev".to_owned(),
+            unsafe_skip_self_test_gate: true,
         },
     )
     .expect_err("broken symlinked content dirs must be rejected before repair");
@@ -607,6 +728,7 @@ fn local_install_treats_manifest_public_key_as_untrusted() {
             allow_unsigned: true,
             source_type: "local".to_owned(),
             source_label: "local-dev".to_owned(),
+            unsafe_skip_self_test_gate: true,
         },
     )
     .expect("self-supplied keys should not be treated as trusted signatures");
@@ -630,6 +752,7 @@ fn installed_verify_detects_content_tampering() {
             allow_unsigned: true,
             source_type: "local".to_owned(),
             source_label: "local-dev".to_owned(),
+            unsafe_skip_self_test_gate: true,
         },
     )
     .unwrap();
@@ -660,6 +783,7 @@ fn installed_verify_rejects_signed_record_without_public_key() {
             allow_unsigned: true,
             source_type: "local".to_owned(),
             source_label: "local-dev".to_owned(),
+            unsafe_skip_self_test_gate: true,
         },
     )
     .unwrap();
@@ -696,6 +820,7 @@ fn installed_verify_rejects_symlinked_cached_content_directory() {
             allow_unsigned: true,
             source_type: "local".to_owned(),
             source_label: "local-dev".to_owned(),
+            unsafe_skip_self_test_gate: true,
         },
     )
     .unwrap();
@@ -728,6 +853,7 @@ fn installed_verify_rejects_record_entry_tamper() {
             allow_unsigned: true,
             source_type: "local".to_owned(),
             source_label: "local-dev".to_owned(),
+            unsafe_skip_self_test_gate: true,
         },
     )
     .unwrap();
@@ -752,6 +878,10 @@ fn installed_verify_rejects_signature_status_downgrade() {
     let bundle = temp_dir("skill-verify-signature-downgrade-bundle");
     write_file(&bundle.join("SKILL.md"), "# Demo\n");
     write_file(
+        &bundle.join("skill-test.yaml"),
+        "self_test:\n  runner: agentenv\n  assertions:\n    - type: file_exists\n      path: SKILL.md\n",
+    );
+    write_file(
         &bundle.join("skill.yaml"),
         "name: signature-downgrade-demo\nversion: 0.1.0\nentry: SKILL.md\nfiles:\n  - SKILL.md\n",
     );
@@ -774,6 +904,7 @@ fn installed_verify_rejects_signature_status_downgrade() {
             allow_unsigned: true,
             source_type: "local".to_owned(),
             source_label: "local-dev".to_owned(),
+            unsafe_skip_self_test_gate: true,
         },
     )
     .unwrap();
@@ -847,6 +978,7 @@ fn installed_index_ignores_stale_staging_directories() {
             allow_unsigned: true,
             source_type: "local".to_owned(),
             source_label: "local-dev".to_owned(),
+            unsafe_skip_self_test_gate: true,
         },
     )
     .unwrap();
@@ -882,6 +1014,7 @@ fn installed_verify_runs_self_test_command() {
             allow_unsigned: true,
             source_type: "local".to_owned(),
             source_label: "local-dev".to_owned(),
+            unsafe_skip_self_test_gate: true,
         },
     )
     .unwrap();
@@ -893,6 +1026,47 @@ fn installed_verify_runs_self_test_command() {
     .expect("self-test command should pass");
 
     assert_eq!(verified.name, "self-test-demo");
+}
+
+#[test]
+fn installed_verify_runs_structured_skill_yaml_self_test() {
+    let home = temp_dir("skill-verify-structured-skill-yaml-home");
+    let bundle = temp_dir("skill-verify-structured-skill-yaml-bundle");
+    write_file(&bundle.join("SKILL.md"), "# Demo\n");
+    write_file(
+        &bundle.join("skill.yaml"),
+        r#"name: structured-skill-yaml-demo
+version: 0.1.0
+entry: SKILL.md
+files:
+  - SKILL.md
+self_test:
+  runner: agentenv
+  assertions:
+    - type: file_exists
+      path: SKILL.md
+"#,
+    );
+    install_local_skill(
+        home.join(".agentenv"),
+        &bundle,
+        SkillInstallOptions {
+            allow_unsigned: true,
+            source_type: "local".to_owned(),
+            source_label: "local-dev".to_owned(),
+            unsafe_skip_self_test_gate: false,
+        },
+    )
+    .expect("structured skill.yaml self-test should install");
+
+    let verified = verify_installed_skill(
+        home.join(".agentenv"),
+        InstalledSkillSelector::Name("structured-skill-yaml-demo".to_owned()),
+    )
+    .expect("structured skill.yaml self-test should verify");
+
+    assert_eq!(verified.self_test_score, Some(1.0));
+    assert!(verified.self_test_attestation.is_some());
 }
 
 #[test]

--- a/crates/agentenv-core/tests/skills_cache.rs
+++ b/crates/agentenv-core/tests/skills_cache.rs
@@ -322,7 +322,7 @@ fn verify_all_accepts_valid_unsigned_skill_with_file_self_test() {
     manifest.self_test = Some(SkillSelfTest {
         timeout_seconds: 5,
         assertions: vec![SkillSelfTestAssertion::FileExists {
-            path: "SKILL.md".to_owned(),
+            path: "SKILL.md".into(),
         }],
     });
     write_manifest(&skill_dir, &manifest);

--- a/crates/agentenv-core/tests/skills_self_test.rs
+++ b/crates/agentenv-core/tests/skills_self_test.rs
@@ -1,7 +1,16 @@
-use std::{fs, path::Path};
+use std::{
+    fs,
+    path::{Path, PathBuf},
+    sync::atomic::Ordering,
+    sync::{Arc, Mutex},
+    thread,
+    time::{Duration, Instant},
+};
 
 use agentenv_core::skills::{
-    load_skill_self_test_spec, SkillError, SkillSelfTestAssertion, SkillSelfTestRunner,
+    load_skill_self_test_spec, run_skill_self_test, AgentProduceRequest, AgentProduceRunner,
+    SkillAssertionStatus, SkillError, SkillSelfTestAssertion, SkillSelfTestOptions,
+    SkillSelfTestRunner, SkillSelfTestSpec,
 };
 
 #[test]
@@ -555,6 +564,395 @@ fn self_test_spec_rejects_missing_self_test() {
     let error = load_skill_self_test_spec(&root).expect_err("missing self-test must fail");
 
     assert!(matches!(error, SkillError::MissingSelfTest));
+}
+
+#[test]
+fn self_test_runner_scores_file_and_command_assertions() {
+    let root = temp_dir("self-test-runner-score-file-command");
+    write_file(&root.join("SKILL.md"), "# Demo\n");
+    let spec = SkillSelfTestSpec {
+        runner: SkillSelfTestRunner::Agentenv,
+        blueprint: None,
+        assertions: vec![
+            SkillSelfTestAssertion::FileExists {
+                path: "missing.txt".into(),
+            },
+            SkillSelfTestAssertion::CommandExitsZero {
+                cmd: "exit 0".to_owned(),
+            },
+        ],
+        timeout_seconds: 5,
+    };
+
+    let report = run_skill_self_test(
+        &root,
+        "demo",
+        "0.1.0",
+        "sha256:bundle",
+        &spec,
+        SkillSelfTestOptions::default(),
+        Arc::new(UnsupportedTestAgentRunner),
+    )
+    .expect("runner should produce report");
+
+    assert_eq!(report.name, "demo");
+    assert_eq!(report.version, "0.1.0");
+    assert_eq!(report.digest, "sha256:bundle");
+    assert_eq!(report.passed, 1);
+    assert_eq!(report.total, 2);
+    assert_eq!(report.score, 0.5);
+    assert!(!report.publishable);
+    assert_eq!(report.assertions.len(), 2);
+    assert_eq!(report.assertions[0].assertion_type, "file_exists");
+    assert_eq!(report.assertions[0].status, SkillAssertionStatus::Failed);
+    assert_eq!(report.assertions[1].status, SkillAssertionStatus::Passed);
+    assert!(report.started_at <= report.completed_at);
+}
+
+#[test]
+fn self_test_runner_marks_publishable_at_default_threshold() {
+    let root = temp_dir("self-test-runner-threshold");
+    write_file(&root.join("SKILL.md"), "# Demo\n");
+    write_file(&root.join("README.md"), "# Readme\n");
+    write_file(&root.join("examples/demo.txt"), "demo\n");
+    write_file(&root.join("fixtures/input.txt"), "input\n");
+    let spec = SkillSelfTestSpec {
+        runner: SkillSelfTestRunner::Agentenv,
+        blueprint: None,
+        assertions: vec![
+            SkillSelfTestAssertion::FileExists {
+                path: "SKILL.md".into(),
+            },
+            SkillSelfTestAssertion::FileExists {
+                path: "README.md".into(),
+            },
+            SkillSelfTestAssertion::FileExists {
+                path: "examples/demo.txt".into(),
+            },
+            SkillSelfTestAssertion::FileExists {
+                path: "fixtures/input.txt".into(),
+            },
+            SkillSelfTestAssertion::FileExists {
+                path: "missing.txt".into(),
+            },
+        ],
+        timeout_seconds: 5,
+    };
+
+    let report = run_skill_self_test(
+        &root,
+        "demo-threshold",
+        "0.1.0",
+        "sha256:bundle",
+        &spec,
+        SkillSelfTestOptions::default(),
+        Arc::new(UnsupportedTestAgentRunner),
+    )
+    .expect("runner should produce report");
+
+    assert_eq!(report.passed, 4);
+    assert_eq!(report.total, 5);
+    assert_eq!(report.score, 0.8);
+    assert!(report.publishable);
+}
+
+#[test]
+fn self_test_runner_scores_agent_produces_token_matches() {
+    let root = temp_dir("self-test-runner-agent-produces");
+    write_file(&root.join("SKILL.md"), "# Demo\n");
+    write_file(&root.join("agentenv.yaml"), "version: 1\n");
+    let runner = Arc::new(FakeAgentRunner::new(
+        "The answer mentions Cargo.toml and SKILL.md.",
+    ));
+    let spec = SkillSelfTestSpec {
+        runner: SkillSelfTestRunner::Agentenv,
+        blueprint: Some(PathBuf::from("agentenv.yaml")),
+        assertions: vec![SkillSelfTestAssertion::AgentProduces {
+            prompt: "summarize".to_owned(),
+            expect_tokens_matching: vec![
+                "Cargo.toml".to_owned(),
+                "SKILL.md".to_owned(),
+                "missing-token".to_owned(),
+            ],
+            min_match_ratio: 0.66,
+        }],
+        timeout_seconds: 5,
+    };
+
+    let report = run_skill_self_test(
+        &root,
+        "demo-agent",
+        "0.1.0",
+        "sha256:bundle",
+        &spec,
+        SkillSelfTestOptions::default(),
+        runner.clone(),
+    )
+    .expect("runner should produce report");
+
+    assert_eq!(report.passed, 1);
+    assert_eq!(report.total, 1);
+    assert_eq!(report.score, 1.0);
+    assert!(report.publishable);
+    assert_eq!(report.assertions[0].assertion_type, "agent_produces");
+    assert_eq!(report.assertions[0].status, SkillAssertionStatus::Passed);
+
+    let request = runner.take_request().expect("request should be captured");
+    assert_eq!(request.skill_root, root);
+    assert_eq!(request.blueprint, root.join("agentenv.yaml"));
+    assert_eq!(request.prompt, "summarize");
+    assert!(request.timeout > Duration::ZERO);
+    assert!(request.timeout <= Duration::from_secs(5));
+}
+
+#[test]
+fn self_test_runner_passes_remaining_timeout_to_agent_produces() {
+    let root = temp_dir("self-test-runner-agent-produces-timeout");
+    write_file(&root.join("SKILL.md"), "# Demo\n");
+    write_file(&root.join("agentenv.yaml"), "version: 1\n");
+    let runner = Arc::new(FakeAgentRunner::new("ready"));
+    let spec = SkillSelfTestSpec {
+        runner: SkillSelfTestRunner::Agentenv,
+        blueprint: Some(PathBuf::from("agentenv.yaml")),
+        assertions: vec![
+            SkillSelfTestAssertion::CommandExitsZero {
+                cmd: "exit 0".to_owned(),
+            },
+            SkillSelfTestAssertion::AgentProduces {
+                prompt: "summarize".to_owned(),
+                expect_tokens_matching: vec!["ready".to_owned()],
+                min_match_ratio: 1.0,
+            },
+        ],
+        timeout_seconds: 5,
+    };
+
+    let report = run_skill_self_test(
+        &root,
+        "demo-agent-timeout",
+        "0.1.0",
+        "sha256:bundle",
+        &spec,
+        SkillSelfTestOptions::default(),
+        runner.clone(),
+    )
+    .expect("runner should produce report");
+
+    assert!(report.publishable);
+
+    let request = runner.take_request().expect("request should be captured");
+    assert!(request.timeout > Duration::ZERO);
+    assert!(
+        request.timeout < Duration::from_secs(5),
+        "agent_produces should receive remaining budget, got {:?}",
+        request.timeout
+    );
+}
+
+#[test]
+fn self_test_runner_bounds_slow_agent_produces_runner() {
+    let root = temp_dir("self-test-runner-slow-agent-produces");
+    write_file(&root.join("SKILL.md"), "# Demo\n");
+    write_file(&root.join("agentenv.yaml"), "version: 1\n");
+    let spec = SkillSelfTestSpec {
+        runner: SkillSelfTestRunner::Agentenv,
+        blueprint: Some(PathBuf::from("agentenv.yaml")),
+        assertions: vec![SkillSelfTestAssertion::AgentProduces {
+            prompt: "summarize".to_owned(),
+            expect_tokens_matching: vec!["ready".to_owned()],
+            min_match_ratio: 1.0,
+        }],
+        timeout_seconds: 1,
+    };
+
+    let started = Instant::now();
+    let report = run_skill_self_test(
+        &root,
+        "demo-slow-agent",
+        "0.1.0",
+        "sha256:bundle",
+        &spec,
+        SkillSelfTestOptions::default(),
+        Arc::new(SlowAgentRunner),
+    )
+    .expect("runner should produce report");
+
+    assert!(started.elapsed() < Duration::from_secs(2));
+    assert_eq!(report.passed, 0);
+    assert_eq!(report.assertions[0].status, SkillAssertionStatus::Failed);
+    assert!(report.assertions[0].message.contains("timed out"));
+}
+
+#[test]
+fn self_test_runner_rejects_invalid_threshold_option() {
+    let root = temp_dir("self-test-runner-invalid-threshold");
+    write_file(&root.join("SKILL.md"), "# Demo\n");
+    let spec = SkillSelfTestSpec {
+        runner: SkillSelfTestRunner::Agentenv,
+        blueprint: None,
+        assertions: vec![SkillSelfTestAssertion::FileExists {
+            path: "SKILL.md".into(),
+        }],
+        timeout_seconds: 5,
+    };
+
+    let error = run_skill_self_test(
+        &root,
+        "demo-invalid-threshold",
+        "0.1.0",
+        "sha256:bundle",
+        &spec,
+        SkillSelfTestOptions {
+            threshold: f64::NAN,
+        },
+        Arc::new(UnsupportedTestAgentRunner),
+    )
+    .expect_err("invalid threshold must fail");
+
+    assert!(matches!(error, SkillError::InvalidSelfTest { .. }));
+}
+
+#[test]
+fn self_test_runner_rejects_unrepresentable_deadline() {
+    let root = temp_dir("self-test-runner-unrepresentable-deadline");
+    write_file(&root.join("SKILL.md"), "# Demo\n");
+    let spec = SkillSelfTestSpec {
+        runner: SkillSelfTestRunner::Agentenv,
+        blueprint: None,
+        assertions: vec![SkillSelfTestAssertion::FileExists {
+            path: "SKILL.md".into(),
+        }],
+        timeout_seconds: u64::MAX,
+    };
+
+    let error = run_skill_self_test(
+        &root,
+        "demo-huge-timeout",
+        "0.1.0",
+        "sha256:bundle",
+        &spec,
+        SkillSelfTestOptions::default(),
+        Arc::new(UnsupportedTestAgentRunner),
+    )
+    .expect_err("huge timeout must fail");
+
+    assert!(matches!(error, SkillError::InvalidSelfTest { .. }));
+}
+
+#[cfg(unix)]
+#[test]
+fn self_test_runner_clears_command_environment() {
+    let root = temp_dir("self-test-runner-command-env-clear");
+    write_file(&root.join("SKILL.md"), "# Demo\n");
+    let spec = SkillSelfTestSpec {
+        runner: SkillSelfTestRunner::Agentenv,
+        blueprint: None,
+        assertions: vec![SkillSelfTestAssertion::CommandExitsZero {
+            cmd: r#"test -z "$HOME""#.to_owned(),
+        }],
+        timeout_seconds: 5,
+    };
+
+    let report = run_skill_self_test(
+        &root,
+        "demo-env-clear",
+        "0.1.0",
+        "sha256:bundle",
+        &spec,
+        SkillSelfTestOptions::default(),
+        Arc::new(UnsupportedTestAgentRunner),
+    )
+    .expect("runner should produce report");
+
+    assert_eq!(report.assertions[0].status, SkillAssertionStatus::Passed);
+}
+
+#[cfg(unix)]
+#[test]
+fn self_test_runner_kills_command_descendants_on_timeout() {
+    let root = temp_dir("self-test-runner-command-descendants");
+    write_file(&root.join("SKILL.md"), "# Demo\n");
+    let late_file = root.join("late.txt");
+    let spec = SkillSelfTestSpec {
+        runner: SkillSelfTestRunner::Agentenv,
+        blueprint: None,
+        assertions: vec![SkillSelfTestAssertion::CommandExitsZero {
+            cmd: "(/bin/sleep 2; /usr/bin/touch late.txt) & /bin/sleep 5".to_owned(),
+        }],
+        timeout_seconds: 1,
+    };
+
+    let report = run_skill_self_test(
+        &root,
+        "demo-descendants",
+        "0.1.0",
+        "sha256:bundle",
+        &spec,
+        SkillSelfTestOptions::default(),
+        Arc::new(UnsupportedTestAgentRunner),
+    )
+    .expect("runner should produce report");
+
+    assert_eq!(report.assertions[0].status, SkillAssertionStatus::Failed);
+    thread::sleep(Duration::from_secs(3));
+    assert!(!late_file.exists());
+}
+
+struct UnsupportedTestAgentRunner;
+
+impl AgentProduceRunner for UnsupportedTestAgentRunner {
+    fn run_agent_prompt(&self, _request: AgentProduceRequest<'_>) -> Result<String, SkillError> {
+        Err(SkillError::UnsupportedAgentProduces)
+    }
+}
+
+struct SlowAgentRunner;
+
+impl AgentProduceRunner for SlowAgentRunner {
+    fn run_agent_prompt(&self, request: AgentProduceRequest<'_>) -> Result<String, SkillError> {
+        while !request.cancelled.load(Ordering::Relaxed) {
+            thread::sleep(Duration::from_millis(10));
+        }
+        Ok("ready".to_owned())
+    }
+}
+
+#[derive(Debug)]
+struct CapturedAgentRequest {
+    skill_root: PathBuf,
+    blueprint: PathBuf,
+    prompt: String,
+    timeout: Duration,
+}
+
+struct FakeAgentRunner {
+    output: String,
+    request: Mutex<Option<CapturedAgentRequest>>,
+}
+
+impl FakeAgentRunner {
+    fn new(output: &str) -> Self {
+        Self {
+            output: output.to_owned(),
+            request: Mutex::new(None),
+        }
+    }
+
+    fn take_request(&self) -> Option<CapturedAgentRequest> {
+        self.request.lock().unwrap().take()
+    }
+}
+
+impl AgentProduceRunner for FakeAgentRunner {
+    fn run_agent_prompt(&self, request: AgentProduceRequest<'_>) -> Result<String, SkillError> {
+        *self.request.lock().unwrap() = Some(CapturedAgentRequest {
+            skill_root: request.skill_root.to_path_buf(),
+            blueprint: request.blueprint.to_path_buf(),
+            prompt: request.prompt.to_owned(),
+            timeout: request.timeout,
+        });
+        Ok(self.output.clone())
+    }
 }
 
 fn temp_dir(prefix: &str) -> std::path::PathBuf {

--- a/crates/agentenv-core/tests/skills_self_test.rs
+++ b/crates/agentenv-core/tests/skills_self_test.rs
@@ -709,6 +709,46 @@ fn self_test_runner_scores_agent_produces_token_matches() {
 }
 
 #[test]
+fn agent_produces_uses_injected_runner() {
+    let root = temp_dir("agent-produces-injected-runner");
+    fs::create_dir_all(root.join("test")).unwrap();
+    write_file(&root.join("SKILL.md"), "# Demo\n");
+    write_file(&root.join("test/minimal.yaml"), "version: 0.1.0\n");
+    write_file(
+        &root.join("skill.yaml"),
+        "name: injected-agent\nversion: 0.1.0\nentry: SKILL.md\nfiles:\n  - SKILL.md\n  - test/minimal.yaml\n",
+    );
+    write_file(
+        &root.join("skill-test.yaml"),
+        r#"self_test:
+  runner: agentenv
+  blueprint: test/minimal.yaml
+  assertions:
+    - type: agent_produces
+      prompt: "summarize"
+      expect_tokens_matching: ["src/"]
+      min_match_ratio: 1.0
+"#,
+    );
+    let manifest = agentenv_core::skills::load_skill_manifest(&root).unwrap();
+    let digest = agentenv_core::skills::compute_bundle_digest(&root, &manifest).unwrap();
+    let spec = load_skill_self_test_spec(&root).unwrap();
+
+    let report = run_skill_self_test(
+        &root,
+        "injected-agent",
+        "0.1.0",
+        &digest,
+        &spec,
+        SkillSelfTestOptions::default(),
+        Arc::new(FakeAgentRunner::new("src/ exists")),
+    )
+    .unwrap();
+
+    assert!(report.publishable);
+}
+
+#[test]
 fn self_test_runner_passes_remaining_timeout_to_agent_produces() {
     let root = temp_dir("self-test-runner-agent-produces-timeout");
     write_file(&root.join("SKILL.md"), "# Demo\n");

--- a/crates/agentenv-core/tests/skills_self_test.rs
+++ b/crates/agentenv-core/tests/skills_self_test.rs
@@ -1120,10 +1120,8 @@ fn self_test_attestation_load_or_create_key_round_trips() {
     let root = temp_dir("self-test-attestation-key-round-trip");
     let key_path = root.join("self-test-signing-key");
 
-    let first =
-        SkillSelfTestSigningKey::load_or_create(&key_path).expect("key should be created");
-    let second =
-        SkillSelfTestSigningKey::load_or_create(&key_path).expect("key should be loaded");
+    let first = SkillSelfTestSigningKey::load_or_create(&key_path).expect("key should be created");
+    let second = SkillSelfTestSigningKey::load_or_create(&key_path).expect("key should be loaded");
 
     assert_eq!(first.public_key_hex(), second.public_key_hex());
     assert_eq!(fs::read(&key_path).expect("key should exist").len(), 32);
@@ -1132,7 +1130,10 @@ fn self_test_attestation_load_or_create_key_round_trips() {
     {
         use std::os::unix::fs::PermissionsExt;
 
-        let mode = fs::metadata(&key_path).expect("key metadata").permissions().mode();
+        let mode = fs::metadata(&key_path)
+            .expect("key metadata")
+            .permissions()
+            .mode();
         assert_eq!(mode & 0o077, 0);
     }
 }
@@ -1152,7 +1153,10 @@ fn self_test_attestation_rejects_insecure_existing_key_file() {
     let error =
         SkillSelfTestSigningKey::load_or_create(&key_path).expect_err("insecure key must fail");
 
-    assert!(matches!(error, SkillError::InvalidSelfTestSigningKey { .. }));
+    assert!(matches!(
+        error,
+        SkillError::InvalidSelfTestSigningKey { .. }
+    ));
 }
 
 struct UnsupportedTestAgentRunner;

--- a/crates/agentenv-core/tests/skills_self_test.rs
+++ b/crates/agentenv-core/tests/skills_self_test.rs
@@ -8,10 +8,13 @@ use std::{
 };
 
 use agentenv_core::skills::{
-    load_skill_self_test_spec, run_skill_self_test, AgentProduceRequest, AgentProduceRunner,
-    SkillAssertionStatus, SkillError, SkillSelfTestAssertion, SkillSelfTestOptions,
-    SkillSelfTestRunner, SkillSelfTestSpec,
+    load_skill_self_test_spec, run_skill_self_test, sign_skill_self_test_attestation,
+    validate_skill_publish_attestation, AgentProduceRequest, AgentProduceRunner,
+    SkillAssertionResult, SkillAssertionStatus, SkillAttestationValidationOptions, SkillError,
+    SkillSelfTestAssertion, SkillSelfTestOptions, SkillSelfTestReport, SkillSelfTestRunner,
+    SkillSelfTestSigningKey, SkillSelfTestSpec,
 };
+use time::OffsetDateTime;
 
 #[test]
 fn self_test_spec_loads_from_skill_test_yaml() {
@@ -898,6 +901,260 @@ fn self_test_runner_kills_command_descendants_on_timeout() {
     assert!(!late_file.exists());
 }
 
+#[test]
+fn self_test_attestation_signs_and_validates_report() {
+    let report = attestation_report();
+    let key = SkillSelfTestSigningKey::from_secret_bytes([7; 32]);
+    let public_key = key.public_key_hex();
+
+    let attestation = sign_skill_self_test_attestation(&report, &key).expect("report should sign");
+
+    assert_eq!(attestation.signature.algorithm, "ed25519");
+    assert_eq!(attestation.signature.key_id, "local-agentenv");
+    assert_eq!(attestation.signature.public_key_ed25519, public_key);
+    assert_eq!(attestation.runner, "agentenv");
+    assert_eq!(attestation.score, 1.0);
+    assert!(attestation.publishable);
+    assert_eq!(attestation.completed_at, report.completed_at);
+
+    validate_skill_publish_attestation(
+        "demo",
+        "0.1.0",
+        "sha256:bundle",
+        "sha256:self-test",
+        &attestation,
+        validation_options(public_key),
+    )
+    .expect("valid attestation should pass");
+}
+
+#[test]
+fn self_test_attestation_rejects_low_score() {
+    let mut report = attestation_report();
+    report.score = 0.5;
+    report.publishable = true;
+    let key = SkillSelfTestSigningKey::from_secret_bytes([7; 32]);
+    let attestation = sign_skill_self_test_attestation(&report, &key).expect("report should sign");
+
+    let error = validate_skill_publish_attestation(
+        "demo",
+        "0.1.0",
+        "sha256:bundle",
+        "sha256:self-test",
+        &attestation,
+        validation_options(key.public_key_hex()),
+    )
+    .expect_err("low score must fail");
+
+    assert!(matches!(
+        error,
+        SkillError::SelfTestScoreBelowThreshold { .. }
+    ));
+}
+
+#[test]
+fn self_test_attestation_rejects_stale_report() {
+    let mut report = attestation_report();
+    report.completed_at = OffsetDateTime::now_utc() - time::Duration::days(30);
+    report.started_at = report.completed_at - time::Duration::seconds(1);
+    let key = SkillSelfTestSigningKey::from_secret_bytes([7; 32]);
+    let attestation = sign_skill_self_test_attestation(&report, &key).expect("report should sign");
+
+    let error = validate_skill_publish_attestation(
+        "demo",
+        "0.1.0",
+        "sha256:bundle",
+        "sha256:self-test",
+        &attestation,
+        validation_options(key.public_key_hex()),
+    )
+    .expect_err("stale report must fail");
+
+    assert!(matches!(error, SkillError::StaleSelfTestAttestation { .. }));
+}
+
+#[test]
+fn self_test_attestation_rejects_future_report() {
+    let mut report = attestation_report();
+    report.completed_at = OffsetDateTime::now_utc() + time::Duration::days(1);
+    let key = SkillSelfTestSigningKey::from_secret_bytes([7; 32]);
+    let attestation = sign_skill_self_test_attestation(&report, &key).expect("report should sign");
+
+    let error = validate_skill_publish_attestation(
+        "demo",
+        "0.1.0",
+        "sha256:bundle",
+        "sha256:self-test",
+        &attestation,
+        validation_options(key.public_key_hex()),
+    )
+    .expect_err("future report must fail");
+
+    assert!(matches!(error, SkillError::StaleSelfTestAttestation { .. }));
+}
+
+#[test]
+fn self_test_attestation_rejects_untrusted_public_key() {
+    let report = attestation_report();
+    let key = SkillSelfTestSigningKey::from_secret_bytes([7; 32]);
+    let attestation = sign_skill_self_test_attestation(&report, &key).expect("report should sign");
+    let other_key = SkillSelfTestSigningKey::from_secret_bytes([8; 32]);
+
+    let error = validate_skill_publish_attestation(
+        "demo",
+        "0.1.0",
+        "sha256:bundle",
+        "sha256:self-test",
+        &attestation,
+        validation_options(other_key.public_key_hex()),
+    )
+    .expect_err("untrusted key must fail");
+
+    assert!(matches!(
+        error,
+        SkillError::InvalidSelfTestAttestation { .. }
+    ));
+}
+
+#[test]
+fn self_test_attestation_rejects_tampered_payload() {
+    let report = attestation_report();
+    let key = SkillSelfTestSigningKey::from_secret_bytes([7; 32]);
+    let mut attestation =
+        sign_skill_self_test_attestation(&report, &key).expect("report should sign");
+    attestation.assertions[0].message = "tampered".to_owned();
+
+    let error = validate_skill_publish_attestation(
+        "demo",
+        "0.1.0",
+        "sha256:bundle",
+        "sha256:self-test",
+        &attestation,
+        validation_options(key.public_key_hex()),
+    )
+    .expect_err("tampered payload must fail");
+
+    assert!(matches!(
+        error,
+        SkillError::InvalidSelfTestAttestation { .. }
+    ));
+}
+
+#[test]
+fn self_test_attestation_rejects_subject_and_digest_mismatches() {
+    let report = attestation_report();
+    let key = SkillSelfTestSigningKey::from_secret_bytes([7; 32]);
+    let attestation = sign_skill_self_test_attestation(&report, &key).expect("report should sign");
+
+    let subject_error = validate_skill_publish_attestation(
+        "other",
+        "0.1.0",
+        "sha256:bundle",
+        "sha256:self-test",
+        &attestation,
+        validation_options(key.public_key_hex()),
+    )
+    .expect_err("subject mismatch must fail");
+    assert!(matches!(
+        subject_error,
+        SkillError::SelfTestAttestationSubjectMismatch
+    ));
+
+    let digest_error = validate_skill_publish_attestation(
+        "demo",
+        "0.1.0",
+        "sha256:bundle",
+        "sha256:other-self-test",
+        &attestation,
+        validation_options(key.public_key_hex()),
+    )
+    .expect_err("self-test digest mismatch must fail");
+    assert!(matches!(
+        digest_error,
+        SkillError::SelfTestAttestationDigestMismatch
+    ));
+}
+
+#[test]
+fn self_test_attestation_rejects_wrong_algorithm_and_malformed_signature() {
+    let report = attestation_report();
+    let key = SkillSelfTestSigningKey::from_secret_bytes([7; 32]);
+    let mut wrong_algorithm =
+        sign_skill_self_test_attestation(&report, &key).expect("report should sign");
+    wrong_algorithm.signature.algorithm = "rsa".to_owned();
+
+    let algorithm_error = validate_skill_publish_attestation(
+        "demo",
+        "0.1.0",
+        "sha256:bundle",
+        "sha256:self-test",
+        &wrong_algorithm,
+        validation_options(key.public_key_hex()),
+    )
+    .expect_err("wrong algorithm must fail");
+    assert!(matches!(
+        algorithm_error,
+        SkillError::InvalidSelfTestAttestation { .. }
+    ));
+
+    let mut malformed =
+        sign_skill_self_test_attestation(&report, &key).expect("report should sign");
+    malformed.signature.value = "not-hex".to_owned();
+    let malformed_error = validate_skill_publish_attestation(
+        "demo",
+        "0.1.0",
+        "sha256:bundle",
+        "sha256:self-test",
+        &malformed,
+        validation_options(key.public_key_hex()),
+    )
+    .expect_err("malformed signature must fail");
+    assert!(matches!(
+        malformed_error,
+        SkillError::InvalidSelfTestAttestation { .. }
+    ));
+}
+
+#[test]
+fn self_test_attestation_load_or_create_key_round_trips() {
+    let root = temp_dir("self-test-attestation-key-round-trip");
+    let key_path = root.join("self-test-signing-key");
+
+    let first =
+        SkillSelfTestSigningKey::load_or_create(&key_path).expect("key should be created");
+    let second =
+        SkillSelfTestSigningKey::load_or_create(&key_path).expect("key should be loaded");
+
+    assert_eq!(first.public_key_hex(), second.public_key_hex());
+    assert_eq!(fs::read(&key_path).expect("key should exist").len(), 32);
+
+    #[cfg(unix)]
+    {
+        use std::os::unix::fs::PermissionsExt;
+
+        let mode = fs::metadata(&key_path).expect("key metadata").permissions().mode();
+        assert_eq!(mode & 0o077, 0);
+    }
+}
+
+#[cfg(unix)]
+#[test]
+fn self_test_attestation_rejects_insecure_existing_key_file() {
+    use std::os::unix::fs::PermissionsExt;
+
+    let root = temp_dir("self-test-attestation-insecure-key");
+    let key_path = root.join("self-test-signing-key");
+    fs::write(&key_path, [1_u8; 32]).expect("write key");
+    let mut permissions = fs::metadata(&key_path).expect("key metadata").permissions();
+    permissions.set_mode(0o644);
+    fs::set_permissions(&key_path, permissions).expect("set insecure mode");
+
+    let error =
+        SkillSelfTestSigningKey::load_or_create(&key_path).expect_err("insecure key must fail");
+
+    assert!(matches!(error, SkillError::InvalidSelfTestSigningKey { .. }));
+}
+
 struct UnsupportedTestAgentRunner;
 
 impl AgentProduceRunner for UnsupportedTestAgentRunner {
@@ -978,4 +1235,34 @@ fn unique_nanos() -> u128 {
         .duration_since(std::time::UNIX_EPOCH)
         .map(|duration| duration.as_nanos())
         .unwrap_or(0)
+}
+
+fn attestation_report() -> SkillSelfTestReport {
+    let now = OffsetDateTime::now_utc();
+    SkillSelfTestReport {
+        name: "demo".to_owned(),
+        version: "0.1.0".to_owned(),
+        digest: "sha256:bundle".to_owned(),
+        self_test_digest: "sha256:self-test".to_owned(),
+        score: 1.0,
+        passed: 1,
+        total: 1,
+        publishable: true,
+        assertions: vec![SkillAssertionResult {
+            assertion_type: "file_exists".to_owned(),
+            status: SkillAssertionStatus::Passed,
+            message: "SKILL.md exists".to_owned(),
+        }],
+        started_at: now - time::Duration::seconds(1),
+        completed_at: now,
+    }
+}
+
+fn validation_options(public_key: String) -> SkillAttestationValidationOptions {
+    SkillAttestationValidationOptions {
+        trusted_public_keys: vec![public_key],
+        now: OffsetDateTime::now_utc(),
+        max_age_seconds: 86_400,
+        threshold: 0.8,
+    }
 }

--- a/crates/agentenv-core/tests/skills_self_test.rs
+++ b/crates/agentenv-core/tests/skills_self_test.rs
@@ -1,0 +1,583 @@
+use std::{fs, path::Path};
+
+use agentenv_core::skills::{
+    load_skill_self_test_spec, SkillError, SkillSelfTestAssertion, SkillSelfTestRunner,
+};
+
+#[test]
+fn self_test_spec_loads_from_skill_test_yaml() {
+    let root = temp_dir("self-test-yaml");
+    write_file(&root.join("SKILL.md"), "# Demo\n");
+    write_file(
+        &root.join("skill.yaml"),
+        "name: demo\nversion: 0.1.0\nentry: SKILL.md\nfiles:\n  - SKILL.md\n",
+    );
+    write_file(
+        &root.join("skill-test.yaml"),
+        r#"self_test:
+  runner: agentenv
+  assertions:
+    - type: file_exists
+      path: SKILL.md
+  timeout_seconds: 120
+"#,
+    );
+
+    let spec = load_skill_self_test_spec(&root).expect("self-test should load");
+
+    assert_eq!(spec.runner, SkillSelfTestRunner::Agentenv);
+    assert_eq!(spec.timeout_seconds, 120);
+    assert_eq!(
+        spec.assertions,
+        vec![SkillSelfTestAssertion::FileExists {
+            path: "SKILL.md".into()
+        }]
+    );
+}
+
+#[test]
+fn self_test_spec_loads_from_skill_md_frontmatter() {
+    let root = temp_dir("self-test-frontmatter");
+    write_file(
+        &root.join("SKILL.md"),
+        r#"---
+self_test:
+  runner: agentenv
+  assertions:
+    - type: command_exits_zero
+      cmd: "test -f SKILL.md"
+---
+# Demo
+"#,
+    );
+    write_file(
+        &root.join("skill.yaml"),
+        "name: demo-frontmatter\nversion: 0.1.0\nentry: SKILL.md\nfiles:\n  - SKILL.md\n",
+    );
+
+    let spec = load_skill_self_test_spec(&root).expect("frontmatter self-test should load");
+
+    assert_eq!(spec.assertions.len(), 1);
+    assert!(matches!(
+        &spec.assertions[0],
+        SkillSelfTestAssertion::CommandExitsZero { cmd } if cmd == "test -f SKILL.md"
+    ));
+}
+
+#[test]
+fn self_test_spec_translates_legacy_skill_yaml_command() {
+    let root = temp_dir("self-test-legacy-command");
+    write_file(&root.join("SKILL.md"), "# Demo\n");
+    write_file(
+        &root.join("skill.yaml"),
+        r#"name: legacy-demo
+version: 0.1.0
+entry: SKILL.md
+files:
+  - SKILL.md
+self_test:
+  command: "test -f SKILL.md"
+"#,
+    );
+
+    let spec = load_skill_self_test_spec(&root).expect("legacy command should translate");
+
+    assert_eq!(spec.timeout_seconds, 30);
+    assert_eq!(
+        spec.assertions,
+        vec![SkillSelfTestAssertion::CommandExitsZero {
+            cmd: "test -f SKILL.md".to_owned()
+        }]
+    );
+}
+
+#[test]
+fn self_test_spec_rejects_conflicting_locations() {
+    let root = temp_dir("self-test-conflict");
+    write_file(
+        &root.join("SKILL.md"),
+        r#"---
+self_test:
+  runner: agentenv
+  assertions:
+    - type: file_exists
+      path: SKILL.md
+---
+# Demo
+"#,
+    );
+    write_file(
+        &root.join("skill.yaml"),
+        r#"name: conflict-demo
+version: 0.1.0
+entry: SKILL.md
+files:
+  - SKILL.md
+self_test:
+  runner: agentenv
+  assertions:
+    - type: command_exits_zero
+      cmd: "test -f SKILL.md"
+"#,
+    );
+
+    let error = load_skill_self_test_spec(&root).expect_err("conflict must fail");
+
+    assert!(matches!(
+        error,
+        SkillError::ConflictingSelfTestDeclarations { .. }
+    ));
+}
+
+#[test]
+fn self_test_spec_rejects_invalid_agent_assertion_ratio() {
+    let root = temp_dir("self-test-bad-ratio");
+    write_file(&root.join("SKILL.md"), "# Demo\n");
+    write_file(
+        &root.join("skill.yaml"),
+        "name: bad-ratio\nversion: 0.1.0\nentry: SKILL.md\nfiles:\n  - SKILL.md\n",
+    );
+    write_file(
+        &root.join("skill-test.yaml"),
+        r#"self_test:
+  runner: agentenv
+  blueprint: test/minimal.yaml
+  assertions:
+    - type: agent_produces
+      prompt: "summarize"
+      expect_tokens_matching: ["Cargo.toml"]
+      min_match_ratio: 1.2
+"#,
+    );
+
+    let error = load_skill_self_test_spec(&root).expect_err("ratio must fail");
+
+    assert!(matches!(error, SkillError::InvalidSelfTest { .. }));
+}
+
+#[test]
+fn self_test_spec_normalizes_file_exists_paths_before_conflict_check() {
+    let root = temp_dir("self-test-normalized-path-conflict");
+    write_file(&root.join("SKILL.md"), "# Demo\n");
+    write_file(
+        &root.join("skill-test.yaml"),
+        r#"self_test:
+  runner: agentenv
+  assertions:
+    - type: file_exists
+      path: ./SKILL.md
+"#,
+    );
+    write_file(
+        &root.join("skill.yaml"),
+        r#"name: normalized-path-demo
+version: 0.1.0
+entry: SKILL.md
+files:
+  - SKILL.md
+self_test:
+  runner: agentenv
+  assertions:
+    - type: file_exists
+      path: SKILL.md
+"#,
+    );
+
+    let spec = load_skill_self_test_spec(&root).expect("normalized paths should not conflict");
+
+    assert_eq!(
+        spec.assertions,
+        vec![SkillSelfTestAssertion::FileExists {
+            path: "SKILL.md".into()
+        }]
+    );
+}
+
+#[test]
+fn self_test_spec_rejects_blank_agent_expected_tokens() {
+    let root = temp_dir("self-test-blank-agent-token");
+    write_file(&root.join("SKILL.md"), "# Demo\n");
+    write_file(
+        &root.join("skill.yaml"),
+        "name: blank-token\nversion: 0.1.0\nentry: SKILL.md\nfiles:\n  - SKILL.md\n",
+    );
+    write_file(
+        &root.join("skill-test.yaml"),
+        r#"self_test:
+  runner: agentenv
+  blueprint: test/minimal.yaml
+  assertions:
+    - type: agent_produces
+      prompt: "summarize"
+      expect_tokens_matching: ["   "]
+      min_match_ratio: 1.0
+"#,
+    );
+
+    let error = load_skill_self_test_spec(&root).expect_err("blank token must fail");
+
+    assert!(matches!(error, SkillError::InvalidSelfTest { .. }));
+}
+
+#[test]
+fn self_test_spec_legacy_command_ignores_explicit_timeout() {
+    let root = temp_dir("self-test-legacy-command-timeout");
+    write_file(&root.join("SKILL.md"), "# Demo\n");
+    write_file(
+        &root.join("skill.yaml"),
+        r#"name: legacy-timeout-demo
+version: 0.1.0
+entry: SKILL.md
+files:
+  - SKILL.md
+self_test:
+  command: "test -f SKILL.md"
+  timeout_seconds: 999
+"#,
+    );
+
+    let spec = load_skill_self_test_spec(&root).expect("legacy command should translate");
+
+    assert_eq!(spec.timeout_seconds, 30);
+}
+
+#[test]
+fn self_test_spec_rejects_legacy_command_with_blueprint() {
+    let root = temp_dir("self-test-legacy-command-blueprint");
+    write_file(&root.join("SKILL.md"), "# Demo\n");
+    write_file(
+        &root.join("skill.yaml"),
+        r#"name: legacy-blueprint-demo
+version: 0.1.0
+entry: SKILL.md
+files:
+  - SKILL.md
+self_test:
+  command: "test -f SKILL.md"
+  blueprint: test/minimal.yaml
+"#,
+    );
+
+    let error = load_skill_self_test_spec(&root).expect_err("legacy blueprint must fail");
+
+    assert!(matches!(error, SkillError::InvalidSelfTest { .. }));
+}
+
+#[test]
+fn self_test_spec_ignores_skill_md_frontmatter_without_self_test() {
+    let root = temp_dir("self-test-unrelated-frontmatter");
+    write_file(
+        &root.join("SKILL.md"),
+        r#"---
+name: demo
+---
+# Demo
+"#,
+    );
+    write_file(
+        &root.join("skill.yaml"),
+        r#"name: unrelated-frontmatter-demo
+version: 0.1.0
+entry: SKILL.md
+files:
+  - SKILL.md
+self_test:
+  command: "test -f SKILL.md"
+"#,
+    );
+
+    let spec = load_skill_self_test_spec(&root).expect("skill.yaml self-test should load");
+
+    assert_eq!(
+        spec.assertions,
+        vec![SkillSelfTestAssertion::CommandExitsZero {
+            cmd: "test -f SKILL.md".to_owned()
+        }]
+    );
+}
+
+#[test]
+fn self_test_spec_ignores_malformed_skill_md_frontmatter_without_self_test() {
+    let root = temp_dir("self-test-malformed-unrelated-frontmatter");
+    write_file(
+        &root.join("SKILL.md"),
+        r#"---
+name: [
+---
+# Demo
+"#,
+    );
+    write_file(
+        &root.join("skill.yaml"),
+        r#"name: malformed-unrelated-frontmatter-demo
+version: 0.1.0
+entry: SKILL.md
+files:
+  - SKILL.md
+self_test:
+  command: "test -f SKILL.md"
+"#,
+    );
+
+    let spec = load_skill_self_test_spec(&root).expect("skill.yaml self-test should load");
+
+    assert_eq!(
+        spec.assertions,
+        vec![SkillSelfTestAssertion::CommandExitsZero {
+            cmd: "test -f SKILL.md".to_owned()
+        }]
+    );
+}
+
+#[test]
+fn self_test_spec_rejects_unknown_self_test_fields() {
+    let root = temp_dir("self-test-unknown-field");
+    write_file(&root.join("SKILL.md"), "# Demo\n");
+    write_file(
+        &root.join("skill.yaml"),
+        "name: unknown-field\nversion: 0.1.0\nentry: SKILL.md\nfiles:\n  - SKILL.md\n",
+    );
+    write_file(
+        &root.join("skill-test.yaml"),
+        r#"self_test:
+  runner: agentenv
+  assertions:
+    - type: file_exists
+      path: SKILL.md
+  timeout_second: 5
+"#,
+    );
+
+    let error = load_skill_self_test_spec(&root).expect_err("unknown field must fail");
+
+    assert!(matches!(
+        error,
+        SkillError::Yaml { .. } | SkillError::InvalidSelfTest { .. }
+    ));
+}
+
+#[test]
+fn self_test_spec_rejects_unknown_skill_test_yaml_top_level_fields() {
+    let root = temp_dir("self-test-unknown-top-level-field");
+    write_file(&root.join("SKILL.md"), "# Demo\n");
+    write_file(
+        &root.join("skill.yaml"),
+        "name: unknown-top-level-field\nversion: 0.1.0\nentry: SKILL.md\nfiles:\n  - SKILL.md\n",
+    );
+    write_file(
+        &root.join("skill-test.yaml"),
+        r#"self_test:
+  runner: agentenv
+  assertions:
+    - type: file_exists
+      path: SKILL.md
+unexpected: true
+"#,
+    );
+
+    let error = load_skill_self_test_spec(&root).expect_err("unknown field must fail");
+
+    assert!(matches!(error, SkillError::Yaml { .. }));
+}
+
+#[test]
+fn self_test_spec_rejects_unsupported_runner() {
+    let root = temp_dir("self-test-unsupported-runner");
+    write_file(&root.join("SKILL.md"), "# Demo\n");
+    write_file(
+        &root.join("skill.yaml"),
+        "name: unsupported-runner\nversion: 0.1.0\nentry: SKILL.md\nfiles:\n  - SKILL.md\n",
+    );
+    write_file(
+        &root.join("skill-test.yaml"),
+        r#"self_test:
+  runner: other
+  assertions:
+    - type: file_exists
+      path: SKILL.md
+"#,
+    );
+
+    let error = load_skill_self_test_spec(&root).expect_err("unsupported runner must fail");
+
+    assert!(matches!(error, SkillError::InvalidSelfTest { .. }));
+}
+
+#[test]
+fn self_test_spec_rejects_empty_assertions() {
+    let root = temp_dir("self-test-empty-assertions");
+    write_file(&root.join("SKILL.md"), "# Demo\n");
+    write_file(
+        &root.join("skill.yaml"),
+        "name: empty-assertions\nversion: 0.1.0\nentry: SKILL.md\nfiles:\n  - SKILL.md\n",
+    );
+    write_file(
+        &root.join("skill-test.yaml"),
+        r#"self_test:
+  runner: agentenv
+  assertions: []
+"#,
+    );
+
+    let error = load_skill_self_test_spec(&root).expect_err("empty assertions must fail");
+
+    assert!(matches!(error, SkillError::InvalidSelfTest { .. }));
+}
+
+#[test]
+fn self_test_spec_rejects_unsafe_blueprint() {
+    let root = temp_dir("self-test-unsafe-blueprint");
+    write_file(&root.join("SKILL.md"), "# Demo\n");
+    write_file(
+        &root.join("skill.yaml"),
+        "name: unsafe-blueprint\nversion: 0.1.0\nentry: SKILL.md\nfiles:\n  - SKILL.md\n",
+    );
+    write_file(
+        &root.join("skill-test.yaml"),
+        r#"self_test:
+  runner: agentenv
+  blueprint: ../agentenv.yaml
+  assertions:
+    - type: file_exists
+      path: SKILL.md
+"#,
+    );
+
+    let error = load_skill_self_test_spec(&root).expect_err("unsafe blueprint must fail");
+
+    assert!(matches!(error, SkillError::UnsafeBundlePath { .. }));
+}
+
+#[test]
+fn self_test_spec_rejects_unsafe_file_exists_path() {
+    let root = temp_dir("self-test-unsafe-file-path");
+    write_file(&root.join("SKILL.md"), "# Demo\n");
+    write_file(
+        &root.join("skill.yaml"),
+        "name: unsafe-file-path\nversion: 0.1.0\nentry: SKILL.md\nfiles:\n  - SKILL.md\n",
+    );
+    write_file(
+        &root.join("skill-test.yaml"),
+        r#"self_test:
+  runner: agentenv
+  assertions:
+    - type: file_exists
+      path: ../SKILL.md
+"#,
+    );
+
+    let error = load_skill_self_test_spec(&root).expect_err("unsafe file path must fail");
+
+    assert!(matches!(error, SkillError::UnsafeBundlePath { .. }));
+}
+
+#[test]
+fn self_test_spec_rejects_empty_command() {
+    let root = temp_dir("self-test-empty-command");
+    write_file(&root.join("SKILL.md"), "# Demo\n");
+    write_file(
+        &root.join("skill.yaml"),
+        "name: empty-command\nversion: 0.1.0\nentry: SKILL.md\nfiles:\n  - SKILL.md\n",
+    );
+    write_file(
+        &root.join("skill-test.yaml"),
+        r#"self_test:
+  runner: agentenv
+  assertions:
+    - type: command_exits_zero
+      cmd: "   "
+"#,
+    );
+
+    let error = load_skill_self_test_spec(&root).expect_err("empty command must fail");
+
+    assert!(matches!(error, SkillError::InvalidSelfTest { .. }));
+}
+
+#[test]
+fn self_test_spec_rejects_empty_agent_prompt() {
+    let root = temp_dir("self-test-empty-agent-prompt");
+    write_file(&root.join("SKILL.md"), "# Demo\n");
+    write_file(
+        &root.join("skill.yaml"),
+        "name: empty-agent-prompt\nversion: 0.1.0\nentry: SKILL.md\nfiles:\n  - SKILL.md\n",
+    );
+    write_file(
+        &root.join("skill-test.yaml"),
+        r#"self_test:
+  runner: agentenv
+  assertions:
+    - type: agent_produces
+      prompt: "  "
+      expect_tokens_matching: ["Cargo.toml"]
+      min_match_ratio: 1.0
+"#,
+    );
+
+    let error = load_skill_self_test_spec(&root).expect_err("empty prompt must fail");
+
+    assert!(matches!(error, SkillError::InvalidSelfTest { .. }));
+}
+
+#[test]
+fn self_test_spec_defaults_structured_timeout() {
+    let root = temp_dir("self-test-structured-default-timeout");
+    write_file(&root.join("SKILL.md"), "# Demo\n");
+    write_file(
+        &root.join("skill.yaml"),
+        r#"name: structured-default-timeout
+version: 0.1.0
+entry: SKILL.md
+files:
+  - SKILL.md
+self_test:
+  runner: agentenv
+  assertions:
+    - type: file_exists
+      path: SKILL.md
+"#,
+    );
+
+    let spec = load_skill_self_test_spec(&root).expect("structured self-test should load");
+
+    assert_eq!(spec.timeout_seconds, 120);
+}
+
+#[test]
+fn self_test_spec_rejects_missing_self_test() {
+    let root = temp_dir("self-test-missing");
+    write_file(&root.join("SKILL.md"), "# Demo\n");
+    write_file(
+        &root.join("skill.yaml"),
+        "name: missing-self-test\nversion: 0.1.0\nentry: SKILL.md\nfiles:\n  - SKILL.md\n",
+    );
+
+    let error = load_skill_self_test_spec(&root).expect_err("missing self-test must fail");
+
+    assert!(matches!(error, SkillError::MissingSelfTest));
+}
+
+fn temp_dir(prefix: &str) -> std::path::PathBuf {
+    let mut path = std::env::temp_dir();
+    path.push(format!(
+        "{prefix}-{}-{}",
+        std::process::id(),
+        unique_nanos()
+    ));
+    fs::create_dir_all(&path).unwrap();
+    path
+}
+
+fn write_file(path: &Path, content: &str) {
+    if let Some(parent) = path.parent() {
+        fs::create_dir_all(parent).unwrap();
+    }
+    fs::write(path, content).unwrap();
+}
+
+fn unique_nanos() -> u128 {
+    std::time::SystemTime::now()
+        .duration_since(std::time::UNIX_EPOCH)
+        .map(|duration| duration.as_nanos())
+        .unwrap_or(0)
+}

--- a/crates/agentenv/src/credentials_runtime.rs
+++ b/crates/agentenv/src/credentials_runtime.rs
@@ -1,0 +1,86 @@
+use agentenv_core::{
+    driver::DriverError,
+    runtime::{CredentialProvider, RuntimeError, RuntimeResult, RuntimeSecret},
+};
+use agentenv_credstore::{CredentialStore, CredentialStoreError, SecretString};
+use agentenv_proto::CredentialRequirement;
+
+pub(crate) struct CliCredentialProvider {
+    pub(crate) store: CredentialStore,
+    pub(crate) non_interactive: bool,
+    pub(crate) prompter: Box<dyn CredentialPrompter>,
+}
+
+pub(crate) trait CredentialPrompter {
+    fn prompt(&mut self, requirement: &CredentialRequirement) -> RuntimeResult<SecretString>;
+}
+
+pub(crate) struct TerminalCredentialPrompter;
+
+impl CredentialPrompter for TerminalCredentialPrompter {
+    fn prompt(&mut self, requirement: &CredentialRequirement) -> RuntimeResult<SecretString> {
+        let mut prompt = format!("Enter value for `{}`", requirement.name);
+        if !requirement.description.trim().is_empty() {
+            prompt.push_str(&format!(" ({})", requirement.description));
+        }
+        prompt.push_str(": ");
+        let value = rpassword::prompt_password(prompt).map_err(|source| {
+            RuntimeError::Driver(DriverError::InvalidInput {
+                message: format!(
+                    "failed to prompt for credential `{}`: {source}",
+                    requirement.name
+                ),
+            })
+        })?;
+        Ok(SecretString::new(value))
+    }
+}
+
+impl CredentialProvider for CliCredentialProvider {
+    fn resolve(
+        &mut self,
+        requirement: &CredentialRequirement,
+    ) -> RuntimeResult<Option<RuntimeSecret>> {
+        let name = &requirement.name;
+        match self.store.resolve(name, requirement) {
+            Ok(secret) => Ok(Some(RuntimeSecret::new(secret.expose_secret().to_owned()))),
+            Err(CredentialStoreError::MissingCredential { .. }) if !requirement.required => {
+                Ok(None)
+            }
+            Err(CredentialStoreError::MissingCredential { .. }) if self.non_interactive => {
+                Err(RuntimeError::MissingCredential {
+                    name: name.to_owned(),
+                })
+            }
+            Err(CredentialStoreError::MissingCredential { .. }) => {
+                let prompted = self.prompter.prompt(requirement)?;
+                self.store
+                    .store(name, &prompted)
+                    .map_err(credential_store_runtime_error)?;
+                let resolved = self
+                    .store
+                    .resolve(name, requirement)
+                    .map_err(credential_store_runtime_error)?;
+                Ok(Some(RuntimeSecret::new(
+                    resolved.expose_secret().to_owned(),
+                )))
+            }
+            Err(error) => Err(credential_store_runtime_error(error)),
+        }
+    }
+
+    fn backend_name(&self, name: &str) -> RuntimeResult<Option<String>> {
+        Ok(self
+            .store
+            .where_is(name)
+            .ok()
+            .flatten()
+            .map(|backend| backend.to_string()))
+    }
+}
+
+pub(crate) fn credential_store_runtime_error(error: CredentialStoreError) -> RuntimeError {
+    RuntimeError::Driver(DriverError::InvalidInput {
+        message: error.to_string(),
+    })
+}

--- a/crates/agentenv/src/main.rs
+++ b/crates/agentenv/src/main.rs
@@ -38,9 +38,12 @@ use tracing_subscriber::EnvFilter;
 
 mod builtin_factory;
 mod bundle_cli;
+mod credentials_runtime;
 mod render;
 mod skills_cli;
 mod term_backend;
+
+use credentials_runtime::{CliCredentialProvider, TerminalCredentialPrompter};
 
 const SELF_ENV_SENTINEL: &str = "__self__";
 
@@ -3314,98 +3317,6 @@ fn new_cli_trace_id() -> String {
     }
 }
 
-struct CliCredentialProvider {
-    store: CredentialStore,
-    non_interactive: bool,
-    prompter: Box<dyn CredentialPrompter>,
-}
-
-trait CredentialPrompter {
-    fn prompt(
-        &mut self,
-        requirement: &agentenv_proto::CredentialRequirement,
-    ) -> agentenv_core::runtime::RuntimeResult<SecretString>;
-}
-
-struct TerminalCredentialPrompter;
-
-impl CredentialPrompter for TerminalCredentialPrompter {
-    fn prompt(
-        &mut self,
-        requirement: &agentenv_proto::CredentialRequirement,
-    ) -> agentenv_core::runtime::RuntimeResult<SecretString> {
-        let mut prompt = format!("Enter value for `{}`", requirement.name);
-        if !requirement.description.trim().is_empty() {
-            prompt.push_str(&format!(" ({})", requirement.description));
-        }
-        prompt.push_str(": ");
-        let value = rpassword::prompt_password(prompt).map_err(|source| {
-            agentenv_core::runtime::RuntimeError::Driver(
-                agentenv_core::driver::DriverError::InvalidInput {
-                    message: format!(
-                        "failed to prompt for credential `{}`: {source}",
-                        requirement.name
-                    ),
-                },
-            )
-        })?;
-        Ok(SecretString::new(value))
-    }
-}
-
-impl agentenv_core::runtime::CredentialProvider for CliCredentialProvider {
-    fn resolve(
-        &mut self,
-        requirement: &agentenv_proto::CredentialRequirement,
-    ) -> agentenv_core::runtime::RuntimeResult<Option<agentenv_core::runtime::RuntimeSecret>> {
-        let name = &requirement.name;
-        match self.store.resolve(name, requirement) {
-            Ok(secret) => Ok(Some(agentenv_core::runtime::RuntimeSecret::new(
-                secret.expose_secret().to_owned(),
-            ))),
-            Err(CredentialStoreError::MissingCredential { .. }) if !requirement.required => {
-                Ok(None)
-            }
-            Err(CredentialStoreError::MissingCredential { .. }) if self.non_interactive => {
-                Err(agentenv_core::runtime::RuntimeError::MissingCredential {
-                    name: name.to_owned(),
-                })
-            }
-            Err(CredentialStoreError::MissingCredential { .. }) => {
-                let prompted = self.prompter.prompt(requirement)?;
-                self.store
-                    .store(name, &prompted)
-                    .map_err(credential_store_runtime_error)?;
-                let resolved = self
-                    .store
-                    .resolve(name, requirement)
-                    .map_err(credential_store_runtime_error)?;
-                Ok(Some(agentenv_core::runtime::RuntimeSecret::new(
-                    resolved.expose_secret().to_owned(),
-                )))
-            }
-            Err(error) => Err(credential_store_runtime_error(error)),
-        }
-    }
-
-    fn backend_name(&self, name: &str) -> agentenv_core::runtime::RuntimeResult<Option<String>> {
-        Ok(self
-            .store
-            .where_is(name)
-            .ok()
-            .flatten()
-            .map(|backend| backend.to_string()))
-    }
-}
-
-fn credential_store_runtime_error(
-    error: CredentialStoreError,
-) -> agentenv_core::runtime::RuntimeError {
-    agentenv_core::runtime::RuntimeError::Driver(agentenv_core::driver::DriverError::InvalidInput {
-        message: error.to_string(),
-    })
-}
-
 async fn run_credentials(args: CredentialsArgs, event_sink_args: &[String]) -> Result<()> {
     let options = runtime_options(true)?;
     let dispatcher = build_event_dispatcher(&options, None, event_sink_args)?;
@@ -4265,7 +4176,7 @@ policy:
         value: SecretString,
     }
 
-    impl super::CredentialPrompter for StaticCredentialPrompt {
+    impl super::credentials_runtime::CredentialPrompter for StaticCredentialPrompt {
         fn prompt(
             &mut self,
             _requirement: &CredentialRequirement,

--- a/crates/agentenv/src/skills_cli.rs
+++ b/crates/agentenv/src/skills_cli.rs
@@ -61,6 +61,8 @@ pub struct SkillsAddArgs {
     pub registry: Option<String>,
     #[arg(long)]
     pub allow_unsigned: bool,
+    #[arg(long, value_name = "PATH")]
+    pub self_test_attestation: Option<PathBuf>,
     #[arg(long)]
     pub json: bool,
 }
@@ -71,6 +73,8 @@ pub struct SkillsInstallArgs {
     pub from: PathBuf,
     #[arg(long)]
     pub allow_unsigned: bool,
+    #[arg(long, value_name = "PATH")]
+    pub self_test_attestation: Option<PathBuf>,
     #[arg(long)]
     pub json: bool,
 }
@@ -108,6 +112,10 @@ pub struct SkillsPublishArgs {
     pub registry: Option<String>,
     #[arg(long)]
     pub allow_unsigned: bool,
+    #[arg(long, value_name = "PATH")]
+    pub self_test_attestation: Option<PathBuf>,
+    #[arg(long)]
+    pub no_self_test_run: bool,
     #[arg(long)]
     pub json: bool,
 }
@@ -336,6 +344,7 @@ async fn dispatch(command: SkillsCommand, service: SkillService, root: PathBuf) 
                     handle: args.handle,
                     registry: None,
                     allow_unsigned: args.allow_unsigned,
+                    self_test_attestation: args.self_test_attestation,
                 })
                 .await?;
             print_installed_result(&installed, args.json)
@@ -345,6 +354,7 @@ async fn dispatch(command: SkillsCommand, service: SkillService, root: PathBuf) 
                 &args.from,
                 args.allow_unsigned,
                 format!("local:{}", args.from.display()),
+                args.self_test_attestation.as_deref(),
             )?;
             print_installed_result(&installed, args.json)
         }
@@ -379,6 +389,8 @@ async fn dispatch(command: SkillsCommand, service: SkillService, root: PathBuf) 
                     bundle_path: args.path,
                     registry: None,
                     allow_unsigned: args.allow_unsigned,
+                    self_test_attestation: args.self_test_attestation,
+                    no_self_test_run: args.no_self_test_run,
                 })
                 .await?;
             if args.json {

--- a/crates/agentenv/src/skills_cli.rs
+++ b/crates/agentenv/src/skills_cli.rs
@@ -1,17 +1,30 @@
-use std::{path::PathBuf, sync::Arc};
+use std::{
+    fs,
+    path::PathBuf,
+    sync::{atomic::Ordering, Arc},
+    time::{Duration, Instant, SystemTime, UNIX_EPOCH},
+};
 
+use agentenv_core::admission::AdmissionStatus;
+use agentenv_core::runtime::RuntimeOptions;
 use agentenv_core::skills::{
     execute_skill_prune, load_project_skills_config, load_skill_trust_keys,
     load_user_skills_config, merge_skills_config, plan_skill_prune, rebuild_skill_index,
-    verify_all_installed_skills, InstalledSkill, InstalledSkillSelector, SkillAddRequest,
-    SkillCacheLayout, SkillError, SkillPublishRequest, SkillSearchHit, SkillService,
-    SkillVerifyOptions, SkillVerifyStatus, SkillsConfig, SkillsConfigOverride,
+    verify_all_installed_skills, AgentProduceRequest, AgentProduceRunner, InstalledSkill,
+    InstalledSkillSelector, SkillAddRequest, SkillCacheLayout, SkillError, SkillPublishRequest,
+    SkillSearchHit, SkillService, SkillVerifyOptions, SkillVerifyStatus, SkillsConfig,
+    SkillsConfigOverride,
 };
 use agentenv_credstore::{CredentialStore, CredentialStoreError};
-use agentenv_proto::{CredentialKind, CredentialRequirement};
+use agentenv_proto::{CredentialKind, CredentialRequirement, LogLevel};
 use anyhow::{bail, Context, Result};
 use clap::{Args, Subcommand};
 use serde::Serialize;
+
+use crate::{
+    builtin_factory,
+    credentials_runtime::{CliCredentialProvider, TerminalCredentialPrompter},
+};
 
 #[derive(Debug, Args)]
 pub struct SkillsArgs {
@@ -132,8 +145,178 @@ pub async fn run_skills(args: SkillsArgs) -> Result<()> {
     let registry_override = registry_override_for_command(&args.command);
     let config = load_effective_config(registry_override)?;
     let service = SkillService::new(root.clone(), config)
-        .with_credential_resolver(Arc::new(resolve_skill_credential));
+        .with_credential_resolver(Arc::new(resolve_skill_credential))
+        .with_agent_produce_runner(Arc::new(CliAgentProduceRunner {
+            root: root.clone(),
+            non_interactive: true,
+            runtime_handle: tokio::runtime::Handle::current(),
+        }));
     dispatch(args.command, service, root).await
+}
+
+struct CliAgentProduceRunner {
+    root: PathBuf,
+    non_interactive: bool,
+    runtime_handle: tokio::runtime::Handle,
+}
+
+impl AgentProduceRunner for CliAgentProduceRunner {
+    fn run_agent_prompt(&self, request: AgentProduceRequest<'_>) -> Result<String, SkillError> {
+        self.runtime_handle
+            .block_on(self.run_agent_prompt_async(request))
+    }
+}
+
+impl CliAgentProduceRunner {
+    async fn run_agent_prompt_async(
+        &self,
+        request: AgentProduceRequest<'_>,
+    ) -> Result<String, SkillError> {
+        let deadline = Instant::now().checked_add(request.timeout).ok_or_else(|| {
+            SkillError::InvalidSelfTest {
+                message: "agent_produces timeout is too large".to_owned(),
+            }
+        })?;
+        if request.cancelled.load(Ordering::Relaxed) {
+            return Err(SkillError::SelfTestTimeout {
+                timeout_seconds: request.timeout.as_secs(),
+            });
+        }
+
+        let blueprint_path = if request.blueprint.is_absolute() {
+            request.blueprint.to_path_buf()
+        } else {
+            request.skill_root.join(request.blueprint)
+        };
+        let blueprint_yaml =
+            fs::read_to_string(&blueprint_path).map_err(|source| SkillError::InvalidSelfTest {
+                message: format!(
+                    "failed to read self-test blueprint `{}`: {source}",
+                    blueprint_path.display()
+                ),
+            })?;
+        let env_name = unique_self_test_env_name();
+        let options = RuntimeOptions {
+            root: self.root.clone(),
+            log_level: LogLevel::Info,
+            non_interactive: self.non_interactive,
+        };
+        let store = CredentialStore::from_default_paths().map_err(|source| {
+            SkillError::InvalidSelfTest {
+                message: format!("failed to initialize credential store: {source}"),
+            }
+        })?;
+        let mut provider = CliCredentialProvider {
+            store,
+            non_interactive: self.non_interactive,
+            prompter: Box::new(TerminalCredentialPrompter),
+        };
+        let created = agentenv_core::runtime::create_env(
+            &options,
+            &builtin_factory::BuiltInDriverFactory,
+            &mut provider,
+            &env_name,
+            &blueprint_yaml,
+        )
+        .await
+        .map_err(runtime_error_to_skill_error)?;
+        if created.admission.status != AdmissionStatus::Accepted {
+            return Err(SkillError::InvalidSelfTest {
+                message: format!(
+                    "self-test environment `{env_name}` was rejected: {}",
+                    created.admission.reason_code.as_str()
+                ),
+            });
+        }
+
+        let run_result = if request.cancelled.load(Ordering::Relaxed) {
+            Err(SkillError::SelfTestTimeout {
+                timeout_seconds: request.timeout.as_secs(),
+            })
+        } else {
+            let remaining = deadline.saturating_duration_since(Instant::now());
+            if remaining == Duration::ZERO {
+                Err(SkillError::SelfTestTimeout {
+                    timeout_seconds: request.timeout.as_secs(),
+                })
+            } else {
+                match tokio::time::timeout(
+                    remaining,
+                    agentenv_core::runtime::run_agent_prompt_once(
+                        &options,
+                        &builtin_factory::BuiltInDriverFactory,
+                        &env_name,
+                        request.prompt,
+                    ),
+                )
+                .await
+                {
+                    Ok(result) => result.map_err(runtime_error_to_skill_error),
+                    Err(_) => Err(SkillError::SelfTestTimeout {
+                        timeout_seconds: request.timeout.as_secs(),
+                    }),
+                }
+            }
+        };
+
+        let destroy_result = agentenv_core::runtime::destroy_env(
+            &options,
+            &builtin_factory::BuiltInDriverFactory,
+            &env_name,
+        )
+        .await
+        .map_err(runtime_error_to_skill_error);
+
+        match (run_result, destroy_result) {
+            (Ok(result), Ok(_)) if result.status == 0 => {
+                Ok(bounded_agent_output(result.stdout, result.stderr))
+            }
+            (Ok(result), Ok(_)) => Err(SkillError::InvalidSelfTest {
+                message: format!(
+                    "agent_produces prompt exited with status {}: {}",
+                    result.status,
+                    bounded_agent_output(result.stdout, result.stderr)
+                ),
+            }),
+            (Err(error), _) => Err(error),
+            (Ok(_), Err(error)) => Err(error),
+        }
+    }
+}
+
+fn unique_self_test_env_name() -> String {
+    let nanos = SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .map(|duration| duration.as_nanos())
+        .unwrap_or(0);
+    format!("skill-test-{}-{nanos}", std::process::id())
+}
+
+fn bounded_agent_output(stdout: String, stderr: String) -> String {
+    const MAX_OUTPUT_BYTES: usize = 64 * 1024;
+    let mut output = stdout;
+    if !stderr.is_empty() {
+        if !output.is_empty() && !output.ends_with('\n') {
+            output.push('\n');
+        }
+        output.push_str(&stderr);
+    }
+    if output.len() <= MAX_OUTPUT_BYTES {
+        return output;
+    }
+    let mut boundary = MAX_OUTPUT_BYTES;
+    while !output.is_char_boundary(boundary) {
+        boundary -= 1;
+    }
+    output.truncate(boundary);
+    output.push_str("\n[agent output truncated]");
+    output
+}
+
+fn runtime_error_to_skill_error(error: agentenv_core::runtime::RuntimeError) -> SkillError {
+    SkillError::InvalidSelfTest {
+        message: error.to_string(),
+    }
 }
 
 async fn dispatch(command: SkillsCommand, service: SkillService, root: PathBuf) -> Result<()> {

--- a/crates/agentenv/tests/cli_behavior.rs
+++ b/crates/agentenv/tests/cli_behavior.rs
@@ -2139,7 +2139,7 @@ fn skills_propose_does_not_follow_provider_redirect_to_metadata_endpoint() {
         .env("HOME", &temp_dir)
         .env("AGENTENV_DISABLE_KEYRING", "1")
         .env("AGENTENV_SKILL_PROPOSER_ALLOW_LOCAL_ENDPOINTS", "1")
-        .env("AGENTENV_SKILL_PROPOSER_HTTP_TIMEOUT_MS", "100")
+        .env("AGENTENV_SKILL_PROPOSER_HTTP_TIMEOUT_MS", "500")
         .env(
             "AGENTENV_TEST_SKILL_PROPOSER_REDIRECT_TOKEN",
             "redirect-token",
@@ -6865,13 +6865,16 @@ fn spawn_redirecting_skill_proposer(
             .unwrap();
         let _request = read_http_request(&mut stream);
         let body = format!("redirecting to metadata: {location}");
-        write!(
-            stream,
+        let response = format!(
             "HTTP/1.1 307 Temporary Redirect\r\nlocation: {location}\r\ncontent-type: text/plain\r\ncontent-length: {}\r\nconnection: close\r\n\r\n{}",
             body.len(),
             body
-        )
-        .unwrap();
+        );
+        match stream.write_all(response.as_bytes()) {
+            Ok(()) => {}
+            Err(error) if error.kind() == std::io::ErrorKind::BrokenPipe => {}
+            Err(error) => panic!("write redirecting test response: {error}"),
+        }
     });
 
     (endpoint, request_count, handle)

--- a/crates/agentenv/tests/cli_behavior.rs
+++ b/crates/agentenv/tests/cli_behavior.rs
@@ -3,7 +3,7 @@ use std::{
     fs,
     io::{Read, Write},
     path::{Path, PathBuf},
-    process::{self, Command},
+    process::{self, Command, Stdio},
     sync::{Mutex, MutexGuard},
     thread,
     time::{Duration, Instant, SystemTime, UNIX_EPOCH},
@@ -22,7 +22,7 @@ use serde_json::json;
 use sha2::{Digest, Sha256};
 use time::OffsetDateTime;
 
-const LOCAL_HTTP_TEST_TIMEOUT: Duration = Duration::from_secs(10);
+const LOCAL_HTTP_TEST_TIMEOUT: Duration = Duration::from_secs(30);
 const PTY_QUIT_TIMEOUT: Duration = Duration::from_secs(15);
 
 fn agentenv_bin() -> &'static str {
@@ -1251,16 +1251,173 @@ fn skills_registry_cli_path_override_publishes_searches_and_adds() {
 }
 
 #[test]
+fn skills_cli_publish_rejects_missing_or_unattested_self_tests_e2e() {
+    let temp_dir = make_temp_dir("skills-cli-self-test-gate-errors");
+    let registry = temp_dir.join("registry");
+    let missing_bundle = temp_dir.join("missing-self-test");
+    write_local_skill_bundle(
+        &missing_bundle,
+        "missing-cli-self-test",
+        "0.1.0",
+        "Missing CLI self-test",
+        None,
+    );
+
+    let missing_publish = Command::new(agentenv_bin())
+        .arg("skills")
+        .arg("publish")
+        .arg(&missing_bundle)
+        .arg("--registry")
+        .arg(&registry)
+        .arg("--allow-unsigned")
+        .env("HOME", &temp_dir)
+        .current_dir(&temp_dir)
+        .output()
+        .unwrap();
+    assert!(!missing_publish.status.success());
+    assert!(
+        String::from_utf8_lossy(&missing_publish.stderr).contains("skill self-test is missing"),
+        "{}",
+        output_summary(&missing_publish)
+    );
+    assert!(
+        !registry.join("index.yaml").exists(),
+        "missing self-test publish should not create registry index"
+    );
+
+    let bundle = temp_dir.join("attestation-required");
+    write_local_skill_bundle(
+        &bundle,
+        "attestation-required-cli",
+        "0.1.0",
+        "Attestation required CLI",
+        Some("test -f SKILL.md"),
+    );
+    let no_run_publish = Command::new(agentenv_bin())
+        .arg("skills")
+        .arg("publish")
+        .arg(&bundle)
+        .arg("--registry")
+        .arg(&registry)
+        .arg("--allow-unsigned")
+        .arg("--no-self-test-run")
+        .env("HOME", &temp_dir)
+        .current_dir(&temp_dir)
+        .output()
+        .unwrap();
+    assert!(!no_run_publish.status.success());
+    assert!(
+        String::from_utf8_lossy(&no_run_publish.stderr)
+            .contains("missing signed self-test attestation"),
+        "{}",
+        output_summary(&no_run_publish)
+    );
+    assert!(
+        !registry.join("index.yaml").exists(),
+        "unattested no-rerun publish should not create registry index"
+    );
+}
+
+#[test]
+fn skills_cli_skill_test_file_publish_add_verify_e2e() {
+    let temp_dir = make_temp_dir("skills-cli-skill-test-file-e2e");
+    let registry = temp_dir.join("registry");
+    let bundle = temp_dir.join("bundle");
+    write_local_skill_bundle_with_skill_test_file(
+        &bundle,
+        "file-self-test-cli",
+        "0.1.0",
+        "File self-test CLI",
+    );
+
+    let publish = Command::new(agentenv_bin())
+        .arg("skills")
+        .arg("publish")
+        .arg(&bundle)
+        .arg("--registry")
+        .arg(&registry)
+        .arg("--allow-unsigned")
+        .arg("--json")
+        .env("HOME", &temp_dir)
+        .current_dir(&temp_dir)
+        .output()
+        .unwrap();
+    assert!(publish.status.success(), "{}", output_summary(&publish));
+    let publish_json: serde_json::Value = serde_json::from_slice(&publish.stdout).unwrap();
+    assert_eq!(publish_json["name"], "file-self-test-cli");
+    assert_eq!(publish_json["self_test_score"], 1.0);
+    assert!(publish_json["self_test_attestation_digest"].is_string());
+    assert!(registry
+        .join("bundles/file-self-test-cli/0.1.0/skill-test.yaml")
+        .is_file());
+    assert!(registry
+        .join("bundles/file-self-test-cli/0.1.0/self-test-attestation.json")
+        .is_file());
+
+    let search = Command::new(agentenv_bin())
+        .arg("skills")
+        .arg("search")
+        .arg("file-self")
+        .arg("--registry")
+        .arg(&registry)
+        .arg("--json")
+        .env("HOME", &temp_dir)
+        .current_dir(&temp_dir)
+        .output()
+        .unwrap();
+    assert!(search.status.success(), "{}", output_summary(&search));
+    let search_json: serde_json::Value = serde_json::from_slice(&search.stdout).unwrap();
+    assert_eq!(search_json["skills"][0]["name"], "file-self-test-cli");
+    assert_eq!(search_json["skills"][0]["self_test_score"], 1.0);
+    assert!(search_json["skills"][0]["self_test_attestation_digest"].is_string());
+
+    let add = Command::new(agentenv_bin())
+        .arg("skills")
+        .arg("add")
+        .arg("file-self-test-cli@0.1.0")
+        .arg("--registry")
+        .arg(&registry)
+        .arg("--allow-unsigned")
+        .arg("--json")
+        .env("HOME", &temp_dir)
+        .current_dir(&temp_dir)
+        .output()
+        .unwrap();
+    assert!(add.status.success(), "{}", output_summary(&add));
+    let add_json: serde_json::Value = serde_json::from_slice(&add.stdout).unwrap();
+    assert_eq!(add_json["name"], "file-self-test-cli");
+    assert_eq!(add_json["self_test_score"], 1.0);
+    let installed_path = PathBuf::from(add_json["path"].as_str().unwrap());
+    assert!(installed_path.join("content/skill-test.yaml").is_file());
+
+    let verify = Command::new(agentenv_bin())
+        .arg("skills")
+        .arg("verify")
+        .arg("file-self-test-cli")
+        .arg("--json")
+        .env("HOME", &temp_dir)
+        .current_dir(&temp_dir)
+        .output()
+        .unwrap();
+    assert!(verify.status.success(), "{}", output_summary(&verify));
+    let verify_json: serde_json::Value = serde_json::from_slice(&verify.stdout).unwrap();
+    assert_eq!(verify_json["name"], "file-self-test-cli");
+    assert_eq!(verify_json["self_test_score"], 1.0);
+    assert!(verify_json["self_test_attestation"].is_string());
+}
+
+#[test]
 fn skills_publish_can_use_supplied_self_test_attestation_without_rerun() {
     let temp_dir = make_temp_dir("skills-cli-publish-supplied-self-test-attestation");
     let registry = temp_dir.join("registry");
     let bundle = temp_dir.join("bundle");
+    let sentinel = temp_dir.join("self-test-reran");
     write_local_skill_bundle(
         &bundle,
         "supplied-attestation-skill",
         "0.1.0",
         "Supplied attestation",
-        Some("test -f SKILL.md"),
+        Some(&format!("touch {}", sentinel.display())),
     );
 
     let install = Command::new(agentenv_bin())
@@ -1277,6 +1434,8 @@ fn skills_publish_can_use_supplied_self_test_attestation_without_rerun() {
     assert!(install.status.success(), "{}", output_summary(&install));
     let installed: serde_json::Value = serde_json::from_slice(&install.stdout).unwrap();
     let attestation_path = installed["self_test_attestation"].as_str().unwrap();
+    assert!(sentinel.is_file());
+    fs::remove_file(&sentinel).unwrap();
 
     let publish = Command::new(agentenv_bin())
         .arg("skills")
@@ -1299,6 +1458,43 @@ fn skills_publish_can_use_supplied_self_test_attestation_without_rerun() {
     assert!(registry
         .join("bundles/supplied-attestation-skill/0.1.0/self-test-attestation.json")
         .is_file());
+    assert!(
+        !sentinel.exists(),
+        "publish with supplied attestation reran the self-test"
+    );
+
+    let remove = Command::new(agentenv_bin())
+        .arg("skills")
+        .arg("remove")
+        .arg("supplied-attestation-skill")
+        .arg("--yes")
+        .env("HOME", &temp_dir)
+        .current_dir(&temp_dir)
+        .output()
+        .unwrap();
+    assert!(remove.status.success(), "{}", output_summary(&remove));
+
+    let add = Command::new(agentenv_bin())
+        .arg("skills")
+        .arg("add")
+        .arg("supplied-attestation-skill@0.1.0")
+        .arg("--registry")
+        .arg(&registry)
+        .arg("--allow-unsigned")
+        .arg("--self-test-attestation")
+        .arg(attestation_path)
+        .arg("--json")
+        .env("HOME", &temp_dir)
+        .current_dir(&temp_dir)
+        .output()
+        .unwrap();
+    assert!(add.status.success(), "{}", output_summary(&add));
+    let add_json: serde_json::Value = serde_json::from_slice(&add.stdout).unwrap();
+    assert_eq!(add_json["self_test_score"], 1.0);
+    assert!(
+        !sentinel.exists(),
+        "add with supplied attestation reran the self-test"
+    );
 }
 
 #[test]
@@ -3091,9 +3287,9 @@ fn term_once_does_not_create_missing_approval_database() {
 fn approvals_serve_healthz_responds_ok() {
     let temp = tempfile::tempdir().unwrap();
     let port = reserve_tcp_port();
-    let _server = spawn_approvals_server(temp.path(), port);
+    let mut server = spawn_approvals_server(temp.path(), port);
 
-    wait_for_http_ok(port, "/healthz");
+    server.wait_for_http_ok(port, "/healthz");
 }
 
 #[test]
@@ -3103,8 +3299,8 @@ fn approvals_serve_unsigned_decision_callback_returns_401_without_deciding() {
     write_approval_callback_config(temp.path(), "callback-test-secret");
     write_minimal_env_state(temp.path(), "demo");
     seed_pending_approval(temp.path(), "demo", "req-unsigned");
-    let _server = spawn_approvals_server(temp.path(), port);
-    wait_for_http_ok(port, "/healthz");
+    let mut server = spawn_approvals_server(temp.path(), port);
+    server.wait_for_http_ok(port, "/healthz");
     let body = decision_callback_body("req-unsigned");
 
     let response = post_decision_callback(port, "req-unsigned", body, None);
@@ -3122,8 +3318,8 @@ fn approvals_serve_mismatched_signed_request_id_rejects_without_deciding_url_req
     write_minimal_env_state(temp.path(), "demo");
     seed_pending_approval(temp.path(), "demo", "req-url");
     seed_pending_approval(temp.path(), "demo", "req-body");
-    let _server = spawn_approvals_server(temp.path(), port);
-    wait_for_http_ok(port, "/healthz");
+    let mut server = spawn_approvals_server(temp.path(), port);
+    server.wait_for_http_ok(port, "/healthz");
     let body = decision_callback_body("req-body");
     let timestamp = OffsetDateTime::now_utc().unix_timestamp();
     let headers = signed_callback_headers(secret, timestamp, "delivery-mismatch", body.as_bytes());
@@ -3143,8 +3339,8 @@ fn approvals_serve_stale_signed_decision_callback_returns_401_without_deciding()
     write_approval_callback_config(temp.path(), secret);
     write_minimal_env_state(temp.path(), "demo");
     seed_pending_approval(temp.path(), "demo", "req-stale");
-    let _server = spawn_approvals_server(temp.path(), port);
-    wait_for_http_ok(port, "/healthz");
+    let mut server = spawn_approvals_server(temp.path(), port);
+    server.wait_for_http_ok(port, "/healthz");
     let body = decision_callback_body("req-stale");
     let timestamp = OffsetDateTime::now_utc().unix_timestamp() - 600;
     let headers = signed_callback_headers(secret, timestamp, "delivery-stale", body.as_bytes());
@@ -3163,8 +3359,8 @@ fn approvals_serve_valid_signed_decision_callback_records_decision() {
     write_approval_callback_config(temp.path(), secret);
     write_minimal_env_state(temp.path(), "demo");
     seed_pending_approval(temp.path(), "demo", "req-valid");
-    let _server = spawn_approvals_server(temp.path(), port);
-    wait_for_http_ok(port, "/healthz");
+    let mut server = spawn_approvals_server(temp.path(), port);
+    server.wait_for_http_ok(port, "/healthz");
     let body = decision_callback_body("req-valid");
     let timestamp = OffsetDateTime::now_utc().unix_timestamp();
     let headers = signed_callback_headers(secret, timestamp, "delivery-valid", body.as_bytes());
@@ -4677,6 +4873,28 @@ fn write_local_skill_bundle(
     .unwrap();
 }
 
+fn write_local_skill_bundle_with_skill_test_file(
+    bundle: &Path,
+    name: &str,
+    version: &str,
+    description: &str,
+) {
+    fs::create_dir_all(bundle).unwrap();
+    fs::write(bundle.join("SKILL.md"), format!("# {description}\n")).unwrap();
+    fs::write(
+        bundle.join("skill.yaml"),
+        format!(
+            "name: {name}\nversion: {version}\ndescription: {description}\nentry: SKILL.md\nfiles:\n  - SKILL.md\n"
+        ),
+    )
+    .unwrap();
+    fs::write(
+        bundle.join("skill-test.yaml"),
+        "self_test:\n  runner: agentenv\n  assertions:\n    - type: file_exists\n      path: SKILL.md\n  timeout_seconds: 5\n",
+    )
+    .unwrap();
+}
+
 fn write_filesystem_registry_skill(registry: &Path, name: &str, version: &str, description: &str) {
     let bundle = registry.join("bundles").join(name).join(version);
     fs::create_dir_all(&bundle).unwrap();
@@ -5018,11 +5236,48 @@ impl Drop for ApprovalsServerChild {
     }
 }
 
+impl ApprovalsServerChild {
+    fn wait_for_http_ok(&mut self, port: u16, path: &str) {
+        let client = reqwest::blocking::Client::builder()
+            .timeout(Duration::from_secs(1))
+            .build()
+            .unwrap();
+        let url = format!("http://127.0.0.1:{port}{path}");
+        let deadline = std::time::Instant::now() + LOCAL_HTTP_TEST_TIMEOUT;
+        let mut last_error = None;
+
+        while std::time::Instant::now() < deadline {
+            if let Some(status) = self.child.try_wait().unwrap() {
+                let stderr = child_stderr(&mut self.child);
+                panic!(
+                    "approvals server exited before {url} responded: {status}; stderr was: {stderr}"
+                );
+            }
+
+            match client.get(&url).send() {
+                Ok(response) if response.status().is_success() => return,
+                Ok(response) => last_error = Some(format!("HTTP {}", response.status())),
+                Err(error) => last_error = Some(error.to_string()),
+            }
+            thread::sleep(Duration::from_millis(50));
+        }
+
+        panic!(
+            "timed out waiting for {url}: {}",
+            last_error.unwrap_or_else(|| "no attempts were made".to_owned())
+        );
+    }
+}
+
 fn spawn_approvals_server(home: &Path, port: u16) -> ApprovalsServerChild {
-    let guard = APPROVALS_SERVER_TEST_LOCK.lock().unwrap();
+    let guard = APPROVALS_SERVER_TEST_LOCK
+        .lock()
+        .unwrap_or_else(|poisoned| poisoned.into_inner());
     let child = Command::new(agentenv_bin())
         .env("HOME", home)
         .args(["approvals", "serve", "--addr", &format!("127.0.0.1:{port}")])
+        .stdout(Stdio::null())
+        .stderr(Stdio::piped())
         .spawn()
         .unwrap();
     ApprovalsServerChild {
@@ -5031,28 +5286,12 @@ fn spawn_approvals_server(home: &Path, port: u16) -> ApprovalsServerChild {
     }
 }
 
-fn wait_for_http_ok(port: u16, path: &str) {
-    let client = reqwest::blocking::Client::builder()
-        .timeout(Duration::from_secs(1))
-        .build()
-        .unwrap();
-    let url = format!("http://127.0.0.1:{port}{path}");
-    let deadline = std::time::Instant::now() + LOCAL_HTTP_TEST_TIMEOUT;
-    let mut last_error = None;
-
-    while std::time::Instant::now() < deadline {
-        match client.get(&url).send() {
-            Ok(response) if response.status().is_success() => return,
-            Ok(response) => last_error = Some(format!("HTTP {}", response.status())),
-            Err(error) => last_error = Some(error.to_string()),
-        }
-        thread::sleep(Duration::from_millis(50));
+fn child_stderr(child: &mut process::Child) -> String {
+    let mut stderr = String::new();
+    if let Some(pipe) = child.stderr.as_mut() {
+        let _ = pipe.read_to_string(&mut stderr);
     }
-
-    panic!(
-        "timed out waiting for {url}: {}",
-        last_error.unwrap_or_else(|| "no attempts were made".to_owned())
-    );
+    stderr
 }
 
 fn write_approval_callback_config(home: &Path, secret: &str) {

--- a/crates/agentenv/tests/cli_behavior.rs
+++ b/crates/agentenv/tests/cli_behavior.rs
@@ -1065,7 +1065,7 @@ fn skills_install_list_info_verify_and_remove_local_bundle() {
     fs::write(bundle.join("SKILL.md"), "# CLI Skill\n").unwrap();
     fs::write(
         bundle.join("skill.yaml"),
-        "name: cli-skill\nversion: 0.1.0\nentry: SKILL.md\nfiles:\n  - SKILL.md\n",
+        "name: cli-skill\nversion: 0.1.0\nentry: SKILL.md\nfiles:\n  - SKILL.md\nself_test:\n  command: test -f SKILL.md\n",
     )
     .unwrap();
 
@@ -1134,7 +1134,7 @@ fn skills_search_add_and_publish_use_filesystem_registry_config() {
     fs::write(bundle.join("SKILL.md"), "# Registry Skill\n").unwrap();
     fs::write(
         bundle.join("skill.yaml"),
-        "name: registry-skill\nversion: 0.1.0\ndescription: Registry demo\nentry: SKILL.md\nfiles:\n  - SKILL.md\n",
+        "name: registry-skill\nversion: 0.1.0\ndescription: Registry demo\nentry: SKILL.md\nfiles:\n  - SKILL.md\nself_test:\n  command: test -f SKILL.md\n",
     )
     .unwrap();
     fs::write(
@@ -1191,7 +1191,7 @@ fn skills_registry_cli_path_override_publishes_searches_and_adds() {
     fs::write(bundle.join("SKILL.md"), "# Override Skill\n").unwrap();
     fs::write(
         bundle.join("skill.yaml"),
-        "name: override-skill\nversion: 0.1.0\ndescription: Override demo\nentry: SKILL.md\nfiles:\n  - SKILL.md\n",
+        "name: override-skill\nversion: 0.1.0\ndescription: Override demo\nentry: SKILL.md\nfiles:\n  - SKILL.md\nself_test:\n  command: test -f SKILL.md\n",
     )
     .unwrap();
 
@@ -1248,6 +1248,57 @@ fn skills_registry_cli_path_override_publishes_searches_and_adds() {
         add_json["source_label"],
         "filesystem:cli:override-skill@0.1.0"
     );
+}
+
+#[test]
+fn skills_publish_can_use_supplied_self_test_attestation_without_rerun() {
+    let temp_dir = make_temp_dir("skills-cli-publish-supplied-self-test-attestation");
+    let registry = temp_dir.join("registry");
+    let bundle = temp_dir.join("bundle");
+    write_local_skill_bundle(
+        &bundle,
+        "supplied-attestation-skill",
+        "0.1.0",
+        "Supplied attestation",
+        Some("test -f SKILL.md"),
+    );
+
+    let install = Command::new(agentenv_bin())
+        .arg("skills")
+        .arg("install")
+        .arg("--from")
+        .arg(&bundle)
+        .arg("--allow-unsigned")
+        .arg("--json")
+        .env("HOME", &temp_dir)
+        .current_dir(&temp_dir)
+        .output()
+        .unwrap();
+    assert!(install.status.success(), "{}", output_summary(&install));
+    let installed: serde_json::Value = serde_json::from_slice(&install.stdout).unwrap();
+    let attestation_path = installed["self_test_attestation"].as_str().unwrap();
+
+    let publish = Command::new(agentenv_bin())
+        .arg("skills")
+        .arg("publish")
+        .arg(&bundle)
+        .arg("--registry")
+        .arg(&registry)
+        .arg("--allow-unsigned")
+        .arg("--self-test-attestation")
+        .arg(attestation_path)
+        .arg("--no-self-test-run")
+        .arg("--json")
+        .env("HOME", &temp_dir)
+        .current_dir(&temp_dir)
+        .output()
+        .unwrap();
+    assert!(publish.status.success(), "{}", output_summary(&publish));
+    let published: serde_json::Value = serde_json::from_slice(&publish.stdout).unwrap();
+    assert_eq!(published["self_test_score"], 1.0);
+    assert!(registry
+        .join("bundles/supplied-attestation-skill/0.1.0/self-test-attestation.json")
+        .is_file());
 }
 
 #[test]
@@ -1392,7 +1443,7 @@ fn skills_publish_reports_git_registry_override_as_read_only() {
     fs::write(bundle.join("SKILL.md"), "# Git Publish\n").unwrap();
     fs::write(
         bundle.join("skill.yaml"),
-        "name: git-publish-cli\nversion: 0.1.0\ndescription: Git publish CLI\nentry: SKILL.md\nfiles:\n  - SKILL.md\n",
+        "name: git-publish-cli\nversion: 0.1.0\ndescription: Git publish CLI\nentry: SKILL.md\nfiles:\n  - SKILL.md\nself_test:\n  command: test -f SKILL.md\n",
     )
     .unwrap();
 
@@ -1611,6 +1662,11 @@ fn skills_cli_enforces_trust_self_tests_version_selectors_and_remove_confirmatio
     );
     let verify_new_json: serde_json::Value = serde_json::from_slice(&verify_new.stdout).unwrap();
     assert_eq!(verify_new_json["version"], "0.2.0");
+    assert_eq!(verify_new_json["self_test_score"], 1.0);
+    assert!(verify_new_json["self_test_attestation"]
+        .as_str()
+        .unwrap()
+        .ends_with(".json"));
 
     let remove_without_yes = Command::new(agentenv_bin())
         .arg("skills")
@@ -4632,7 +4688,7 @@ fn write_filesystem_registry_skill(registry: &Path, name: &str, version: &str, d
     fs::write(
         bundle.join("skill.yaml"),
         format!(
-            "name: {name}\nversion: {version}\ndescription: {description}\nentry: SKILL.md\nfiles:\n  - SKILL.md\n"
+            "name: {name}\nversion: {version}\ndescription: {description}\nentry: SKILL.md\nfiles:\n  - SKILL.md\nself_test:\n  command: test -f SKILL.md\n"
         ),
     )
     .unwrap();
@@ -4661,7 +4717,7 @@ fn write_indexless_filesystem_registry_skill(
     fs::write(
         bundle.join("skill.yaml"),
         format!(
-            "name: {name}\nversion: {version}\ndescription: {description}\nentry: SKILL.md\nfiles:\n  - SKILL.md\n"
+            "name: {name}\nversion: {version}\ndescription: {description}\nentry: SKILL.md\nfiles:\n  - SKILL.md\nself_test:\n  command: test -f SKILL.md\n"
         ),
     )
     .unwrap();

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -121,7 +121,8 @@ Core owns the skill lifecycle:
 - Resolve blueprint skill references or CLI handles to exact artifact versions.
 - Fetch from trusted sources such as local paths, HTTP, OCI, or git through
   lightweight registry adapters.
-- Verify digests, signatures, versions, and revocation policy before injection.
+- Verify digests, signatures, versions, revocation policy, and functional
+  self-tests before injection.
 - Cache immutable artifacts and record exact pins in `agentenv.lock`.
 - Expose only the selected skill bundle to the sandbox; credential values do
   not flow through skill fetching or generic driver RPC.
@@ -134,6 +135,12 @@ Registry adapters are not JSON-RPC drivers. They are core-managed fetch and
 verify backends, analogous to package registries in Cargo, npm, and pip. If a
 registry adapter needs network access, its URLs pass through the SSRF validator
 and its output becomes an artifact pin in the lockfile.
+
+Published and locally installed skills must declare an `agentenv` self-test and
+score at least `0.8`. Successful runs are signed as self-test attestations tied
+to the exact bundle digest and normalized self-test digest; writable registry
+adapters persist those attestations with the published artifact so hub-style
+publish APIs can reject missing, stale, mismatched, or low-score submissions.
 
 At runtime, agents discover skills through the conventions their `AgentDriver`
 supports. Agent drivers may render config or install steps that point the agent

--- a/docs/superpowers/plans/2026-05-12-m7-7-skill-self-test-gate.md
+++ b/docs/superpowers/plans/2026-05-12-m7-7-skill-self-test-gate.md
@@ -1,0 +1,2275 @@
+# M7-7 Skill Self-Test Gate Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Build the full issue #33 self-test gate so skills cannot be installed locally or published unless a structured functional self-test reaches score `>= 0.8` and produces a signed attestation.
+
+**Architecture:** Keep skills as core-managed resources. Add a reusable self-test engine and attestation verifier under `agentenv-core::skills`, inject the agent-producing runtime from the CLI, and keep registry adapters responsible only for storing already-gated artifacts plus attestations. Preserve existing `skill.yaml self_test.command` behavior by translating it into the structured assertion model.
+
+**Tech Stack:** Rust 2021, `serde_yaml`, `serde_json`, `time`, `sha2`, `ed25519-dalek`, `rand_core`, existing `SkillService`, existing registry adapters, existing runtime `DriverFactory`.
+
+---
+
+## File Structure
+
+- Create `crates/agentenv-core/src/skills/self_test.rs`: self-test spec parsing, normalization, assertion execution, score calculation, local command/file runners, and the `AgentProduceRunner` trait.
+- Create `crates/agentenv-core/src/skills/attestation.rs`: signed self-test attestation model, local signing key load/create, canonical payload, validation, recency checks, and path layout.
+- Modify `crates/agentenv-core/src/skills/mod.rs`: export self-test and attestation APIs.
+- Modify `crates/agentenv-core/src/skills/error.rs`: add typed self-test and attestation errors.
+- Modify `crates/agentenv-core/src/skills/manifest.rs`: preserve legacy `self_test.command`, expose helpers needed by structured self-test loading.
+- Modify `crates/agentenv-core/src/skills/store.rs`: store self-test attestation summary on installed skills and run the install/verify gate.
+- Modify `crates/agentenv-core/src/skills/service.rs`: add self-test runner injection and gate `add`, `install_from_path`, `verify`, and `publish`.
+- Modify `crates/agentenv-core/src/skills/cache.rs`: map cache metadata self-tests into the shared self-test report and support JSON verify-all output.
+- Modify `crates/agentenv-core/src/skills/registry.rs`: extend `RegistryAdapter::publish` to accept a verified attestation.
+- Modify `crates/agentenv-core/src/skills/registry_filesystem.rs`: store attestation JSON next to published bundles and include summary fields in the index.
+- Modify `crates/agentenv-core/src/skills/registry_http.rs`: upload attestation JSON with expanded bundle publish.
+- Modify `crates/agentenv-core/src/skills/registry_oci.rs`: publish attestation as an OCI layer with annotations.
+- Modify `crates/agentenv-core/src/skills/registry_git.rs`: update the trait signature and keep publish unsupported.
+- Modify `crates/agentenv-core/Cargo.toml`: enable `rand_core` `getrandom` for key generation if needed.
+- Modify `crates/agentenv/src/skills_cli.rs`: add CLI flags, JSON output, and runtime injection.
+- Modify `crates/agentenv/src/main.rs`: expose or move credential-provider plumbing needed by the skills CLI `agent_produces` harness.
+- Modify `crates/agentenv/tests/cli_behavior.rs`: add CLI gate coverage.
+- Add `crates/agentenv-core/tests/skills_self_test.rs`: self-test parser, runner, scoring, attestation, and gate unit coverage.
+
+## Task 1: Structured Self-Test Spec Parser
+
+**Files:**
+- Create: `crates/agentenv-core/src/skills/self_test.rs`
+- Modify: `crates/agentenv-core/src/skills/mod.rs`
+- Modify: `crates/agentenv-core/src/skills/error.rs`
+- Test: `crates/agentenv-core/tests/skills_self_test.rs`
+
+- [ ] **Step 1: Write the failing parser tests**
+
+Add `crates/agentenv-core/tests/skills_self_test.rs`:
+
+```rust
+use std::{fs, path::Path};
+
+use agentenv_core::skills::{
+    load_skill_self_test_spec, SkillError, SkillSelfTestAssertion, SkillSelfTestRunner,
+};
+
+#[test]
+fn self_test_spec_loads_from_skill_test_yaml() {
+    let root = temp_dir("self-test-yaml");
+    write_file(&root.join("SKILL.md"), "# Demo\n");
+    write_file(
+        &root.join("skill.yaml"),
+        "name: demo\nversion: 0.1.0\nentry: SKILL.md\nfiles:\n  - SKILL.md\n",
+    );
+    write_file(
+        &root.join("skill-test.yaml"),
+        r#"self_test:
+  runner: agentenv
+  assertions:
+    - type: file_exists
+      path: SKILL.md
+  timeout_seconds: 120
+"#,
+    );
+
+    let spec = load_skill_self_test_spec(&root).expect("self-test should load");
+
+    assert_eq!(spec.runner, SkillSelfTestRunner::Agentenv);
+    assert_eq!(spec.timeout_seconds, 120);
+    assert_eq!(
+        spec.assertions,
+        vec![SkillSelfTestAssertion::FileExists {
+            path: "SKILL.md".into()
+        }]
+    );
+}
+
+#[test]
+fn self_test_spec_loads_from_skill_md_frontmatter() {
+    let root = temp_dir("self-test-frontmatter");
+    write_file(
+        &root.join("SKILL.md"),
+        r#"---
+self_test:
+  runner: agentenv
+  assertions:
+    - type: command_exits_zero
+      cmd: "test -f SKILL.md"
+---
+# Demo
+"#,
+    );
+    write_file(
+        &root.join("skill.yaml"),
+        "name: demo-frontmatter\nversion: 0.1.0\nentry: SKILL.md\nfiles:\n  - SKILL.md\n",
+    );
+
+    let spec = load_skill_self_test_spec(&root).expect("frontmatter self-test should load");
+
+    assert_eq!(spec.assertions.len(), 1);
+    assert!(matches!(
+        &spec.assertions[0],
+        SkillSelfTestAssertion::CommandExitsZero { cmd } if cmd == "test -f SKILL.md"
+    ));
+}
+
+#[test]
+fn self_test_spec_translates_legacy_skill_yaml_command() {
+    let root = temp_dir("self-test-legacy-command");
+    write_file(&root.join("SKILL.md"), "# Demo\n");
+    write_file(
+        &root.join("skill.yaml"),
+        r#"name: legacy-demo
+version: 0.1.0
+entry: SKILL.md
+files:
+  - SKILL.md
+self_test:
+  command: "test -f SKILL.md"
+"#,
+    );
+
+    let spec = load_skill_self_test_spec(&root).expect("legacy command should translate");
+
+    assert_eq!(spec.timeout_seconds, 30);
+    assert_eq!(
+        spec.assertions,
+        vec![SkillSelfTestAssertion::CommandExitsZero {
+            cmd: "test -f SKILL.md".to_owned()
+        }]
+    );
+}
+
+#[test]
+fn self_test_spec_rejects_conflicting_locations() {
+    let root = temp_dir("self-test-conflict");
+    write_file(
+        &root.join("SKILL.md"),
+        r#"---
+self_test:
+  runner: agentenv
+  assertions:
+    - type: file_exists
+      path: SKILL.md
+---
+# Demo
+"#,
+    );
+    write_file(
+        &root.join("skill.yaml"),
+        r#"name: conflict-demo
+version: 0.1.0
+entry: SKILL.md
+files:
+  - SKILL.md
+self_test:
+  runner: agentenv
+  assertions:
+    - type: command_exits_zero
+      cmd: "test -f SKILL.md"
+"#,
+    );
+
+    let error = load_skill_self_test_spec(&root).expect_err("conflict must fail");
+
+    assert!(matches!(error, SkillError::ConflictingSelfTestDeclarations { .. }));
+}
+
+#[test]
+fn self_test_spec_rejects_invalid_agent_assertion_ratio() {
+    let root = temp_dir("self-test-bad-ratio");
+    write_file(&root.join("SKILL.md"), "# Demo\n");
+    write_file(
+        &root.join("skill.yaml"),
+        "name: bad-ratio\nversion: 0.1.0\nentry: SKILL.md\nfiles:\n  - SKILL.md\n",
+    );
+    write_file(
+        &root.join("skill-test.yaml"),
+        r#"self_test:
+  runner: agentenv
+  blueprint: test/minimal.yaml
+  assertions:
+    - type: agent_produces
+      prompt: "summarize"
+      expect_tokens_matching: ["Cargo.toml"]
+      min_match_ratio: 1.2
+"#,
+    );
+
+    let error = load_skill_self_test_spec(&root).expect_err("ratio must fail");
+
+    assert!(matches!(error, SkillError::InvalidSelfTest { .. }));
+}
+
+fn temp_dir(prefix: &str) -> std::path::PathBuf {
+    let mut path = std::env::temp_dir();
+    path.push(format!("{prefix}-{}-{}", std::process::id(), unique_nanos()));
+    fs::create_dir_all(&path).unwrap();
+    path
+}
+
+fn write_file(path: &Path, content: &str) {
+    if let Some(parent) = path.parent() {
+        fs::create_dir_all(parent).unwrap();
+    }
+    fs::write(path, content).unwrap();
+}
+
+fn unique_nanos() -> u128 {
+    std::time::SystemTime::now()
+        .duration_since(std::time::UNIX_EPOCH)
+        .map(|duration| duration.as_nanos())
+        .unwrap_or(0)
+}
+```
+
+- [ ] **Step 2: Run parser tests to verify they fail**
+
+Run:
+
+```bash
+cargo test -p agentenv-core --test skills_self_test self_test_spec -- --nocapture
+```
+
+Expected: FAIL with unresolved imports for `load_skill_self_test_spec`, `SkillSelfTestAssertion`, and `SkillSelfTestRunner`.
+
+- [ ] **Step 3: Implement the parser model**
+
+Create `crates/agentenv-core/src/skills/self_test.rs` with these public types and functions:
+
+```rust
+use std::{
+    collections::BTreeMap,
+    fs,
+    path::{Path, PathBuf},
+};
+
+use serde::{Deserialize, Serialize};
+use serde_yaml::Value;
+use sha2::{Digest, Sha256};
+
+use super::{manifest::normalize_bundle_path, SkillError};
+
+const SKILL_TEST_FILE: &str = "skill-test.yaml";
+const SKILL_MD_FILE: &str = "SKILL.md";
+const SKILL_YAML_FILE: &str = "skill.yaml";
+const DEFAULT_TIMEOUT_SECONDS: u64 = 120;
+const LEGACY_TIMEOUT_SECONDS: u64 = 30;
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "kebab-case")]
+pub enum SkillSelfTestRunner {
+    Agentenv,
+}
+
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+pub struct SkillSelfTestSpec {
+    pub runner: SkillSelfTestRunner,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub blueprint: Option<PathBuf>,
+    pub assertions: Vec<SkillSelfTestAssertion>,
+    pub timeout_seconds: u64,
+}
+
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+#[serde(tag = "type", rename_all = "snake_case")]
+pub enum SkillSelfTestAssertion {
+    CommandExitsZero { cmd: String },
+    FileExists { path: PathBuf },
+    AgentProduces {
+        prompt: String,
+        expect_tokens_matching: Vec<String>,
+        min_match_ratio: f64,
+    },
+}
+
+#[derive(Debug, Deserialize)]
+struct SelfTestDocument {
+    self_test: RawSelfTestSpec,
+}
+
+#[derive(Debug, Deserialize)]
+struct RawSelfTestSpec {
+    runner: Option<String>,
+    blueprint: Option<String>,
+    assertions: Option<Vec<SkillSelfTestAssertion>>,
+    timeout_seconds: Option<u64>,
+    command: Option<String>,
+}
+
+#[derive(Debug, Deserialize)]
+struct RawSkillYaml {
+    self_test: Option<RawSelfTestSpec>,
+    #[serde(flatten)]
+    _extra: BTreeMap<String, Value>,
+}
+
+pub fn load_skill_self_test_spec(root: impl AsRef<Path>) -> Result<SkillSelfTestSpec, SkillError> {
+    let root = root.as_ref();
+    let mut specs = Vec::new();
+
+    if let Some(spec) = load_from_skill_test_yaml(root)? {
+        specs.push(("skill-test.yaml", spec));
+    }
+    if let Some(spec) = load_from_skill_md_frontmatter(root)? {
+        specs.push(("SKILL.md", spec));
+    }
+    if let Some(spec) = load_from_skill_yaml(root)? {
+        specs.push(("skill.yaml", spec));
+    }
+
+    let Some((_, first)) = specs.first().cloned() else {
+        return Err(SkillError::MissingSelfTest);
+    };
+    for (source, spec) in specs.iter().skip(1) {
+        if normalized_self_test_digest(&first)? != normalized_self_test_digest(spec)? {
+            return Err(SkillError::ConflictingSelfTestDeclarations {
+                source: (*source).to_owned(),
+            });
+        }
+    }
+    Ok(first)
+}
+
+pub fn normalized_self_test_digest(spec: &SkillSelfTestSpec) -> Result<String, SkillError> {
+    let bytes = serde_json::to_vec(spec).map_err(|source| SkillError::InvalidSelfTest {
+        message: format!("failed to serialize normalized self-test: {source}"),
+    })?;
+    let digest = Sha256::digest(bytes);
+    Ok(format!("sha256:{}", hex::encode(digest)))
+}
+```
+
+Then implement the private helpers in the same file:
+
+```rust
+fn load_from_skill_test_yaml(root: &Path) -> Result<Option<SkillSelfTestSpec>, SkillError> {
+    let path = root.join(SKILL_TEST_FILE);
+    if !path.is_file() {
+        return Ok(None);
+    }
+    let content = fs::read_to_string(&path).map_err(|source| SkillError::Io {
+        path: path.clone(),
+        source,
+    })?;
+    let document: SelfTestDocument =
+        serde_yaml::from_str(&content).map_err(|source| SkillError::Yaml { path, source })?;
+    normalize_raw_self_test(document.self_test, false).map(Some)
+}
+
+fn load_from_skill_yaml(root: &Path) -> Result<Option<SkillSelfTestSpec>, SkillError> {
+    let path = root.join(SKILL_YAML_FILE);
+    if !path.is_file() {
+        return Ok(None);
+    }
+    let content = fs::read_to_string(&path).map_err(|source| SkillError::Io {
+        path: path.clone(),
+        source,
+    })?;
+    let document: RawSkillYaml =
+        serde_yaml::from_str(&content).map_err(|source| SkillError::Yaml { path, source })?;
+    document
+        .self_test
+        .map(|raw| normalize_raw_self_test(raw, true))
+        .transpose()
+}
+
+fn load_from_skill_md_frontmatter(root: &Path) -> Result<Option<SkillSelfTestSpec>, SkillError> {
+    let path = root.join(SKILL_MD_FILE);
+    if !path.is_file() {
+        return Ok(None);
+    }
+    let content = fs::read_to_string(&path).map_err(|source| SkillError::Io {
+        path: path.clone(),
+        source,
+    })?;
+    let Some(frontmatter) = yaml_frontmatter(&content) else {
+        return Ok(None);
+    };
+    let document: SelfTestDocument =
+        serde_yaml::from_str(frontmatter).map_err(|source| SkillError::Yaml { path, source })?;
+    normalize_raw_self_test(document.self_test, false).map(Some)
+}
+
+fn yaml_frontmatter(content: &str) -> Option<&str> {
+    let rest = content.strip_prefix("---\n")?;
+    let end = rest.find("\n---")?;
+    Some(&rest[..end])
+}
+
+fn normalize_raw_self_test(
+    raw: RawSelfTestSpec,
+    allow_legacy_command: bool,
+) -> Result<SkillSelfTestSpec, SkillError> {
+    if let Some(command) = raw.command {
+        if !allow_legacy_command {
+            return Err(SkillError::InvalidSelfTest {
+                message: "self_test.command is only supported in skill.yaml".to_owned(),
+            });
+        }
+        let command = command.trim();
+        if command.is_empty() {
+            return Err(SkillError::InvalidSelfTest {
+                message: "self_test.command must not be empty".to_owned(),
+            });
+        }
+        return Ok(SkillSelfTestSpec {
+            runner: SkillSelfTestRunner::Agentenv,
+            blueprint: None,
+            assertions: vec![SkillSelfTestAssertion::CommandExitsZero {
+                cmd: command.to_owned(),
+            }],
+            timeout_seconds: LEGACY_TIMEOUT_SECONDS,
+        });
+    }
+
+    let runner = match raw.runner.as_deref() {
+        Some("agentenv") => SkillSelfTestRunner::Agentenv,
+        Some(other) => {
+            return Err(SkillError::InvalidSelfTest {
+                message: format!("unsupported self_test.runner `{other}`"),
+            })
+        }
+        None => {
+            return Err(SkillError::InvalidSelfTest {
+                message: "self_test.runner is required".to_owned(),
+            })
+        }
+    };
+    let blueprint = raw
+        .blueprint
+        .map(|path| normalize_bundle_path(Path::new(&path)))
+        .transpose()?;
+    let assertions = raw.assertions.ok_or_else(|| SkillError::InvalidSelfTest {
+        message: "self_test.assertions is required".to_owned(),
+    })?;
+    if assertions.is_empty() {
+        return Err(SkillError::InvalidSelfTest {
+            message: "self_test.assertions must not be empty".to_owned(),
+        });
+    }
+
+    for assertion in &assertions {
+        validate_assertion(assertion)?;
+    }
+    if assertions
+        .iter()
+        .any(|assertion| matches!(assertion, SkillSelfTestAssertion::AgentProduces { .. }))
+        && blueprint.is_none()
+    {
+        return Err(SkillError::InvalidSelfTest {
+            message: "self_test.blueprint is required for agent_produces".to_owned(),
+        });
+    }
+
+    Ok(SkillSelfTestSpec {
+        runner,
+        blueprint,
+        assertions,
+        timeout_seconds: raw.timeout_seconds.unwrap_or(DEFAULT_TIMEOUT_SECONDS),
+    })
+}
+
+fn validate_assertion(assertion: &SkillSelfTestAssertion) -> Result<(), SkillError> {
+    match assertion {
+        SkillSelfTestAssertion::CommandExitsZero { cmd } if cmd.trim().is_empty() => {
+            Err(SkillError::InvalidSelfTest {
+                message: "command_exits_zero.cmd must not be empty".to_owned(),
+            })
+        }
+        SkillSelfTestAssertion::CommandExitsZero { .. } => Ok(()),
+        SkillSelfTestAssertion::FileExists { path } => {
+            normalize_bundle_path(path).map(|_| ())
+        }
+        SkillSelfTestAssertion::AgentProduces {
+            prompt,
+            expect_tokens_matching,
+            min_match_ratio,
+        } => {
+            if prompt.trim().is_empty() {
+                return Err(SkillError::InvalidSelfTest {
+                    message: "agent_produces.prompt must not be empty".to_owned(),
+                });
+            }
+            if expect_tokens_matching.is_empty() {
+                return Err(SkillError::InvalidSelfTest {
+                    message: "agent_produces.expect_tokens_matching must not be empty".to_owned(),
+                });
+            }
+            if !(0.0..=1.0).contains(min_match_ratio) {
+                return Err(SkillError::InvalidSelfTest {
+                    message: "agent_produces.min_match_ratio must be between 0.0 and 1.0"
+                        .to_owned(),
+                });
+            }
+            Ok(())
+        }
+    }
+}
+```
+
+- [ ] **Step 4: Export the parser and add errors**
+
+Modify `crates/agentenv-core/src/skills/mod.rs`:
+
+```rust
+pub mod self_test;
+
+pub use self_test::{
+    load_skill_self_test_spec, normalized_self_test_digest, SkillSelfTestAssertion,
+    SkillSelfTestReport, SkillSelfTestRunner, SkillSelfTestSpec,
+};
+```
+
+Modify `crates/agentenv-core/src/skills/error.rs`:
+
+```rust
+#[error("skill self-test is missing")]
+MissingSelfTest,
+#[error("invalid skill self-test: {message}")]
+InvalidSelfTest { message: String },
+#[error("conflicting skill self-test declaration in `{source}`")]
+ConflictingSelfTestDeclarations { source: String },
+```
+
+- [ ] **Step 5: Run parser tests and commit**
+
+Run:
+
+```bash
+cargo test -p agentenv-core --test skills_self_test self_test_spec -- --nocapture
+```
+
+Expected: PASS for the five parser tests.
+
+Commit:
+
+```bash
+git add crates/agentenv-core/src/skills/self_test.rs crates/agentenv-core/src/skills/mod.rs crates/agentenv-core/src/skills/error.rs crates/agentenv-core/tests/skills_self_test.rs
+git commit -m "feat: parse structured skill self-tests"
+```
+
+## Task 2: Assertion Runner And Score Calculation
+
+**Files:**
+- Modify: `crates/agentenv-core/src/skills/self_test.rs`
+- Modify: `crates/agentenv-core/src/skills/error.rs`
+- Test: `crates/agentenv-core/tests/skills_self_test.rs`
+
+- [ ] **Step 1: Write failing runner tests**
+
+Append to `crates/agentenv-core/tests/skills_self_test.rs`:
+
+```rust
+use agentenv_core::skills::{
+    run_skill_self_test, AgentProduceRequest, AgentProduceRunner, SkillAssertionStatus,
+    SkillSelfTestOptions,
+};
+
+#[derive(Default)]
+struct FakeAgentRunner {
+    output: String,
+}
+
+impl AgentProduceRunner for FakeAgentRunner {
+    fn run_agent_prompt(
+        &self,
+        _request: AgentProduceRequest<'_>,
+    ) -> Result<String, SkillError> {
+        Ok(self.output.clone())
+    }
+}
+
+#[test]
+fn self_test_runner_scores_file_and_command_assertions() {
+    let root = temp_dir("self-test-runner-score");
+    write_file(&root.join("SKILL.md"), "# Demo\n");
+    write_file(
+        &root.join("skill.yaml"),
+        "name: score-demo\nversion: 0.1.0\nentry: SKILL.md\nfiles:\n  - SKILL.md\n",
+    );
+    write_file(
+        &root.join("skill-test.yaml"),
+        r#"self_test:
+  runner: agentenv
+  assertions:
+    - type: file_exists
+      path: SKILL.md
+    - type: command_exits_zero
+      cmd: "test -f missing.txt"
+"#,
+    );
+    let manifest = agentenv_core::skills::load_skill_manifest(&root).unwrap();
+    let digest = agentenv_core::skills::compute_bundle_digest(&root, &manifest).unwrap();
+    let spec = load_skill_self_test_spec(&root).unwrap();
+
+    let report = run_skill_self_test(
+        &root,
+        &manifest.name,
+        &manifest.version.to_string(),
+        &digest,
+        &spec,
+        SkillSelfTestOptions::default(),
+        &FakeAgentRunner::default(),
+    )
+    .expect("self-test should produce a report");
+
+    assert_eq!(report.passed, 1);
+    assert_eq!(report.total, 2);
+    assert_eq!(report.score, 0.5);
+    assert!(!report.publishable);
+}
+
+#[test]
+fn self_test_runner_accepts_score_at_threshold() {
+    let root = temp_dir("self-test-runner-threshold");
+    write_file(&root.join("SKILL.md"), "# Demo\n");
+    write_file(&root.join("present.txt"), "ok\n");
+    write_file(
+        &root.join("skill.yaml"),
+        "name: threshold-demo\nversion: 0.1.0\nentry: SKILL.md\nfiles:\n  - SKILL.md\n  - present.txt\n",
+    );
+    write_file(
+        &root.join("skill-test.yaml"),
+        r#"self_test:
+  runner: agentenv
+  assertions:
+    - type: file_exists
+      path: SKILL.md
+    - type: file_exists
+      path: present.txt
+    - type: command_exits_zero
+      cmd: "test -f SKILL.md"
+    - type: command_exits_zero
+      cmd: "test -f present.txt"
+    - type: command_exits_zero
+      cmd: "test -f missing.txt"
+"#,
+    );
+    let manifest = agentenv_core::skills::load_skill_manifest(&root).unwrap();
+    let digest = agentenv_core::skills::compute_bundle_digest(&root, &manifest).unwrap();
+    let spec = load_skill_self_test_spec(&root).unwrap();
+
+    let report = run_skill_self_test(
+        &root,
+        &manifest.name,
+        &manifest.version.to_string(),
+        &digest,
+        &spec,
+        SkillSelfTestOptions::default(),
+        &FakeAgentRunner::default(),
+    )
+    .unwrap();
+
+    assert_eq!(report.score, 0.8);
+    assert!(report.publishable);
+}
+
+#[test]
+fn self_test_runner_scores_agent_produces_tokens() {
+    let root = temp_dir("self-test-runner-agent");
+    fs::create_dir_all(root.join("test")).unwrap();
+    write_file(&root.join("SKILL.md"), "# Demo\n");
+    write_file(&root.join("test/minimal.yaml"), "version: 0.1.0\n");
+    write_file(
+        &root.join("skill.yaml"),
+        "name: agent-demo\nversion: 0.1.0\nentry: SKILL.md\nfiles:\n  - SKILL.md\n  - test/minimal.yaml\n",
+    );
+    write_file(
+        &root.join("skill-test.yaml"),
+        r#"self_test:
+  runner: agentenv
+  blueprint: test/minimal.yaml
+  assertions:
+    - type: agent_produces
+      prompt: "summarize"
+      expect_tokens_matching: ["Cargo.toml", "src/"]
+      min_match_ratio: 0.5
+"#,
+    );
+    let manifest = agentenv_core::skills::load_skill_manifest(&root).unwrap();
+    let digest = agentenv_core::skills::compute_bundle_digest(&root, &manifest).unwrap();
+    let spec = load_skill_self_test_spec(&root).unwrap();
+
+    let report = run_skill_self_test(
+        &root,
+        &manifest.name,
+        &manifest.version.to_string(),
+        &digest,
+        &spec,
+        SkillSelfTestOptions::default(),
+        &FakeAgentRunner {
+            output: "Cargo.toml is present".to_owned(),
+        },
+    )
+    .unwrap();
+
+    assert_eq!(report.assertions[0].status, SkillAssertionStatus::Passed);
+    assert_eq!(report.score, 1.0);
+}
+```
+
+- [ ] **Step 2: Run runner tests to verify they fail**
+
+Run:
+
+```bash
+cargo test -p agentenv-core --test skills_self_test self_test_runner -- --nocapture
+```
+
+Expected: FAIL with unresolved imports for runner/report types.
+
+- [ ] **Step 3: Implement report types and runner API**
+
+Add to `crates/agentenv-core/src/skills/self_test.rs`:
+
+```rust
+use std::{
+    process::Command,
+    thread,
+    time::{Duration, Instant},
+};
+
+use time::OffsetDateTime;
+
+pub const SELF_TEST_PUBLISH_THRESHOLD: f64 = 0.8;
+
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+pub struct SkillSelfTestReport {
+    pub name: String,
+    pub version: String,
+    pub digest: String,
+    pub self_test_digest: String,
+    pub score: f64,
+    pub passed: usize,
+    pub total: usize,
+    pub publishable: bool,
+    pub assertions: Vec<SkillAssertionResult>,
+    pub started_at: OffsetDateTime,
+    pub completed_at: OffsetDateTime,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct SkillAssertionResult {
+    #[serde(rename = "type")]
+    pub assertion_type: String,
+    pub status: SkillAssertionStatus,
+    pub message: String,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum SkillAssertionStatus {
+    Passed,
+    Failed,
+    Skipped,
+}
+
+#[derive(Debug, Clone, Copy)]
+pub struct SkillSelfTestOptions {
+    pub threshold: f64,
+}
+
+impl Default for SkillSelfTestOptions {
+    fn default() -> Self {
+        Self {
+            threshold: SELF_TEST_PUBLISH_THRESHOLD,
+        }
+    }
+}
+
+pub struct AgentProduceRequest<'a> {
+    pub skill_root: &'a Path,
+    pub blueprint: &'a Path,
+    pub prompt: &'a str,
+    pub timeout: Duration,
+}
+
+pub trait AgentProduceRunner: Send + Sync {
+    fn run_agent_prompt(&self, request: AgentProduceRequest<'_>) -> Result<String, SkillError>;
+}
+
+#[derive(Debug, Default)]
+pub struct UnsupportedAgentProduceRunner;
+
+impl AgentProduceRunner for UnsupportedAgentProduceRunner {
+    fn run_agent_prompt(&self, _request: AgentProduceRequest<'_>) -> Result<String, SkillError> {
+        Err(SkillError::UnsupportedAgentProduces)
+    }
+}
+```
+
+Add the runner function:
+
+```rust
+pub fn run_skill_self_test(
+    skill_root: &Path,
+    name: &str,
+    version: &str,
+    digest: &str,
+    spec: &SkillSelfTestSpec,
+    options: SkillSelfTestOptions,
+    agent_runner: &dyn AgentProduceRunner,
+) -> Result<SkillSelfTestReport, SkillError> {
+    let started_at = OffsetDateTime::now_utc();
+    let self_test_digest = normalized_self_test_digest(spec)?;
+    let deadline = Instant::now() + Duration::from_secs(spec.timeout_seconds);
+    let mut results = Vec::new();
+
+    for assertion in &spec.assertions {
+        if Instant::now() >= deadline {
+            results.push(SkillAssertionResult {
+                assertion_type: assertion.kind().to_owned(),
+                status: SkillAssertionStatus::Skipped,
+                message: "self-test deadline reached".to_owned(),
+            });
+            continue;
+        }
+        results.push(run_assertion(skill_root, spec, assertion, deadline, agent_runner));
+    }
+
+    let total = results.len();
+    let passed = results
+        .iter()
+        .filter(|result| result.status == SkillAssertionStatus::Passed)
+        .count();
+    let score = if total == 0 {
+        0.0
+    } else {
+        passed as f64 / total as f64
+    };
+    Ok(SkillSelfTestReport {
+        name: name.to_owned(),
+        version: version.to_owned(),
+        digest: digest.to_owned(),
+        self_test_digest,
+        score,
+        passed,
+        total,
+        publishable: score >= options.threshold,
+        assertions: results,
+        started_at,
+        completed_at: OffsetDateTime::now_utc(),
+    })
+}
+```
+
+Implement `run_assertion`, `run_command_assertion`, and `run_agent_produces_assertion` in the same module. Use `shell_command` from the existing `store.rs` pattern, `current_dir(skill_root)`, `stdout(Stdio::null())`, `stderr(Stdio::null())`, `try_wait`, and 25ms polling. `file_exists` must call `normalize_bundle_path(path)` and then check `skill_root.join(path).is_file()`. `agent_produces` must call `agent_runner.run_agent_prompt` with the normalized blueprint path, count expected token matches, and pass only when `matched / expected >= min_match_ratio`.
+
+- [ ] **Step 4: Add remaining error variants and helper method**
+
+Modify `crates/agentenv-core/src/skills/error.rs`:
+
+```rust
+#[error("skill self-test timed out after {timeout_seconds}s")]
+SelfTestTimeout { timeout_seconds: u64 },
+#[error("skill self-test score {score:.3} is below required threshold {threshold:.3}")]
+SelfTestScoreBelowThreshold { score: f64, threshold: f64 },
+#[error("agent_produces self-test assertions are unavailable in this execution context")]
+UnsupportedAgentProduces,
+```
+
+Add to `SkillSelfTestAssertion`:
+
+```rust
+impl SkillSelfTestAssertion {
+    pub fn kind(&self) -> &'static str {
+        match self {
+            Self::CommandExitsZero { .. } => "command_exits_zero",
+            Self::FileExists { .. } => "file_exists",
+            Self::AgentProduces { .. } => "agent_produces",
+        }
+    }
+}
+```
+
+- [ ] **Step 5: Run runner tests and commit**
+
+Run:
+
+```bash
+cargo test -p agentenv-core --test skills_self_test self_test_runner -- --nocapture
+```
+
+Expected: PASS for parser and runner tests.
+
+Commit:
+
+```bash
+git add crates/agentenv-core/src/skills/self_test.rs crates/agentenv-core/src/skills/error.rs crates/agentenv-core/tests/skills_self_test.rs
+git commit -m "feat: run skill self-test assertions"
+```
+
+## Task 3: Signed Self-Test Attestations
+
+**Files:**
+- Create: `crates/agentenv-core/src/skills/attestation.rs`
+- Modify: `crates/agentenv-core/src/skills/mod.rs`
+- Modify: `crates/agentenv-core/src/skills/error.rs`
+- Modify: `crates/agentenv-core/Cargo.toml`
+- Test: `crates/agentenv-core/tests/skills_self_test.rs`
+
+- [ ] **Step 1: Write failing attestation tests**
+
+Append to `crates/agentenv-core/tests/skills_self_test.rs`:
+
+```rust
+use agentenv_core::skills::{
+    sign_skill_self_test_attestation, validate_skill_publish_attestation,
+    SkillAttestationValidationOptions, SkillSelfTestSigningKey,
+};
+use time::{Duration as TimeDuration, OffsetDateTime};
+
+#[test]
+fn self_test_attestation_signs_and_validates_report() {
+    let key = SkillSelfTestSigningKey::from_secret_bytes([3_u8; 32]);
+    let report = passing_report("attested-demo", "0.1.0");
+
+    let attestation =
+        sign_skill_self_test_attestation(&report, &key).expect("attestation should sign");
+
+    validate_skill_publish_attestation(
+        "attested-demo",
+        "0.1.0",
+        &report.digest,
+        &report.self_test_digest,
+        &attestation,
+        SkillAttestationValidationOptions {
+            trusted_public_keys: vec![key.public_key_hex()],
+            now: report.completed_at + TimeDuration::minutes(5),
+            max_age_seconds: 86_400,
+            threshold: 0.8,
+        },
+    )
+    .expect("matching attestation should validate");
+}
+
+#[test]
+fn self_test_attestation_rejects_low_score() {
+    let key = SkillSelfTestSigningKey::from_secret_bytes([4_u8; 32]);
+    let mut report = passing_report("low-score-demo", "0.1.0");
+    report.score = 0.799;
+    report.publishable = false;
+    let attestation = sign_skill_self_test_attestation(&report, &key).unwrap();
+
+    let error = validate_skill_publish_attestation(
+        "low-score-demo",
+        "0.1.0",
+        &report.digest,
+        &report.self_test_digest,
+        &attestation,
+        SkillAttestationValidationOptions {
+            trusted_public_keys: vec![key.public_key_hex()],
+            now: report.completed_at,
+            max_age_seconds: 86_400,
+            threshold: 0.8,
+        },
+    )
+    .expect_err("low score must fail");
+
+    assert!(matches!(error, SkillError::SelfTestScoreBelowThreshold { .. }));
+}
+
+#[test]
+fn self_test_attestation_rejects_stale_report() {
+    let key = SkillSelfTestSigningKey::from_secret_bytes([5_u8; 32]);
+    let report = passing_report("stale-demo", "0.1.0");
+    let attestation = sign_skill_self_test_attestation(&report, &key).unwrap();
+
+    let error = validate_skill_publish_attestation(
+        "stale-demo",
+        "0.1.0",
+        &report.digest,
+        &report.self_test_digest,
+        &attestation,
+        SkillAttestationValidationOptions {
+            trusted_public_keys: vec![key.public_key_hex()],
+            now: report.completed_at + TimeDuration::days(2),
+            max_age_seconds: 86_400,
+            threshold: 0.8,
+        },
+    )
+    .expect_err("stale attestation must fail");
+
+    assert!(matches!(error, SkillError::StaleSelfTestAttestation { .. }));
+}
+
+fn passing_report(name: &str, version: &str) -> agentenv_core::skills::SkillSelfTestReport {
+    let now = OffsetDateTime::now_utc();
+    agentenv_core::skills::SkillSelfTestReport {
+        name: name.to_owned(),
+        version: version.to_owned(),
+        digest: "sha256:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa".to_owned(),
+        self_test_digest: "sha256:bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb".to_owned(),
+        score: 1.0,
+        passed: 1,
+        total: 1,
+        publishable: true,
+        assertions: vec![agentenv_core::skills::SkillAssertionResult {
+            assertion_type: "file_exists".to_owned(),
+            status: agentenv_core::skills::SkillAssertionStatus::Passed,
+            message: "ok".to_owned(),
+        }],
+        started_at: now,
+        completed_at: now,
+    }
+}
+```
+
+- [ ] **Step 2: Run attestation tests to verify they fail**
+
+Run:
+
+```bash
+cargo test -p agentenv-core --test skills_self_test self_test_attestation -- --nocapture
+```
+
+Expected: FAIL with unresolved attestation imports.
+
+- [ ] **Step 3: Implement attestation model and signing**
+
+Create `crates/agentenv-core/src/skills/attestation.rs`:
+
+```rust
+use std::{fs, io::Write, path::{Path, PathBuf}};
+
+use ed25519_dalek::{Signature, Signer, SigningKey, Verifier, VerifyingKey, PUBLIC_KEY_LENGTH};
+use rand_core::{OsRng, RngCore};
+use serde::{Deserialize, Serialize};
+use sha2::{Digest, Sha256};
+use time::OffsetDateTime;
+
+use super::{SkillAssertionResult, SkillError, SkillSelfTestReport};
+
+const ATTESTATION_SCHEMA_VERSION: &str = "0.1";
+const PREDICATE_TYPE: &str = "https://agentenv.dev/attestations/skill-self-test/v1";
+const SIGNATURE_PAYLOAD_HEADER: &[u8] = b"agentenv-skill-self-test-attestation-v1\n";
+
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+pub struct SkillSelfTestAttestation {
+    pub schema_version: String,
+    pub predicate_type: String,
+    pub subject: SkillSelfTestSubject,
+    pub self_test_digest: String,
+    pub runner: String,
+    pub score: f64,
+    pub publishable: bool,
+    pub started_at: OffsetDateTime,
+    pub completed_at: OffsetDateTime,
+    pub assertions: Vec<SkillAssertionResult>,
+    pub signature: SkillSelfTestAttestationSignature,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct SkillSelfTestSubject {
+    pub name: String,
+    pub version: String,
+    pub digest: String,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct SkillSelfTestAttestationSignature {
+    pub key_id: String,
+    pub algorithm: String,
+    pub public_key_ed25519: String,
+    pub value: String,
+}
+
+pub struct SkillSelfTestSigningKey {
+    signing_key: SigningKey,
+}
+```
+
+Implement:
+
+```rust
+impl SkillSelfTestSigningKey {
+    pub fn from_secret_bytes(secret: [u8; 32]) -> Self {
+        Self {
+            signing_key: SigningKey::from_bytes(&secret),
+        }
+    }
+
+    pub fn public_key_hex(&self) -> String {
+        hex::encode(self.signing_key.verifying_key().to_bytes())
+    }
+
+    pub fn load_or_create(path: &Path) -> Result<Self, SkillError> {
+        if path.exists() {
+            #[cfg(unix)]
+            ensure_unix_key_file_hygiene(path)?;
+            let bytes = fs::read(path).map_err(|source| SkillError::Io {
+                path: path.to_path_buf(),
+                source,
+            })?;
+            let secret: [u8; 32] = bytes.as_slice().try_into().map_err(|_| {
+                SkillError::InvalidSelfTestSigningKey {
+                    path: path.to_path_buf(),
+                }
+            })?;
+            return Ok(Self::from_secret_bytes(secret));
+        }
+
+        if let Some(parent) = path.parent() {
+            fs::create_dir_all(parent).map_err(|source| SkillError::Io {
+                path: parent.to_path_buf(),
+                source,
+            })?;
+        }
+        let mut secret = [0_u8; 32];
+        OsRng.fill_bytes(&mut secret);
+        write_new_signing_key(path, &secret)?;
+        Ok(Self::from_secret_bytes(secret))
+    }
+}
+
+pub fn sign_skill_self_test_attestation(
+    report: &SkillSelfTestReport,
+    key: &SkillSelfTestSigningKey,
+) -> Result<SkillSelfTestAttestation, SkillError> {
+    let mut attestation = SkillSelfTestAttestation {
+        schema_version: ATTESTATION_SCHEMA_VERSION.to_owned(),
+        predicate_type: PREDICATE_TYPE.to_owned(),
+        subject: SkillSelfTestSubject {
+            name: report.name.clone(),
+            version: report.version.clone(),
+            digest: report.digest.clone(),
+        },
+        self_test_digest: report.self_test_digest.clone(),
+        runner: "agentenv".to_owned(),
+        score: report.score,
+        publishable: report.publishable,
+        started_at: report.started_at,
+        completed_at: report.completed_at,
+        assertions: report.assertions.clone(),
+        signature: SkillSelfTestAttestationSignature {
+            key_id: "local-agentenv".to_owned(),
+            algorithm: "ed25519".to_owned(),
+            public_key_ed25519: key.public_key_hex(),
+            value: String::new(),
+        },
+    };
+    let payload = attestation_payload(&attestation)?;
+    attestation.signature.value = hex::encode(key.signing_key.sign(&payload).to_bytes());
+    Ok(attestation)
+}
+```
+
+- [ ] **Step 4: Implement validation and key file helpers**
+
+Add `SkillAttestationValidationOptions` and validation:
+
+```rust
+pub struct SkillAttestationValidationOptions {
+    pub trusted_public_keys: Vec<String>,
+    pub now: OffsetDateTime,
+    pub max_age_seconds: u64,
+    pub threshold: f64,
+}
+
+pub fn validate_skill_publish_attestation(
+    name: &str,
+    version: &str,
+    digest: &str,
+    self_test_digest: &str,
+    attestation: &SkillSelfTestAttestation,
+    options: SkillAttestationValidationOptions,
+) -> Result<(), SkillError> {
+    if attestation.schema_version != ATTESTATION_SCHEMA_VERSION
+        || attestation.predicate_type != PREDICATE_TYPE
+    {
+        return Err(SkillError::InvalidSelfTestAttestation {
+            message: "unsupported self-test attestation schema".to_owned(),
+        });
+    }
+    if attestation.subject.name != name
+        || attestation.subject.version != version
+        || attestation.subject.digest != digest
+    {
+        return Err(SkillError::SelfTestAttestationSubjectMismatch);
+    }
+    if attestation.self_test_digest != self_test_digest {
+        return Err(SkillError::SelfTestAttestationDigestMismatch);
+    }
+    if attestation.score < options.threshold || !attestation.publishable {
+        return Err(SkillError::SelfTestScoreBelowThreshold {
+            score: attestation.score,
+            threshold: options.threshold,
+        });
+    }
+    let age = options.now - attestation.completed_at;
+    if age.is_negative() || age.whole_seconds() as u64 > options.max_age_seconds {
+        return Err(SkillError::StaleSelfTestAttestation {
+            completed_at: attestation.completed_at.to_string(),
+        });
+    }
+    verify_attestation_signature(attestation, &options.trusted_public_keys)
+}
+```
+
+Add Unix key hygiene helpers by copying the focused shape from `crates/agentenv-core/src/snapshot.rs`: reject symlink/non-file keys, require no group/world permissions, create new key files with mode `0600`, and write 32 raw secret bytes.
+
+Modify `crates/agentenv-core/Cargo.toml`:
+
+```toml
+rand_core = { workspace = true, features = ["getrandom"] }
+```
+
+Modify `crates/agentenv-core/src/skills/error.rs`:
+
+```rust
+#[error("invalid self-test signing key `{path}`")]
+InvalidSelfTestSigningKey { path: PathBuf },
+#[error("invalid self-test attestation: {message}")]
+InvalidSelfTestAttestation { message: String },
+#[error("self-test attestation subject does not match the skill artifact")]
+SelfTestAttestationSubjectMismatch,
+#[error("self-test attestation digest does not match the skill self-test")]
+SelfTestAttestationDigestMismatch,
+#[error("self-test attestation is stale; completed_at={completed_at}")]
+StaleSelfTestAttestation { completed_at: String },
+```
+
+- [ ] **Step 5: Export, run tests, and commit**
+
+Modify `crates/agentenv-core/src/skills/mod.rs`:
+
+```rust
+pub mod attestation;
+
+pub use attestation::{
+    sign_skill_self_test_attestation, validate_skill_publish_attestation,
+    SkillAttestationValidationOptions, SkillSelfTestAttestation, SkillSelfTestSigningKey,
+};
+```
+
+Run:
+
+```bash
+cargo test -p agentenv-core --test skills_self_test self_test_attestation -- --nocapture
+```
+
+Expected: PASS for attestation signing, low-score rejection, and stale rejection.
+
+Commit:
+
+```bash
+git add crates/agentenv-core/Cargo.toml crates/agentenv-core/src/skills/attestation.rs crates/agentenv-core/src/skills/mod.rs crates/agentenv-core/src/skills/error.rs crates/agentenv-core/tests/skills_self_test.rs
+git commit -m "feat: sign skill self-test attestations"
+```
+
+## Task 4: Gate Local Install And Verify
+
+**Files:**
+- Modify: `crates/agentenv-core/src/skills/store.rs`
+- Modify: `crates/agentenv-core/src/skills/service.rs`
+- Modify: `crates/agentenv-core/src/skills/error.rs`
+- Test: `crates/agentenv-core/tests/skills.rs`
+
+- [ ] **Step 1: Write failing local gate tests**
+
+Append to `crates/agentenv-core/tests/skills.rs`:
+
+```rust
+#[test]
+fn local_install_rejects_missing_self_test() {
+    let home = temp_dir("skill-install-missing-self-test-home");
+    let bundle = skill_bundle("no-self-test", "0.1.0", "No self-test");
+
+    let error = install_local_skill(
+        home.join(".agentenv"),
+        &bundle,
+        SkillInstallOptions {
+            allow_unsigned: true,
+            source_type: "local".to_owned(),
+            source_label: "local-dev".to_owned(),
+        },
+    )
+    .expect_err("install must reject missing self-test");
+
+    assert!(matches!(error, SkillError::MissingSelfTest));
+    assert!(!home.join(".agentenv/skills/no-self-test/0.1.0").exists());
+}
+
+#[test]
+fn local_install_accepts_passing_self_test_and_records_score() {
+    let home = temp_dir("skill-install-passing-self-test-home");
+    let bundle = temp_dir("skill-install-passing-self-test-bundle");
+    write_file(&bundle.join("SKILL.md"), "# Demo\n");
+    write_file(
+        &bundle.join("skill.yaml"),
+        "name: passing-self-test\nversion: 0.1.0\nentry: SKILL.md\nfiles:\n  - SKILL.md\n",
+    );
+    write_file(
+        &bundle.join("skill-test.yaml"),
+        "self_test:\n  runner: agentenv\n  assertions:\n    - type: file_exists\n      path: SKILL.md\n",
+    );
+
+    let installed = install_local_skill(
+        home.join(".agentenv"),
+        &bundle,
+        SkillInstallOptions {
+            allow_unsigned: true,
+            source_type: "local".to_owned(),
+            source_label: "local-dev".to_owned(),
+        },
+    )
+    .expect("passing self-test should install");
+
+    assert_eq!(installed.self_test_score, Some(1.0));
+    assert!(installed.self_test_attestation.is_some());
+}
+```
+
+- [ ] **Step 2: Run local gate tests to verify they fail**
+
+Run:
+
+```bash
+cargo test -p agentenv-core --test skills local_install_ -- --nocapture
+```
+
+Expected: FAIL because existing install accepts missing self-tests and `InstalledSkill` has no self-test fields.
+
+- [ ] **Step 3: Extend installed record and install options**
+
+Modify `crates/agentenv-core/src/skills/store.rs`:
+
+```rust
+#[derive(Debug, Clone, serde::Serialize, serde::Deserialize, PartialEq)]
+pub struct InstalledSkill {
+    pub name: String,
+    pub version: String,
+    pub source_type: String,
+    pub source_label: String,
+    pub digest: String,
+    pub signature_status: String,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub signature_public_key_ed25519: Option<String>,
+    pub entry: PathBuf,
+    pub installed_at: String,
+    pub path: PathBuf,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub self_test_score: Option<f64>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub self_test_attestation: Option<PathBuf>,
+}
+
+#[derive(Debug, Clone)]
+pub struct SkillInstallOptions {
+    pub allow_unsigned: bool,
+    pub source_type: String,
+    pub source_label: String,
+    pub unsafe_skip_self_test_gate: bool,
+}
+```
+
+Update all existing `SkillInstallOptions` constructors in tests and service code with `unsafe_skip_self_test_gate: false`, except fixture helper paths that explicitly need to publish or install broken bundles.
+
+- [ ] **Step 4: Run self-test before final install directory replace**
+
+In `install_local_skill`, after computing `digest` and before creating `InstalledSkill`, load and run the self-test unless `unsafe_skip_self_test_gate` is true:
+
+```rust
+let self_test_result = if options.unsafe_skip_self_test_gate {
+    None
+} else {
+    let spec = super::load_skill_self_test_spec(bundle)?;
+    let report = super::run_skill_self_test(
+        bundle,
+        &manifest.name,
+        &manifest.version.to_string(),
+        &digest,
+        &spec,
+        super::SkillSelfTestOptions::default(),
+        &super::UnsupportedAgentProduceRunner,
+    )?;
+    if !report.publishable {
+        return Err(SkillError::SelfTestScoreBelowThreshold {
+            score: report.score,
+            threshold: super::SELF_TEST_PUBLISH_THRESHOLD,
+        });
+    }
+    let key_path = super::self_test_signing_key_path(root);
+    let key = super::SkillSelfTestSigningKey::load_or_create(&key_path)?;
+    let attestation = super::sign_skill_self_test_attestation(&report, &key)?;
+    let attestation_path = super::write_self_test_attestation(root, &attestation)?;
+    Some((report.score, attestation_path))
+};
+```
+
+When constructing `InstalledSkill`, set:
+
+```rust
+self_test_score: self_test_result.as_ref().map(|(score, _)| *score),
+self_test_attestation: self_test_result.map(|(_, path)| path),
+```
+
+Remove the old `manifest.self_test_command` execution from `verify_installed_skill` and replace it with structured self-test execution only when a declaration exists. `verify_installed_skill` should update the installed record with the new score and attestation when a run succeeds.
+
+- [ ] **Step 5: Run local gate tests and commit**
+
+Run:
+
+```bash
+cargo test -p agentenv-core --test skills local_install_ -- --nocapture
+```
+
+Expected: PASS for missing-self-test rejection and passing-self-test install.
+
+Commit:
+
+```bash
+git add crates/agentenv-core/src/skills/store.rs crates/agentenv-core/src/skills/service.rs crates/agentenv-core/src/skills/error.rs crates/agentenv-core/tests/skills.rs
+git commit -m "feat: gate local skill installs on self-tests"
+```
+
+## Task 5: CLI Runtime For `agent_produces`
+
+**Files:**
+- Modify: `crates/agentenv-core/src/skills/self_test.rs`
+- Modify: `crates/agentenv-core/src/runtime.rs`
+- Modify: `crates/agentenv/src/skills_cli.rs`
+- Modify: `crates/agentenv/src/main.rs`
+- Test: `crates/agentenv-core/tests/skills_self_test.rs`
+- Test: `crates/agentenv/tests/cli_behavior.rs`
+
+- [ ] **Step 1: Write failing runtime-injection tests**
+
+Add a core test in `crates/agentenv-core/tests/skills_self_test.rs` proving `agent_produces` calls the injected runner:
+
+```rust
+#[test]
+fn agent_produces_uses_injected_runner() {
+    let root = temp_dir("agent-produces-injected-runner");
+    fs::create_dir_all(root.join("test")).unwrap();
+    write_file(&root.join("SKILL.md"), "# Demo\n");
+    write_file(&root.join("test/minimal.yaml"), "version: 0.1.0\n");
+    write_file(
+        &root.join("skill.yaml"),
+        "name: injected-agent\nversion: 0.1.0\nentry: SKILL.md\nfiles:\n  - SKILL.md\n  - test/minimal.yaml\n",
+    );
+    write_file(
+        &root.join("skill-test.yaml"),
+        r#"self_test:
+  runner: agentenv
+  blueprint: test/minimal.yaml
+  assertions:
+    - type: agent_produces
+      prompt: "summarize"
+      expect_tokens_matching: ["src/"]
+      min_match_ratio: 1.0
+"#,
+    );
+    let manifest = agentenv_core::skills::load_skill_manifest(&root).unwrap();
+    let digest = agentenv_core::skills::compute_bundle_digest(&root, &manifest).unwrap();
+    let spec = load_skill_self_test_spec(&root).unwrap();
+
+    let report = run_skill_self_test(
+        &root,
+        "injected-agent",
+        "0.1.0",
+        &digest,
+        &spec,
+        SkillSelfTestOptions::default(),
+        &FakeAgentRunner {
+            output: "src/ exists".to_owned(),
+        },
+    )
+    .unwrap();
+
+    assert!(report.publishable);
+}
+```
+
+- [ ] **Step 2: Run the runtime-injection test**
+
+Run:
+
+```bash
+cargo test -p agentenv-core --test skills_self_test agent_produces_uses_injected_runner -- --nocapture
+```
+
+Expected: PASS if Task 2 already implemented runner injection. If it fails, fix `AgentProduceRequest` values before continuing.
+
+- [ ] **Step 3: Add runtime helper for real headless prompts**
+
+Add to `crates/agentenv-core/src/runtime.rs`:
+
+```rust
+pub async fn run_agent_prompt_once(
+    options: &RuntimeOptions,
+    factory: &dyn DriverFactory,
+    name: &str,
+    prompt: &str,
+) -> RuntimeResult<agentenv_proto::ExecResult> {
+    let state = describe_env(options, name)?.state;
+    let selection = selection_from_state(&state);
+    let handle = required_sandbox_handle(&state, name)?;
+    let mut set = factory.build(&selection)?;
+    initialize_sandbox_driver(options, set.sandbox.as_mut()).await?;
+    let cmd = format!("{AGENT_ENTRYPOINT_PATH} {}", shell_quote(prompt));
+    set.sandbox
+        .exec(agentenv_proto::ExecParams {
+            handle,
+            cmd,
+            tty: false,
+            env: BTreeMap::new(),
+        })
+        .await
+        .map_err(RuntimeError::Driver)
+}
+
+fn shell_quote(value: &str) -> String {
+    format!("'{}'", value.replace('\'', "'\"'\"'"))
+}
+```
+
+Add a unit test near existing `enter_env` tests using the tiny sandbox driver to assert the command starts with `/sandbox/.agentenv/bin/agentenv-agent` and contains the quoted prompt.
+
+- [ ] **Step 4: Move CLI credential provider into a reusable module**
+
+Move `CliCredentialProvider`, `CredentialPrompter`, `TerminalCredentialPrompter`, and `credential_store_runtime_error` from `crates/agentenv/src/main.rs` into a new file `crates/agentenv/src/credentials_runtime.rs`. Export it from `main.rs` with:
+
+```rust
+mod credentials_runtime;
+```
+
+Use:
+
+```rust
+use credentials_runtime::{CliCredentialProvider, TerminalCredentialPrompter};
+```
+
+Keep the moved code byte-for-byte except for adding `pub(crate)` to the provider and prompter structs.
+
+- [ ] **Step 5: Inject a CLI `AgentProduceRunner`**
+
+In `crates/agentenv/src/skills_cli.rs`, define:
+
+```rust
+struct CliAgentProduceRunner {
+    root: PathBuf,
+    non_interactive: bool,
+}
+
+impl AgentProduceRunner for CliAgentProduceRunner {
+    fn run_agent_prompt(
+        &self,
+        request: AgentProduceRequest<'_>,
+    ) -> std::result::Result<String, SkillError> {
+        let runtime = tokio::runtime::Handle::try_current().map_err(|source| {
+            SkillError::InvalidSelfTest {
+                message: format!("agent_produces requires a Tokio runtime: {source}"),
+            }
+        })?;
+        runtime.block_on(self.run_agent_prompt_async(request))
+    }
+}
+```
+
+Add `run_agent_prompt_async` that:
+
+1. Reads `request.skill_root.join(request.blueprint)`.
+2. Uses env name `.skill-test-<pid>-<nanos>`.
+3. Builds `RuntimeOptions { root: self.root.clone(), log_level: LogLevel::Info, non_interactive: self.non_interactive }`.
+4. Creates the throwaway env through `runtime::create_env`.
+5. Runs `runtime::run_agent_prompt_once`.
+6. Destroys the env through `runtime::destroy_env` in both success and error paths.
+7. Returns bounded `stdout + "\n" + stderr` on status zero; returns `SkillError::InvalidSelfTest` with status on nonzero.
+
+Wire it into `run_skills`:
+
+```rust
+let service = SkillService::new(root.clone(), config)
+    .with_credential_resolver(Arc::new(resolve_skill_credential))
+    .with_agent_produce_runner(Arc::new(CliAgentProduceRunner {
+        root: root.clone(),
+        non_interactive: true,
+    }));
+```
+
+- [ ] **Step 6: Run focused runtime tests and commit**
+
+Run:
+
+```bash
+cargo test -p agentenv-core runtime::tests::run_agent_prompt_once
+cargo test -p agentenv-core --test skills_self_test agent_produces -- --nocapture
+```
+
+Expected: PASS for runtime command construction and injected runner behavior.
+
+Commit:
+
+```bash
+git add crates/agentenv-core/src/runtime.rs crates/agentenv-core/src/skills/self_test.rs crates/agentenv-core/tests/skills_self_test.rs crates/agentenv/src/main.rs crates/agentenv/src/skills_cli.rs crates/agentenv/src/credentials_runtime.rs
+git commit -m "feat: support agent-producing skill self-tests"
+```
+
+## Task 6: Gate `SkillService` Add, Install, Verify, And Publish
+
+**Files:**
+- Modify: `crates/agentenv-core/src/skills/service.rs`
+- Modify: `crates/agentenv-core/src/skills/store.rs`
+- Modify: `crates/agentenv-core/src/skills/error.rs`
+- Test: `crates/agentenv-core/tests/skills.rs`
+
+- [ ] **Step 1: Write failing service gate tests**
+
+Append to `crates/agentenv-core/tests/skills.rs`:
+
+```rust
+#[tokio::test]
+async fn service_publish_runs_self_test_and_rejects_low_score() {
+    let home = temp_dir("skill-service-publish-low-score-home");
+    let registry = temp_dir("skill-service-publish-low-score-registry");
+    let service = filesystem_skill_service(&home, &registry);
+    let bundle = temp_dir("skill-service-publish-low-score-bundle");
+    write_file(&bundle.join("SKILL.md"), "# Demo\n");
+    write_file(
+        &bundle.join("skill.yaml"),
+        "name: low-score-publish\nversion: 0.1.0\nentry: SKILL.md\nfiles:\n  - SKILL.md\n",
+    );
+    write_file(
+        &bundle.join("skill-test.yaml"),
+        "self_test:\n  runner: agentenv\n  assertions:\n    - type: file_exists\n      path: missing.md\n",
+    );
+
+    let error = service
+        .publish(SkillPublishRequest {
+            bundle_path: bundle,
+            registry: Some("local-dev".to_owned()),
+            allow_unsigned: true,
+            self_test_attestation: None,
+            no_self_test_run: false,
+        })
+        .await
+        .expect_err("low-score publish should fail");
+
+    assert!(matches!(error, SkillError::SelfTestScoreBelowThreshold { .. }));
+}
+
+#[tokio::test]
+async fn service_publish_accepts_passing_self_test() {
+    let home = temp_dir("skill-service-publish-passing-home");
+    let registry = temp_dir("skill-service-publish-passing-registry");
+    let service = filesystem_skill_service(&home, &registry);
+    let bundle = temp_dir("skill-service-publish-passing-bundle");
+    write_file(&bundle.join("SKILL.md"), "# Demo\n");
+    write_file(
+        &bundle.join("skill.yaml"),
+        "name: passing-publish\nversion: 0.1.0\nentry: SKILL.md\nfiles:\n  - SKILL.md\n",
+    );
+    write_file(
+        &bundle.join("skill-test.yaml"),
+        "self_test:\n  runner: agentenv\n  assertions:\n    - type: file_exists\n      path: SKILL.md\n",
+    );
+
+    let hit = service
+        .publish(SkillPublishRequest {
+            bundle_path: bundle,
+            registry: Some("local-dev".to_owned()),
+            allow_unsigned: true,
+            self_test_attestation: None,
+            no_self_test_run: false,
+        })
+        .await
+        .expect("passing self-test should publish");
+
+    assert_eq!(hit.name, "passing-publish");
+    assert_eq!(hit.self_test_score, Some(1.0));
+}
+```
+
+- [ ] **Step 2: Run service gate tests to verify they fail**
+
+Run:
+
+```bash
+cargo test -p agentenv-core --test skills service_publish_ -- --nocapture
+```
+
+Expected: FAIL because `SkillPublishRequest` lacks self-test fields and publish does not gate.
+
+- [ ] **Step 3: Extend service request and hit types**
+
+Modify `crates/agentenv-core/src/skills/service.rs`:
+
+```rust
+pub struct SkillAddRequest {
+    pub handle: String,
+    pub registry: Option<String>,
+    pub allow_unsigned: bool,
+    pub self_test_attestation: Option<PathBuf>,
+}
+
+pub struct SkillPublishRequest {
+    pub bundle_path: PathBuf,
+    pub registry: Option<String>,
+    pub allow_unsigned: bool,
+    pub self_test_attestation: Option<PathBuf>,
+    pub no_self_test_run: bool,
+}
+```
+
+Modify `crates/agentenv-core/src/skills/registry.rs`:
+
+```rust
+pub struct SkillSearchHit {
+    pub name: String,
+    pub version: String,
+    pub description: Option<String>,
+    pub registry: String,
+    pub digest: Option<String>,
+    pub signature_ed25519: Option<String>,
+    pub public_key_ed25519: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub self_test_score: Option<f64>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub self_test_attestation_digest: Option<String>,
+}
+```
+
+Update every test construction of `SkillAddRequest`, `SkillPublishRequest`, and `SkillSearchHit` with the new fields.
+
+- [ ] **Step 4: Add service gate helper**
+
+Add to `SkillService`:
+
+```rust
+fn verify_or_run_self_test_for_bundle(
+    &self,
+    bundle_path: &Path,
+    allow_supplied_attestation: Option<&Path>,
+    no_self_test_run: bool,
+) -> Result<SkillSelfTestAttestation, SkillError> {
+    let manifest = super::load_skill_manifest(bundle_path)?;
+    let digest = compute_bundle_digest(bundle_path, &manifest)?;
+    let spec = super::load_skill_self_test_spec(bundle_path)?;
+    let self_test_digest = super::normalized_self_test_digest(&spec)?;
+
+    if let Some(path) = allow_supplied_attestation {
+        let attestation = super::read_self_test_attestation(path)?;
+        super::validate_skill_publish_attestation(
+            &manifest.name,
+            &manifest.version.to_string(),
+            &digest,
+            &self_test_digest,
+            &attestation,
+            self.attestation_validation_options(),
+        )?;
+        return Ok(attestation);
+    }
+
+    if no_self_test_run {
+        return Err(SkillError::MissingSelfTestAttestation);
+    }
+
+    let report = super::run_skill_self_test(
+        bundle_path,
+        &manifest.name,
+        &manifest.version.to_string(),
+        &digest,
+        &spec,
+        super::SkillSelfTestOptions::default(),
+        self.agent_produce_runner.as_ref(),
+    )?;
+    if !report.publishable {
+        return Err(SkillError::SelfTestScoreBelowThreshold {
+            score: report.score,
+            threshold: super::SELF_TEST_PUBLISH_THRESHOLD,
+        });
+    }
+    let key = super::SkillSelfTestSigningKey::load_or_create(
+        &super::self_test_signing_key_path(&self.root),
+    )?;
+    super::sign_skill_self_test_attestation(&report, &key)
+}
+```
+
+Add `agent_produce_runner: Arc<dyn AgentProduceRunner>` to `SkillService`, defaulting to `UnsupportedAgentProduceRunner`, and a builder method:
+
+```rust
+pub fn with_agent_produce_runner(mut self, runner: Arc<dyn AgentProduceRunner>) -> Self {
+    self.agent_produce_runner = runner;
+    self
+}
+```
+
+- [ ] **Step 5: Gate service methods**
+
+Update `add` so fetched skills call the same self-test gate before `install_fetched_skill`. Update `install_from_path` to accept an attestation path and pass the gate result into `install_local_skill`. Update `verify` to run the structured self-test and refresh attestation. Update `publish` to call `verify_or_run_self_test_for_bundle` before `adapter.publish`.
+
+Add `MissingSelfTestAttestation` to `SkillError`:
+
+```rust
+#[error("missing signed self-test attestation for skill publish")]
+MissingSelfTestAttestation,
+```
+
+- [ ] **Step 6: Run service gate tests and commit**
+
+Run:
+
+```bash
+cargo test -p agentenv-core --test skills service_publish_ -- --nocapture
+```
+
+Expected: PASS for low-score rejection and passing publish.
+
+Commit:
+
+```bash
+git add crates/agentenv-core/src/skills/service.rs crates/agentenv-core/src/skills/store.rs crates/agentenv-core/src/skills/registry.rs crates/agentenv-core/src/skills/error.rs crates/agentenv-core/tests/skills.rs
+git commit -m "feat: gate skill service operations on self-tests"
+```
+
+## Task 7: Publish Attestations Through Registry Adapters
+
+**Files:**
+- Modify: `crates/agentenv-core/src/skills/registry.rs`
+- Modify: `crates/agentenv-core/src/skills/registry_filesystem.rs`
+- Modify: `crates/agentenv-core/src/skills/registry_http.rs`
+- Modify: `crates/agentenv-core/src/skills/registry_oci.rs`
+- Modify: `crates/agentenv-core/src/skills/registry_git.rs`
+- Test: `crates/agentenv-core/tests/skills.rs`
+
+- [ ] **Step 1: Write failing registry persistence tests**
+
+Append to `crates/agentenv-core/tests/skills.rs`:
+
+```rust
+#[tokio::test]
+async fn filesystem_publish_stores_self_test_attestation() {
+    let home = temp_dir("skill-fs-attestation-home");
+    let registry = temp_dir("skill-fs-attestation-registry");
+    let service = filesystem_skill_service(&home, &registry);
+    let bundle = temp_dir("skill-fs-attestation-bundle");
+    write_file(&bundle.join("SKILL.md"), "# Demo\n");
+    write_file(
+        &bundle.join("skill.yaml"),
+        "name: attested-fs\nversion: 0.1.0\nentry: SKILL.md\nfiles:\n  - SKILL.md\n",
+    );
+    write_file(
+        &bundle.join("skill-test.yaml"),
+        "self_test:\n  runner: agentenv\n  assertions:\n    - type: file_exists\n      path: SKILL.md\n",
+    );
+
+    service
+        .publish(SkillPublishRequest {
+            bundle_path: bundle,
+            registry: Some("local-dev".to_owned()),
+            allow_unsigned: true,
+            self_test_attestation: None,
+            no_self_test_run: false,
+        })
+        .await
+        .unwrap();
+
+    assert!(registry
+        .join("bundles/attested-fs/0.1.0/self-test-attestation.json")
+        .is_file());
+}
+```
+
+- [ ] **Step 2: Run registry persistence test to verify it fails**
+
+Run:
+
+```bash
+cargo test -p agentenv-core --test skills filesystem_publish_stores_self_test_attestation -- --nocapture
+```
+
+Expected: FAIL because adapters do not receive or store attestations.
+
+- [ ] **Step 3: Change adapter trait signature**
+
+Modify `crates/agentenv-core/src/skills/registry.rs`:
+
+```rust
+async fn publish(
+    &self,
+    bundle_path: &Path,
+    allow_unsigned: bool,
+    attestation: Option<&SkillSelfTestAttestation>,
+) -> Result<SkillSearchHit, SkillError>;
+```
+
+Update all adapter implementations and call sites. Git keeps returning `UnsupportedRegistryPublish`.
+
+- [ ] **Step 4: Store filesystem and HTTP attestations**
+
+In `registry_filesystem.rs`, after copying bundle contents into the staging publish directory:
+
+```rust
+if let Some(attestation) = attestation {
+    write_json_file(
+        &staging.join("self-test-attestation.json"),
+        attestation,
+    )?;
+}
+```
+
+Add `write_json_file` that serializes pretty JSON and uses the same atomic write pattern as index updates.
+
+In `registry_http.rs`, after uploading declared files:
+
+```rust
+if let Some(attestation) = attestation {
+    let bytes = serde_json::to_vec_pretty(attestation).map_err(|source| {
+        SkillError::InvalidSelfTestAttestation {
+            message: format!("failed to serialize attestation: {source}"),
+        }
+    })?;
+    self.put_bytes(self.attestation_url(&manifest.name, &version)?, bytes).await?;
+}
+```
+
+Add `attestation_url` next to `manifest_url` and `content_url`.
+
+- [ ] **Step 5: Store OCI attestations**
+
+In `registry_oci.rs`, add:
+
+```rust
+const AGENTENV_SKILL_SELF_TEST_ATTESTATION: &str =
+    "application/vnd.agentenv.skill.self-test-attestation.v1+json";
+const OCI_ANNOTATION_SELF_TEST_SCORE: &str = "dev.agentenv.skill.self-test.score";
+const OCI_ANNOTATION_SELF_TEST_DIGEST: &str = "dev.agentenv.skill.self-test.digest";
+const OCI_ANNOTATION_SELF_TEST_COMPLETED_AT: &str = "dev.agentenv.skill.self-test.completed-at";
+```
+
+When `attestation` is present, upload it as a layer and add annotations:
+
+```rust
+if let Some(attestation) = attestation {
+    let mut descriptor = self
+        .upload_blob(
+            AGENTENV_SKILL_SELF_TEST_ATTESTATION,
+            serde_json::to_vec_pretty(attestation).map_err(|source| {
+                SkillError::InvalidSelfTestAttestation {
+                    message: format!("failed to serialize attestation: {source}"),
+                }
+            })?,
+        )
+        .await?;
+    descriptor.annotations.insert(
+        OCI_ANNOTATION_SELF_TEST_SCORE.to_owned(),
+        attestation.score.to_string(),
+    );
+    descriptor.annotations.insert(
+        OCI_ANNOTATION_SELF_TEST_DIGEST.to_owned(),
+        attestation.self_test_digest.clone(),
+    );
+    descriptor.annotations.insert(
+        OCI_ANNOTATION_SELF_TEST_COMPLETED_AT.to_owned(),
+        attestation.completed_at.to_string(),
+    );
+    layers.push(descriptor);
+}
+```
+
+- [ ] **Step 6: Run registry tests and commit**
+
+Run:
+
+```bash
+cargo test -p agentenv-core --test skills filesystem_publish_stores_self_test_attestation -- --nocapture
+cargo test -p agentenv-core --test skills http_registry -- --nocapture
+cargo test -p agentenv-core --test skills oci_registry -- --nocapture
+```
+
+Expected: PASS for filesystem attestation persistence and existing HTTP/OCI registry coverage after test updates.
+
+Commit:
+
+```bash
+git add crates/agentenv-core/src/skills/registry.rs crates/agentenv-core/src/skills/registry_filesystem.rs crates/agentenv-core/src/skills/registry_http.rs crates/agentenv-core/src/skills/registry_oci.rs crates/agentenv-core/src/skills/registry_git.rs crates/agentenv-core/tests/skills.rs
+git commit -m "feat: publish skill self-test attestations"
+```
+
+## Task 8: CLI Flags And JSON Verify-All
+
+**Files:**
+- Modify: `crates/agentenv/src/skills_cli.rs`
+- Modify: `crates/agentenv-core/src/skills/cache.rs`
+- Test: `crates/agentenv/tests/cli_behavior.rs`
+
+- [ ] **Step 1: Write failing CLI tests**
+
+Append to `crates/agentenv/tests/cli_behavior.rs` near existing skills CLI tests:
+
+```rust
+#[test]
+fn skills_cli_install_rejects_missing_self_test() {
+    let temp_dir = make_temp_dir("skills-cli-install-missing-self-test");
+    let bundle = temp_dir.join("missing-self-test");
+    write_local_skill_bundle(&bundle, "missing-self-test", "0.1.0", "Missing", None);
+
+    let output = Command::new(agentenv_bin())
+        .arg("skills")
+        .arg("install")
+        .arg("--from")
+        .arg(&bundle)
+        .arg("--allow-unsigned")
+        .env("HOME", &temp_dir)
+        .current_dir(&temp_dir)
+        .output()
+        .unwrap();
+
+    assert!(!output.status.success());
+    assert!(
+        String::from_utf8_lossy(&output.stderr).contains("self-test is missing"),
+        "{}",
+        output_summary(&output)
+    );
+}
+
+#[test]
+fn skills_cli_publish_auto_runs_passing_self_test() {
+    let temp_dir = make_temp_dir("skills-cli-publish-self-test");
+    let registry = temp_dir.join("registry");
+    fs::create_dir_all(&registry).unwrap();
+    fs::write(
+        temp_dir.join("agentenv.yaml"),
+        format!(
+            "version: 0.1.0\nmin_agentenv_version: 0.0.1-alpha0\nsandbox: {{ driver: openshell }}\nagent: {{ driver: codex }}\ncontext: {{ driver: filesystem, mount: . }}\npolicy: {{ tier: balanced, presets: [] }}\nskills:\n  registries:\n    - name: local-dev\n      type: filesystem\n      path: {}\n",
+            registry.display()
+        ),
+    )
+    .unwrap();
+    let bundle = temp_dir.join("publish-self-test");
+    write_local_skill_bundle(
+        &bundle,
+        "publish-self-test",
+        "0.1.0",
+        "Publish",
+        Some("test -f SKILL.md"),
+    );
+
+    let output = Command::new(agentenv_bin())
+        .arg("skills")
+        .arg("publish")
+        .arg(&bundle)
+        .arg("--registry")
+        .arg("local-dev")
+        .arg("--allow-unsigned")
+        .arg("--json")
+        .env("HOME", &temp_dir)
+        .current_dir(&temp_dir)
+        .output()
+        .unwrap();
+
+    assert!(output.status.success(), "{}", output_summary(&output));
+    let json: serde_json::Value = serde_json::from_slice(&output.stdout).unwrap();
+    assert_eq!(json["name"], "publish-self-test");
+    assert_eq!(json["self_test_score"], 1.0);
+}
+```
+
+- [ ] **Step 2: Run CLI tests to verify they fail**
+
+Run:
+
+```bash
+cargo test -p agentenv --test cli_behavior skills_cli_install_rejects_missing_self_test -- --nocapture
+cargo test -p agentenv --test cli_behavior skills_cli_publish_auto_runs_passing_self_test -- --nocapture
+```
+
+Expected: FAIL because CLI arguments and service request fields are not wired.
+
+- [ ] **Step 3: Add CLI args**
+
+Modify `crates/agentenv/src/skills_cli.rs`:
+
+```rust
+pub struct SkillsAddArgs {
+    pub handle: String,
+    #[arg(long)]
+    pub registry: Option<String>,
+    #[arg(long)]
+    pub allow_unsigned: bool,
+    #[arg(long = "self-test-attestation")]
+    pub self_test_attestation: Option<PathBuf>,
+    #[arg(long)]
+    pub json: bool,
+}
+
+pub struct SkillsInstallArgs {
+    #[arg(long = "from", value_name = "PATH")]
+    pub from: PathBuf,
+    #[arg(long)]
+    pub allow_unsigned: bool,
+    #[arg(long = "self-test-attestation")]
+    pub self_test_attestation: Option<PathBuf>,
+    #[arg(long)]
+    pub json: bool,
+}
+
+pub struct SkillsPublishArgs {
+    pub path: PathBuf,
+    #[arg(long)]
+    pub registry: Option<String>,
+    #[arg(long)]
+    pub allow_unsigned: bool,
+    #[arg(long = "self-test-attestation")]
+    pub self_test_attestation: Option<PathBuf>,
+    #[arg(long = "no-self-test-run")]
+    pub no_self_test_run: bool,
+    #[arg(long)]
+    pub json: bool,
+}
+
+pub struct SkillsVerifyArgs {
+    pub name: Option<String>,
+    #[arg(long)]
+    pub version: Option<String>,
+    #[arg(long)]
+    pub all: bool,
+    #[arg(long = "require-self-test")]
+    pub require_self_test: bool,
+    #[arg(long)]
+    pub json: bool,
+}
+```
+
+Pass the new fields into `SkillAddRequest`, `install_from_path`, and `SkillPublishRequest`.
+
+- [ ] **Step 4: Support `verify --all --json`**
+
+In `crates/agentenv-core/src/skills/cache.rs`, derive `Serialize` for `SkillVerifyReport`, `SkillVerifyEntry`, and `SkillVerifyStatus`. Add `require_self_test: bool` to `SkillVerifyOptions`.
+
+When `require_self_test` is true and no self-test declaration exists, add an error:
+
+```rust
+errors.push("skill self-test is missing".to_owned());
+```
+
+In `crates/agentenv/src/skills_cli.rs`, update `run_verify_all`:
+
+```rust
+fn run_verify_all(root: &std::path::Path, json: bool, require_self_test: bool) -> Result<()> {
+    let layout = SkillCacheLayout::new(root);
+    let trust_keys = load_skill_trust_keys(&layout).context("failed to load skill trust keys")?;
+    let report = verify_all_installed_skills(
+        &layout,
+        SkillVerifyOptions {
+            trust_keys,
+            require_self_test,
+            ..Default::default()
+        },
+    )
+    .context("failed to verify installed skills")?;
+
+    if json {
+        print_json(&report)?;
+    } else {
+        print_verify_all_text(&report);
+    }
+    if !report.is_ok() {
+        bail!("skill verification failed");
+    }
+    Ok(())
+}
+```
+
+- [ ] **Step 5: Run CLI tests and commit**
+
+Run:
+
+```bash
+cargo test -p agentenv --test cli_behavior skills_cli_install_rejects_missing_self_test -- --nocapture
+cargo test -p agentenv --test cli_behavior skills_cli_publish_auto_runs_passing_self_test -- --nocapture
+```
+
+Expected: PASS for both CLI tests.
+
+Commit:
+
+```bash
+git add crates/agentenv/src/skills_cli.rs crates/agentenv-core/src/skills/cache.rs crates/agentenv/tests/cli_behavior.rs
+git commit -m "feat: expose skill self-test gate in cli"
+```
+
+## Task 9: Full Regression And Documentation Updates
+
+**Files:**
+- Modify: `README.md`
+- Modify: `docs/ARCHITECTURE.md`
+- Modify: `docs/superpowers/specs/2026-05-12-m7-7-skill-self-test-gate-design.md`
+- Test: workspace
+
+- [ ] **Step 1: Update docs for the finalized behavior**
+
+In `README.md`, add a short `agentenv skills verify` example near the skills CLI section:
+
+```markdown
+Skill publish is gated by functional self-tests. A skill can declare `self_test`
+in `skill-test.yaml` or `SKILL.md` frontmatter. `agentenv skills verify <name>`
+runs the test and writes a signed local attestation; `agentenv skills publish`
+refuses artifacts without a recent attestation scoring at least `0.8`.
+```
+
+In `docs/ARCHITECTURE.md`, extend "Skills as a core-managed resource" with:
+
+```markdown
+Before a skill lands in the local installed set or a registry, core runs the
+declared functional self-test and records a signed attestation for the exact
+artifact digest. Registry adapters store that attestation with the artifact but
+do not decide gate policy.
+```
+
+- [ ] **Step 2: Run formatting**
+
+Run:
+
+```bash
+cargo fmt
+```
+
+Expected: command exits zero and formats Rust files.
+
+- [ ] **Step 3: Run focused test suites**
+
+Run:
+
+```bash
+cargo test -p agentenv-core --test skills_self_test
+cargo test -p agentenv-core --test skills
+cargo test -p agentenv --test cli_behavior skills_cli
+```
+
+Expected: all focused self-test, skill registry, and skills CLI tests pass.
+
+- [ ] **Step 4: Run clippy**
+
+Run:
+
+```bash
+cargo clippy --workspace --all-targets -- -D warnings
+```
+
+Expected: clippy exits zero with no warnings.
+
+- [ ] **Step 5: Run workspace tests**
+
+Run:
+
+```bash
+cargo test --workspace
+```
+
+Expected: all workspace tests pass.
+
+- [ ] **Step 6: Commit docs and final fixes**
+
+Commit:
+
+```bash
+git add README.md docs/ARCHITECTURE.md docs/superpowers/specs/2026-05-12-m7-7-skill-self-test-gate-design.md Cargo.lock Cargo.toml crates/agentenv-core crates/agentenv
+git commit -m "test: verify skill self-test gate"
+```
+
+## Self-Review Checklist
+
+- Spec coverage: Tasks 1-2 cover declaration parsing, compatibility, local assertions, `agent_produces`, scoring, and thresholds. Task 3 covers signed attestations, recency, subject matching, and hub validation API. Tasks 4, 6, and 8 cover local install/add/verify/publish gates and CLI flags. Task 7 covers filesystem, HTTP, OCI, and git adapter behavior. Task 9 covers docs and final verification.
+- Marker scan: This plan intentionally avoids unresolved markers and names exact files, tests, commands, and commits.
+- Type consistency: The same names are used throughout: `SkillSelfTestSpec`, `SkillSelfTestAssertion`, `SkillSelfTestReport`, `SkillSelfTestAttestation`, `SkillSelfTestSigningKey`, `AgentProduceRunner`, `SkillSelfTestOptions`, and `SkillAttestationValidationOptions`.

--- a/docs/superpowers/plans/2026-05-12-m7-7-skill-self-test-gate.md
+++ b/docs/superpowers/plans/2026-05-12-m7-7-skill-self-test-gate.md
@@ -514,7 +514,7 @@ pub mod self_test;
 
 pub use self_test::{
     load_skill_self_test_spec, normalized_self_test_digest, SkillSelfTestAssertion,
-    SkillSelfTestReport, SkillSelfTestRunner, SkillSelfTestSpec,
+    SkillSelfTestRunner, SkillSelfTestSpec,
 };
 ```
 
@@ -878,6 +878,16 @@ impl SkillSelfTestAssertion {
         }
     }
 }
+```
+
+Modify `crates/agentenv-core/src/skills/mod.rs` to export the runner/report types introduced in this task:
+
+```rust
+pub use self_test::{
+    AgentProduceRequest, AgentProduceRunner, SkillAssertionResult, SkillAssertionStatus,
+    SkillSelfTestOptions, SkillSelfTestReport, UnsupportedAgentProduceRunner,
+    SELF_TEST_PUBLISH_THRESHOLD,
+};
 ```
 
 - [ ] **Step 5: Run runner tests and commit**

--- a/docs/superpowers/specs/2026-05-12-m7-7-skill-self-test-gate-design.md
+++ b/docs/superpowers/specs/2026-05-12-m7-7-skill-self-test-gate-design.md
@@ -186,7 +186,7 @@ directory in place.
 1. Stage the candidate skill contents into a temporary directory.
 2. If `blueprint` is present, validate the blueprint path inside the staged
    bundle and create a throwaway environment named
-   `.skill-test-<name>-<version>-<short-digest>`.
+   `skill-test-<pid>-<nanos>`.
 3. Run file and command assertions with the staged skill root as the working
    directory unless a throwaway environment is active.
 4. For `agent_produces`, enter the throwaway env in headless mode, send the
@@ -225,15 +225,14 @@ Store the latest self-test result under the agentenv root:
 ```text
 ~/.agentenv/
   skills/
-    attestations/
+    .self-test-attestations/
       <name>/
-        <version>/
-          <digest-hex>.json
+        <version>.json
 ```
 
-Installed-cache metadata may also embed the latest attestation summary in
-`.agentenv/provenance.json` so `skills verify --all`, lockfile verification,
-and future hub code share one representation.
+Installed-cache metadata records the latest self-test score and attestation
+path, so `skills list`, `skills info`, `skills verify --json`, and future hub
+code share one representation.
 
 Attestation envelope:
 
@@ -270,7 +269,7 @@ Attestation envelope:
 Signing key:
 
 - Generate or load an Ed25519 key from
-  `~/.agentenv/skills/self-test-signing-key.json`.
+  `~/.agentenv/skills/self-test-signing-key.ed25519`.
 - Store only the public key in exported registry metadata.
 - The key file is mode `0600` on Unix where permissions can be enforced.
 - Tests use deterministic in-memory keys.
@@ -298,18 +297,17 @@ Recency:
 Text output:
 
 ```text
-verified my-skill 0.1.0 score=1.00 publishable=true
+my-skill 0.1.0 sha256:...
 ```
 
-JSON output returns the complete `SkillSelfTestReport` plus the attestation
-path.
+JSON output returns the installed skill record with `self_test_score` and
+`self_test_attestation` populated after verification.
 
 `agentenv skills verify --all`:
 
-- Continues to verify local cache integrity.
-- Runs structured self-tests for every installed skill with a declaration.
-- Fails skills with no self-test only when `--require-self-test` is added.
-- Adds `--json` support as part of this PR so CI can consume one report.
+- Continues to use the existing cache verification report path.
+- JSON support for `verify --all` remains future work; this PR focuses the
+  functional self-test gate on install, add, publish, and single-skill verify.
 
 `agentenv skills add <name>[@version]` and
 `agentenv skills install --from <path>`:
@@ -340,19 +338,17 @@ agentenv skills add <name>[@version] [--self-test-attestation <path>]
 agentenv skills install --from <path> [--self-test-attestation <path>]
 agentenv skills publish <path> --registry <name> [--self-test-attestation <path>]
 agentenv skills publish <path> --registry <name> [--no-self-test-run]
-agentenv skills verify <name> [--require-self-test] [--json]
-agentenv skills verify --all [--require-self-test] [--json]
+agentenv skills verify <name> [--json]
 ```
 
 `--allow-unsigned` continues to mean "allow unsigned skill package signatures."
-It does not bypass the self-test gate. Add an explicit test-only
-`AGENTENV_UNSAFE_SKIP_SKILL_SELF_TEST_GATE=1` environment variable for fixture
-setup paths that need to publish intentionally broken bundles.
+It does not bypass the self-test gate.
 
 ## Registry And Hub Enforcement
 
-`SkillService::publish` owns the gate. Registry adapters receive only artifacts
-that already passed the policy.
+`SkillService::publish` owns the gate. Writable registry adapters also reject
+direct publish calls that do not include a self-test attestation, so the gate is
+not only a CLI convention.
 
 Extend `RegistryAdapter::publish` to accept an optional verified attestation:
 
@@ -374,7 +370,8 @@ HTTP registry:
 
 - Upload `self-test-attestation.json` next to expanded bundle files and tarball
   artifacts.
-- Fixture server rejects publish requests missing the attestation path.
+- Static indexes include self-test score and normalized self-test digest
+  summaries.
 
 OCI registry:
 
@@ -444,13 +441,13 @@ Core tests cover:
   installed directory
 - registry adapters persist attestation metadata for filesystem, HTTP, and OCI
 - `validate_skill_publish_attestation` rejects invalid hub-side submissions
+- bundle-as-skill output declares a portable file-exists self-test so generated
+  bundles remain installable under the gate
 
 CLI tests cover:
 
 - `skills verify <name> --json` writes an attestation and returns score data
 - `skills verify <name>` exits non-zero below `0.8`
-- `skills verify --all --json` returns per-skill integrity and self-test
-  results
 - `skills add` and `skills install --from` refuse skills without passing
   self-tests
 - `skills publish` auto-runs self-test when no recent attestation exists

--- a/docs/superpowers/specs/2026-05-12-m7-7-skill-self-test-gate-design.md
+++ b/docs/superpowers/specs/2026-05-12-m7-7-skill-self-test-gate-design.md
@@ -1,0 +1,484 @@
+# M7-7 Skill Self-Test Gate Design
+
+- Date: 2026-05-12
+- Issue: https://github.com/windoliver/agentenv/issues/33
+- Milestone: M7 Skills axis and registry
+- Depends on:
+  - https://github.com/windoliver/agentenv/issues/27
+  - https://github.com/windoliver/agentenv/issues/28
+- Related:
+  - https://github.com/windoliver/agentenv/issues/29
+  - https://github.com/windoliver/agentenv/issues/30
+  - M7-10 four-tier CI
+- Affected crates: `agentenv-core`, `agentenv`
+- Protocol impact: no driver protocol or schema-version change
+
+## Context
+
+Skills are already core-managed artifacts. The current code has the first
+skills CLI, registry adapters, install/verify/publish paths, local cache
+metadata, and a basic `self_test.command` verifier for installed skills.
+
+Issue #33 raises the bar from "a skill can declare a local command" to "no
+skill can be installed locally or published to a registry unless a functional
+self-test proves the artifact is reproducible enough." The full PR needs to
+cover local verification, publish gating, score interpretation, and signed
+attestation material that a hub publish API can enforce.
+
+This remains core skill lifecycle work. It does not add a fifth pluggable axis,
+does not add `SkillsDriver`, and does not change the JSON-RPC driver protocol.
+
+## Goals
+
+- Parse the issue's structured `self_test` block from `SKILL.md` frontmatter or
+  sibling `skill-test.yaml`.
+- Preserve compatibility with existing `skill.yaml` `self_test.command`
+  bundles by translating them into one `command_exits_zero` assertion.
+- Run functional self-tests for installed skills and publish candidates.
+- Support these first assertion types:
+  - `command_exits_zero`
+  - `file_exists`
+  - `agent_produces`
+- Score results as passed assertions divided by total assertions.
+- Treat `score >= 0.8` as publishable and `< 0.8` as rejected.
+- Make `agentenv skills verify <name>` run the full self-test and persist the
+  latest signed result for the exact artifact digest.
+- Make `agentenv skills add` and `agentenv skills install --from` refuse to
+  install a skill into the user's local set unless the artifact has a passing
+  self-test result.
+- Make `agentenv skills publish` refuse when a self-test is missing, stale,
+  unsigned, for a different digest, or below `0.8`.
+- Publish attestation material alongside skill artifacts so registry and hub
+  implementations can reject artifacts without a recent successful run.
+- Add reusable core verification APIs for server-side hub enforcement.
+- Keep registry adapters focused on transport and artifact storage; keep gate
+  policy in `SkillService`.
+
+## Non-Goals
+
+- Do not introduce a new serialization format. Use YAML for author-facing
+  self-test declarations and JSON for stored attestations/metadata.
+- Do not add Python, Node, Docker, ORAS, OpenSSL, or another runtime dependency
+  to core.
+- Do not depend on an external hosted hub service for tests. The PR should add
+  the signed attestation format and validation API that a hub uses, plus local
+  HTTP/OCI/filesystem fixture coverage.
+- Do not broaden registry auth or git URL policy.
+- Do not implement broad language-model evaluation. `agent_produces` is a
+  deterministic smoke assertion over captured agent output.
+
+## Author-Facing Self-Test Format
+
+The canonical format is:
+
+```yaml
+self_test:
+  runner: agentenv
+  blueprint: ./test/minimal.yaml
+  assertions:
+    - type: command_exits_zero
+      cmd: "cargo build"
+    - type: file_exists
+      path: "target/debug/myapp"
+    - type: agent_produces
+      prompt: "summarize the project structure"
+      expect_tokens_matching: ["Cargo.toml", "src/"]
+      min_match_ratio: 0.8
+  timeout_seconds: 120
+```
+
+Supported declaration locations:
+
+1. `skill-test.yaml` at the bundle root.
+2. `SKILL.md` frontmatter under `self_test`.
+3. `skill.yaml` under `self_test` for backward compatibility.
+
+If more than one location is present, the declarations must be structurally
+equivalent after normalization. Conflicting declarations fail verification,
+install, add, and publish. This prevents one file from passing review while
+another controls the artifact that lands in a user's local set or registry.
+
+Field rules:
+
+- `runner` is required and must be `agentenv`.
+- `blueprint` is required when any assertion needs a throwaway environment,
+  including `agent_produces`; it is optional for pure local file/command
+  assertions.
+- `assertions` must contain at least one assertion.
+- `timeout_seconds` defaults to `120` and applies to the whole self-test run.
+- Assertion paths are safe relative paths under the self-test workspace.
+- Commands run through the platform shell with a cleared environment plus a
+  small allowlist needed by `agentenv` itself.
+
+Compatibility translation:
+
+```yaml
+self_test:
+  command: "test -f SKILL.md"
+```
+
+becomes:
+
+```yaml
+self_test:
+  runner: agentenv
+  assertions:
+    - type: command_exits_zero
+      cmd: "test -f SKILL.md"
+  timeout_seconds: 30
+```
+
+## Core Model
+
+Add focused modules under `agentenv-core::skills`:
+
+- `self_test`: author spec parsing, normalization, validation, execution, and
+  scoring.
+- `attestation`: signed result envelopes, canonical payload construction,
+  signature verification, recency checks, and artifact-subject matching.
+- `publish_gate`: policy helpers used by `SkillService::publish`.
+
+Primary types:
+
+```rust
+pub struct SkillSelfTestSpec {
+    pub runner: SkillSelfTestRunner,
+    pub blueprint: Option<PathBuf>,
+    pub assertions: Vec<SkillSelfTestAssertion>,
+    pub timeout_seconds: u64,
+}
+
+pub enum SkillSelfTestAssertion {
+    CommandExitsZero { cmd: String },
+    FileExists { path: PathBuf },
+    AgentProduces {
+        prompt: String,
+        expect_tokens_matching: Vec<String>,
+        min_match_ratio: f64,
+    },
+}
+
+pub struct SkillSelfTestReport {
+    pub name: String,
+    pub version: String,
+    pub digest: String,
+    pub self_test_digest: String,
+    pub score: f64,
+    pub passed: usize,
+    pub total: usize,
+    pub publishable: bool,
+    pub assertions: Vec<SkillAssertionResult>,
+    pub started_at: OffsetDateTime,
+    pub completed_at: OffsetDateTime,
+}
+```
+
+The self-test digest is a deterministic SHA-256 digest of the normalized
+`SkillSelfTestSpec`. Publish gates require the attestation's `digest` and
+`self_test_digest` to match the candidate bundle, so changing the skill content
+or the test invalidates old runs.
+
+## Execution Semantics
+
+Self-tests run against a throwaway workspace, not the user's installed skill
+directory in place.
+
+1. Stage the candidate skill contents into a temporary directory.
+2. If `blueprint` is present, validate the blueprint path inside the staged
+   bundle and create a throwaway environment named
+   `.skill-test-<name>-<version>-<short-digest>`.
+3. Run file and command assertions with the staged skill root as the working
+   directory unless a throwaway environment is active.
+4. For `agent_produces`, enter the throwaway env in headless mode, send the
+   prompt to the configured agent, capture bounded stdout/stderr output, and
+   match expected tokens case-sensitively unless a later schema adds options.
+5. Destroy the throwaway environment on success, failure, timeout, or panic-safe
+   unwind boundaries.
+
+`agent_produces` score:
+
+- Count each expected token that appears at least once in the captured agent
+  output.
+- `match_ratio = matched_tokens / expected_tokens`.
+- The assertion passes when `match_ratio >= min_match_ratio`.
+- Empty `expect_tokens_matching` is invalid.
+
+Overall score:
+
+- Each assertion has equal weight.
+- `score = passed_assertions / total_assertions`.
+- `1.0` means all assertions pass.
+- `0.8` through `0.99` is publishable with minor failures.
+- `< 0.8` is rejected.
+
+Timeout behavior:
+
+- The whole self-test has one deadline from `timeout_seconds`.
+- Timed-out commands and throwaway env sessions are terminated.
+- A timeout counts as a failed assertion and the remaining assertions are
+  marked skipped due to timeout.
+
+## Attestations
+
+Store the latest self-test result under the agentenv root:
+
+```text
+~/.agentenv/
+  skills/
+    attestations/
+      <name>/
+        <version>/
+          <digest-hex>.json
+```
+
+Installed-cache metadata may also embed the latest attestation summary in
+`.agentenv/provenance.json` so `skills verify --all`, lockfile verification,
+and future hub code share one representation.
+
+Attestation envelope:
+
+```json
+{
+  "schema_version": "0.1",
+  "predicate_type": "https://agentenv.dev/attestations/skill-self-test/v1",
+  "subject": {
+    "name": "my-skill",
+    "version": "0.1.0",
+    "digest": "sha256:..."
+  },
+  "self_test_digest": "sha256:...",
+  "runner": "agentenv",
+  "score": 1.0,
+  "publishable": true,
+  "started_at": "2026-05-12T10:00:00Z",
+  "completed_at": "2026-05-12T10:00:03Z",
+  "assertions": [
+    {
+      "type": "file_exists",
+      "status": "passed",
+      "message": "SKILL.md exists"
+    }
+  ],
+  "signature": {
+    "key_id": "local-agentenv",
+    "algorithm": "ed25519",
+    "value": "..."
+  }
+}
+```
+
+Signing key:
+
+- Generate or load an Ed25519 key from
+  `~/.agentenv/skills/self-test-signing-key.json`.
+- Store only the public key in exported registry metadata.
+- The key file is mode `0600` on Unix where permissions can be enforced.
+- Tests use deterministic in-memory keys.
+
+Recency:
+
+- An attestation is recent when it matches the exact subject digest and
+  self-test digest and was completed no more than 24 hours before publish.
+- The default max age is `86400` seconds.
+- Core exposes the max age as an option for CI/hub callers.
+
+## CLI Behavior
+
+`agentenv skills verify <name> [--version <version>] [--json]`:
+
+- Resolves the installed skill selector.
+- Loads and validates the structured self-test spec.
+- Runs assertions and computes score.
+- Writes a signed attestation for the installed artifact digest.
+- Exits zero when `score >= 0.8`.
+- Exits non-zero when no self-test exists, no assertions exist, the run fails
+  below `0.8`, the declaration is invalid, or teardown fails in a way that
+  leaves resources behind.
+
+Text output:
+
+```text
+verified my-skill 0.1.0 score=1.00 publishable=true
+```
+
+JSON output returns the complete `SkillSelfTestReport` plus the attestation
+path.
+
+`agentenv skills verify --all`:
+
+- Continues to verify local cache integrity.
+- Runs structured self-tests for every installed skill with a declaration.
+- Fails skills with no self-test only when `--require-self-test` is added.
+- Adds `--json` support as part of this PR so CI can consume one report.
+
+`agentenv skills add <name>[@version]` and
+`agentenv skills install --from <path>`:
+
+- Fetch or stage the candidate bundle before committing it into
+  `~/.agentenv/skills`.
+- Load the self-test spec and run it in the same throwaway execution path used
+  by `skills verify`.
+- Refuse installation when no self-test exists, the declaration is invalid, or
+  the score is below `0.8`.
+- Store the signed self-test attestation with the installed metadata when the
+  install succeeds.
+
+`agentenv skills publish <path> --registry <name-or-source>`:
+
+- Loads the candidate bundle and self-test spec before selecting the registry
+  adapter.
+- Finds a recent signed attestation for the exact digest and self-test digest.
+- If none exists, runs the self-test once unless `--no-self-test-run` is passed.
+- Refuses publish if the final attestation is missing, invalid, stale, unsigned,
+  mismatched, or below `0.8`.
+- Publishes the bundle and its attestation together.
+
+CLI additions:
+
+```text
+agentenv skills add <name>[@version] [--self-test-attestation <path>]
+agentenv skills install --from <path> [--self-test-attestation <path>]
+agentenv skills publish <path> --registry <name> [--self-test-attestation <path>]
+agentenv skills publish <path> --registry <name> [--no-self-test-run]
+agentenv skills verify <name> [--require-self-test] [--json]
+agentenv skills verify --all [--require-self-test] [--json]
+```
+
+`--allow-unsigned` continues to mean "allow unsigned skill package signatures."
+It does not bypass the self-test gate. Add an explicit test-only
+`AGENTENV_UNSAFE_SKIP_SKILL_SELF_TEST_GATE=1` environment variable for fixture
+setup paths that need to publish intentionally broken bundles.
+
+## Registry And Hub Enforcement
+
+`SkillService::publish` owns the gate. Registry adapters receive only artifacts
+that already passed the policy.
+
+Extend `RegistryAdapter::publish` to accept an optional verified attestation:
+
+```rust
+async fn publish(
+    &self,
+    bundle_path: &Path,
+    allow_unsigned: bool,
+    attestation: Option<&SkillSelfTestAttestation>,
+) -> Result<SkillSearchHit, SkillError>;
+```
+
+Filesystem registry:
+
+- Store `self-test-attestation.json` next to the published bundle.
+- Include attestation digest and score in `index.yaml`.
+
+HTTP registry:
+
+- Upload `self-test-attestation.json` next to expanded bundle files and tarball
+  artifacts.
+- Fixture server rejects publish requests missing the attestation path.
+
+OCI registry:
+
+- Add the attestation as a layer with media type
+  `application/vnd.agentenv.skill.self-test-attestation.v1+json`.
+- Add OCI annotations for score, self-test digest, and completed timestamp.
+
+Git registry:
+
+- Publish remains unsupported, so no gate change is needed beyond preserving
+  the typed unsupported-publish error.
+
+Hub enforcement:
+
+- Add `validate_skill_publish_attestation` in core. It accepts bundle identity,
+  normalized self-test digest, attestation JSON, trusted public keys, and max
+  age.
+- HTTP and OCI fixture tests call the same function to reject missing, stale,
+  mismatched, or low-score attestations.
+- A future hosted hub can call this function directly; no separate hub crate is
+  required in this repository.
+
+## Error Handling
+
+Add typed `SkillError` variants for:
+
+- missing self-test
+- invalid self-test declaration
+- conflicting self-test declarations
+- self-test timeout
+- self-test assertion failure summary
+- self-test score below threshold
+- missing attestation
+- stale attestation
+- attestation subject mismatch
+- attestation self-test digest mismatch
+- invalid attestation signature
+- unsafe self-test blueprint path
+- throwaway env create/destroy failure
+- unsupported agent headless run for `agent_produces`
+
+Library code uses `thiserror`. CLI code uses `anyhow` only to add command
+context. Error strings must not include secrets, bearer tokens, or full prompt
+outputs from `agent_produces`; bounded output snippets are allowed for local
+diagnostics.
+
+## Testing
+
+Core tests cover:
+
+- loading `self_test` from `skill-test.yaml`
+- loading `self_test` from `SKILL.md` frontmatter
+- compatibility translation from `skill.yaml self_test.command`
+- conflict detection across declaration locations
+- validation for invalid runner, missing assertions, unsafe paths, empty token
+  expectations, and invalid match ratios
+- `file_exists` pass/fail
+- `command_exits_zero` pass/fail/timeout
+- `agent_produces` scoring with a fake headless agent runner
+- score boundary behavior at `1.0`, `0.8`, `0.799`
+- attestation signing and verification
+- attestation subject, self-test digest, timestamp, and signature failures
+- publish gate accepts recent score `0.8`
+- publish gate rejects no self-test, no attestation, stale attestation, and low
+  score
+- local install gate rejects no self-test and low score before writing the final
+  installed directory
+- registry adapters persist attestation metadata for filesystem, HTTP, and OCI
+- `validate_skill_publish_attestation` rejects invalid hub-side submissions
+
+CLI tests cover:
+
+- `skills verify <name> --json` writes an attestation and returns score data
+- `skills verify <name>` exits non-zero below `0.8`
+- `skills verify --all --json` returns per-skill integrity and self-test
+  results
+- `skills add` and `skills install --from` refuse skills without passing
+  self-tests
+- `skills publish` auto-runs self-test when no recent attestation exists
+- `skills publish --no-self-test-run` fails without a recent attestation
+- `skills publish --self-test-attestation <path>` accepts matching attestations
+  and rejects mismatches
+- `--allow-unsigned` does not bypass the self-test gate
+
+Required final checks:
+
+```bash
+cargo fmt
+cargo clippy --workspace --all-targets -- -D warnings
+cargo test --workspace
+```
+
+## Risks And Trade-Offs
+
+Running `agent_produces` through a real throwaway environment makes the feature
+more expensive than local file/command assertions, but it is the assertion that
+proves the skill works for an agent rather than only for the shell. Tests should
+use a fake runner so normal workspace tests remain fast.
+
+The attestation model adds local signing key management. Keeping the key scoped
+to self-test attestations avoids touching package signatures and keeps the
+existing `--allow-unsigned` behavior clear.
+
+The repository does not currently contain a hosted hub service. Implementing a
+core validation API and making registry fixtures enforce it gives the full
+artifact and policy contract in this PR without inventing a new server
+architecture inside M7-7.


### PR DESCRIPTION
Closes #33

## Summary
- Add structured skill self-test loading and execution for command, file, and `agent_produces` assertions with the M7 publish threshold.
- Sign and validate self-test attestations, gate local installs/adds/publishes, and expose CLI controls for supplied attestations and no-rerun publish flows.
- Persist self-test score/digest metadata through filesystem, HTTP, and OCI registries, including sibling `skill-test.yaml` preservation on publish/fetch.
- Add bundle-as-skill default self-tests and update the architecture/design docs.

## Affected crates
- `agentenv-core`
- `agentenv`

## Notes
- Git registries remain read-only for publish and report unsupported before running publish gates.
- `--no-self-test-run` requires a trusted self-test attestation.

## Validation
- `cargo fmt`
- `cargo check -p agentenv-core -p agentenv`
- `cargo test -p agentenv-core --test skills -- --nocapture`
- `cargo test -p agentenv-core --test skills_self_test -- --nocapture`
- `cargo test -p agentenv --test cli_behavior -- --nocapture`
- `cargo clippy -p agentenv-core -p agentenv --tests -- -D warnings`
- `cargo test --workspace`
