### PR TITLE
[codex] Add four-tier skill CI validation

### DIFF
--- a/.github/workflows/skill-ci.yaml
+++ b/.github/workflows/skill-ci.yaml
@@ -1,0 +1,231 @@
+name: Skill CI
+
+on:
+  workflow_call:
+    inputs:
+      registry-snapshot:
+        description: Optional path to a registry snapshot JSON file.
+        required: false
+        type: string
+  pull_request:
+    # Run on all PR changes so bundled skill support files cannot bypass CI.
+
+jobs:
+  validate:
+    name: Validate skills
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    outputs:
+      count: ${{ steps.discover.outputs.count }}
+      failed: ${{ steps.run.outputs.failed || '0' }}
+
+    steps:
+      - name: Checkout skill repository
+        uses: actions/checkout@v4
+        with:
+          path: skill-workspace
+          persist-credentials: false
+
+      - name: Checkout agentenv
+        uses: actions/checkout@v4
+        with:
+          repository: ${{ job.workflow_repository }}
+          ref: ${{ job.workflow_sha }}
+          path: agentenv-src
+          persist-credentials: false
+
+      - name: Install Rust stable
+        uses: dtolnay/rust-toolchain@stable
+
+      - name: Cache Rust build
+        uses: Swatinem/rust-cache@v2
+
+      - name: Build agentenv
+        working-directory: agentenv-src
+        run: cargo build -p agentenv
+
+      - name: Discover skill candidates
+        id: discover
+        shell: bash
+        run: |
+          set -euo pipefail
+          mkdir -p skill-ci-reports
+          : > skill-ci-candidates.txt
+          while IFS= read -r manifest; do
+            dirname "$manifest" >> skill-ci-candidates.txt
+          done < <(cd skill-workspace && find . \( -path ./target -o -path ./.git \) -prune -o -name skill.yaml -type f -print | sort)
+          count="$(wc -l < skill-ci-candidates.txt | tr -d ' ')"
+          echo "count=${count}" >> "$GITHUB_OUTPUT"
+          if [[ "${count}" == "0" ]]; then
+            echo "No skill.yaml candidates found." > skill-ci-summary.md
+          fi
+
+      - name: Run skill CI
+        id: run
+        if: steps.discover.outputs.count != '0'
+        shell: bash
+        env:
+          REGISTRY_SNAPSHOT: ${{ inputs['registry-snapshot'] || '' }}
+        run: |
+          set -u
+          failed=0
+          {
+            echo "## Skill CI"
+            echo
+            echo "| Skill | Status | Findings |"
+            echo "| --- | --- | ---: |"
+          } > skill-ci-summary.md
+
+          report_index=0
+          while IFS= read -r skill_dir; do
+            report_index=$((report_index + 1))
+            rel="${skill_dir#./}"
+            safe_name="$(printf '%s' "$rel" | tr -c 'A-Za-z0-9_.-' '_' | sed 's/^_*//; s/_*$//')"
+            if [[ -z "${safe_name}" ]]; then
+              safe_name="skill"
+            fi
+            safe_name="$(printf '%04d_%s' "$report_index" "$safe_name")"
+            json_report="skill-ci-reports/${safe_name}.json"
+            sarif_report="skill-ci-reports/${safe_name}.sarif-part"
+            stderr_report="skill-ci-reports/${safe_name}.stderr"
+            args=()
+            if [[ -n "${REGISTRY_SNAPSHOT:-}" ]]; then
+              snapshot_path="${REGISTRY_SNAPSHOT}"
+              if [[ "${snapshot_path}" != /* ]]; then
+                snapshot_path="${GITHUB_WORKSPACE}/skill-workspace/${snapshot_path}"
+              fi
+              args+=(--registry-snapshot "${snapshot_path}")
+            fi
+
+            # Run agentenv skills ci from the checked-out agentenv source.
+            set +e
+            (
+              cd skill-workspace
+              "${GITHUB_WORKSPACE}/agentenv-src/target/debug/agentenv" skills ci "$skill_dir" --json --sarif "${GITHUB_WORKSPACE}/${sarif_report}" --no-fail-fast "${args[@]}"
+            ) > "$json_report" 2> "$stderr_report"
+            status_code=$?
+            set -e
+
+            if [[ -s "$sarif_report" ]]; then
+              jq --arg prefix "${rel}/" '
+                .runs[].results[]?.locations[]?.physicalLocation.artifactLocation.uri |=
+                  if . == null or startswith("/") or startswith($prefix) then . else $prefix + . end
+              ' "$sarif_report" > "${sarif_report}.tmp"
+              mv "${sarif_report}.tmp" "$sarif_report"
+            fi
+
+            if [[ "$status_code" -ne 0 ]]; then
+              failed=1
+            fi
+
+            status="error"
+            findings="0"
+            if command -v jq >/dev/null 2>&1 && [[ -s "$json_report" ]]; then
+              status="$(jq -r '.status // "error"' "$json_report" 2>/dev/null || echo "error")"
+              findings="$(jq '[.tiers[].findings[]?] | length' "$json_report" 2>/dev/null || echo "0")"
+            elif [[ "$status_code" -eq 0 ]]; then
+              status="passed"
+            fi
+            echo "| \`${rel}\` | ${status} | ${findings} |" >> skill-ci-summary.md
+          done < skill-ci-candidates.txt
+
+          echo "failed=${failed}" >> "$GITHUB_OUTPUT"
+          mapfile -t sarif_parts < <(find skill-ci-reports -name '*.sarif-part' -type f -print | sort)
+          if [[ "${#sarif_parts[@]}" -ne 0 ]]; then
+            jq -s '{
+              "version": "2.1.0",
+              "$schema": "https://json.schemastore.org/sarif-2.1.0.json",
+              "runs": [{
+                "tool": {
+                  "driver": {
+                    "name": "agentenv skill ci"
+                  }
+                },
+                "results": [.[].runs[].results[]?]
+              }]
+            }' "${sarif_parts[@]}" > skill-ci-reports/agentenv-skill-ci.sarif
+          fi
+
+      - name: Upload skill CI reports
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: skill-ci-reports
+          path: |
+            skill-ci-reports
+            skill-ci-summary.md
+          if-no-files-found: ignore
+
+      - name: Fail on skill CI errors
+        if: always() && steps.run.outputs.failed == '1'
+        run: exit 1
+
+  report:
+    name: Publish skill CI results
+    runs-on: ubuntu-latest
+    needs: validate
+    if: always()
+    permissions:
+      actions: read
+      contents: read
+      pull-requests: write
+      security-events: write
+
+    steps:
+      - name: Download skill CI reports
+        uses: actions/download-artifact@v4
+        with:
+          name: skill-ci-reports
+          path: .
+
+      - name: Upload SARIF
+        if: always() && needs.validate.outputs.count != '0' && hashFiles('skill-ci-reports/agentenv-skill-ci.sarif') != '' && (github.event_name != 'pull_request' || (github.event.pull_request.head.repo.full_name == github.repository && github.actor != 'dependabot[bot]'))
+        uses: github/codeql-action/upload-sarif@v4
+        with:
+          sarif_file: skill-ci-reports/agentenv-skill-ci.sarif
+          category: agentenv-skill-ci
+
+      - name: Comment PR summary
+        if: always() && github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name == github.repository && github.actor != 'dependabot[bot]'
+        uses: actions/github-script@v7
+        continue-on-error: true
+        with:
+          script: |
+            const fs = require('fs');
+            const marker = '<!-- agentenv-skill-ci -->';
+            const summaryPath = 'skill-ci-summary.md';
+            const summary = fs.existsSync(summaryPath)
+              ? fs.readFileSync(summaryPath, 'utf8')
+              : 'Skill CI did not produce a summary.';
+            const body = `${marker}\n${summary}`;
+            const { owner, repo } = context.repo;
+            const issue_number = context.issue.number;
+            const comments = await github.paginate(github.rest.issues.listComments, {
+              owner,
+              repo,
+              issue_number,
+              per_page: 100,
+            });
+            const existing = comments.find((comment) =>
+              comment.user.type === 'Bot' && comment.body.includes(marker)
+            );
+            if (existing) {
+              await github.rest.issues.updateComment({
+                owner,
+                repo,
+                comment_id: existing.id,
+                body,
+              });
+            } else {
+              await github.rest.issues.createComment({
+                owner,
+                repo,
+                issue_number,
+                body,
+              });
+            }
+
+      - name: Fail on skill CI errors
+        if: always() && needs.validate.outputs.failed == '1'
+        run: exit 1

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -75,6 +75,7 @@ dependencies = [
  "context-none",
  "crossterm",
  "dirs",
+ "ed25519-dalek",
  "hex",
  "http-body-util",
  "hyper 1.9.0",

--- a/README.md
+++ b/README.md
@@ -179,6 +179,38 @@ If neither OrbStack nor Docker Desktop is installed, `agentenv create` stops wit
 | `container_runtime_unavailable` | Open OrbStack or Docker Desktop and wait until Docker is running, then rerun `agentenv create`. |
 | `missing credential OPENAI_API_KEY` | Export it, run `agentenv credentials set OPENAI_API_KEY`, or omit `--non-interactive` and let create prompt. |
 
+### Skill CI
+
+Use `agentenv skills ci <path>` to validate a local skill bundle before publishing
+or reviewing it in a pull request. The path should point at a directory with
+`skill.yaml` and the declared skill files.
+
+Skill CI runs four tiers:
+
+- `static_lint` validates the manifest, bundled files, Markdown structure,
+  signatures, self-test metadata, and secret-like text.
+- `agent_review` applies a built-in review pass for unsafe or under-specified
+  skill instructions.
+- `semantic_dedup` compares the candidate against an optional registry snapshot
+  to catch duplicate or near-duplicate skills.
+- `functional_regression` runs the skill self-test and checks the score against
+  the publish threshold.
+
+For automation, emit machine-readable JSON and SARIF in one run:
+
+```bash
+agentenv skills ci .agents/skills/my-skill \
+  --json \
+  --sarif skill-ci-reports/my-skill.sarif
+```
+
+Pass `--registry-snapshot <path>` with a JSON registry snapshot to enable
+duplicate detection against already-published skills. Use `--no-fail-fast` when
+CI should report every tier even after an earlier failure.
+
+The built-in secret scan is part of `static_lint`; it does not require
+`gitleaks` or any other external scanner.
+
 ---
 
 ## How it compares

--- a/crates/agentenv-core/src/skills/ci.rs
+++ b/crates/agentenv-core/src/skills/ci.rs
@@ -34,6 +34,23 @@ const SECRET_KEYWORDS: &[&str] = &[
     "password",
     "token",
 ];
+const DESTRUCTIVE_REVIEW_PATTERNS: &[&str] =
+    &["rm -rf", "delete all", "drop database", "format disk"];
+const REVIEW_CONSENT_PHRASES: &[&str] = &[
+    "ask before",
+    "with user consent",
+    "after confirmation",
+    "explicit consent",
+];
+const REVIEW_CONSENT_NEGATIONS: &[&str] = &[
+    "do not ask",
+    "don't ask",
+    "without consent",
+    "without user consent",
+    "no consent",
+    "without confirmation",
+    "no confirmation",
+];
 
 #[derive(Clone)]
 pub struct SkillCiRequest {
@@ -183,7 +200,7 @@ pub trait SkillReviewJudge: Send + Sync {
 }
 
 pub struct SkillReviewInput<'a> {
-    pub manifest: &'a super::SkillManifest,
+    pub manifest: &'a SkillManifest,
     pub skill_md: &'a str,
 }
 
@@ -217,12 +234,7 @@ impl SkillReviewJudge for RuleBasedSkillReviewJudge {
             ));
         }
 
-        let destructive = ["rm -rf", "delete all", "drop database", "format disk"];
-        let asks_consent = text.contains("ask before")
-            || text.contains("with user consent")
-            || text.contains("after confirmation")
-            || text.contains("explicit consent");
-        if destructive.iter().any(|needle| text.contains(needle)) && !asks_consent {
+        if contains_destructive_without_consent(&text) {
             findings.push(error_finding(
                 "agentenv.skill.review.destructive-without-consent",
                 "destructive operation is described without explicit user consent",
@@ -231,7 +243,7 @@ impl SkillReviewJudge for RuleBasedSkillReviewJudge {
             ));
         }
 
-        if text.contains("api key") && !text.contains("credential") {
+        if contains_api_key_reference(&text) && !text.contains("credential") {
             findings.push(error_finding(
                 "agentenv.skill.review.credential-handling",
                 "credential handling must use agentenv credential language",
@@ -242,6 +254,58 @@ impl SkillReviewJudge for RuleBasedSkillReviewJudge {
 
         Ok(SkillReviewReport { findings })
     }
+}
+
+fn contains_destructive_without_consent(text: &str) -> bool {
+    DESTRUCTIVE_REVIEW_PATTERNS
+        .iter()
+        .any(|needle| destructive_matches_without_consent(text, needle))
+}
+
+fn destructive_matches_without_consent(text: &str, needle: &str) -> bool {
+    let mut cursor = 0;
+    while let Some(relative_start) = text[cursor..].find(needle) {
+        let start = cursor + relative_start;
+        let end = start + needle.len();
+        let segment = review_segment_around(text, start, end);
+        if !segment_has_valid_consent(segment) {
+            return true;
+        }
+        cursor = end;
+    }
+
+    false
+}
+
+fn review_segment_around(text: &str, start: usize, end: usize) -> &str {
+    let segment_start = text[..start]
+        .char_indices()
+        .rev()
+        .find_map(|(index, ch)| review_segment_boundary(ch).then_some(index + ch.len_utf8()))
+        .unwrap_or(0);
+    let segment_end = text[end..]
+        .char_indices()
+        .find_map(|(offset, ch)| review_segment_boundary(ch).then_some(end + offset))
+        .unwrap_or(text.len());
+
+    text[segment_start..segment_end].trim()
+}
+
+fn review_segment_boundary(ch: char) -> bool {
+    matches!(ch, '.' | '!' | '?' | ';' | '\n' | '\r')
+}
+
+fn segment_has_valid_consent(segment: &str) -> bool {
+    !REVIEW_CONSENT_NEGATIONS
+        .iter()
+        .any(|negation| segment.contains(negation))
+        && REVIEW_CONSENT_PHRASES
+            .iter()
+            .any(|phrase| segment.contains(phrase))
+}
+
+fn contains_api_key_reference(text: &str) -> bool {
+    text.contains("api key") || text.contains("api-key") || text.contains("apikey")
 }
 
 pub fn run_skill_ci(request: SkillCiRequest) -> Result<SkillCiReport, SkillError> {

--- a/crates/agentenv-core/src/skills/ci.rs
+++ b/crates/agentenv-core/src/skills/ci.rs
@@ -394,10 +394,8 @@ fn consent_phrase_match_governs_destructive(
             return ask_before_gap_governs_destructive(gap);
         }
         !contains_unrelated_consent_separator(gap)
-    } else if phrase_start >= destructive_end {
-        segment[destructive_end..phrase_start].len() <= REVIEW_CONSENT_MAX_DISTANCE
     } else {
-        true
+        phrase_start < destructive_end
     }
 }
 

--- a/crates/agentenv-core/src/skills/ci.rs
+++ b/crates/agentenv-core/src/skills/ci.rs
@@ -8,6 +8,7 @@ use std::{
 
 use serde::{Deserialize, Serialize};
 use serde_json::{json, Map, Value};
+use serde_yaml::Value as YamlValue;
 use time::OffsetDateTime;
 
 use super::{
@@ -479,6 +480,8 @@ pub fn run_skill_ci(request: SkillCiRequest) -> Result<SkillCiReport, SkillError
         findings,
         manifest,
         entry_content,
+        functional_regression_ready,
+        self_test_source_path,
     } = run_static_lint(&request.candidate_path)?;
     let mut static_report = tier_from_findings(SkillCiTier::StaticLint, findings);
     static_report.duration_ms = static_started.elapsed().as_millis();
@@ -498,6 +501,7 @@ pub fn run_skill_ci(request: SkillCiRequest) -> Result<SkillCiReport, SkillError
         let review = RuleBasedSkillReviewJudge.review(SkillReviewInput { manifest, skill_md })?;
         let mut review_report = tier_from_findings(SkillCiTier::AgentReview, review.findings);
         review_report.duration_ms = review_started.elapsed().as_millis();
+        let review_failed = review_report.status == SkillCiTierStatus::Failed;
         tiers.push(review_report);
 
         let dedup_started = Instant::now();
@@ -508,7 +512,31 @@ pub fn run_skill_ci(request: SkillCiRequest) -> Result<SkillCiReport, SkillError
             request.registry_snapshot.as_ref(),
         );
         dedup_report.duration_ms = dedup_started.elapsed().as_millis();
+        let dedup_failed = dedup_report.status == SkillCiTierStatus::Failed;
         tiers.push(dedup_report);
+
+        if request.fail_fast && (static_failed || review_failed || dedup_failed) {
+            tiers.push(skipped_tier(
+                SkillCiTier::FunctionalRegression,
+                "skipped because an earlier tier failed",
+            ));
+        } else if !functional_regression_ready {
+            tiers.push(skipped_tier(
+                SkillCiTier::FunctionalRegression,
+                "skipped because static_lint found an invalid signature or self-test",
+            ));
+        } else {
+            let regression_started = Instant::now();
+            let mut regression_report = run_functional_regression(
+                &request.candidate_path,
+                manifest,
+                &candidate.digest,
+                self_test_source_path.unwrap_or_else(|| PathBuf::from("skill-test.yaml")),
+                Arc::clone(&request.agent_runner),
+            )?;
+            regression_report.duration_ms = regression_started.elapsed().as_millis();
+            tiers.push(regression_report);
+        }
     }
 
     let status = if tiers
@@ -625,6 +653,49 @@ fn run_semantic_dedup(
         "probable_duplicate": probable_duplicate
     }));
     report
+}
+
+fn run_functional_regression(
+    candidate_path: &std::path::Path,
+    manifest: &super::SkillManifest,
+    digest: &str,
+    self_test_source_path: PathBuf,
+    agent_runner: Arc<dyn AgentProduceRunner>,
+) -> Result<SkillCiTierReport, SkillError> {
+    let spec = load_skill_self_test_spec(candidate_path)?;
+    let report = super::run_skill_self_test(
+        candidate_path,
+        manifest.name.clone(),
+        manifest.version.to_string(),
+        digest.to_owned(),
+        &spec,
+        super::SkillSelfTestOptions::default(),
+        agent_runner,
+    )?;
+
+    let mut findings = Vec::new();
+    if !report.publishable {
+        findings.push(error_finding(
+            "agentenv.skill.self-test.score-below-threshold",
+            &format!(
+                "self-test score {:.3} is below required threshold {:.3}",
+                report.score,
+                super::SELF_TEST_PUBLISH_THRESHOLD
+            ),
+            Some(self_test_source_path),
+            None,
+        ));
+    }
+
+    let mut tier = tier_from_findings(SkillCiTier::FunctionalRegression, findings);
+    tier.details = Some(serde_json::json!({
+        "score": report.score,
+        "passed": report.passed,
+        "total": report.total,
+        "publishable": report.publishable,
+        "self_test_digest": report.self_test_digest
+    }));
+    Ok(tier)
 }
 
 fn text_similarity(left: &str, right: &str) -> Option<f32> {
@@ -897,6 +968,8 @@ struct StaticLintResult {
     findings: Vec<SkillCiFinding>,
     manifest: Option<SkillManifest>,
     entry_content: Option<String>,
+    functional_regression_ready: bool,
+    self_test_source_path: Option<PathBuf>,
 }
 
 fn run_static_lint(candidate_path: &Path) -> Result<StaticLintResult, SkillError> {
@@ -917,6 +990,8 @@ fn run_static_lint(candidate_path: &Path) -> Result<StaticLintResult, SkillError
                 findings,
                 manifest: None,
                 entry_content: None,
+                functional_regression_ready: false,
+                self_test_source_path: None,
             });
         }
     };
@@ -933,12 +1008,14 @@ fn run_static_lint(candidate_path: &Path) -> Result<StaticLintResult, SkillError
         ));
     }
 
+    let mut functional_regression_ready = true;
     let digest = match compute_bundle_digest(candidate_path, &manifest) {
         Ok(digest) => {
             candidate.digest = digest.clone();
             Some(digest)
         }
         Err(_) => {
+            functional_regression_ready = false;
             findings.push(error_finding(
                 "agentenv.skill.signature.invalid",
                 "skill package signature could not be verified",
@@ -951,6 +1028,7 @@ fn run_static_lint(candidate_path: &Path) -> Result<StaticLintResult, SkillError
 
     if let Some(digest) = digest.as_deref() {
         if super::signature::verify_skill_package_signature(&manifest, digest, false).is_err() {
+            functional_regression_ready = false;
             findings.push(error_finding(
                 "agentenv.skill.signature.invalid",
                 "skill package signature is invalid",
@@ -960,14 +1038,19 @@ fn run_static_lint(candidate_path: &Path) -> Result<StaticLintResult, SkillError
         }
     }
 
-    if load_skill_self_test_spec(candidate_path).is_err() {
-        findings.push(error_finding(
-            "agentenv.skill.self-test.invalid",
-            "skill self-test is invalid",
-            Some(PathBuf::from("skill.yaml")),
-            None,
-        ));
-    }
+    let self_test_source_path = match load_skill_self_test_spec(candidate_path) {
+        Ok(_) => Some(self_test_source_path(candidate_path)),
+        Err(_) => {
+            functional_regression_ready = false;
+            findings.push(error_finding(
+                "agentenv.skill.self-test.invalid",
+                "skill self-test is invalid",
+                Some(PathBuf::from("skill.yaml")),
+                None,
+            ));
+            None
+        }
+    };
 
     let entry_content = match read_declared_text(candidate_path, &manifest.entry) {
         Ok(content) => {
@@ -992,7 +1075,41 @@ fn run_static_lint(candidate_path: &Path) -> Result<StaticLintResult, SkillError
         findings,
         manifest: Some(manifest),
         entry_content,
+        functional_regression_ready,
+        self_test_source_path,
     })
+}
+
+fn self_test_source_path(candidate_path: &Path) -> PathBuf {
+    if candidate_path.join("skill-test.yaml").is_file() {
+        return PathBuf::from("skill-test.yaml");
+    }
+
+    if skill_md_declares_self_test(candidate_path) {
+        return PathBuf::from("SKILL.md");
+    }
+
+    PathBuf::from("skill.yaml")
+}
+
+fn skill_md_declares_self_test(candidate_path: &Path) -> bool {
+    let Ok(content) = read_declared_text(candidate_path, Path::new("SKILL.md")) else {
+        return false;
+    };
+    let FrontmatterState::Closed(end_line) = frontmatter_end_line(&content) else {
+        return false;
+    };
+
+    let yaml = content
+        .lines()
+        .skip(1)
+        .take(end_line.saturating_sub(2))
+        .collect::<Vec<_>>()
+        .join("\n");
+    let Ok(YamlValue::Mapping(mapping)) = serde_yaml::from_str::<YamlValue>(&yaml) else {
+        return false;
+    };
+    mapping.contains_key(YamlValue::String("self_test".to_owned()))
 }
 
 fn fallback_candidate(candidate_path: &Path) -> SkillCiCandidate {

--- a/crates/agentenv-core/src/skills/ci.rs
+++ b/crates/agentenv-core/src/skills/ci.rs
@@ -15,6 +15,23 @@ use super::{
 };
 
 pub const SKILL_CI_SCHEMA_VERSION: &str = "0.1";
+const SECRET_REDACTION: &str = "[REDACTED]";
+const SECRET_PREFIX_PATTERNS: &[(&str, usize)] = &[
+    ("sk-", 20),
+    ("ghp_", 20),
+    ("github_pat_", 20),
+    ("xoxb-", 20),
+    ("xoxp-", 20),
+    ("AKIA", 16),
+];
+const SECRET_KEYWORDS: &[&str] = &[
+    "api_key",
+    "apikey",
+    "access_token",
+    "secret",
+    "password",
+    "token",
+];
 
 #[derive(Clone)]
 pub struct SkillCiRequest {
@@ -276,12 +293,13 @@ pub fn skill_ci_sarif(report: &SkillCiReport) -> Result<String, SkillError> {
 
 fn sarif_result(finding: &SkillCiFinding) -> Value {
     let mut result = Map::new();
+    let message = redact_sarif_message(&finding.message);
     result.insert("ruleId".to_owned(), json!(finding.rule_id));
     result.insert("level".to_owned(), json!(sarif_level(finding.severity)));
     result.insert(
         "message".to_owned(),
         json!({
-            "text": finding.message,
+            "text": message,
         }),
     );
 
@@ -324,6 +342,123 @@ fn sarif_level(severity: SkillCiSeverity) -> &'static str {
 
 fn sarif_uri(path: &Path) -> String {
     path.to_string_lossy().replace('\\', "/")
+}
+
+fn redact_sarif_message(message: &str) -> String {
+    redact_labeled_secrets(&redact_prefixed_secrets(message))
+}
+
+fn redact_prefixed_secrets(message: &str) -> String {
+    let mut redacted = String::with_capacity(message.len());
+    let mut cursor = 0;
+
+    while let Some((start, end)) = find_next_prefixed_secret(message, cursor) {
+        redacted.push_str(&message[cursor..start]);
+        redacted.push_str(SECRET_REDACTION);
+        cursor = end;
+    }
+
+    redacted.push_str(&message[cursor..]);
+    redacted
+}
+
+fn find_next_prefixed_secret(message: &str, start_at: usize) -> Option<(usize, usize)> {
+    SECRET_PREFIX_PATTERNS
+        .iter()
+        .filter_map(|(prefix, minimum_suffix)| {
+            find_next_prefixed_secret_for_prefix(message, start_at, prefix, *minimum_suffix)
+        })
+        .min_by_key(|(start, _)| *start)
+}
+
+fn find_next_prefixed_secret_for_prefix(
+    message: &str,
+    start_at: usize,
+    prefix: &str,
+    minimum_suffix: usize,
+) -> Option<(usize, usize)> {
+    let mut cursor = start_at;
+    loop {
+        let start = cursor + message[cursor..].find(prefix)?;
+        let suffix_start = start + prefix.len();
+        let end = secret_token_end(message, suffix_start);
+        let suffix_length = message[suffix_start..end].chars().count();
+        if suffix_length >= minimum_suffix {
+            return Some((start, end));
+        }
+        cursor = suffix_start;
+    }
+}
+
+fn redact_labeled_secrets(message: &str) -> String {
+    let mut redacted = String::with_capacity(message.len());
+    let mut cursor = 0;
+
+    while let Some((start, end)) = find_next_labeled_secret(message, cursor) {
+        redacted.push_str(&message[cursor..start]);
+        redacted.push_str(SECRET_REDACTION);
+        cursor = end;
+    }
+
+    redacted.push_str(&message[cursor..]);
+    redacted
+}
+
+fn find_next_labeled_secret(message: &str, start_at: usize) -> Option<(usize, usize)> {
+    let lower = message.to_ascii_lowercase();
+    let mut cursor = start_at;
+
+    loop {
+        let (keyword_start, keyword) = SECRET_KEYWORDS
+            .iter()
+            .filter_map(|keyword| {
+                lower[cursor..]
+                    .find(keyword)
+                    .map(|relative| (cursor + relative, *keyword))
+            })
+            .min_by_key(|(start, _)| *start)?;
+
+        let keyword_end = keyword_start + keyword.len();
+        let tail = &message[keyword_end..];
+        let Some(separator_index) = tail.find([':', '=']) else {
+            return None;
+        };
+        let value_start = keyword_end + separator_index + 1;
+        let secret_start = secret_value_start(message, value_start);
+        let secret_end = secret_token_end(message, secret_start);
+        let secret_length = message[secret_start..secret_end].chars().count();
+        if secret_length >= 20 {
+            return Some((secret_start, secret_end));
+        }
+
+        cursor = keyword_end;
+    }
+}
+
+fn secret_value_start(message: &str, start_at: usize) -> usize {
+    message[start_at..]
+        .char_indices()
+        .find_map(|(offset, ch)| {
+            if ch.is_whitespace() || matches!(ch, '"' | '\'') {
+                None
+            } else {
+                Some(start_at + offset)
+            }
+        })
+        .unwrap_or(message.len())
+}
+
+fn secret_token_end(message: &str, start_at: usize) -> usize {
+    message[start_at..]
+        .char_indices()
+        .find_map(|(offset, ch)| {
+            if is_secret_char(ch) {
+                None
+            } else {
+                Some(start_at + offset)
+            }
+        })
+        .unwrap_or(message.len())
 }
 
 struct StaticLintResult {
@@ -631,16 +766,9 @@ fn is_text_path(path: &Path) -> bool {
 }
 
 fn contains_secret_like_text(text: &str) -> bool {
-    [
-        ("sk-", 20),
-        ("ghp_", 20),
-        ("github_pat_", 20),
-        ("xoxb-", 20),
-        ("xoxp-", 20),
-        ("AKIA", 16),
-    ]
-    .iter()
-    .any(|(prefix, minimum_suffix)| has_prefixed_secret(text, prefix, *minimum_suffix))
+    SECRET_PREFIX_PATTERNS
+        .iter()
+        .any(|(prefix, minimum_suffix)| has_prefixed_secret(text, prefix, *minimum_suffix))
         || has_keyword_assigned_secret(text)
 }
 
@@ -653,16 +781,7 @@ fn has_prefixed_secret(text: &str, prefix: &str, minimum_suffix: usize) -> bool 
 
 fn has_keyword_assigned_secret(text: &str) -> bool {
     let lower = text.to_ascii_lowercase();
-    [
-        "api_key",
-        "apikey",
-        "access_token",
-        "secret",
-        "password",
-        "token",
-    ]
-    .iter()
-    .any(|keyword| {
+    SECRET_KEYWORDS.iter().any(|keyword| {
         let Some(index) = lower.find(keyword) else {
             return false;
         };

--- a/crates/agentenv-core/src/skills/ci.rs
+++ b/crates/agentenv-core/src/skills/ci.rs
@@ -59,6 +59,18 @@ const REVIEW_UNSAFE_EXECUTION_PHRASES: &[&str] = &[
     "without consent",
     "without user consent",
 ];
+const ASK_BEFORE_DESTRUCTIVE_ACTIONS: &[&str] = &[
+    "run",
+    "running",
+    "execute",
+    "executing",
+    "delete",
+    "deleting",
+    "drop",
+    "dropping",
+    "format",
+    "formatting",
+];
 const REVIEW_CONSENT_MAX_DISTANCE: usize = 40;
 
 #[derive(Clone)]
@@ -351,6 +363,7 @@ fn consent_phrase_governs_destructive(
         let phrase_end = phrase_start + phrase.len();
         if consent_phrase_match_governs_destructive(
             segment,
+            phrase,
             phrase_end,
             phrase_start,
             destructive_start,
@@ -366,6 +379,7 @@ fn consent_phrase_governs_destructive(
 
 fn consent_phrase_match_governs_destructive(
     segment: &str,
+    phrase: &str,
     phrase_end: usize,
     phrase_start: usize,
     destructive_start: usize,
@@ -373,12 +387,62 @@ fn consent_phrase_match_governs_destructive(
 ) -> bool {
     if phrase_end <= destructive_start {
         let gap = &segment[phrase_end..destructive_start];
-        gap.len() <= REVIEW_CONSENT_MAX_DISTANCE && !gap.contains(" and ")
+        if gap.len() > REVIEW_CONSENT_MAX_DISTANCE {
+            return false;
+        }
+        if phrase == "ask before" {
+            return ask_before_gap_governs_destructive(gap);
+        }
+        !contains_unrelated_consent_separator(gap)
     } else if phrase_start >= destructive_end {
         segment[destructive_end..phrase_start].len() <= REVIEW_CONSENT_MAX_DISTANCE
     } else {
         true
     }
+}
+
+fn ask_before_gap_governs_destructive(gap: &str) -> bool {
+    if contains_unrelated_consent_separator(gap) {
+        return false;
+    }
+
+    let gap = gap.trim_matches(|ch: char| {
+        ch.is_whitespace() || matches!(ch, '`' | '"' | '\'' | ':' | '-' | '>')
+    });
+    gap.is_empty()
+        || ASK_BEFORE_DESTRUCTIVE_ACTIONS
+            .iter()
+            .any(|action| starts_with_word(gap, action))
+}
+
+fn contains_unrelated_consent_separator(text: &str) -> bool {
+    text.contains(',') || contains_word(text, "then") || contains_word(text, "and")
+}
+
+fn starts_with_word(text: &str, word: &str) -> bool {
+    text.strip_prefix(word).is_some_and(|tail| {
+        tail.chars()
+            .next()
+            .is_none_or(|ch| !ch.is_ascii_alphanumeric())
+    })
+}
+
+fn contains_word(text: &str, word: &str) -> bool {
+    let mut cursor = 0;
+    while let Some(relative_start) = text[cursor..].find(word) {
+        let start = cursor + relative_start;
+        let end = start + word.len();
+        let before = text[..start].chars().next_back();
+        let after = text[end..].chars().next();
+        if before.is_none_or(|ch| !ch.is_ascii_alphanumeric())
+            && after.is_none_or(|ch| !ch.is_ascii_alphanumeric())
+        {
+            return true;
+        }
+        cursor = end;
+    }
+
+    false
 }
 
 fn previous_char_boundary(text: &str, index: usize) -> usize {

--- a/crates/agentenv-core/src/skills/ci.rs
+++ b/crates/agentenv-core/src/skills/ci.rs
@@ -165,7 +165,7 @@ pub fn run_skill_ci(request: SkillCiRequest) -> Result<SkillCiReport, SkillError
 
     let mut tiers = Vec::new();
     let static_report = run_tier(SkillCiTier::StaticLint, || {
-        run_static_lint(&request.candidate_path)
+        run_static_lint(&request.candidate_path, &manifest.entry)
             .map(|findings| tier_from_findings(SkillCiTier::StaticLint, findings))
     })?;
     let static_failed = static_report.status == SkillCiTierStatus::Failed;
@@ -251,9 +251,12 @@ fn skipped_tier(tier: SkillCiTier, message: &str) -> SkillCiTierReport {
     }
 }
 
-fn run_static_lint(candidate_path: &std::path::Path) -> Result<Vec<SkillCiFinding>, SkillError> {
+fn run_static_lint(
+    candidate_path: &std::path::Path,
+    entry_path: &std::path::Path,
+) -> Result<Vec<SkillCiFinding>, SkillError> {
     let mut findings = Vec::new();
-    let skill_md = candidate_path.join("SKILL.md");
+    let skill_md = candidate_path.join(entry_path);
     let content = std::fs::read_to_string(&skill_md).map_err(|source| SkillError::Io {
         path: skill_md.clone(),
         source,
@@ -263,7 +266,7 @@ fn run_static_lint(candidate_path: &std::path::Path) -> Result<Vec<SkillCiFindin
             rule_id: "agentenv.skill.markdown.unclosed-fence".to_owned(),
             severity: SkillCiSeverity::Error,
             message: "Markdown fenced code block is not closed".to_owned(),
-            path: Some(skill_md),
+            path: Some(entry_path.to_path_buf()),
             line: None,
         });
     }

--- a/crates/agentenv-core/src/skills/ci.rs
+++ b/crates/agentenv-core/src/skills/ci.rs
@@ -1,11 +1,17 @@
-use std::{fmt, path::PathBuf, sync::Arc, time::Instant};
+use std::{
+    fmt,
+    path::{Path, PathBuf},
+    sync::Arc,
+    time::Instant,
+};
 
 use serde::{Deserialize, Serialize};
+use serde_json::{json, Map, Value};
 use time::OffsetDateTime;
 
 use super::{
     compute_bundle_digest, load_skill_manifest, load_skill_self_test_spec, AgentProduceRunner,
-    SkillError,
+    SkillError, SkillManifest,
 };
 
 pub const SKILL_CI_SCHEMA_VERSION: &str = "0.1";
@@ -155,19 +161,13 @@ pub enum SkillCiSeverity {
 
 pub fn run_skill_ci(request: SkillCiRequest) -> Result<SkillCiReport, SkillError> {
     let started_at = OffsetDateTime::now_utc();
-    let manifest = load_skill_manifest(&request.candidate_path)?;
-    let digest = compute_bundle_digest(&request.candidate_path, &manifest)?;
-    let candidate = SkillCiCandidate {
-        name: manifest.name.clone(),
-        version: manifest.version.to_string(),
-        digest,
-    };
 
     let mut tiers = Vec::new();
-    let static_report = run_tier(SkillCiTier::StaticLint, || {
-        run_static_lint(&request.candidate_path, &manifest.entry)
-            .map(|findings| tier_from_findings(SkillCiTier::StaticLint, findings))
-    })?;
+    let static_started = Instant::now();
+    let static_lint = run_static_lint(&request.candidate_path)?;
+    let candidate = static_lint.candidate;
+    let mut static_report = tier_from_findings(SkillCiTier::StaticLint, static_lint.findings);
+    static_report.duration_ms = static_started.elapsed().as_millis();
     let static_failed = static_report.status == SkillCiTierStatus::Failed;
     tiers.push(static_report);
 
@@ -195,7 +195,6 @@ pub fn run_skill_ci(request: SkillCiRequest) -> Result<SkillCiReport, SkillError
         SkillCiStatus::Passed
     };
 
-    let _ = load_skill_self_test_spec(&request.candidate_path);
     Ok(SkillCiReport {
         schema_version: SKILL_CI_SCHEMA_VERSION,
         candidate,
@@ -204,17 +203,6 @@ pub fn run_skill_ci(request: SkillCiRequest) -> Result<SkillCiReport, SkillError
         started_at,
         completed_at: OffsetDateTime::now_utc(),
     })
-}
-
-fn run_tier<F>(tier: SkillCiTier, run: F) -> Result<SkillCiTierReport, SkillError>
-where
-    F: FnOnce() -> Result<SkillCiTierReport, SkillError>,
-{
-    let started = Instant::now();
-    let mut report = run()?;
-    report.tier = tier;
-    report.duration_ms = started.elapsed().as_millis();
-    Ok(report)
 }
 
 fn tier_from_findings(tier: SkillCiTier, findings: Vec<SkillCiFinding>) -> SkillCiTierReport {
@@ -251,34 +239,447 @@ fn skipped_tier(tier: SkillCiTier, message: &str) -> SkillCiTierReport {
     }
 }
 
-fn run_static_lint(
-    candidate_path: &std::path::Path,
-    entry_path: &std::path::Path,
-) -> Result<Vec<SkillCiFinding>, SkillError> {
-    let mut findings = Vec::new();
-    let skill_md = candidate_path.join(entry_path);
-    let content = std::fs::read_to_string(&skill_md).map_err(|source| SkillError::Io {
-        path: skill_md.clone(),
-        source,
-    })?;
-    if has_unclosed_fence(&content) {
-        findings.push(SkillCiFinding {
-            rule_id: "agentenv.skill.markdown.unclosed-fence".to_owned(),
-            severity: SkillCiSeverity::Error,
-            message: "Markdown fenced code block is not closed".to_owned(),
-            path: Some(entry_path.to_path_buf()),
-            line: None,
-        });
-    }
-    Ok(findings)
+pub fn skill_ci_sarif(report: &SkillCiReport) -> Result<String, SkillError> {
+    let results: Vec<Value> = report
+        .tiers
+        .iter()
+        .filter(|tier| {
+            matches!(
+                tier.tier,
+                SkillCiTier::StaticLint | SkillCiTier::AgentReview
+            )
+        })
+        .flat_map(|tier| tier.findings.iter())
+        .filter(|finding| finding.severity != SkillCiSeverity::Note)
+        .map(sarif_result)
+        .collect();
+
+    let sarif = json!({
+        "version": "2.1.0",
+        "$schema": "https://json.schemastore.org/sarif-2.1.0.json",
+        "runs": [
+            {
+                "tool": {
+                    "driver": {
+                        "name": "agentenv skill ci"
+                    }
+                },
+                "results": results
+            }
+        ]
+    });
+
+    serde_json::to_string_pretty(&sarif).map_err(|source| SkillError::SkillCiSarif {
+        message: source.to_string(),
+    })
 }
 
-fn has_unclosed_fence(content: &str) -> bool {
-    let mut open = false;
-    for line in content.lines() {
-        if line.trim_start().starts_with("```") {
-            open = !open;
+fn sarif_result(finding: &SkillCiFinding) -> Value {
+    let mut result = Map::new();
+    result.insert("ruleId".to_owned(), json!(finding.rule_id));
+    result.insert("level".to_owned(), json!(sarif_level(finding.severity)));
+    result.insert(
+        "message".to_owned(),
+        json!({
+            "text": finding.message,
+        }),
+    );
+
+    if let Some(path) = &finding.path {
+        let mut physical_location = Map::new();
+        physical_location.insert(
+            "artifactLocation".to_owned(),
+            json!({
+                "uri": sarif_uri(path),
+            }),
+        );
+        if let Some(line) = finding.line {
+            physical_location.insert(
+                "region".to_owned(),
+                json!({
+                    "startLine": line,
+                }),
+            );
+        }
+        result.insert(
+            "locations".to_owned(),
+            json!([
+                {
+                    "physicalLocation": Value::Object(physical_location),
+                }
+            ]),
+        );
+    }
+
+    Value::Object(result)
+}
+
+fn sarif_level(severity: SkillCiSeverity) -> &'static str {
+    match severity {
+        SkillCiSeverity::Error => "error",
+        SkillCiSeverity::Warning => "warning",
+        SkillCiSeverity::Note => "note",
+    }
+}
+
+fn sarif_uri(path: &Path) -> String {
+    path.to_string_lossy().replace('\\', "/")
+}
+
+struct StaticLintResult {
+    candidate: SkillCiCandidate,
+    findings: Vec<SkillCiFinding>,
+}
+
+fn run_static_lint(candidate_path: &Path) -> Result<StaticLintResult, SkillError> {
+    let mut findings = Vec::new();
+    let mut candidate = fallback_candidate(candidate_path);
+
+    let manifest = match load_skill_manifest(candidate_path) {
+        Ok(manifest) => manifest,
+        Err(_) => {
+            findings.push(error_finding(
+                "agentenv.skill.manifest.invalid",
+                "skill manifest is invalid",
+                Some(PathBuf::from("skill.yaml")),
+                None,
+            ));
+            return Ok(StaticLintResult {
+                candidate,
+                findings,
+            });
+        }
+    };
+
+    candidate.name = manifest.name.clone();
+    candidate.version = manifest.version.to_string();
+
+    if !manifest.version.pre.is_empty() {
+        findings.push(error_finding(
+            "agentenv.skill.version.prerelease",
+            "skill manifest version must not be a prerelease",
+            Some(PathBuf::from("skill.yaml")),
+            None,
+        ));
+    }
+
+    let digest = match compute_bundle_digest(candidate_path, &manifest) {
+        Ok(digest) => {
+            candidate.digest = digest.clone();
+            Some(digest)
+        }
+        Err(_) => {
+            findings.push(error_finding(
+                "agentenv.skill.signature.invalid",
+                "skill package signature could not be verified",
+                Some(PathBuf::from("skill.yaml")),
+                None,
+            ));
+            None
+        }
+    };
+
+    if let Some(digest) = digest.as_deref() {
+        if super::signature::verify_skill_package_signature(&manifest, digest, false).is_err() {
+            findings.push(error_finding(
+                "agentenv.skill.signature.invalid",
+                "skill package signature is invalid",
+                Some(PathBuf::from("skill.yaml")),
+                None,
+            ));
         }
     }
-    open
+
+    if load_skill_self_test_spec(candidate_path).is_err() {
+        findings.push(error_finding(
+            "agentenv.skill.self-test.invalid",
+            "skill self-test is invalid",
+            Some(PathBuf::from("skill.yaml")),
+            None,
+        ));
+    }
+
+    match read_declared_text(candidate_path, &manifest.entry) {
+        Ok(content) => lint_markdown(&manifest.entry, &content, &mut findings),
+        Err(_) => findings.push(error_finding(
+            "agentenv.skill.manifest.invalid",
+            "skill manifest entry cannot be read as text",
+            Some(manifest.entry.clone()),
+            None,
+        )),
+    }
+
+    lint_declared_text_secrets(candidate_path, &manifest, &mut findings);
+
+    Ok(StaticLintResult {
+        candidate,
+        findings,
+    })
+}
+
+fn fallback_candidate(candidate_path: &Path) -> SkillCiCandidate {
+    SkillCiCandidate {
+        name: candidate_path
+            .file_name()
+            .map(|name| name.to_string_lossy().into_owned())
+            .unwrap_or_else(|| "unknown".to_owned()),
+        version: "unknown".to_owned(),
+        digest: String::new(),
+    }
+}
+
+fn error_finding(
+    rule_id: &str,
+    message: &str,
+    path: Option<PathBuf>,
+    line: Option<usize>,
+) -> SkillCiFinding {
+    SkillCiFinding {
+        rule_id: rule_id.to_owned(),
+        severity: SkillCiSeverity::Error,
+        message: message.to_owned(),
+        path,
+        line,
+    }
+}
+
+fn read_declared_text(root: &Path, declared: &Path) -> Result<String, SkillError> {
+    let path = root.join(declared);
+    std::fs::read_to_string(&path).map_err(|source| SkillError::Io { path, source })
+}
+
+fn lint_markdown(path: &Path, content: &str, findings: &mut Vec<SkillCiFinding>) {
+    let frontmatter_end_line = match frontmatter_end_line(content) {
+        FrontmatterState::Absent => 0,
+        FrontmatterState::Closed(line) => line,
+        FrontmatterState::Unclosed => {
+            findings.push(error_finding(
+                "agentenv.skill.frontmatter.unclosed",
+                "YAML frontmatter is not closed",
+                Some(path.to_path_buf()),
+                Some(1),
+            ));
+            usize::MAX
+        }
+    };
+
+    let mut fence: Option<(String, usize)> = None;
+    let mut previous_heading_level: Option<usize> = None;
+    for (index, line) in content.lines().enumerate() {
+        let line_number = index + 1;
+        if line_number <= frontmatter_end_line {
+            continue;
+        }
+
+        let trimmed = line.trim_start();
+        if let Some((marker, _)) = fence.as_ref() {
+            if trimmed.starts_with(marker) {
+                fence = None;
+            }
+            continue;
+        }
+
+        if let Some(marker) = opening_fence_marker(trimmed) {
+            fence = Some((marker.to_owned(), line_number));
+            continue;
+        }
+
+        let Some(heading_level) = markdown_heading_level(trimmed) else {
+            continue;
+        };
+        if let Some(previous) = previous_heading_level {
+            if heading_level > previous + 1 {
+                findings.push(error_finding(
+                    "agentenv.skill.markdown.heading-jump",
+                    "Markdown heading level jumps by more than one",
+                    Some(path.to_path_buf()),
+                    Some(line_number),
+                ));
+            }
+        }
+        previous_heading_level = Some(heading_level);
+    }
+
+    if let Some((_, line)) = fence {
+        findings.push(error_finding(
+            "agentenv.skill.markdown.unclosed-fence",
+            "Markdown fenced code block is not closed",
+            Some(path.to_path_buf()),
+            Some(line),
+        ));
+    }
+}
+
+enum FrontmatterState {
+    Absent,
+    Closed(usize),
+    Unclosed,
+}
+
+fn frontmatter_end_line(content: &str) -> FrontmatterState {
+    let mut lines = content.lines();
+    if lines.next() != Some("---") {
+        return FrontmatterState::Absent;
+    }
+
+    for (index, line) in lines.enumerate() {
+        if line.trim_end() == "---" {
+            return FrontmatterState::Closed(index + 2);
+        }
+    }
+
+    FrontmatterState::Unclosed
+}
+
+fn opening_fence_marker(line: &str) -> Option<&'static str> {
+    if line.starts_with("```") {
+        Some("```")
+    } else if line.starts_with("~~~") {
+        Some("~~~")
+    } else {
+        None
+    }
+}
+
+fn markdown_heading_level(trimmed: &str) -> Option<usize> {
+    let level = trimmed
+        .chars()
+        .take_while(|character| *character == '#')
+        .count();
+    if !(1..=6).contains(&level) {
+        return None;
+    }
+
+    match trimmed[level..].chars().next() {
+        None | Some(' ' | '\t') => Some(level),
+        _ => None,
+    }
+}
+
+fn lint_declared_text_secrets(
+    candidate_path: &Path,
+    manifest: &SkillManifest,
+    findings: &mut Vec<SkillCiFinding>,
+) {
+    for declared in &manifest.declared_files {
+        if !is_text_path(declared) {
+            continue;
+        }
+        let Ok(content) = read_declared_text(candidate_path, declared) else {
+            continue;
+        };
+        lint_secrets(declared, &content, findings);
+    }
+}
+
+fn lint_secrets(path: &Path, content: &str, findings: &mut Vec<SkillCiFinding>) {
+    if let Some((index, _)) = content
+        .lines()
+        .enumerate()
+        .find(|(_, line)| contains_secret_like_text(line))
+    {
+        findings.push(error_finding(
+            "agentenv.skill.secret.detected",
+            "secret-like content detected in bundled text",
+            Some(path.to_path_buf()),
+            Some(index + 1),
+        ));
+    }
+}
+
+fn is_text_path(path: &Path) -> bool {
+    let file_name = path
+        .file_name()
+        .map(|name| name.to_string_lossy().to_ascii_lowercase())
+        .unwrap_or_default();
+    if matches!(
+        file_name.as_str(),
+        "skill.md" | "skill.yaml" | "skill.yml" | "skill-test.yaml" | "skill-test.yml"
+    ) {
+        return true;
+    }
+
+    let Some(extension) = path
+        .extension()
+        .map(|extension| extension.to_string_lossy().to_ascii_lowercase())
+    else {
+        return false;
+    };
+
+    matches!(
+        extension.as_str(),
+        "md" | "mdx"
+            | "txt"
+            | "yaml"
+            | "yml"
+            | "json"
+            | "toml"
+            | "rs"
+            | "sh"
+            | "bash"
+            | "zsh"
+            | "fish"
+            | "py"
+            | "js"
+            | "ts"
+            | "tsx"
+            | "jsx"
+            | "html"
+            | "css"
+            | "csv"
+    )
+}
+
+fn contains_secret_like_text(text: &str) -> bool {
+    [
+        ("sk-", 20),
+        ("ghp_", 20),
+        ("github_pat_", 20),
+        ("xoxb-", 20),
+        ("xoxp-", 20),
+        ("AKIA", 16),
+    ]
+    .iter()
+    .any(|(prefix, minimum_suffix)| has_prefixed_secret(text, prefix, *minimum_suffix))
+        || has_keyword_assigned_secret(text)
+}
+
+fn has_prefixed_secret(text: &str, prefix: &str, minimum_suffix: usize) -> bool {
+    text.match_indices(prefix).any(|(index, _)| {
+        let suffix = &text[index + prefix.len()..];
+        suffix.chars().take_while(|ch| is_secret_char(*ch)).count() >= minimum_suffix
+    })
+}
+
+fn has_keyword_assigned_secret(text: &str) -> bool {
+    let lower = text.to_ascii_lowercase();
+    [
+        "api_key",
+        "apikey",
+        "access_token",
+        "secret",
+        "password",
+        "token",
+    ]
+    .iter()
+    .any(|keyword| {
+        let Some(index) = lower.find(keyword) else {
+            return false;
+        };
+        let tail = &text[index + keyword.len()..];
+        let Some(separator_index) = tail.find([':', '=']) else {
+            return false;
+        };
+        let candidate = tail[separator_index + 1..]
+            .trim_start_matches(|ch: char| ch.is_whitespace() || matches!(ch, '"' | '\''));
+        candidate
+            .chars()
+            .take_while(|ch| is_secret_char(*ch))
+            .count()
+            >= 20
+    })
+}
+
+fn is_secret_char(ch: char) -> bool {
+    ch.is_ascii_alphanumeric() || matches!(ch, '-' | '_' | '.')
 }

--- a/crates/agentenv-core/src/skills/ci.rs
+++ b/crates/agentenv-core/src/skills/ci.rs
@@ -178,26 +178,102 @@ pub enum SkillCiSeverity {
     Note,
 }
 
+pub trait SkillReviewJudge: Send + Sync {
+    fn review(&self, input: SkillReviewInput<'_>) -> Result<SkillReviewReport, SkillError>;
+}
+
+pub struct SkillReviewInput<'a> {
+    pub manifest: &'a super::SkillManifest,
+    pub skill_md: &'a str,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+pub struct SkillReviewReport {
+    pub findings: Vec<SkillCiFinding>,
+}
+
+#[derive(Debug, Default, Clone, Copy)]
+pub struct RuleBasedSkillReviewJudge;
+
+impl SkillReviewJudge for RuleBasedSkillReviewJudge {
+    fn review(&self, input: SkillReviewInput<'_>) -> Result<SkillReviewReport, SkillError> {
+        let mut findings = Vec::new();
+        let text = input.skill_md.to_ascii_lowercase();
+
+        if input
+            .manifest
+            .description
+            .as_deref()
+            .unwrap_or("")
+            .trim()
+            .len()
+            < 8
+        {
+            findings.push(warning_finding(
+                "agentenv.skill.review.description-vague",
+                "description is too short to describe behavior",
+                Some(PathBuf::from("skill.yaml")),
+                None,
+            ));
+        }
+
+        let destructive = ["rm -rf", "delete all", "drop database", "format disk"];
+        let asks_consent = text.contains("ask before")
+            || text.contains("with user consent")
+            || text.contains("after confirmation")
+            || text.contains("explicit consent");
+        if destructive.iter().any(|needle| text.contains(needle)) && !asks_consent {
+            findings.push(error_finding(
+                "agentenv.skill.review.destructive-without-consent",
+                "destructive operation is described without explicit user consent",
+                Some(input.manifest.entry.clone()),
+                None,
+            ));
+        }
+
+        if text.contains("api key") && !text.contains("credential") {
+            findings.push(error_finding(
+                "agentenv.skill.review.credential-handling",
+                "credential handling must use agentenv credential language",
+                Some(input.manifest.entry.clone()),
+                None,
+            ));
+        }
+
+        Ok(SkillReviewReport { findings })
+    }
+}
+
 pub fn run_skill_ci(request: SkillCiRequest) -> Result<SkillCiReport, SkillError> {
     let started_at = OffsetDateTime::now_utc();
 
     let mut tiers = Vec::new();
     let static_started = Instant::now();
-    let static_lint = run_static_lint(&request.candidate_path)?;
-    let candidate = static_lint.candidate;
-    let mut static_report = tier_from_findings(SkillCiTier::StaticLint, static_lint.findings);
+    let StaticLintResult {
+        candidate,
+        findings,
+        manifest,
+        entry_content,
+    } = run_static_lint(&request.candidate_path)?;
+    let mut static_report = tier_from_findings(SkillCiTier::StaticLint, findings);
     static_report.duration_ms = static_started.elapsed().as_millis();
     let static_failed = static_report.status == SkillCiTierStatus::Failed;
     tiers.push(static_report);
 
-    for tier in [
-        SkillCiTier::AgentReview,
-        SkillCiTier::SemanticDedup,
-        SkillCiTier::FunctionalRegression,
-    ] {
-        if request.fail_fast && static_failed {
+    if request.fail_fast && static_failed {
+        for tier in [
+            SkillCiTier::AgentReview,
+            SkillCiTier::SemanticDedup,
+            SkillCiTier::FunctionalRegression,
+        ] {
             tiers.push(skipped_tier(tier, "skipped because static_lint failed"));
         }
+    } else if let (Some(manifest), Some(skill_md)) = (manifest.as_ref(), entry_content.as_deref()) {
+        let review_started = Instant::now();
+        let review = RuleBasedSkillReviewJudge.review(SkillReviewInput { manifest, skill_md })?;
+        let mut review_report = tier_from_findings(SkillCiTier::AgentReview, review.findings);
+        review_report.duration_ms = review_started.elapsed().as_millis();
+        tiers.push(review_report);
     }
 
     let status = if tiers
@@ -464,6 +540,8 @@ fn secret_token_end(message: &str, start_at: usize) -> usize {
 struct StaticLintResult {
     candidate: SkillCiCandidate,
     findings: Vec<SkillCiFinding>,
+    manifest: Option<SkillManifest>,
+    entry_content: Option<String>,
 }
 
 fn run_static_lint(candidate_path: &Path) -> Result<StaticLintResult, SkillError> {
@@ -482,6 +560,8 @@ fn run_static_lint(candidate_path: &Path) -> Result<StaticLintResult, SkillError
             return Ok(StaticLintResult {
                 candidate,
                 findings,
+                manifest: None,
+                entry_content: None,
             });
         }
     };
@@ -534,21 +614,29 @@ fn run_static_lint(candidate_path: &Path) -> Result<StaticLintResult, SkillError
         ));
     }
 
-    match read_declared_text(candidate_path, &manifest.entry) {
-        Ok(content) => lint_markdown(&manifest.entry, &content, &mut findings),
-        Err(_) => findings.push(error_finding(
-            "agentenv.skill.manifest.invalid",
-            "skill manifest entry cannot be read as text",
-            Some(manifest.entry.clone()),
-            None,
-        )),
-    }
+    let entry_content = match read_declared_text(candidate_path, &manifest.entry) {
+        Ok(content) => {
+            lint_markdown(&manifest.entry, &content, &mut findings);
+            Some(content)
+        }
+        Err(_) => {
+            findings.push(error_finding(
+                "agentenv.skill.manifest.invalid",
+                "skill manifest entry cannot be read as text",
+                Some(manifest.entry.clone()),
+                None,
+            ));
+            None
+        }
+    };
 
     lint_declared_text_secrets(candidate_path, &manifest, &mut findings);
 
     Ok(StaticLintResult {
         candidate,
         findings,
+        manifest: Some(manifest),
+        entry_content,
     })
 }
 
@@ -573,6 +661,21 @@ fn error_finding(
         rule_id: rule_id.to_owned(),
         severity: SkillCiSeverity::Error,
         message: message.to_owned(),
+        path,
+        line,
+    }
+}
+
+fn warning_finding(
+    rule_id: impl Into<String>,
+    message: impl Into<String>,
+    path: Option<PathBuf>,
+    line: Option<usize>,
+) -> SkillCiFinding {
+    SkillCiFinding {
+        rule_id: rule_id.into(),
+        severity: SkillCiSeverity::Warning,
+        message: message.into(),
         path,
         line,
     }

--- a/crates/agentenv-core/src/skills/ci.rs
+++ b/crates/agentenv-core/src/skills/ci.rs
@@ -1,4 +1,5 @@
 use std::{
+    collections::BTreeSet,
     fmt,
     path::{Path, PathBuf},
     sync::Arc,
@@ -10,8 +11,9 @@ use serde_json::{json, Map, Value};
 use time::OffsetDateTime;
 
 use super::{
-    compute_bundle_digest, load_skill_manifest, load_skill_self_test_spec, AgentProduceRunner,
-    SkillError, SkillManifest,
+    compute_bundle_digest, load_skill_manifest, load_skill_self_test_spec,
+    manifest::{normalize_bundle_path, validated_bundle_file},
+    AgentProduceRunner, SkillError, SkillManifest,
 };
 
 pub const SKILL_CI_SCHEMA_VERSION: &str = "0.1";
@@ -420,9 +422,7 @@ fn find_next_labeled_secret(message: &str, start_at: usize) -> Option<(usize, us
 
         let keyword_end = keyword_start + keyword.len();
         let tail = &message[keyword_end..];
-        let Some(separator_index) = tail.find([':', '=']) else {
-            return None;
-        };
+        let separator_index = tail.find([':', '='])?;
         let value_start = keyword_end + separator_index + 1;
         let secret_start = secret_value_start(message, value_start);
         let secret_end = secret_token_end(message, secret_start);
@@ -579,7 +579,8 @@ fn error_finding(
 }
 
 fn read_declared_text(root: &Path, declared: &Path) -> Result<String, SkillError> {
-    let path = root.join(declared);
+    let declared = normalize_bundle_path(declared)?;
+    let path = validated_bundle_file(root, &declared)?;
     std::fs::read_to_string(&path).map_err(|source| SkillError::Io { path, source })
 }
 
@@ -696,15 +697,27 @@ fn lint_declared_text_secrets(
     manifest: &SkillManifest,
     findings: &mut Vec<SkillCiFinding>,
 ) {
-    for declared in &manifest.declared_files {
-        if !is_text_path(declared) {
-            continue;
-        }
-        let Ok(content) = read_declared_text(candidate_path, declared) else {
+    for declared in secret_scan_paths(manifest) {
+        let Ok(content) = read_declared_text(candidate_path, &declared) else {
             continue;
         };
-        lint_secrets(declared, &content, findings);
+        lint_secrets(&declared, &content, findings);
     }
+}
+
+fn secret_scan_paths(manifest: &SkillManifest) -> BTreeSet<PathBuf> {
+    let mut paths = BTreeSet::new();
+    paths.insert(PathBuf::from("skill.yaml"));
+    paths.insert(PathBuf::from("skill-test.yaml"));
+    paths.insert(manifest.entry.clone());
+
+    for declared in &manifest.declared_files {
+        if is_text_path(declared) {
+            paths.insert(declared.clone());
+        }
+    }
+
+    paths
 }
 
 fn lint_secrets(path: &Path, content: &str, findings: &mut Vec<SkillCiFinding>) {

--- a/crates/agentenv-core/src/skills/ci.rs
+++ b/crates/agentenv-core/src/skills/ci.rs
@@ -1,0 +1,281 @@
+use std::{fmt, path::PathBuf, sync::Arc, time::Instant};
+
+use serde::{Deserialize, Serialize};
+use time::OffsetDateTime;
+
+use super::{
+    compute_bundle_digest, load_skill_manifest, load_skill_self_test_spec, AgentProduceRunner,
+    SkillError,
+};
+
+pub const SKILL_CI_SCHEMA_VERSION: &str = "0.1";
+
+#[derive(Clone)]
+pub struct SkillCiRequest {
+    pub candidate_path: PathBuf,
+    pub registry_snapshot: Option<SkillCiRegistrySnapshot>,
+    pub fail_fast: bool,
+    pub agent_runner: Arc<dyn AgentProduceRunner>,
+}
+
+impl fmt::Debug for SkillCiRequest {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        formatter
+            .debug_struct("SkillCiRequest")
+            .field("candidate_path", &self.candidate_path)
+            .field("registry_snapshot", &self.registry_snapshot)
+            .field("fail_fast", &self.fail_fast)
+            .field("agent_runner", &"<agent runner>")
+            .finish()
+    }
+}
+
+#[derive(Debug, Clone, Default, Serialize, Deserialize, PartialEq)]
+pub struct SkillCiRegistrySnapshot {
+    #[serde(default)]
+    pub skills: Vec<SkillCiRegistrySkill>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+pub struct SkillCiRegistrySkill {
+    pub name: String,
+    pub version: String,
+    #[serde(default)]
+    pub description: String,
+    #[serde(default)]
+    pub procedure_text: String,
+    #[serde(default)]
+    pub fingerprint: Option<String>,
+}
+
+#[derive(Debug, Clone, Serialize, PartialEq)]
+pub struct SkillCiReport {
+    pub schema_version: &'static str,
+    pub candidate: SkillCiCandidate,
+    pub status: SkillCiStatus,
+    pub tiers: Vec<SkillCiTierReport>,
+    pub started_at: OffsetDateTime,
+    pub completed_at: OffsetDateTime,
+}
+
+#[derive(Debug, Deserialize)]
+struct SkillCiReportWire {
+    schema_version: String,
+    candidate: SkillCiCandidate,
+    status: SkillCiStatus,
+    tiers: Vec<SkillCiTierReport>,
+    started_at: OffsetDateTime,
+    completed_at: OffsetDateTime,
+}
+
+impl<'de> Deserialize<'de> for SkillCiReport {
+    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+    where
+        D: serde::Deserializer<'de>,
+    {
+        let wire = SkillCiReportWire::deserialize(deserializer)?;
+        if wire.schema_version != SKILL_CI_SCHEMA_VERSION {
+            return Err(serde::de::Error::custom(format!(
+                "unsupported skill CI schema version `{}`",
+                wire.schema_version
+            )));
+        }
+
+        Ok(Self {
+            schema_version: SKILL_CI_SCHEMA_VERSION,
+            candidate: wire.candidate,
+            status: wire.status,
+            tiers: wire.tiers,
+            started_at: wire.started_at,
+            completed_at: wire.completed_at,
+        })
+    }
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+pub struct SkillCiCandidate {
+    pub name: String,
+    pub version: String,
+    pub digest: String,
+}
+
+#[derive(Debug, Clone, Copy, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(rename_all = "snake_case")]
+pub enum SkillCiStatus {
+    Passed,
+    Failed,
+    Skipped,
+}
+
+#[derive(Debug, Clone, Copy, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(rename_all = "snake_case")]
+pub enum SkillCiTier {
+    StaticLint,
+    AgentReview,
+    SemanticDedup,
+    FunctionalRegression,
+}
+
+#[derive(Debug, Clone, Copy, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(rename_all = "snake_case")]
+pub enum SkillCiTierStatus {
+    Passed,
+    Failed,
+    Skipped,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+pub struct SkillCiTierReport {
+    pub tier: SkillCiTier,
+    pub status: SkillCiTierStatus,
+    pub duration_ms: u128,
+    pub findings: Vec<SkillCiFinding>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub details: Option<serde_json::Value>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub struct SkillCiFinding {
+    pub rule_id: String,
+    pub severity: SkillCiSeverity,
+    pub message: String,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub path: Option<PathBuf>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub line: Option<usize>,
+}
+
+#[derive(Debug, Clone, Copy, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(rename_all = "snake_case")]
+pub enum SkillCiSeverity {
+    Error,
+    Warning,
+    Note,
+}
+
+pub fn run_skill_ci(request: SkillCiRequest) -> Result<SkillCiReport, SkillError> {
+    let started_at = OffsetDateTime::now_utc();
+    let manifest = load_skill_manifest(&request.candidate_path)?;
+    let digest = compute_bundle_digest(&request.candidate_path, &manifest)?;
+    let candidate = SkillCiCandidate {
+        name: manifest.name.clone(),
+        version: manifest.version.to_string(),
+        digest,
+    };
+
+    let mut tiers = Vec::new();
+    let static_report = run_tier(SkillCiTier::StaticLint, || {
+        run_static_lint(&request.candidate_path)
+            .map(|findings| tier_from_findings(SkillCiTier::StaticLint, findings))
+    })?;
+    let static_failed = static_report.status == SkillCiTierStatus::Failed;
+    tiers.push(static_report);
+
+    for tier in [
+        SkillCiTier::AgentReview,
+        SkillCiTier::SemanticDedup,
+        SkillCiTier::FunctionalRegression,
+    ] {
+        if request.fail_fast && static_failed {
+            tiers.push(skipped_tier(tier, "skipped because static_lint failed"));
+        }
+    }
+
+    let status = if tiers
+        .iter()
+        .any(|tier| tier.status == SkillCiTierStatus::Failed)
+    {
+        SkillCiStatus::Failed
+    } else if tiers
+        .iter()
+        .any(|tier| tier.status == SkillCiTierStatus::Skipped)
+    {
+        SkillCiStatus::Skipped
+    } else {
+        SkillCiStatus::Passed
+    };
+
+    let _ = load_skill_self_test_spec(&request.candidate_path);
+    Ok(SkillCiReport {
+        schema_version: SKILL_CI_SCHEMA_VERSION,
+        candidate,
+        status,
+        tiers,
+        started_at,
+        completed_at: OffsetDateTime::now_utc(),
+    })
+}
+
+fn run_tier<F>(tier: SkillCiTier, run: F) -> Result<SkillCiTierReport, SkillError>
+where
+    F: FnOnce() -> Result<SkillCiTierReport, SkillError>,
+{
+    let started = Instant::now();
+    let mut report = run()?;
+    report.tier = tier;
+    report.duration_ms = started.elapsed().as_millis();
+    Ok(report)
+}
+
+fn tier_from_findings(tier: SkillCiTier, findings: Vec<SkillCiFinding>) -> SkillCiTierReport {
+    let status = if findings
+        .iter()
+        .any(|finding| finding.severity == SkillCiSeverity::Error)
+    {
+        SkillCiTierStatus::Failed
+    } else {
+        SkillCiTierStatus::Passed
+    };
+    SkillCiTierReport {
+        tier,
+        status,
+        duration_ms: 0,
+        findings,
+        details: None,
+    }
+}
+
+fn skipped_tier(tier: SkillCiTier, message: &str) -> SkillCiTierReport {
+    SkillCiTierReport {
+        tier,
+        status: SkillCiTierStatus::Skipped,
+        duration_ms: 0,
+        findings: vec![SkillCiFinding {
+            rule_id: "agentenv.skill.ci.skipped".to_owned(),
+            severity: SkillCiSeverity::Note,
+            message: message.to_owned(),
+            path: None,
+            line: None,
+        }],
+        details: None,
+    }
+}
+
+fn run_static_lint(candidate_path: &std::path::Path) -> Result<Vec<SkillCiFinding>, SkillError> {
+    let mut findings = Vec::new();
+    let skill_md = candidate_path.join("SKILL.md");
+    let content = std::fs::read_to_string(&skill_md).map_err(|source| SkillError::Io {
+        path: skill_md.clone(),
+        source,
+    })?;
+    if has_unclosed_fence(&content) {
+        findings.push(SkillCiFinding {
+            rule_id: "agentenv.skill.markdown.unclosed-fence".to_owned(),
+            severity: SkillCiSeverity::Error,
+            message: "Markdown fenced code block is not closed".to_owned(),
+            path: Some(skill_md),
+            line: None,
+        });
+    }
+    Ok(findings)
+}
+
+fn has_unclosed_fence(content: &str) -> bool {
+    let mut open = false;
+    for line in content.lines() {
+        if line.trim_start().starts_with("```") {
+            open = !open;
+        }
+    }
+    open
+}

--- a/crates/agentenv-core/src/skills/ci.rs
+++ b/crates/agentenv-core/src/skills/ci.rs
@@ -541,39 +541,51 @@ fn run_semantic_dedup(
     skill_md: &str,
     snapshot: Option<&SkillCiRegistrySnapshot>,
 ) -> SkillCiTierReport {
-    let mut best: Option<(SkillCiRegistrySkill, f32, String)> = None;
+    let mut best: Option<(SkillCiRegistrySkill, f32, String, bool)> = None;
     let mut novelty = 0.9_f64;
 
     if let Some(snapshot) = snapshot {
         for existing in &snapshot.skills {
             let exact_fingerprint = existing.fingerprint.as_deref() == Some(digest);
-            let similarity = if exact_fingerprint {
-                1.0
-            } else {
-                jaccard(skill_md, &existing.procedure_text).max(jaccard(
+            let semantic_similarity = [
+                text_similarity(skill_md, &existing.procedure_text),
+                text_similarity(
                     manifest.description.as_deref().unwrap_or(""),
                     &existing.description,
-                ))
+                ),
+            ]
+            .into_iter()
+            .flatten()
+            .fold(None, |best: Option<f32>, similarity| {
+                Some(best.map_or(similarity, |best| best.max(similarity)))
+            });
+
+            let (similarity, reason) = if exact_fingerprint {
+                (1.0, "exact fingerprint match".to_owned())
+            } else if let Some(similarity) = semantic_similarity {
+                (similarity, "local semantic similarity".to_owned())
+            } else {
+                continue;
             };
 
             if best
                 .as_ref()
-                .is_none_or(|(_, current, _)| similarity > *current)
+                .is_none_or(|(_, current_similarity, _, current_exact_fingerprint)| {
+                    similarity > *current_similarity
+                        || (similarity == *current_similarity
+                            && exact_fingerprint
+                            && !*current_exact_fingerprint)
+                })
             {
-                let reason = if exact_fingerprint {
-                    "exact fingerprint match".to_owned()
-                } else {
-                    "local semantic similarity".to_owned()
-                };
-                best = Some((existing.clone(), similarity, reason));
+                best = Some((existing.clone(), similarity, reason, exact_fingerprint));
             }
         }
     }
 
     let probable_duplicate = best
         .as_ref()
-        .is_some_and(|(_, similarity, _)| *similarity > 0.92);
-    if let Some((_, similarity, _)) = &best {
+        .is_some_and(|(_, similarity, _, _)| *similarity > 0.92);
+    if let Some((_, similarity, _, _)) = &best {
         novelty = if *similarity > 0.92 {
             0.0
         } else if *similarity >= 0.85 {
@@ -597,7 +609,7 @@ fn run_semantic_dedup(
 
     let nearest_neighbors: Vec<Value> = best
         .into_iter()
-        .map(|(skill, similarity, reason)| {
+        .map(|(skill, similarity, reason, _)| {
             json!({
                 "name": skill.name,
                 "version": skill.version,
@@ -615,15 +627,19 @@ fn run_semantic_dedup(
     report
 }
 
-fn jaccard(left: &str, right: &str) -> f32 {
+fn text_similarity(left: &str, right: &str) -> Option<f32> {
     let left = tokens(left);
     let right = tokens(right);
-    if left.is_empty() && right.is_empty() {
-        return 1.0;
+    if left.is_empty() || right.is_empty() {
+        return None;
     }
 
-    let intersection = left.intersection(&right).count() as f32;
-    let union = left.union(&right).count() as f32;
+    Some(jaccard_tokens(&left, &right))
+}
+
+fn jaccard_tokens(left: &BTreeSet<String>, right: &BTreeSet<String>) -> f32 {
+    let intersection = left.intersection(right).count() as f32;
+    let union = left.union(right).count() as f32;
     if union == 0.0 {
         0.0
     } else {

--- a/crates/agentenv-core/src/skills/ci.rs
+++ b/crates/agentenv-core/src/skills/ci.rs
@@ -499,6 +499,16 @@ pub fn run_skill_ci(request: SkillCiRequest) -> Result<SkillCiReport, SkillError
         let mut review_report = tier_from_findings(SkillCiTier::AgentReview, review.findings);
         review_report.duration_ms = review_started.elapsed().as_millis();
         tiers.push(review_report);
+
+        let dedup_started = Instant::now();
+        let mut dedup_report = run_semantic_dedup(
+            manifest,
+            &candidate.digest,
+            skill_md,
+            request.registry_snapshot.as_ref(),
+        );
+        dedup_report.duration_ms = dedup_started.elapsed().as_millis();
+        tiers.push(dedup_report);
     }
 
     let status = if tiers
@@ -523,6 +533,110 @@ pub fn run_skill_ci(request: SkillCiRequest) -> Result<SkillCiReport, SkillError
         started_at,
         completed_at: OffsetDateTime::now_utc(),
     })
+}
+
+fn run_semantic_dedup(
+    manifest: &super::SkillManifest,
+    digest: &str,
+    skill_md: &str,
+    snapshot: Option<&SkillCiRegistrySnapshot>,
+) -> SkillCiTierReport {
+    let mut best: Option<(SkillCiRegistrySkill, f32, String)> = None;
+    let mut novelty = 0.9_f64;
+
+    if let Some(snapshot) = snapshot {
+        for existing in &snapshot.skills {
+            let exact_fingerprint = existing.fingerprint.as_deref() == Some(digest);
+            let similarity = if exact_fingerprint {
+                1.0
+            } else {
+                jaccard(skill_md, &existing.procedure_text).max(jaccard(
+                    manifest.description.as_deref().unwrap_or(""),
+                    &existing.description,
+                ))
+            };
+
+            if best
+                .as_ref()
+                .is_none_or(|(_, current, _)| similarity > *current)
+            {
+                let reason = if exact_fingerprint {
+                    "exact fingerprint match".to_owned()
+                } else {
+                    "local semantic similarity".to_owned()
+                };
+                best = Some((existing.clone(), similarity, reason));
+            }
+        }
+    }
+
+    let probable_duplicate = best
+        .as_ref()
+        .is_some_and(|(_, similarity, _)| *similarity > 0.92);
+    if let Some((_, similarity, _)) = &best {
+        novelty = if *similarity > 0.92 {
+            0.0
+        } else if *similarity >= 0.85 {
+            0.3
+        } else if *similarity >= 0.45 {
+            0.6
+        } else {
+            0.9
+        };
+    }
+
+    let mut findings = Vec::new();
+    if probable_duplicate {
+        findings.push(error_finding(
+            "agentenv.skill.dedup.probable-duplicate",
+            "candidate is probably a duplicate of an existing skill",
+            Some(manifest.entry.clone()),
+            None,
+        ));
+    }
+
+    let nearest_neighbors: Vec<Value> = best
+        .into_iter()
+        .map(|(skill, similarity, reason)| {
+            json!({
+                "name": skill.name,
+                "version": skill.version,
+                "similarity": similarity,
+                "reason": reason
+            })
+        })
+        .collect();
+    let mut report = tier_from_findings(SkillCiTier::SemanticDedup, findings);
+    report.details = Some(json!({
+        "nearest_neighbors": nearest_neighbors,
+        "novelty_score": novelty,
+        "probable_duplicate": probable_duplicate
+    }));
+    report
+}
+
+fn jaccard(left: &str, right: &str) -> f32 {
+    let left = tokens(left);
+    let right = tokens(right);
+    if left.is_empty() && right.is_empty() {
+        return 1.0;
+    }
+
+    let intersection = left.intersection(&right).count() as f32;
+    let union = left.union(&right).count() as f32;
+    if union == 0.0 {
+        0.0
+    } else {
+        intersection / union
+    }
+}
+
+fn tokens(value: &str) -> BTreeSet<String> {
+    value
+        .split(|character: char| !character.is_ascii_alphanumeric())
+        .filter(|token| !token.is_empty())
+        .map(|token| token.to_ascii_lowercase())
+        .collect()
 }
 
 fn tier_from_findings(tier: SkillCiTier, findings: Vec<SkillCiFinding>) -> SkillCiTierReport {

--- a/crates/agentenv-core/src/skills/ci.rs
+++ b/crates/agentenv-core/src/skills/ci.rs
@@ -504,38 +504,49 @@ pub fn run_skill_ci(request: SkillCiRequest) -> Result<SkillCiReport, SkillError
         let review_failed = review_report.status == SkillCiTierStatus::Failed;
         tiers.push(review_report);
 
-        let dedup_started = Instant::now();
-        let mut dedup_report = run_semantic_dedup(
-            manifest,
-            &candidate.digest,
-            skill_md,
-            request.registry_snapshot.as_ref(),
-        );
-        dedup_report.duration_ms = dedup_started.elapsed().as_millis();
-        let dedup_failed = dedup_report.status == SkillCiTierStatus::Failed;
-        tiers.push(dedup_report);
-
-        if request.fail_fast && (static_failed || review_failed || dedup_failed) {
+        if request.fail_fast && review_failed {
+            tiers.push(skipped_tier(
+                SkillCiTier::SemanticDedup,
+                "skipped because agent_review failed",
+            ));
             tiers.push(skipped_tier(
                 SkillCiTier::FunctionalRegression,
                 "skipped because an earlier tier failed",
             ));
-        } else if !functional_regression_ready {
-            tiers.push(skipped_tier(
-                SkillCiTier::FunctionalRegression,
-                "skipped because static_lint found an invalid signature or self-test",
-            ));
         } else {
-            let regression_started = Instant::now();
-            let mut regression_report = run_functional_regression(
-                &request.candidate_path,
+            let dedup_started = Instant::now();
+            let mut dedup_report = run_semantic_dedup(
                 manifest,
                 &candidate.digest,
-                self_test_source_path.unwrap_or_else(|| PathBuf::from("skill-test.yaml")),
-                Arc::clone(&request.agent_runner),
-            )?;
-            regression_report.duration_ms = regression_started.elapsed().as_millis();
-            tiers.push(regression_report);
+                skill_md,
+                request.registry_snapshot.as_ref(),
+            );
+            dedup_report.duration_ms = dedup_started.elapsed().as_millis();
+            let dedup_failed = dedup_report.status == SkillCiTierStatus::Failed;
+            tiers.push(dedup_report);
+
+            if request.fail_fast && dedup_failed {
+                tiers.push(skipped_tier(
+                    SkillCiTier::FunctionalRegression,
+                    "skipped because an earlier tier failed",
+                ));
+            } else if !functional_regression_ready {
+                tiers.push(skipped_tier(
+                    SkillCiTier::FunctionalRegression,
+                    "skipped because static_lint found an invalid signature or self-test",
+                ));
+            } else {
+                let regression_started = Instant::now();
+                let mut regression_report = run_functional_regression(
+                    &request.candidate_path,
+                    manifest,
+                    &candidate.digest,
+                    self_test_source_path.unwrap_or_else(|| PathBuf::from("skill-test.yaml")),
+                    Arc::clone(&request.agent_runner),
+                )?;
+                regression_report.duration_ms = regression_started.elapsed().as_millis();
+                tiers.push(regression_report);
+            }
         }
     }
 
@@ -1370,20 +1381,28 @@ fn has_prefixed_secret(text: &str, prefix: &str, minimum_suffix: usize) -> bool 
 fn has_keyword_assigned_secret(text: &str) -> bool {
     let lower = text.to_ascii_lowercase();
     SECRET_KEYWORDS.iter().any(|keyword| {
-        let Some(index) = lower.find(keyword) else {
-            return false;
-        };
-        let tail = &text[index + keyword.len()..];
-        let Some(separator_index) = tail.find([':', '=']) else {
-            return false;
-        };
-        let candidate = tail[separator_index + 1..]
-            .trim_start_matches(|ch: char| ch.is_whitespace() || matches!(ch, '"' | '\''));
-        candidate
-            .chars()
-            .take_while(|ch| is_secret_char(*ch))
-            .count()
-            >= 20
+        let mut cursor = 0;
+        while let Some(relative_index) = lower[cursor..].find(keyword) {
+            let index = cursor + relative_index;
+            let tail = &text[index + keyword.len()..];
+
+            if let Some(separator_index) = tail.find([':', '=']) {
+                let candidate = tail[separator_index + 1..]
+                    .trim_start_matches(|ch: char| ch.is_whitespace() || matches!(ch, '"' | '\''));
+                if candidate
+                    .chars()
+                    .take_while(|ch| is_secret_char(*ch))
+                    .count()
+                    >= 20
+                {
+                    return true;
+                }
+            }
+
+            cursor = index + keyword.len();
+        }
+
+        false
     })
 }
 

--- a/crates/agentenv-core/src/skills/ci.rs
+++ b/crates/agentenv-core/src/skills/ci.rs
@@ -51,6 +51,15 @@ const REVIEW_CONSENT_NEGATIONS: &[&str] = &[
     "without confirmation",
     "no confirmation",
 ];
+const REVIEW_UNSAFE_EXECUTION_PHRASES: &[&str] = &[
+    "automatically",
+    "immediately",
+    "without asking",
+    "without confirmation",
+    "without consent",
+    "without user consent",
+];
+const REVIEW_CONSENT_MAX_DISTANCE: usize = 40;
 
 #[derive(Clone)]
 pub struct SkillCiRequest {
@@ -267,8 +276,9 @@ fn destructive_matches_without_consent(text: &str, needle: &str) -> bool {
     while let Some(relative_start) = text[cursor..].find(needle) {
         let start = cursor + relative_start;
         let end = start + needle.len();
-        let segment = review_segment_around(text, start, end);
-        if !segment_has_valid_consent(segment) {
+        let (segment_start, segment_end) = review_segment_bounds(text, start, end);
+        let segment = &text[segment_start..segment_end];
+        if !segment_has_valid_consent(segment, start - segment_start, end - segment_start) {
             return true;
         }
         cursor = end;
@@ -277,7 +287,7 @@ fn destructive_matches_without_consent(text: &str, needle: &str) -> bool {
     false
 }
 
-fn review_segment_around(text: &str, start: usize, end: usize) -> &str {
+fn review_segment_bounds(text: &str, start: usize, end: usize) -> (usize, usize) {
     let segment_start = text[..start]
         .char_indices()
         .rev()
@@ -288,20 +298,109 @@ fn review_segment_around(text: &str, start: usize, end: usize) -> &str {
         .find_map(|(offset, ch)| review_segment_boundary(ch).then_some(end + offset))
         .unwrap_or(text.len());
 
-    text[segment_start..segment_end].trim()
+    (segment_start, segment_end)
 }
 
 fn review_segment_boundary(ch: char) -> bool {
     matches!(ch, '.' | '!' | '?' | ';' | '\n' | '\r')
 }
 
-fn segment_has_valid_consent(segment: &str) -> bool {
+fn segment_has_valid_consent(
+    segment: &str,
+    destructive_start: usize,
+    destructive_end: usize,
+) -> bool {
     !REVIEW_CONSENT_NEGATIONS
         .iter()
         .any(|negation| segment.contains(negation))
-        && REVIEW_CONSENT_PHRASES
-            .iter()
-            .any(|phrase| segment.contains(phrase))
+        && !destructive_window_has_unsafe_execution(segment, destructive_start, destructive_end)
+        && REVIEW_CONSENT_PHRASES.iter().any(|phrase| {
+            consent_phrase_governs_destructive(segment, phrase, destructive_start, destructive_end)
+        })
+}
+
+fn destructive_window_has_unsafe_execution(
+    segment: &str,
+    destructive_start: usize,
+    destructive_end: usize,
+) -> bool {
+    let window_start = previous_char_boundary(
+        segment,
+        destructive_start.saturating_sub(REVIEW_CONSENT_MAX_DISTANCE),
+    );
+    let window_end = next_char_boundary(
+        segment,
+        (destructive_end + REVIEW_CONSENT_MAX_DISTANCE).min(segment.len()),
+    );
+    let window = &segment[window_start..window_end];
+
+    REVIEW_UNSAFE_EXECUTION_PHRASES
+        .iter()
+        .any(|phrase| window.contains(phrase))
+}
+
+fn consent_phrase_governs_destructive(
+    segment: &str,
+    phrase: &str,
+    destructive_start: usize,
+    destructive_end: usize,
+) -> bool {
+    let mut cursor = 0;
+    while let Some(relative_start) = segment[cursor..].find(phrase) {
+        let phrase_start = cursor + relative_start;
+        let phrase_end = phrase_start + phrase.len();
+        if consent_phrase_match_governs_destructive(
+            segment,
+            phrase_end,
+            phrase_start,
+            destructive_start,
+            destructive_end,
+        ) {
+            return true;
+        }
+        cursor = phrase_end;
+    }
+
+    false
+}
+
+fn consent_phrase_match_governs_destructive(
+    segment: &str,
+    phrase_end: usize,
+    phrase_start: usize,
+    destructive_start: usize,
+    destructive_end: usize,
+) -> bool {
+    if phrase_end <= destructive_start {
+        let gap = &segment[phrase_end..destructive_start];
+        gap.len() <= REVIEW_CONSENT_MAX_DISTANCE && !gap.contains(" and ")
+    } else if phrase_start >= destructive_end {
+        segment[destructive_end..phrase_start].len() <= REVIEW_CONSENT_MAX_DISTANCE
+    } else {
+        true
+    }
+}
+
+fn previous_char_boundary(text: &str, index: usize) -> usize {
+    if text.is_char_boundary(index) {
+        return index;
+    }
+
+    text.char_indices()
+        .take_while(|(boundary, _)| *boundary < index)
+        .last()
+        .map(|(boundary, _)| boundary)
+        .unwrap_or(0)
+}
+
+fn next_char_boundary(text: &str, index: usize) -> usize {
+    if text.is_char_boundary(index) {
+        return index;
+    }
+
+    text.char_indices()
+        .find_map(|(boundary, _)| (boundary > index).then_some(boundary))
+        .unwrap_or(text.len())
 }
 
 fn contains_api_key_reference(text: &str) -> bool {

--- a/crates/agentenv-core/src/skills/error.rs
+++ b/crates/agentenv-core/src/skills/error.rs
@@ -108,6 +108,12 @@ pub enum SkillError {
     SkillNotInstalled { name: String },
     #[error("skill `{name}` has multiple installed versions: {versions}")]
     AmbiguousInstalledVersion { name: String, versions: String },
+    #[error("invalid skill CI candidate `{path}`: {message}")]
+    InvalidSkillCiCandidate { path: PathBuf, message: String },
+    #[error("skill CI validation failed at tier `{tier}`")]
+    SkillCiFailed { tier: String },
+    #[error("failed to serialize skill CI SARIF: {message}")]
+    SkillCiSarif { message: String },
     #[error("skill `{name}` version `{version}` already exists with digest `{existing}`")]
     AlreadyInstalledDifferentDigest {
         name: String,

--- a/crates/agentenv-core/src/skills/mod.rs
+++ b/crates/agentenv-core/src/skills/mod.rs
@@ -30,9 +30,10 @@ pub use cache::{
     SkillVerifyReport, SkillVerifyStatus, SKILL_METADATA_SCHEMA_VERSION,
 };
 pub use ci::{
-    run_skill_ci, skill_ci_sarif, SkillCiCandidate, SkillCiFinding, SkillCiRegistrySkill,
-    SkillCiRegistrySnapshot, SkillCiReport, SkillCiRequest, SkillCiSeverity, SkillCiStatus,
-    SkillCiTier, SkillCiTierReport, SkillCiTierStatus, SKILL_CI_SCHEMA_VERSION,
+    run_skill_ci, skill_ci_sarif, RuleBasedSkillReviewJudge, SkillCiCandidate, SkillCiFinding,
+    SkillCiRegistrySkill, SkillCiRegistrySnapshot, SkillCiReport, SkillCiRequest, SkillCiSeverity,
+    SkillCiStatus, SkillCiTier, SkillCiTierReport, SkillCiTierStatus, SkillReviewInput,
+    SkillReviewJudge, SkillReviewReport, SKILL_CI_SCHEMA_VERSION,
 };
 pub use config::{
     load_project_skills_config, load_user_skills_config, merge_skills_config, ProposalConfig,

--- a/crates/agentenv-core/src/skills/mod.rs
+++ b/crates/agentenv-core/src/skills/mod.rs
@@ -32,7 +32,7 @@ pub use cache::{
 pub use ci::{
     run_skill_ci, SkillCiCandidate, SkillCiFinding, SkillCiRegistrySkill, SkillCiRegistrySnapshot,
     SkillCiReport, SkillCiRequest, SkillCiSeverity, SkillCiStatus, SkillCiTier, SkillCiTierReport,
-    SkillCiTierStatus,
+    SkillCiTierStatus, SKILL_CI_SCHEMA_VERSION,
 };
 pub use config::{
     load_project_skills_config, load_user_skills_config, merge_skills_config, ProposalConfig,

--- a/crates/agentenv-core/src/skills/mod.rs
+++ b/crates/agentenv-core/src/skills/mod.rs
@@ -30,9 +30,9 @@ pub use cache::{
     SkillVerifyReport, SkillVerifyStatus, SKILL_METADATA_SCHEMA_VERSION,
 };
 pub use ci::{
-    run_skill_ci, SkillCiCandidate, SkillCiFinding, SkillCiRegistrySkill, SkillCiRegistrySnapshot,
-    SkillCiReport, SkillCiRequest, SkillCiSeverity, SkillCiStatus, SkillCiTier, SkillCiTierReport,
-    SkillCiTierStatus, SKILL_CI_SCHEMA_VERSION,
+    run_skill_ci, skill_ci_sarif, SkillCiCandidate, SkillCiFinding, SkillCiRegistrySkill,
+    SkillCiRegistrySnapshot, SkillCiReport, SkillCiRequest, SkillCiSeverity, SkillCiStatus,
+    SkillCiTier, SkillCiTierReport, SkillCiTierStatus, SKILL_CI_SCHEMA_VERSION,
 };
 pub use config::{
     load_project_skills_config, load_user_skills_config, merge_skills_config, ProposalConfig,

--- a/crates/agentenv-core/src/skills/mod.rs
+++ b/crates/agentenv-core/src/skills/mod.rs
@@ -1,5 +1,6 @@
 mod attestation;
 pub mod cache;
+mod ci;
 mod config;
 mod digest;
 mod error;
@@ -27,6 +28,11 @@ pub use cache::{
     SkillCacheLayout, SkillIndex, SkillIndexEntry, SkillProvenance, SkillProvenanceSubject,
     SkillPrunePlan, SkillSelfTest, SkillTrustKey, SkillVerifyEntry, SkillVerifyOptions,
     SkillVerifyReport, SkillVerifyStatus, SKILL_METADATA_SCHEMA_VERSION,
+};
+pub use ci::{
+    run_skill_ci, SkillCiCandidate, SkillCiFinding, SkillCiRegistrySkill, SkillCiRegistrySnapshot,
+    SkillCiReport, SkillCiRequest, SkillCiSeverity, SkillCiStatus, SkillCiTier, SkillCiTierReport,
+    SkillCiTierStatus,
 };
 pub use config::{
     load_project_skills_config, load_user_skills_config, merge_skills_config, ProposalConfig,

--- a/crates/agentenv-core/src/skills/service.rs
+++ b/crates/agentenv-core/src/skills/service.rs
@@ -81,6 +81,10 @@ impl SkillService {
         self
     }
 
+    pub fn agent_produce_runner(&self) -> Arc<dyn AgentProduceRunner> {
+        Arc::clone(&self.agent_produce_runner)
+    }
+
     pub async fn search(&self, query: &str) -> Result<Vec<SkillSearchHit>, SkillError> {
         let mut hits = Vec::new();
         for registry in self.ordered_registries()? {

--- a/crates/agentenv-core/src/skills/store.rs
+++ b/crates/agentenv-core/src/skills/store.rs
@@ -610,6 +610,9 @@ fn cache_can_be_repaired(error: &SkillError) -> bool {
         | SkillError::InvalidSignature { .. }
         | SkillError::SkillNotInstalled { .. }
         | SkillError::AmbiguousInstalledVersion { .. }
+        | SkillError::InvalidSkillCiCandidate { .. }
+        | SkillError::SkillCiFailed { .. }
+        | SkillError::SkillCiSarif { .. }
         | SkillError::AlreadyInstalledDifferentDigest { .. }
         | SkillError::Serde { .. }
         | SkillError::Toml { .. }

--- a/crates/agentenv-core/tests/skills_ci.rs
+++ b/crates/agentenv-core/tests/skills_ci.rs
@@ -62,6 +62,42 @@ fn skill_ci_fail_fast_skips_later_tiers_after_static_failure() {
 }
 
 #[test]
+fn skill_ci_fail_fast_skips_later_tiers_after_review_failure() {
+    let bundle = skill_bundle(
+        "ci-review-fail-fast",
+        "0.1.0",
+        "# Review fail-fast\n\nRun `rm -rf target` immediately before asking the user.\n",
+    );
+
+    let report = run_skill_ci(SkillCiRequest {
+        candidate_path: bundle,
+        registry_snapshot: None,
+        fail_fast: true,
+        agent_runner: Arc::new(PanicAgentRunner),
+    })
+    .expect("ci should run");
+
+    assert_eq!(report.status, SkillCiStatus::Failed);
+
+    let review = report
+        .tiers
+        .iter()
+        .find(|tier| tier.tier == SkillCiTier::AgentReview)
+        .unwrap();
+    assert_eq!(review.status, SkillCiTierStatus::Failed);
+
+    let dedup = semantic_dedup_tier(&report);
+    assert_eq!(dedup.status, SkillCiTierStatus::Skipped);
+    assert!(dedup
+        .findings
+        .iter()
+        .any(|finding| finding.rule_id == "agentenv.skill.ci.skipped"));
+
+    let regression = functional_regression_tier(&report);
+    assert_eq!(regression.status, SkillCiTierStatus::Skipped);
+}
+
+#[test]
 fn skill_ci_static_tier_lints_nested_manifest_entry() {
     let bundle = skill_bundle_with_entry(
         "ci-nested-entry",
@@ -114,6 +150,34 @@ fn static_lint_rejects_secret_like_text_and_redacts_sarif() {
     let sarif = agentenv_core::skills::skill_ci_sarif(&report).unwrap();
     assert!(sarif.contains("agentenv.skill.secret.detected"));
     assert!(!sarif.contains("sk-test-1234567890abcdefghijklmnop"));
+}
+
+#[test]
+fn static_lint_rejects_later_keyword_secret_on_same_line() {
+    let bundle = skill_bundle(
+        "ci-secret-later-keyword",
+        "0.1.0",
+        "# Later secret\n\nIgnore token=short before token=tok_1234567890abcdefghijklmnop.\n",
+    );
+
+    let report = run_skill_ci(SkillCiRequest {
+        candidate_path: bundle,
+        registry_snapshot: None,
+        fail_fast: true,
+        agent_runner: Arc::new(PanicAgentRunner),
+    })
+    .expect("ci should run");
+
+    let static_tier = report
+        .tiers
+        .iter()
+        .find(|tier| tier.tier == SkillCiTier::StaticLint)
+        .unwrap();
+    assert_eq!(static_tier.status, SkillCiTierStatus::Failed);
+    assert!(static_tier
+        .findings
+        .iter()
+        .any(|finding| finding.rule_id == "agentenv.skill.secret.detected"));
 }
 
 #[test]

--- a/crates/agentenv-core/tests/skills_ci.rs
+++ b/crates/agentenv-core/tests/skills_ci.rs
@@ -744,6 +744,108 @@ fn semantic_dedup_fails_high_semantic_similarity_without_fingerprint_match() {
     );
 }
 
+#[test]
+fn functional_regression_fails_below_threshold() {
+    let bundle = skill_bundle_with_skill_test_file("ci-low-score", "0.1.0", "# Low Score\n");
+    write_file(
+        &bundle.join("skill-test.yaml"),
+        "self_test:\n  runner: agentenv\n  assertions:\n    - type: file_exists\n      path: SKILL.md\n    - type: file_exists\n      path: missing-one\n    - type: file_exists\n      path: missing-two\n    - type: file_exists\n      path: missing-three\n    - type: file_exists\n      path: missing-four\n",
+    );
+
+    let report = run_skill_ci(SkillCiRequest {
+        candidate_path: bundle,
+        registry_snapshot: None,
+        fail_fast: false,
+        agent_runner: Arc::new(PanicAgentRunner),
+    })
+    .expect("ci should run");
+
+    let regression = report
+        .tiers
+        .iter()
+        .find(|tier| tier.tier == SkillCiTier::FunctionalRegression)
+        .unwrap();
+    assert_eq!(regression.status, SkillCiTierStatus::Failed);
+    assert!(regression
+        .findings
+        .iter()
+        .any(|finding| finding.rule_id == "agentenv.skill.self-test.score-below-threshold"));
+    assert_eq!(regression.details.as_ref().unwrap()["score"], 0.2);
+}
+
+#[test]
+fn functional_regression_passes_at_threshold() {
+    let bundle = skill_bundle_with_skill_test_file("ci-threshold", "0.1.0", "# Threshold\n");
+    write_file(
+        &bundle.join("skill-test.yaml"),
+        "self_test:\n  runner: agentenv\n  assertions:\n    - type: file_exists\n      path: SKILL.md\n    - type: file_exists\n      path: skill.yaml\n    - type: file_exists\n      path: SKILL.md\n    - type: file_exists\n      path: skill.yaml\n    - type: file_exists\n      path: missing-one\n",
+    );
+
+    let report = run_skill_ci(SkillCiRequest {
+        candidate_path: bundle,
+        registry_snapshot: None,
+        fail_fast: false,
+        agent_runner: Arc::new(PanicAgentRunner),
+    })
+    .expect("ci should run");
+
+    let regression = report
+        .tiers
+        .iter()
+        .find(|tier| tier.tier == SkillCiTier::FunctionalRegression)
+        .unwrap();
+    assert_eq!(regression.status, SkillCiTierStatus::Passed);
+    assert_eq!(regression.details.as_ref().unwrap()["score"], 0.8);
+}
+
+#[test]
+fn functional_regression_skips_invalid_self_test_without_fail_fast() {
+    let bundle =
+        skill_bundle_with_skill_test_file("ci-invalid-self-test", "0.1.0", "# Invalid Self Test\n");
+    write_file(
+        &bundle.join("skill-test.yaml"),
+        "self_test:\n  runner: agentenv\n  assertions: []\n",
+    );
+
+    let report = run_skill_ci(SkillCiRequest {
+        candidate_path: bundle,
+        registry_snapshot: None,
+        fail_fast: false,
+        agent_runner: Arc::new(PanicAgentRunner),
+    })
+    .expect("ci should report static self-test failure without running regression");
+
+    let regression = functional_regression_tier(&report);
+    assert_eq!(regression.status, SkillCiTierStatus::Skipped);
+    assert!(regression.details.is_none());
+}
+
+#[test]
+fn functional_regression_reports_frontmatter_self_test_source() {
+    let bundle = skill_bundle_with_skill_test_file(
+        "ci-frontmatter-self-test",
+        "0.1.0",
+        "---\nself_test:\n  runner: agentenv\n  assertions:\n    - type: file_exists\n      path: SKILL.md\n    - type: file_exists\n      path: missing-one\n---\n# Frontmatter Self Test\n",
+    );
+
+    let report = run_skill_ci(SkillCiRequest {
+        candidate_path: bundle,
+        registry_snapshot: None,
+        fail_fast: false,
+        agent_runner: Arc::new(PanicAgentRunner),
+    })
+    .expect("ci should run");
+
+    let regression = functional_regression_tier(&report);
+    assert_eq!(regression.status, SkillCiTierStatus::Failed);
+    let finding = regression
+        .findings
+        .iter()
+        .find(|finding| finding.rule_id == "agentenv.skill.self-test.score-below-threshold")
+        .unwrap();
+    assert_eq!(finding.path.as_deref(), Some(Path::new("SKILL.md")));
+}
+
 #[derive(Debug)]
 struct PanicAgentRunner;
 
@@ -783,11 +885,32 @@ fn skill_bundle_with_entry(name: &str, version: &str, entry: &str, skill_md: &st
     root
 }
 
+fn skill_bundle_with_skill_test_file(name: &str, version: &str, skill_md: &str) -> PathBuf {
+    let root = temp_dir(&format!("skill-ci-{name}-{version}"));
+    write_file(&root.join("SKILL.md"), skill_md);
+    write_file(
+        &root.join("skill.yaml"),
+        &format!(
+            "name: {name}\nversion: {version}\ndescription: {name} skill\nentry: SKILL.md\nfiles:\n  - SKILL.md\n"
+        ),
+    );
+    sign_skill_bundle(&root);
+    root
+}
+
 fn semantic_dedup_tier(report: &agentenv_core::skills::SkillCiReport) -> &SkillCiTierReport {
     report
         .tiers
         .iter()
         .find(|tier| tier.tier == SkillCiTier::SemanticDedup)
+        .unwrap()
+}
+
+fn functional_regression_tier(report: &agentenv_core::skills::SkillCiReport) -> &SkillCiTierReport {
+    report
+        .tiers
+        .iter()
+        .find(|tier| tier.tier == SkillCiTier::FunctionalRegression)
         .unwrap()
 }
 

--- a/crates/agentenv-core/tests/skills_ci.rs
+++ b/crates/agentenv-core/tests/skills_ci.rs
@@ -373,6 +373,86 @@ fn agent_review_fails_same_sentence_unrelated_consent_for_automatic_destructive_
 }
 
 #[test]
+fn agent_review_fails_comma_then_unrelated_consent_for_destructive_command() {
+    let bundle = skill_bundle(
+        "ci-comma-then-unrelated-consent",
+        "0.1.0",
+        "# Comma Then Consent\n\nAsk before editing files, then run `rm -rf target`.\n",
+    );
+
+    let report = run_skill_ci(SkillCiRequest {
+        candidate_path: bundle,
+        registry_snapshot: None,
+        fail_fast: false,
+        agent_runner: Arc::new(PanicAgentRunner),
+    })
+    .expect("ci should run");
+
+    let review = report
+        .tiers
+        .iter()
+        .find(|tier| tier.tier == SkillCiTier::AgentReview)
+        .unwrap();
+    assert_eq!(review.status, SkillCiTierStatus::Failed);
+    assert!(review
+        .findings
+        .iter()
+        .any(|finding| finding.rule_id == "agentenv.skill.review.destructive-without-consent"));
+}
+
+#[test]
+fn agent_review_fails_then_unrelated_consent_for_destructive_command() {
+    let bundle = skill_bundle(
+        "ci-then-unrelated-consent",
+        "0.1.0",
+        "# Then Consent\n\nAsk before editing files then run `rm -rf target`.\n",
+    );
+
+    let report = run_skill_ci(SkillCiRequest {
+        candidate_path: bundle,
+        registry_snapshot: None,
+        fail_fast: false,
+        agent_runner: Arc::new(PanicAgentRunner),
+    })
+    .expect("ci should run");
+
+    let review = report
+        .tiers
+        .iter()
+        .find(|tier| tier.tier == SkillCiTier::AgentReview)
+        .unwrap();
+    assert_eq!(review.status, SkillCiTierStatus::Failed);
+    assert!(review
+        .findings
+        .iter()
+        .any(|finding| finding.rule_id == "agentenv.skill.review.destructive-without-consent"));
+}
+
+#[test]
+fn agent_review_passes_consent_directly_governing_destructive_command() {
+    let bundle = skill_bundle(
+        "ci-direct-destructive-consent",
+        "0.1.0",
+        "# Direct Consent\n\nAsk before running `rm -rf target`.\n",
+    );
+
+    let report = run_skill_ci(SkillCiRequest {
+        candidate_path: bundle,
+        registry_snapshot: None,
+        fail_fast: false,
+        agent_runner: Arc::new(PanicAgentRunner),
+    })
+    .expect("ci should run");
+
+    let review = report
+        .tiers
+        .iter()
+        .find(|tier| tier.tier == SkillCiTier::AgentReview)
+        .unwrap();
+    assert_eq!(review.status, SkillCiTierStatus::Passed);
+}
+
+#[test]
 fn agent_review_fails_api_key_variants_without_credential_language() {
     for (name, skill_md) in [
         (

--- a/crates/agentenv-core/tests/skills_ci.rs
+++ b/crates/agentenv-core/tests/skills_ci.rs
@@ -1,0 +1,119 @@
+use std::{
+    fs,
+    path::{Path, PathBuf},
+    sync::Arc,
+};
+
+use ed25519_dalek::{Signer, SigningKey};
+
+use agentenv_core::skills::{
+    compute_bundle_digest, load_skill_manifest, run_skill_ci, signature_payload,
+    AgentProduceRequest, AgentProduceRunner, SkillCiRequest, SkillCiStatus, SkillCiTier,
+    SkillCiTierStatus, SkillError,
+};
+
+#[test]
+fn skill_ci_reports_candidate_and_runs_static_tier_first() {
+    let bundle = skill_bundle(
+        "ci-valid",
+        "0.1.0",
+        "# CI valid\n\nUse this skill safely.\n",
+    );
+
+    let report = run_skill_ci(SkillCiRequest {
+        candidate_path: bundle,
+        registry_snapshot: None,
+        fail_fast: true,
+        agent_runner: Arc::new(PanicAgentRunner),
+    })
+    .expect("ci should run");
+
+    assert_eq!(report.schema_version, "0.1");
+    assert_eq!(report.candidate.name, "ci-valid");
+    assert_eq!(report.candidate.version, "0.1.0");
+    assert!(report.candidate.digest.starts_with("sha256:"));
+    assert_eq!(report.tiers[0].tier, SkillCiTier::StaticLint);
+    assert_eq!(report.tiers[0].status, SkillCiTierStatus::Passed);
+}
+
+#[test]
+fn skill_ci_fail_fast_skips_later_tiers_after_static_failure() {
+    let bundle = skill_bundle("ci-bad-md", "0.1.0", "# Bad\n\n```rust\nfn main() {}\n");
+
+    let report = run_skill_ci(SkillCiRequest {
+        candidate_path: bundle,
+        registry_snapshot: None,
+        fail_fast: true,
+        agent_runner: Arc::new(PanicAgentRunner),
+    })
+    .expect("ci should return report for validation failure");
+
+    assert_eq!(report.status, SkillCiStatus::Failed);
+    assert_eq!(report.tiers[0].tier, SkillCiTier::StaticLint);
+    assert_eq!(report.tiers[0].status, SkillCiTierStatus::Failed);
+    assert!(report
+        .tiers
+        .iter()
+        .any(|tier| tier.status == SkillCiTierStatus::Skipped));
+}
+
+#[derive(Debug)]
+struct PanicAgentRunner;
+
+impl AgentProduceRunner for PanicAgentRunner {
+    fn run_agent_prompt(&self, _request: AgentProduceRequest<'_>) -> Result<String, SkillError> {
+        panic!("agent runner should not be used by these tests");
+    }
+}
+
+fn skill_bundle(name: &str, version: &str, skill_md: &str) -> PathBuf {
+    let root = temp_dir(&format!("skill-ci-{name}-{version}"));
+    write_file(&root.join("SKILL.md"), skill_md);
+    write_file(
+        &root.join("skill.yaml"),
+        &format!(
+            "name: {name}\nversion: {version}\ndescription: {name} skill\nentry: SKILL.md\nfiles:\n  - SKILL.md\nself_test:\n  command: test -f SKILL.md\n"
+        ),
+    );
+    sign_skill_bundle(&root);
+    root
+}
+
+fn sign_skill_bundle(root: &Path) {
+    let manifest = load_skill_manifest(root).unwrap();
+    let digest = compute_bundle_digest(root, &manifest).unwrap();
+    let signing_key = SigningKey::from_bytes(&[36_u8; 32]);
+    let payload = signature_payload(&manifest, &digest).unwrap();
+    let signature = hex::encode(signing_key.sign(&payload).to_bytes());
+    let public_key = hex::encode(signing_key.verifying_key().to_bytes());
+    let mut manifest_text = fs::read_to_string(root.join("skill.yaml")).unwrap();
+    manifest_text.push_str(&format!(
+        "signatures:\n  ed25519: {signature}\n  public_key_ed25519: {public_key}\n"
+    ));
+    fs::write(root.join("skill.yaml"), manifest_text).unwrap();
+}
+
+fn temp_dir(prefix: &str) -> PathBuf {
+    let mut path = std::env::temp_dir();
+    path.push(format!(
+        "{prefix}-{}-{}",
+        std::process::id(),
+        unique_nanos()
+    ));
+    fs::create_dir_all(&path).unwrap();
+    path
+}
+
+fn write_file(path: &Path, content: &str) {
+    if let Some(parent) = path.parent() {
+        fs::create_dir_all(parent).unwrap();
+    }
+    fs::write(path, content).unwrap();
+}
+
+fn unique_nanos() -> u128 {
+    std::time::SystemTime::now()
+        .duration_since(std::time::UNIX_EPOCH)
+        .map(|duration| duration.as_nanos())
+        .unwrap_or(0)
+}

--- a/crates/agentenv-core/tests/skills_ci.rs
+++ b/crates/agentenv-core/tests/skills_ci.rs
@@ -345,6 +345,34 @@ fn agent_review_fails_unrelated_consent_before_later_destructive_command() {
 }
 
 #[test]
+fn agent_review_fails_same_sentence_unrelated_consent_for_automatic_destructive_command() {
+    let bundle = skill_bundle(
+        "ci-same-sentence-unrelated-consent",
+        "0.1.0",
+        "# Same Sentence Consent\n\nAsk before editing files and run `rm -rf target` automatically.\n",
+    );
+
+    let report = run_skill_ci(SkillCiRequest {
+        candidate_path: bundle,
+        registry_snapshot: None,
+        fail_fast: false,
+        agent_runner: Arc::new(PanicAgentRunner),
+    })
+    .expect("ci should run");
+
+    let review = report
+        .tiers
+        .iter()
+        .find(|tier| tier.tier == SkillCiTier::AgentReview)
+        .unwrap();
+    assert_eq!(review.status, SkillCiTierStatus::Failed);
+    assert!(review
+        .findings
+        .iter()
+        .any(|finding| finding.rule_id == "agentenv.skill.review.destructive-without-consent"));
+}
+
+#[test]
 fn agent_review_fails_api_key_variants_without_credential_language() {
     for (name, skill_md) in [
         (

--- a/crates/agentenv-core/tests/skills_ci.rs
+++ b/crates/agentenv-core/tests/skills_ci.rs
@@ -429,6 +429,62 @@ fn agent_review_fails_then_unrelated_consent_for_destructive_command() {
 }
 
 #[test]
+fn agent_review_fails_delayed_explicit_consent_after_destructive_command() {
+    let bundle = skill_bundle(
+        "ci-delayed-explicit-consent",
+        "0.1.0",
+        "# Delayed Consent\n\nRun `rm -rf target`, then ask for explicit consent.\n",
+    );
+
+    let report = run_skill_ci(SkillCiRequest {
+        candidate_path: bundle,
+        registry_snapshot: None,
+        fail_fast: false,
+        agent_runner: Arc::new(PanicAgentRunner),
+    })
+    .expect("ci should run");
+
+    let review = report
+        .tiers
+        .iter()
+        .find(|tier| tier.tier == SkillCiTier::AgentReview)
+        .unwrap();
+    assert_eq!(review.status, SkillCiTierStatus::Failed);
+    assert!(review
+        .findings
+        .iter()
+        .any(|finding| finding.rule_id == "agentenv.skill.review.destructive-without-consent"));
+}
+
+#[test]
+fn agent_review_fails_explicit_consent_after_destructive_command_before_asking() {
+    let bundle = skill_bundle(
+        "ci-before-asking-explicit-consent",
+        "0.1.0",
+        "# Before Asking Consent\n\nRun `rm -rf target` before asking for explicit consent.\n",
+    );
+
+    let report = run_skill_ci(SkillCiRequest {
+        candidate_path: bundle,
+        registry_snapshot: None,
+        fail_fast: false,
+        agent_runner: Arc::new(PanicAgentRunner),
+    })
+    .expect("ci should run");
+
+    let review = report
+        .tiers
+        .iter()
+        .find(|tier| tier.tier == SkillCiTier::AgentReview)
+        .unwrap();
+    assert_eq!(review.status, SkillCiTierStatus::Failed);
+    assert!(review
+        .findings
+        .iter()
+        .any(|finding| finding.rule_id == "agentenv.skill.review.destructive-without-consent"));
+}
+
+#[test]
 fn agent_review_passes_consent_directly_governing_destructive_command() {
     let bundle = skill_bundle(
         "ci-direct-destructive-consent",

--- a/crates/agentenv-core/tests/skills_ci.rs
+++ b/crates/agentenv-core/tests/skills_ci.rs
@@ -9,7 +9,7 @@ use ed25519_dalek::{Signer, SigningKey};
 use agentenv_core::skills::{
     compute_bundle_digest, load_skill_manifest, run_skill_ci, signature_payload,
     AgentProduceRequest, AgentProduceRunner, SkillCiFinding, SkillCiRequest, SkillCiSeverity,
-    SkillCiStatus, SkillCiTier, SkillCiTierStatus, SkillError,
+    SkillCiStatus, SkillCiTier, SkillCiTierReport, SkillCiTierStatus, SkillError,
 };
 
 #[test]
@@ -629,6 +629,121 @@ fn semantic_dedup_reports_high_novelty_without_snapshot() {
     assert_eq!(dedup.details.as_ref().unwrap()["novelty_score"], 0.9);
 }
 
+#[test]
+fn semantic_dedup_ignores_blank_descriptions_as_similarity_signal() {
+    let bundle = skill_bundle_without_description(
+        "ci-blank-description",
+        "0.1.0",
+        "# Blank Description\n\nInspect shell scripts for portability.\n",
+    );
+
+    let report = run_skill_ci(SkillCiRequest {
+        candidate_path: bundle,
+        registry_snapshot: Some(agentenv_core::skills::SkillCiRegistrySnapshot {
+            skills: vec![
+                agentenv_core::skills::SkillCiRegistrySkill {
+                    name: "empty-existing".to_owned(),
+                    version: "0.1.0".to_owned(),
+                    description: String::new(),
+                    procedure_text: String::new(),
+                    fingerprint: None,
+                },
+                agentenv_core::skills::SkillCiRegistrySkill {
+                    name: "whitespace-existing".to_owned(),
+                    version: "0.1.0".to_owned(),
+                    description: " \n\t ".to_owned(),
+                    procedure_text: " \n\t ".to_owned(),
+                    fingerprint: None,
+                },
+            ],
+        }),
+        fail_fast: false,
+        agent_runner: Arc::new(PanicAgentRunner),
+    })
+    .expect("ci should run");
+
+    let dedup = semantic_dedup_tier(&report);
+    assert_eq!(dedup.status, SkillCiTierStatus::Passed);
+    assert_eq!(dedup.details.as_ref().unwrap()["novelty_score"], 0.9);
+    assert_eq!(dedup.details.as_ref().unwrap()["probable_duplicate"], false);
+}
+
+#[test]
+fn semantic_dedup_exact_fingerprint_wins_over_earlier_semantic_tie() {
+    let bundle = skill_bundle("ci-tie-copy", "0.1.0", "# Tie\n\nSummarize Rust modules.\n");
+    let digest = {
+        let manifest = agentenv_core::skills::load_skill_manifest(&bundle).unwrap();
+        agentenv_core::skills::compute_bundle_digest(&bundle, &manifest).unwrap()
+    };
+
+    let report = run_skill_ci(SkillCiRequest {
+        candidate_path: bundle,
+        registry_snapshot: Some(agentenv_core::skills::SkillCiRegistrySnapshot {
+            skills: vec![
+                agentenv_core::skills::SkillCiRegistrySkill {
+                    name: "semantic-tie".to_owned(),
+                    version: "0.1.0".to_owned(),
+                    description: "Semantic tie".to_owned(),
+                    procedure_text: "# Tie\n\nSummarize Rust modules.\n".to_owned(),
+                    fingerprint: None,
+                },
+                agentenv_core::skills::SkillCiRegistrySkill {
+                    name: "exact-tie".to_owned(),
+                    version: "0.1.0".to_owned(),
+                    description: "Exact tie".to_owned(),
+                    procedure_text: "Unrelated procedure.".to_owned(),
+                    fingerprint: Some(digest),
+                },
+            ],
+        }),
+        fail_fast: false,
+        agent_runner: Arc::new(PanicAgentRunner),
+    })
+    .expect("ci should run");
+
+    let dedup = semantic_dedup_tier(&report);
+    let nearest_neighbor = &dedup.details.as_ref().unwrap()["nearest_neighbors"][0];
+    assert_eq!(nearest_neighbor["name"], "exact-tie");
+    assert_eq!(nearest_neighbor["reason"], "exact fingerprint match");
+}
+
+#[test]
+fn semantic_dedup_fails_high_semantic_similarity_without_fingerprint_match() {
+    let bundle = skill_bundle(
+        "ci-semantic-copy",
+        "0.1.0",
+        "# Semantic Copy\n\nSummarize Rust modules for ownership risks.\n",
+    );
+
+    let report = run_skill_ci(SkillCiRequest {
+        candidate_path: bundle,
+        registry_snapshot: Some(agentenv_core::skills::SkillCiRegistrySnapshot {
+            skills: vec![agentenv_core::skills::SkillCiRegistrySkill {
+                name: "semantic-existing".to_owned(),
+                version: "0.1.0".to_owned(),
+                description: "Existing semantic copy".to_owned(),
+                procedure_text: "# Semantic Copy\n\nSummarize Rust modules for ownership risks.\n"
+                    .to_owned(),
+                fingerprint: None,
+            }],
+        }),
+        fail_fast: false,
+        agent_runner: Arc::new(PanicAgentRunner),
+    })
+    .expect("ci should run");
+
+    let dedup = semantic_dedup_tier(&report);
+    assert_eq!(dedup.status, SkillCiTierStatus::Failed);
+    assert!(dedup
+        .findings
+        .iter()
+        .any(|finding| finding.rule_id == "agentenv.skill.dedup.probable-duplicate"));
+    assert_eq!(
+        dedup.details.as_ref().unwrap()["nearest_neighbors"][0]["reason"],
+        "local semantic similarity"
+    );
+}
+
 #[derive(Debug)]
 struct PanicAgentRunner;
 
@@ -642,6 +757,19 @@ fn skill_bundle(name: &str, version: &str, skill_md: &str) -> PathBuf {
     skill_bundle_with_entry(name, version, "SKILL.md", skill_md)
 }
 
+fn skill_bundle_without_description(name: &str, version: &str, skill_md: &str) -> PathBuf {
+    let root = temp_dir(&format!("skill-ci-{name}-{version}"));
+    write_file(&root.join("SKILL.md"), skill_md);
+    write_file(
+        &root.join("skill.yaml"),
+        &format!(
+            "name: {name}\nversion: {version}\nentry: SKILL.md\nfiles:\n  - SKILL.md\nself_test:\n  command: test -f SKILL.md\n"
+        ),
+    );
+    sign_skill_bundle(&root);
+    root
+}
+
 fn skill_bundle_with_entry(name: &str, version: &str, entry: &str, skill_md: &str) -> PathBuf {
     let root = temp_dir(&format!("skill-ci-{name}-{version}"));
     write_file(&root.join(entry), skill_md);
@@ -653,6 +781,14 @@ fn skill_bundle_with_entry(name: &str, version: &str, entry: &str, skill_md: &st
     );
     sign_skill_bundle(&root);
     root
+}
+
+fn semantic_dedup_tier(report: &agentenv_core::skills::SkillCiReport) -> &SkillCiTierReport {
+    report
+        .tiers
+        .iter()
+        .find(|tier| tier.tier == SkillCiTier::SemanticDedup)
+        .unwrap()
 }
 
 fn sign_skill_bundle(root: &Path) {

--- a/crates/agentenv-core/tests/skills_ci.rs
+++ b/crates/agentenv-core/tests/skills_ci.rs
@@ -51,10 +51,37 @@ fn skill_ci_fail_fast_skips_later_tiers_after_static_failure() {
     assert_eq!(report.status, SkillCiStatus::Failed);
     assert_eq!(report.tiers[0].tier, SkillCiTier::StaticLint);
     assert_eq!(report.tiers[0].status, SkillCiTierStatus::Failed);
+    assert!(report.tiers[0].findings.iter().any(|finding| {
+        finding.rule_id == "agentenv.skill.markdown.unclosed-fence"
+            && finding.path.as_deref() == Some(Path::new("SKILL.md"))
+    }));
     assert!(report
         .tiers
         .iter()
         .any(|tier| tier.status == SkillCiTierStatus::Skipped));
+}
+
+#[test]
+fn skill_ci_static_tier_lints_nested_manifest_entry() {
+    let bundle = skill_bundle_with_entry(
+        "ci-nested-entry",
+        "0.1.0",
+        "docs/SKILL.md",
+        "# Nested entry\n\nUse this nested skill safely.\n",
+    );
+    assert!(!bundle.join("SKILL.md").exists());
+
+    let report = run_skill_ci(SkillCiRequest {
+        candidate_path: bundle,
+        registry_snapshot: None,
+        fail_fast: true,
+        agent_runner: Arc::new(PanicAgentRunner),
+    })
+    .expect("ci should run");
+
+    assert_eq!(report.status, SkillCiStatus::Passed);
+    assert_eq!(report.tiers[0].tier, SkillCiTier::StaticLint);
+    assert_eq!(report.tiers[0].status, SkillCiTierStatus::Passed);
 }
 
 #[derive(Debug)]
@@ -67,12 +94,16 @@ impl AgentProduceRunner for PanicAgentRunner {
 }
 
 fn skill_bundle(name: &str, version: &str, skill_md: &str) -> PathBuf {
+    skill_bundle_with_entry(name, version, "SKILL.md", skill_md)
+}
+
+fn skill_bundle_with_entry(name: &str, version: &str, entry: &str, skill_md: &str) -> PathBuf {
     let root = temp_dir(&format!("skill-ci-{name}-{version}"));
-    write_file(&root.join("SKILL.md"), skill_md);
+    write_file(&root.join(entry), skill_md);
     write_file(
         &root.join("skill.yaml"),
         &format!(
-            "name: {name}\nversion: {version}\ndescription: {name} skill\nentry: SKILL.md\nfiles:\n  - SKILL.md\nself_test:\n  command: test -f SKILL.md\n"
+            "name: {name}\nversion: {version}\ndescription: {name} skill\nentry: {entry}\nfiles:\n  - {entry}\nself_test:\n  command: test -f {entry}\n"
         ),
     );
     sign_skill_bundle(&root);

--- a/crates/agentenv-core/tests/skills_ci.rs
+++ b/crates/agentenv-core/tests/skills_ci.rs
@@ -567,6 +567,68 @@ fn agent_review_passes_clear_bounded_non_destructive_skill() {
     assert_eq!(review.status, SkillCiTierStatus::Passed);
 }
 
+#[test]
+fn semantic_dedup_fails_exact_fingerprint_match() {
+    let bundle = skill_bundle("ci-copy", "0.1.0", "# Copy\n\nSummarize Rust modules.\n");
+    let digest = {
+        let manifest = agentenv_core::skills::load_skill_manifest(&bundle).unwrap();
+        agentenv_core::skills::compute_bundle_digest(&bundle, &manifest).unwrap()
+    };
+
+    let report = run_skill_ci(SkillCiRequest {
+        candidate_path: bundle,
+        registry_snapshot: Some(agentenv_core::skills::SkillCiRegistrySnapshot {
+            skills: vec![agentenv_core::skills::SkillCiRegistrySkill {
+                name: "existing-copy".to_owned(),
+                version: "0.1.0".to_owned(),
+                description: "Existing copy".to_owned(),
+                procedure_text: "Summarize Rust modules.".to_owned(),
+                fingerprint: Some(digest),
+            }],
+        }),
+        fail_fast: false,
+        agent_runner: Arc::new(PanicAgentRunner),
+    })
+    .expect("ci should run");
+
+    let dedup = report
+        .tiers
+        .iter()
+        .find(|tier| tier.tier == SkillCiTier::SemanticDedup)
+        .unwrap();
+    assert_eq!(dedup.status, SkillCiTierStatus::Failed);
+    assert!(dedup
+        .findings
+        .iter()
+        .any(|finding| finding.rule_id == "agentenv.skill.dedup.probable-duplicate"));
+    assert_eq!(dedup.details.as_ref().unwrap()["novelty_score"], 0.0);
+}
+
+#[test]
+fn semantic_dedup_reports_high_novelty_without_snapshot() {
+    let bundle = skill_bundle(
+        "ci-new",
+        "0.1.0",
+        "# New\n\nInspect shell scripts for portability.\n",
+    );
+
+    let report = run_skill_ci(SkillCiRequest {
+        candidate_path: bundle,
+        registry_snapshot: None,
+        fail_fast: false,
+        agent_runner: Arc::new(PanicAgentRunner),
+    })
+    .expect("ci should run");
+
+    let dedup = report
+        .tiers
+        .iter()
+        .find(|tier| tier.tier == SkillCiTier::SemanticDedup)
+        .unwrap();
+    assert_eq!(dedup.status, SkillCiTierStatus::Passed);
+    assert_eq!(dedup.details.as_ref().unwrap()["novelty_score"], 0.9);
+}
+
 #[derive(Debug)]
 struct PanicAgentRunner;
 

--- a/crates/agentenv-core/tests/skills_ci.rs
+++ b/crates/agentenv-core/tests/skills_ci.rs
@@ -8,8 +8,8 @@ use ed25519_dalek::{Signer, SigningKey};
 
 use agentenv_core::skills::{
     compute_bundle_digest, load_skill_manifest, run_skill_ci, signature_payload,
-    AgentProduceRequest, AgentProduceRunner, SkillCiRequest, SkillCiStatus, SkillCiTier,
-    SkillCiTierStatus, SkillError,
+    AgentProduceRequest, AgentProduceRunner, SkillCiFinding, SkillCiRequest, SkillCiSeverity,
+    SkillCiStatus, SkillCiTier, SkillCiTierStatus, SkillError,
 };
 
 #[test]
@@ -166,6 +166,34 @@ fn static_lint_rejects_unclosed_frontmatter() {
         .findings
         .iter()
         .any(|finding| finding.rule_id == "agentenv.skill.frontmatter.unclosed"));
+}
+
+#[test]
+fn static_lint_sarif_redacts_secret_values_in_finding_messages() {
+    let bundle = skill_bundle("ci-sarif-redaction", "0.1.0", "# Redaction\n");
+
+    let mut report = run_skill_ci(SkillCiRequest {
+        candidate_path: bundle,
+        registry_snapshot: None,
+        fail_fast: true,
+        agent_runner: Arc::new(PanicAgentRunner),
+    })
+    .expect("ci should run");
+    report.tiers[0].findings.push(SkillCiFinding {
+        rule_id: "agentenv.skill.synthetic".to_owned(),
+        severity: SkillCiSeverity::Error,
+        message:
+            "review output included sk-test-1234567890abcdefghijklmnop and token=tok_1234567890abcdefghijklmnop"
+                .to_owned(),
+        path: Some(PathBuf::from("SKILL.md")),
+        line: Some(1),
+    });
+
+    let sarif = agentenv_core::skills::skill_ci_sarif(&report).unwrap();
+
+    assert!(!sarif.contains("sk-test-1234567890abcdefghijklmnop"));
+    assert!(!sarif.contains("tok_1234567890abcdefghijklmnop"));
+    assert!(sarif.contains("[REDACTED]"));
 }
 
 #[derive(Debug)]

--- a/crates/agentenv-core/tests/skills_ci.rs
+++ b/crates/agentenv-core/tests/skills_ci.rs
@@ -84,6 +84,90 @@ fn skill_ci_static_tier_lints_nested_manifest_entry() {
     assert_eq!(report.tiers[0].status, SkillCiTierStatus::Passed);
 }
 
+#[test]
+fn static_lint_rejects_secret_like_text_and_redacts_sarif() {
+    let bundle = skill_bundle(
+        "ci-secret",
+        "0.1.0",
+        "# Secret\n\nUse token sk-test-1234567890abcdefghijklmnop carefully.\n",
+    );
+
+    let report = run_skill_ci(SkillCiRequest {
+        candidate_path: bundle,
+        registry_snapshot: None,
+        fail_fast: true,
+        agent_runner: Arc::new(PanicAgentRunner),
+    })
+    .expect("ci should run");
+
+    let static_tier = report
+        .tiers
+        .iter()
+        .find(|tier| tier.tier == SkillCiTier::StaticLint)
+        .unwrap();
+    assert_eq!(static_tier.status, SkillCiTierStatus::Failed);
+    assert!(static_tier
+        .findings
+        .iter()
+        .any(|finding| finding.rule_id == "agentenv.skill.secret.detected"));
+
+    let sarif = agentenv_core::skills::skill_ci_sarif(&report).unwrap();
+    assert!(sarif.contains("agentenv.skill.secret.detected"));
+    assert!(!sarif.contains("sk-test-1234567890abcdefghijklmnop"));
+}
+
+#[test]
+fn static_lint_rejects_prerelease_versions() {
+    let bundle = skill_bundle("ci-prerelease", "1.0.0-alpha.1", "# Prerelease\n");
+
+    let report = run_skill_ci(SkillCiRequest {
+        candidate_path: bundle,
+        registry_snapshot: None,
+        fail_fast: true,
+        agent_runner: Arc::new(PanicAgentRunner),
+    })
+    .expect("ci should run");
+
+    let static_tier = report
+        .tiers
+        .iter()
+        .find(|tier| tier.tier == SkillCiTier::StaticLint)
+        .unwrap();
+    assert_eq!(static_tier.status, SkillCiTierStatus::Failed);
+    assert!(static_tier
+        .findings
+        .iter()
+        .any(|finding| finding.rule_id == "agentenv.skill.version.prerelease"));
+}
+
+#[test]
+fn static_lint_rejects_unclosed_frontmatter() {
+    let bundle = skill_bundle(
+        "ci-frontmatter",
+        "0.1.0",
+        "---\nname: ci-frontmatter\n# Missing close marker\n",
+    );
+
+    let report = run_skill_ci(SkillCiRequest {
+        candidate_path: bundle,
+        registry_snapshot: None,
+        fail_fast: true,
+        agent_runner: Arc::new(PanicAgentRunner),
+    })
+    .expect("ci should run");
+
+    let static_tier = report
+        .tiers
+        .iter()
+        .find(|tier| tier.tier == SkillCiTier::StaticLint)
+        .unwrap();
+    assert_eq!(static_tier.status, SkillCiTierStatus::Failed);
+    assert!(static_tier
+        .findings
+        .iter()
+        .any(|finding| finding.rule_id == "agentenv.skill.frontmatter.unclosed"));
+}
+
 #[derive(Debug)]
 struct PanicAgentRunner;
 

--- a/crates/agentenv-core/tests/skills_ci.rs
+++ b/crates/agentenv-core/tests/skills_ci.rs
@@ -196,6 +196,70 @@ fn static_lint_sarif_redacts_secret_values_in_finding_messages() {
     assert!(sarif.contains("[REDACTED]"));
 }
 
+#[test]
+fn static_lint_rejects_secret_like_text_in_skill_yaml() {
+    let bundle = temp_dir("skill-ci-secret-skill-yaml");
+    write_file(&bundle.join("SKILL.md"), "# Secret metadata\n");
+    write_file(
+        &bundle.join("skill.yaml"),
+        "name: ci-secret-skill-yaml\nversion: 0.1.0\ndescription: token=tok_1234567890abcdefghijklmnop\nentry: SKILL.md\nfiles:\n  - SKILL.md\nself_test:\n  command: test -f SKILL.md\n",
+    );
+    sign_skill_bundle(&bundle);
+
+    let report = run_skill_ci(SkillCiRequest {
+        candidate_path: bundle,
+        registry_snapshot: None,
+        fail_fast: true,
+        agent_runner: Arc::new(PanicAgentRunner),
+    })
+    .expect("ci should run");
+
+    let static_tier = report
+        .tiers
+        .iter()
+        .find(|tier| tier.tier == SkillCiTier::StaticLint)
+        .unwrap();
+    assert_eq!(static_tier.status, SkillCiTierStatus::Failed);
+    assert!(static_tier.findings.iter().any(|finding| {
+        finding.rule_id == "agentenv.skill.secret.detected"
+            && finding.path.as_deref() == Some(Path::new("skill.yaml"))
+    }));
+}
+
+#[test]
+fn static_lint_rejects_secret_like_text_in_skill_test_yaml() {
+    let bundle = temp_dir("skill-ci-secret-skill-test-yaml");
+    write_file(&bundle.join("SKILL.md"), "# Secret self-test\n");
+    write_file(
+        &bundle.join("skill.yaml"),
+        "name: ci-secret-skill-test-yaml\nversion: 0.1.0\ndescription: self-test secret fixture\nentry: SKILL.md\nfiles:\n  - SKILL.md\n",
+    );
+    write_file(
+        &bundle.join("skill-test.yaml"),
+        "self_test:\n  runner: agentenv\n  assertions:\n    - type: agent_produces\n      prompt: \"Use sk-test-1234567890abcdefghijklmnop\"\n      expect_tokens_matching:\n        - ok\n      min_match_ratio: 1.0\n",
+    );
+    sign_skill_bundle(&bundle);
+
+    let report = run_skill_ci(SkillCiRequest {
+        candidate_path: bundle,
+        registry_snapshot: None,
+        fail_fast: true,
+        agent_runner: Arc::new(PanicAgentRunner),
+    })
+    .expect("ci should run");
+
+    let static_tier = report
+        .tiers
+        .iter()
+        .find(|tier| tier.tier == SkillCiTier::StaticLint)
+        .unwrap();
+    assert_eq!(static_tier.status, SkillCiTierStatus::Failed);
+    assert!(static_tier.findings.iter().any(|finding| {
+        finding.rule_id == "agentenv.skill.secret.detected"
+            && finding.path.as_deref() == Some(Path::new("skill-test.yaml"))
+    }));
+}
+
 #[derive(Debug)]
 struct PanicAgentRunner;
 

--- a/crates/agentenv-core/tests/skills_ci.rs
+++ b/crates/agentenv-core/tests/skills_ci.rs
@@ -289,6 +289,97 @@ fn agent_review_fails_destructive_instruction_without_consent() {
 }
 
 #[test]
+fn agent_review_fails_negated_consent_with_destructive_command() {
+    let bundle = skill_bundle(
+        "ci-negated-consent",
+        "0.1.0",
+        "# Negated Consent\n\nDo not ask before running `rm -rf target`.\n",
+    );
+
+    let report = run_skill_ci(SkillCiRequest {
+        candidate_path: bundle,
+        registry_snapshot: None,
+        fail_fast: false,
+        agent_runner: Arc::new(PanicAgentRunner),
+    })
+    .expect("ci should run");
+
+    let review = report
+        .tiers
+        .iter()
+        .find(|tier| tier.tier == SkillCiTier::AgentReview)
+        .unwrap();
+    assert_eq!(review.status, SkillCiTierStatus::Failed);
+    assert!(review
+        .findings
+        .iter()
+        .any(|finding| finding.rule_id == "agentenv.skill.review.destructive-without-consent"));
+}
+
+#[test]
+fn agent_review_fails_unrelated_consent_before_later_destructive_command() {
+    let bundle = skill_bundle(
+        "ci-unrelated-consent",
+        "0.1.0",
+        "# Unrelated Consent\n\nAsk before editing files. Run `rm -rf target` automatically.\n",
+    );
+
+    let report = run_skill_ci(SkillCiRequest {
+        candidate_path: bundle,
+        registry_snapshot: None,
+        fail_fast: false,
+        agent_runner: Arc::new(PanicAgentRunner),
+    })
+    .expect("ci should run");
+
+    let review = report
+        .tiers
+        .iter()
+        .find(|tier| tier.tier == SkillCiTier::AgentReview)
+        .unwrap();
+    assert_eq!(review.status, SkillCiTierStatus::Failed);
+    assert!(review
+        .findings
+        .iter()
+        .any(|finding| finding.rule_id == "agentenv.skill.review.destructive-without-consent"));
+}
+
+#[test]
+fn agent_review_fails_api_key_variants_without_credential_language() {
+    for (name, skill_md) in [
+        (
+            "ci-api-key",
+            "# API Key\n\nDocument how to request an api-key from the provider.\n",
+        ),
+        (
+            "ci-apikey",
+            "# APIKey\n\nDocument how to request an apikey from the provider.\n",
+        ),
+    ] {
+        let bundle = skill_bundle(name, "0.1.0", skill_md);
+
+        let report = run_skill_ci(SkillCiRequest {
+            candidate_path: bundle,
+            registry_snapshot: None,
+            fail_fast: false,
+            agent_runner: Arc::new(PanicAgentRunner),
+        })
+        .expect("ci should run");
+
+        let review = report
+            .tiers
+            .iter()
+            .find(|tier| tier.tier == SkillCiTier::AgentReview)
+            .unwrap();
+        assert_eq!(review.status, SkillCiTierStatus::Failed);
+        assert!(review
+            .findings
+            .iter()
+            .any(|finding| finding.rule_id == "agentenv.skill.review.credential-handling"));
+    }
+}
+
+#[test]
 fn agent_review_passes_clear_bounded_non_destructive_skill() {
     let bundle = skill_bundle(
         "ci-clear",

--- a/crates/agentenv-core/tests/skills_ci.rs
+++ b/crates/agentenv-core/tests/skills_ci.rs
@@ -260,6 +260,58 @@ fn static_lint_rejects_secret_like_text_in_skill_test_yaml() {
     }));
 }
 
+#[test]
+fn agent_review_fails_destructive_instruction_without_consent() {
+    let bundle = skill_bundle(
+        "ci-destructive",
+        "0.1.0",
+        "# Destructive\n\nRun `rm -rf target` immediately before asking the user.\n",
+    );
+
+    let report = run_skill_ci(SkillCiRequest {
+        candidate_path: bundle,
+        registry_snapshot: None,
+        fail_fast: false,
+        agent_runner: Arc::new(PanicAgentRunner),
+    })
+    .expect("ci should run");
+
+    let review = report
+        .tiers
+        .iter()
+        .find(|tier| tier.tier == SkillCiTier::AgentReview)
+        .unwrap();
+    assert_eq!(review.status, SkillCiTierStatus::Failed);
+    assert!(review
+        .findings
+        .iter()
+        .any(|finding| finding.rule_id == "agentenv.skill.review.destructive-without-consent"));
+}
+
+#[test]
+fn agent_review_passes_clear_bounded_non_destructive_skill() {
+    let bundle = skill_bundle(
+        "ci-clear",
+        "0.1.0",
+        "# Clear Skill\n\nUse this skill to inspect Rust files, summarize findings, and ask before changing files.\n",
+    );
+
+    let report = run_skill_ci(SkillCiRequest {
+        candidate_path: bundle,
+        registry_snapshot: None,
+        fail_fast: false,
+        agent_runner: Arc::new(PanicAgentRunner),
+    })
+    .expect("ci should run");
+
+    let review = report
+        .tiers
+        .iter()
+        .find(|tier| tier.tier == SkillCiTier::AgentReview)
+        .unwrap();
+    assert_eq!(review.status, SkillCiTierStatus::Passed);
+}
+
 #[derive(Debug)]
 struct PanicAgentRunner;
 

--- a/crates/agentenv/Cargo.toml
+++ b/crates/agentenv/Cargo.toml
@@ -57,6 +57,7 @@ url.workspace = true
 
 [dev-dependencies]
 assert_cmd = "=2.0.16"
+ed25519-dalek.workspace = true
 portable-pty = "0.8"
 predicates = "3"
 reqwest = { workspace = true, features = ["blocking"] }

--- a/crates/agentenv/src/skills_cli.rs
+++ b/crates/agentenv/src/skills_cli.rs
@@ -1,6 +1,8 @@
 use std::{
     fs,
+    io::{self, Write},
     path::PathBuf,
+    process,
     sync::{atomic::Ordering, Arc},
     time::{Duration, Instant, SystemTime, UNIX_EPOCH},
 };
@@ -10,10 +12,11 @@ use agentenv_core::runtime::RuntimeOptions;
 use agentenv_core::skills::{
     execute_skill_prune, load_project_skills_config, load_skill_trust_keys,
     load_user_skills_config, merge_skills_config, plan_skill_prune, rebuild_skill_index,
-    verify_all_installed_skills, AgentProduceRequest, AgentProduceRunner, InstalledSkill,
-    InstalledSkillSelector, SkillAddRequest, SkillCacheLayout, SkillError, SkillPublishRequest,
-    SkillSearchHit, SkillService, SkillVerifyOptions, SkillVerifyStatus, SkillsConfig,
-    SkillsConfigOverride,
+    run_skill_ci, skill_ci_sarif, verify_all_installed_skills, AgentProduceRequest,
+    AgentProduceRunner, InstalledSkill, InstalledSkillSelector, SkillAddRequest, SkillCacheLayout,
+    SkillCiRegistrySnapshot, SkillCiRequest, SkillCiSeverity, SkillCiStatus, SkillCiTier,
+    SkillCiTierStatus, SkillError, SkillPublishRequest, SkillSearchHit, SkillService,
+    SkillVerifyOptions, SkillVerifyStatus, SkillsConfig, SkillsConfigOverride,
 };
 use agentenv_credstore::{CredentialStore, CredentialStoreError};
 use agentenv_proto::{CredentialKind, CredentialRequirement, LogLevel};
@@ -44,6 +47,7 @@ pub enum SkillsCommand {
     Remove(SkillsRemoveArgs),
     Publish(SkillsPublishArgs),
     Verify(SkillsVerifyArgs),
+    Ci(SkillsCiArgs),
     Prune(SkillsPruneArgs),
 }
 
@@ -131,6 +135,19 @@ pub struct SkillsVerifyArgs {
     pub all: bool,
     #[arg(long)]
     pub json: bool,
+}
+
+#[derive(Debug, Args)]
+pub struct SkillsCiArgs {
+    pub path: PathBuf,
+    #[arg(long, value_name = "PATH")]
+    pub registry_snapshot: Option<PathBuf>,
+    #[arg(long, value_name = "PATH")]
+    pub sarif: Option<PathBuf>,
+    #[arg(long)]
+    pub json: bool,
+    #[arg(long)]
+    pub no_fail_fast: bool,
 }
 
 #[derive(Debug, Args)]
@@ -423,6 +440,7 @@ async fn dispatch(command: SkillsCommand, service: SkillService, root: PathBuf) 
                 print_installed_result(&installed, args.json)
             }
         }
+        SkillsCommand::Ci(args) => run_ci(&service, args),
         SkillsCommand::Prune(args) => run_prune(&root, args),
     }
 }
@@ -438,8 +456,48 @@ fn registry_override_for_command(command: &SkillsCommand) -> Option<String> {
         | SkillsCommand::Info(_)
         | SkillsCommand::Remove(_)
         | SkillsCommand::Verify(_)
+        | SkillsCommand::Ci(_)
         | SkillsCommand::Prune(_) => None,
     }
+}
+
+fn run_ci(service: &SkillService, args: SkillsCiArgs) -> Result<()> {
+    let registry_snapshot = match args.registry_snapshot.as_deref() {
+        Some(path) => Some(
+            serde_json::from_str::<SkillCiRegistrySnapshot>(
+                &fs::read_to_string(path).with_context(|| format!("read `{}`", path.display()))?,
+            )
+            .with_context(|| format!("parse registry snapshot `{}`", path.display()))?,
+        ),
+        None => None,
+    };
+
+    let report = run_skill_ci(SkillCiRequest {
+        candidate_path: args.path,
+        registry_snapshot,
+        fail_fast: !args.no_fail_fast,
+        agent_runner: service.agent_produce_runner(),
+    })?;
+
+    if let Some(path) = args.sarif.as_deref() {
+        if let Some(parent) = path.parent() {
+            fs::create_dir_all(parent)
+                .with_context(|| format!("create SARIF directory `{}`", parent.display()))?;
+        }
+        fs::write(path, skill_ci_sarif(&report)?)
+            .with_context(|| format!("write SARIF `{}`", path.display()))?;
+    }
+
+    if args.json {
+        print_json(&report)?;
+    } else {
+        print_ci_summary(&report);
+    }
+
+    if report.status != SkillCiStatus::Passed {
+        exit_process(1);
+    }
+    Ok(())
 }
 
 fn run_verify_all(root: &std::path::Path, json: bool) -> Result<()> {
@@ -622,4 +680,90 @@ fn print_installed_info(installed: &InstalledSkill) {
     println!("entry: {}", installed.entry.display());
     println!("installed_at: {}", installed.installed_at);
     println!("path: {}", installed.path.display());
+}
+
+fn print_ci_summary(report: &agentenv_core::skills::SkillCiReport) {
+    println!("status: {}", ci_status(report.status));
+    println!(
+        "candidate: {} {} {}",
+        report.candidate.name, report.candidate.version, report.candidate.digest
+    );
+    println!("TIER STATUS FINDINGS");
+    for tier in &report.tiers {
+        println!(
+            "{} {} {}",
+            ci_tier(tier.tier),
+            ci_tier_status(tier.status),
+            tier.findings.len()
+        );
+        for finding in tier
+            .findings
+            .iter()
+            .filter(|finding| finding.severity != SkillCiSeverity::Note)
+            .take(3)
+        {
+            match (&finding.path, finding.line) {
+                (Some(path), Some(line)) => println!(
+                    "  {} {} {}:{} {}",
+                    ci_severity(finding.severity),
+                    finding.rule_id,
+                    path.display(),
+                    line,
+                    finding.message
+                ),
+                (Some(path), None) => println!(
+                    "  {} {} {} {}",
+                    ci_severity(finding.severity),
+                    finding.rule_id,
+                    path.display(),
+                    finding.message
+                ),
+                (None, _) => println!(
+                    "  {} {} {}",
+                    ci_severity(finding.severity),
+                    finding.rule_id,
+                    finding.message
+                ),
+            }
+        }
+    }
+}
+
+fn ci_status(status: SkillCiStatus) -> &'static str {
+    match status {
+        SkillCiStatus::Passed => "passed",
+        SkillCiStatus::Failed => "failed",
+        SkillCiStatus::Skipped => "skipped",
+    }
+}
+
+fn ci_tier(tier: SkillCiTier) -> &'static str {
+    match tier {
+        SkillCiTier::StaticLint => "static_lint",
+        SkillCiTier::AgentReview => "agent_review",
+        SkillCiTier::SemanticDedup => "semantic_dedup",
+        SkillCiTier::FunctionalRegression => "functional_regression",
+    }
+}
+
+fn ci_tier_status(status: SkillCiTierStatus) -> &'static str {
+    match status {
+        SkillCiTierStatus::Passed => "passed",
+        SkillCiTierStatus::Failed => "failed",
+        SkillCiTierStatus::Skipped => "skipped",
+    }
+}
+
+fn ci_severity(severity: SkillCiSeverity) -> &'static str {
+    match severity {
+        SkillCiSeverity::Error => "error",
+        SkillCiSeverity::Warning => "warning",
+        SkillCiSeverity::Note => "note",
+    }
+}
+
+fn exit_process(code: i32) -> ! {
+    let _ = io::stdout().flush();
+    let _ = io::stderr().flush();
+    process::exit(code);
 }

--- a/crates/agentenv/tests/cli_behavior.rs
+++ b/crates/agentenv/tests/cli_behavior.rs
@@ -2656,6 +2656,18 @@ fn skills_ci_registry_snapshot_drives_dedup_failure() {
 }
 
 #[test]
+fn skill_ci_workflow_references_cli_command() {
+    let workflow_path =
+        PathBuf::from(env!("CARGO_MANIFEST_DIR")).join("../../.github/workflows/skill-ci.yaml");
+    let workflow = fs::read_to_string(&workflow_path)
+        .unwrap_or_else(|err| panic!("failed to read {}: {err}", workflow_path.display()));
+
+    assert!(workflow.contains("workflow_call"));
+    assert!(workflow.contains("agentenv skills ci"));
+    assert!(workflow.contains("upload-sarif"));
+}
+
+#[test]
 fn skills_install_list_info_verify_and_remove_local_bundle() {
     let temp_dir = make_temp_dir("skills-cli-local");
     let bundle = temp_dir.join("bundle");

--- a/crates/agentenv/tests/cli_behavior.rs
+++ b/crates/agentenv/tests/cli_behavior.rs
@@ -15,11 +15,13 @@ use std::{
 use agentenv_approvals::{
     sign_payload, ApprovalKind, ApprovalRequest, ApprovalScope, ApprovalStore,
 };
+use agentenv_core::skills::{compute_bundle_digest, load_skill_manifest, signature_payload};
 use agentenv_events::{
     audit::{AuditSigningKey, AuditStore},
     store::{EventQuery, SqliteEventStore},
     ActivityEvent, ActivityKind, ActivityResult,
 };
+use ed25519_dalek::{Signer, SigningKey};
 use portable_pty::{native_pty_system, CommandBuilder, PtySize};
 use serde_json::json;
 use sha2::{Digest, Sha256};
@@ -2504,6 +2506,152 @@ fn skills_prune_deletes_unreferenced_archive() {
     assert!(
         !archive.exists(),
         "prune should delete unreferenced archive"
+    );
+}
+
+#[test]
+fn skills_ci_json_passes_valid_bundle() {
+    let temp_dir = make_temp_dir("skills-ci-json-pass");
+    let bundle = temp_dir.join("bundle");
+    write_signed_ci_skill_bundle(&bundle, "ci-cli-pass", "0.1.0", "CI pass fixture");
+
+    let output = Command::new(agentenv_bin())
+        .arg("skills")
+        .arg("ci")
+        .arg(&bundle)
+        .arg("--json")
+        .env("HOME", &temp_dir)
+        .current_dir(&temp_dir)
+        .output()
+        .unwrap();
+
+    assert!(output.status.success(), "{}", output_summary(&output));
+    let report: serde_json::Value = serde_json::from_slice(&output.stdout)
+        .unwrap_or_else(|err| panic!("JSON parse failed: {err}\n{}", output_summary(&output)));
+    assert_eq!(report["status"], "passed");
+    assert_eq!(report["candidate"]["name"], "ci-cli-pass");
+    assert_eq!(report["candidate"]["version"], "0.1.0");
+    assert_ci_tier_status(&report, "static_lint", "passed");
+    assert_ci_tier_status(&report, "functional_regression", "passed");
+}
+
+#[test]
+fn skills_ci_json_exits_one_for_invalid_bundle() {
+    let temp_dir = make_temp_dir("skills-ci-json-invalid");
+    let bundle = temp_dir.join("bundle");
+    write_signed_ci_skill_bundle(&bundle, "ci-cli-invalid", "0.1.0", "CI invalid fixture");
+    fs::write(
+        bundle.join("SKILL.md"),
+        "# Invalid\n\n```rust\nfn main() {}\n",
+    )
+    .unwrap();
+
+    let output = Command::new(agentenv_bin())
+        .arg("skills")
+        .arg("ci")
+        .arg(&bundle)
+        .arg("--json")
+        .env("HOME", &temp_dir)
+        .current_dir(&temp_dir)
+        .output()
+        .unwrap();
+
+    assert_eq!(output.status.code(), Some(1), "{}", output_summary(&output));
+    let report: serde_json::Value = serde_json::from_slice(&output.stdout)
+        .unwrap_or_else(|err| panic!("JSON parse failed: {err}\n{}", output_summary(&output)));
+    assert_eq!(report["status"], "failed");
+    assert_ci_tier_status(&report, "static_lint", "failed");
+    assert_ci_findings_include(
+        &report,
+        "static_lint",
+        "agentenv.skill.markdown.unclosed-fence",
+    );
+}
+
+#[test]
+fn skills_ci_writes_sarif_file() {
+    let temp_dir = make_temp_dir("skills-ci-sarif");
+    let bundle = temp_dir.join("bundle");
+    let sarif_path = temp_dir.join("skill-ci.sarif");
+    write_signed_ci_skill_bundle(&bundle, "ci-cli-sarif", "0.1.0", "CI SARIF fixture");
+    fs::write(
+        bundle.join("SKILL.md"),
+        "# SARIF\n\nUse token sk-test-1234567890abcdefghijklmnop carefully.\n",
+    )
+    .unwrap();
+
+    let output = Command::new(agentenv_bin())
+        .arg("skills")
+        .arg("ci")
+        .arg(&bundle)
+        .arg("--sarif")
+        .arg(&sarif_path)
+        .env("HOME", &temp_dir)
+        .current_dir(&temp_dir)
+        .output()
+        .unwrap();
+
+    assert_eq!(output.status.code(), Some(1), "{}", output_summary(&output));
+    assert!(sarif_path.is_file(), "SARIF file was not written");
+    let sarif: serde_json::Value =
+        serde_json::from_str(&fs::read_to_string(&sarif_path).unwrap()).unwrap();
+    assert_eq!(sarif["version"], "2.1.0");
+    let results = sarif["runs"][0]["results"].as_array().unwrap();
+    assert!(results
+        .iter()
+        .any(|result| { result["ruleId"].as_str() == Some("agentenv.skill.secret.detected") }));
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    assert!(stdout.contains("status"), "stdout was: {stdout}");
+}
+
+#[test]
+fn skills_ci_registry_snapshot_drives_dedup_failure() {
+    let temp_dir = make_temp_dir("skills-ci-dedup");
+    let bundle = temp_dir.join("bundle");
+    write_signed_ci_skill_bundle(&bundle, "ci-cli-dedup", "0.1.0", "CI dedup fixture");
+    let manifest = load_skill_manifest(&bundle).unwrap();
+    let digest = compute_bundle_digest(&bundle, &manifest).unwrap();
+    let snapshot = temp_dir.join("registry-snapshot.json");
+    fs::write(
+        &snapshot,
+        serde_json::to_string_pretty(&json!({
+            "skills": [
+                {
+                    "name": "existing-dedup",
+                    "version": "1.0.0",
+                    "description": "CI dedup fixture",
+                    "procedure_text": "# CI dedup fixture\n\nUse this skill safely. Ask before destructive actions.\n",
+                    "fingerprint": digest,
+                }
+            ]
+        }))
+        .unwrap(),
+    )
+    .unwrap();
+
+    let output = Command::new(agentenv_bin())
+        .arg("skills")
+        .arg("ci")
+        .arg(&bundle)
+        .arg("--registry-snapshot")
+        .arg(&snapshot)
+        .arg("--no-fail-fast")
+        .arg("--json")
+        .env("HOME", &temp_dir)
+        .current_dir(&temp_dir)
+        .output()
+        .unwrap();
+
+    assert_eq!(output.status.code(), Some(1), "{}", output_summary(&output));
+    let report: serde_json::Value = serde_json::from_slice(&output.stdout)
+        .unwrap_or_else(|err| panic!("JSON parse failed: {err}\n{}", output_summary(&output)));
+    assert_eq!(report["status"], "failed");
+    assert_ci_tier_status(&report, "semantic_dedup", "failed");
+    assert_ci_tier_status(&report, "functional_regression", "passed");
+    assert_ci_findings_include(
+        &report,
+        "semantic_dedup",
+        "agentenv.skill.dedup.probable-duplicate",
     );
 }
 
@@ -6323,6 +6471,37 @@ fn write_local_skill_bundle(
     .unwrap();
 }
 
+fn write_signed_ci_skill_bundle(bundle: &Path, name: &str, version: &str, description: &str) {
+    fs::create_dir_all(bundle).unwrap();
+    fs::write(
+        bundle.join("SKILL.md"),
+        format!("# {description}\n\nUse this skill safely. Ask before destructive actions.\n"),
+    )
+    .unwrap();
+    fs::write(
+        bundle.join("skill.yaml"),
+        format!(
+            "name: {name}\nversion: {version}\ndescription: {description}\nentry: SKILL.md\nfiles:\n  - SKILL.md\nself_test:\n  command: test -f SKILL.md\n"
+        ),
+    )
+    .unwrap();
+    sign_local_skill_bundle(bundle);
+}
+
+fn sign_local_skill_bundle(bundle: &Path) {
+    let manifest = load_skill_manifest(bundle).unwrap();
+    let digest = compute_bundle_digest(bundle, &manifest).unwrap();
+    let signing_key = SigningKey::from_bytes(&[42_u8; 32]);
+    let payload = signature_payload(&manifest, &digest).unwrap();
+    let signature = hex::encode(signing_key.sign(&payload).to_bytes());
+    let public_key = hex::encode(signing_key.verifying_key().to_bytes());
+    let mut manifest_text = fs::read_to_string(bundle.join("skill.yaml")).unwrap();
+    manifest_text.push_str(&format!(
+        "signatures:\n  ed25519: {signature}\n  public_key_ed25519: {public_key}\n"
+    ));
+    fs::write(bundle.join("skill.yaml"), manifest_text).unwrap();
+}
+
 fn write_local_skill_bundle_with_skill_test_file(
     bundle: &Path,
     name: &str,
@@ -6389,6 +6568,35 @@ fn write_indexless_filesystem_registry_skill(
         ),
     )
     .unwrap();
+}
+
+fn assert_ci_tier_status(report: &serde_json::Value, tier_name: &str, expected_status: &str) {
+    let tier = ci_tier(report, tier_name);
+    assert_eq!(
+        tier["status"].as_str(),
+        Some(expected_status),
+        "report was: {report}"
+    );
+}
+
+fn assert_ci_findings_include(report: &serde_json::Value, tier_name: &str, rule_id: &str) {
+    let tier = ci_tier(report, tier_name);
+    let findings = tier["findings"].as_array().unwrap();
+    assert!(
+        findings
+            .iter()
+            .any(|finding| finding["rule_id"].as_str() == Some(rule_id)),
+        "missing {rule_id}; tier was: {tier}"
+    );
+}
+
+fn ci_tier<'a>(report: &'a serde_json::Value, tier_name: &str) -> &'a serde_json::Value {
+    report["tiers"]
+        .as_array()
+        .unwrap()
+        .iter()
+        .find(|tier| tier["tier"].as_str() == Some(tier_name))
+        .unwrap_or_else(|| panic!("missing {tier_name}; report was: {report}"))
 }
 
 fn assert_skill_search_names(stdout: &[u8], expected: &[&str]) {

--- a/crates/agentenv/tests/cli_behavior.rs
+++ b/crates/agentenv/tests/cli_behavior.rs
@@ -2536,6 +2536,46 @@ fn skills_ci_json_passes_valid_bundle() {
 }
 
 #[test]
+fn skills_ci_summary_reports_valid_bundle_tiers() {
+    let temp_dir = make_temp_dir("skills-ci-summary-pass");
+    let bundle = temp_dir.join("bundle");
+    write_signed_ci_skill_bundle(&bundle, "ci-cli-summary", "0.1.0", "CI summary fixture");
+
+    let output = Command::new(agentenv_bin())
+        .arg("skills")
+        .arg("ci")
+        .arg(&bundle)
+        .env("HOME", &temp_dir)
+        .current_dir(&temp_dir)
+        .output()
+        .unwrap();
+
+    assert!(output.status.success(), "{}", output_summary(&output));
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    assert!(stdout.contains("status: passed"), "stdout was: {stdout}");
+    assert!(
+        stdout.contains("candidate: ci-cli-summary 0.1.0 sha256:"),
+        "stdout was: {stdout}"
+    );
+    assert!(
+        stdout.contains("static_lint passed 0"),
+        "stdout was: {stdout}"
+    );
+    assert!(
+        stdout.contains("agent_review passed 0"),
+        "stdout was: {stdout}"
+    );
+    assert!(
+        stdout.contains("semantic_dedup passed 0"),
+        "stdout was: {stdout}"
+    );
+    assert!(
+        stdout.contains("functional_regression passed 0"),
+        "stdout was: {stdout}"
+    );
+}
+
+#[test]
 fn skills_ci_json_exits_one_for_invalid_bundle() {
     let temp_dir = make_temp_dir("skills-ci-json-invalid");
     let bundle = temp_dir.join("bundle");
@@ -2561,6 +2601,9 @@ fn skills_ci_json_exits_one_for_invalid_bundle() {
         .unwrap_or_else(|err| panic!("JSON parse failed: {err}\n{}", output_summary(&output)));
     assert_eq!(report["status"], "failed");
     assert_ci_tier_status(&report, "static_lint", "failed");
+    assert_ci_tier_status(&report, "agent_review", "skipped");
+    assert_ci_tier_status(&report, "semantic_dedup", "skipped");
+    assert_ci_tier_status(&report, "functional_regression", "skipped");
     assert_ci_findings_include(
         &report,
         "static_lint",
@@ -2569,10 +2612,47 @@ fn skills_ci_json_exits_one_for_invalid_bundle() {
 }
 
 #[test]
+fn skills_ci_no_fail_fast_continues_after_static_failure() {
+    let temp_dir = make_temp_dir("skills-ci-no-fail-fast-static");
+    let bundle = temp_dir.join("bundle");
+    write_signed_ci_skill_bundle(
+        &bundle,
+        "ci-cli-no-fail-fast-static",
+        "0.1.0",
+        "CI no fail-fast fixture",
+    );
+    fs::write(
+        bundle.join("SKILL.md"),
+        "# Invalid but reviewable\n\nUse this skill safely.\n\n```rust\nfn main() {}\n",
+    )
+    .unwrap();
+
+    let output = Command::new(agentenv_bin())
+        .arg("skills")
+        .arg("ci")
+        .arg(&bundle)
+        .arg("--no-fail-fast")
+        .arg("--json")
+        .env("HOME", &temp_dir)
+        .current_dir(&temp_dir)
+        .output()
+        .unwrap();
+
+    assert_eq!(output.status.code(), Some(1), "{}", output_summary(&output));
+    let report: serde_json::Value = serde_json::from_slice(&output.stdout)
+        .unwrap_or_else(|err| panic!("JSON parse failed: {err}\n{}", output_summary(&output)));
+    assert_eq!(report["status"], "failed");
+    assert_ci_tier_status(&report, "static_lint", "failed");
+    assert_ci_tier_status(&report, "agent_review", "passed");
+    assert_ci_tier_status(&report, "semantic_dedup", "passed");
+    assert_ci_tier_status(&report, "functional_regression", "skipped");
+}
+
+#[test]
 fn skills_ci_writes_sarif_file() {
     let temp_dir = make_temp_dir("skills-ci-sarif");
     let bundle = temp_dir.join("bundle");
-    let sarif_path = temp_dir.join("skill-ci.sarif");
+    let sarif_path = temp_dir.join("reports/nested/skill-ci.sarif");
     write_signed_ci_skill_bundle(&bundle, "ci-cli-sarif", "0.1.0", "CI SARIF fixture");
     fs::write(
         bundle.join("SKILL.md"),

--- a/docs/superpowers/plans/2026-05-15-m7-10-skill-ci-validation.md
+++ b/docs/superpowers/plans/2026-05-15-m7-10-skill-ci-validation.md
@@ -1,0 +1,1849 @@
+# M7-10 Skill CI Validation Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Build `agentenv skills ci` and a reusable GitHub Actions workflow that validate skill publish candidates through static lint, deterministic review, semantic dedup, and functional self-test tiers.
+
+**Architecture:** Add a focused `agentenv-core::skills::ci` module that owns report types, tier orchestration, SARIF serialization, static checks, review checks, dedup checks, and self-test tier integration. Keep registry storage and publish gates in the existing `SkillService`; the CLI and workflow call the new reusable validation engine without adding a driver protocol surface. The workflow remains a thin shell around `agentenv skills ci` so policy lives in Rust.
+
+**Tech Stack:** Rust 2021, existing `agentenv-core::skills` APIs, `serde`, `serde_json`, `serde_yaml`, `sha2`, `ed25519-dalek`, `time`, `clap`, GitHub Actions YAML, optional external `gitleaks` process detected at runtime.
+
+---
+
+## File Structure
+
+- Create `crates/agentenv-core/src/skills/ci.rs`: public CI request/report types, tier orchestration, candidate loading, static lint, review, dedup, self-test tier, and SARIF serialization.
+- Modify `crates/agentenv-core/src/skills/mod.rs`: export the CI API.
+- Modify `crates/agentenv-core/src/skills/error.rs`: add typed CI errors.
+- Modify `crates/agentenv-core/src/skills/propose/score.rs`: expose a small reusable similarity helper or move equivalent token scoring into `ci.rs` without changing proposal behavior.
+- Create `crates/agentenv-core/tests/skills_ci.rs`: core tier and SARIF tests.
+- Modify `crates/agentenv/src/skills_cli.rs`: add the `skills ci` subcommand, JSON output, SARIF file output, registry snapshot loading, fail-fast flag handling, and process exit behavior.
+- Modify `crates/agentenv/tests/cli_behavior.rs`: add CLI tests for pass, failure, SARIF, and dedup snapshot.
+- Add `.github/workflows/skill-ci.yaml`: reusable skill validation workflow.
+- Modify `README.md`: document `agentenv skills ci`.
+
+## Task 1: Core CI Report Model and Fail-Fast Orchestrator
+
+**Files:**
+- Create: `crates/agentenv-core/src/skills/ci.rs`
+- Modify: `crates/agentenv-core/src/skills/mod.rs`
+- Modify: `crates/agentenv-core/src/skills/error.rs`
+- Test: `crates/agentenv-core/tests/skills_ci.rs`
+
+- [ ] **Step 1: Write failing orchestration tests**
+
+Create `crates/agentenv-core/tests/skills_ci.rs` with these first tests and helpers:
+
+```rust
+use std::{
+    fs,
+    path::{Path, PathBuf},
+    sync::Arc,
+};
+
+use ed25519_dalek::{Signer, SigningKey};
+
+use agentenv_core::skills::{
+    compute_bundle_digest, load_skill_manifest, run_skill_ci, signature_payload,
+    AgentProduceRequest, AgentProduceRunner, SkillCiRequest, SkillCiStatus, SkillCiTier,
+    SkillCiTierStatus, SkillError,
+};
+
+#[test]
+fn skill_ci_reports_candidate_and_runs_static_tier_first() {
+    let bundle = skill_bundle("ci-valid", "0.1.0", "# CI valid\n\nUse this skill safely.\n");
+
+    let report = run_skill_ci(SkillCiRequest {
+        candidate_path: bundle,
+        registry_snapshot: None,
+        fail_fast: true,
+        agent_runner: Arc::new(PanicAgentRunner),
+    })
+    .expect("ci should run");
+
+    assert_eq!(report.schema_version, "0.1");
+    assert_eq!(report.candidate.name, "ci-valid");
+    assert_eq!(report.candidate.version, "0.1.0");
+    assert!(report.candidate.digest.starts_with("sha256:"));
+    assert_eq!(report.tiers[0].tier, SkillCiTier::StaticLint);
+    assert_eq!(report.tiers[0].status, SkillCiTierStatus::Passed);
+}
+
+#[test]
+fn skill_ci_fail_fast_skips_later_tiers_after_static_failure() {
+    let bundle = skill_bundle("ci-bad-md", "0.1.0", "# Bad\n\n```rust\nfn main() {}\n");
+
+    let report = run_skill_ci(SkillCiRequest {
+        candidate_path: bundle,
+        registry_snapshot: None,
+        fail_fast: true,
+        agent_runner: Arc::new(PanicAgentRunner),
+    })
+    .expect("ci should return report for validation failure");
+
+    assert_eq!(report.status, SkillCiStatus::Failed);
+    assert_eq!(report.tiers[0].tier, SkillCiTier::StaticLint);
+    assert_eq!(report.tiers[0].status, SkillCiTierStatus::Failed);
+    assert!(report.tiers.iter().any(|tier| tier.status == SkillCiTierStatus::Skipped));
+}
+
+#[derive(Debug)]
+struct PanicAgentRunner;
+
+impl AgentProduceRunner for PanicAgentRunner {
+    fn run_agent_prompt(&self, _request: AgentProduceRequest<'_>) -> Result<String, SkillError> {
+        panic!("agent runner should not be used by these tests");
+    }
+}
+
+fn skill_bundle(name: &str, version: &str, skill_md: &str) -> PathBuf {
+    let root = temp_dir(&format!("skill-ci-{name}-{version}"));
+    write_file(&root.join("SKILL.md"), skill_md);
+    write_file(
+        &root.join("skill.yaml"),
+        &format!(
+            "name: {name}\nversion: {version}\ndescription: {name} skill\nentry: SKILL.md\nfiles:\n  - SKILL.md\nself_test:\n  command: test -f SKILL.md\n"
+        ),
+    );
+    sign_skill_bundle(&root);
+    root
+}
+
+fn sign_skill_bundle(root: &Path) {
+    let manifest = load_skill_manifest(root).unwrap();
+    let digest = compute_bundle_digest(root, &manifest).unwrap();
+    let signing_key = SigningKey::from_bytes(&[36_u8; 32]);
+    let payload = signature_payload(&manifest, &digest).unwrap();
+    let signature = hex::encode(signing_key.sign(&payload).to_bytes());
+    let public_key = hex::encode(signing_key.verifying_key().to_bytes());
+    let mut manifest_text = fs::read_to_string(root.join("skill.yaml")).unwrap();
+    manifest_text.push_str(&format!(
+        "signatures:\n  ed25519: {signature}\n  public_key_ed25519: {public_key}\n"
+    ));
+    fs::write(root.join("skill.yaml"), manifest_text).unwrap();
+}
+
+fn temp_dir(prefix: &str) -> PathBuf {
+    let mut path = std::env::temp_dir();
+    path.push(format!("{prefix}-{}-{}", std::process::id(), unique_nanos()));
+    fs::create_dir_all(&path).unwrap();
+    path
+}
+
+fn write_file(path: &Path, content: &str) {
+    if let Some(parent) = path.parent() {
+        fs::create_dir_all(parent).unwrap();
+    }
+    fs::write(path, content).unwrap();
+}
+
+fn unique_nanos() -> u128 {
+    std::time::SystemTime::now()
+        .duration_since(std::time::UNIX_EPOCH)
+        .map(|duration| duration.as_nanos())
+        .unwrap_or(0)
+}
+```
+
+- [ ] **Step 2: Run tests to verify RED**
+
+Run:
+
+```bash
+cargo test -p agentenv-core --test skills_ci skill_ci_reports_candidate_and_runs_static_tier_first -- --nocapture
+```
+
+Expected: FAIL with unresolved imports for `run_skill_ci`, `SkillCiRequest`, `SkillCiStatus`, `SkillCiTier`, or `SkillCiTierStatus`.
+
+- [ ] **Step 3: Add CI model and basic orchestration**
+
+Create `crates/agentenv-core/src/skills/ci.rs` with the public surface below. The first implementation may make static lint check only candidate loading and Markdown fences; Task 2 expands static lint.
+
+```rust
+use std::{path::PathBuf, sync::Arc, time::Instant};
+
+use serde::{Deserialize, Serialize};
+use time::OffsetDateTime;
+
+use super::{
+    compute_bundle_digest, load_skill_manifest, load_skill_self_test_spec, AgentProduceRunner,
+    SkillError,
+};
+
+pub const SKILL_CI_SCHEMA_VERSION: &str = "0.1";
+
+#[derive(Debug, Clone)]
+pub struct SkillCiRequest {
+    pub candidate_path: PathBuf,
+    pub registry_snapshot: Option<SkillCiRegistrySnapshot>,
+    pub fail_fast: bool,
+    pub agent_runner: Arc<dyn AgentProduceRunner>,
+}
+
+#[derive(Debug, Clone, Default, Serialize, Deserialize, PartialEq)]
+pub struct SkillCiRegistrySnapshot {
+    #[serde(default)]
+    pub skills: Vec<SkillCiRegistrySkill>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+pub struct SkillCiRegistrySkill {
+    pub name: String,
+    pub version: String,
+    #[serde(default)]
+    pub description: String,
+    #[serde(default)]
+    pub procedure_text: String,
+    #[serde(default)]
+    pub fingerprint: Option<String>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+pub struct SkillCiReport {
+    pub schema_version: &'static str,
+    pub candidate: SkillCiCandidate,
+    pub status: SkillCiStatus,
+    pub tiers: Vec<SkillCiTierReport>,
+    pub started_at: OffsetDateTime,
+    pub completed_at: OffsetDateTime,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+pub struct SkillCiCandidate {
+    pub name: String,
+    pub version: String,
+    pub digest: String,
+}
+
+#[derive(Debug, Clone, Copy, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(rename_all = "snake_case")]
+pub enum SkillCiStatus {
+    Passed,
+    Failed,
+    Skipped,
+}
+
+#[derive(Debug, Clone, Copy, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(rename_all = "snake_case")]
+pub enum SkillCiTier {
+    StaticLint,
+    AgentReview,
+    SemanticDedup,
+    FunctionalRegression,
+}
+
+#[derive(Debug, Clone, Copy, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(rename_all = "snake_case")]
+pub enum SkillCiTierStatus {
+    Passed,
+    Failed,
+    Skipped,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+pub struct SkillCiTierReport {
+    pub tier: SkillCiTier,
+    pub status: SkillCiTierStatus,
+    pub duration_ms: u128,
+    pub findings: Vec<SkillCiFinding>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub details: Option<serde_json::Value>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub struct SkillCiFinding {
+    pub rule_id: String,
+    pub severity: SkillCiSeverity,
+    pub message: String,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub path: Option<PathBuf>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub line: Option<usize>,
+}
+
+#[derive(Debug, Clone, Copy, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(rename_all = "snake_case")]
+pub enum SkillCiSeverity {
+    Error,
+    Warning,
+    Note,
+}
+
+pub fn run_skill_ci(request: SkillCiRequest) -> Result<SkillCiReport, SkillError> {
+    let started_at = OffsetDateTime::now_utc();
+    let manifest = load_skill_manifest(&request.candidate_path)?;
+    let digest = compute_bundle_digest(&request.candidate_path, &manifest)?;
+    let candidate = SkillCiCandidate {
+        name: manifest.name.clone(),
+        version: manifest.version.to_string(),
+        digest,
+    };
+
+    let mut tiers = Vec::new();
+    let static_report = run_tier(SkillCiTier::StaticLint, || {
+        run_static_lint(&request.candidate_path).map(|findings| tier_from_findings(SkillCiTier::StaticLint, findings))
+    })?;
+    let static_failed = static_report.status == SkillCiTierStatus::Failed;
+    tiers.push(static_report);
+
+    for tier in [
+        SkillCiTier::AgentReview,
+        SkillCiTier::SemanticDedup,
+        SkillCiTier::FunctionalRegression,
+    ] {
+        if request.fail_fast && static_failed {
+            tiers.push(skipped_tier(tier, "skipped because static_lint failed"));
+        }
+    }
+
+    let status = if tiers.iter().any(|tier| tier.status == SkillCiTierStatus::Failed) {
+        SkillCiStatus::Failed
+    } else if tiers.iter().any(|tier| tier.status == SkillCiTierStatus::Skipped) {
+        SkillCiStatus::Skipped
+    } else {
+        SkillCiStatus::Passed
+    };
+
+    let _ = load_skill_self_test_spec(&request.candidate_path);
+    Ok(SkillCiReport {
+        schema_version: SKILL_CI_SCHEMA_VERSION,
+        candidate,
+        status,
+        tiers,
+        started_at,
+        completed_at: OffsetDateTime::now_utc(),
+    })
+}
+
+fn run_tier<F>(tier: SkillCiTier, run: F) -> Result<SkillCiTierReport, SkillError>
+where
+    F: FnOnce() -> Result<SkillCiTierReport, SkillError>,
+{
+    let started = Instant::now();
+    let mut report = run()?;
+    report.tier = tier;
+    report.duration_ms = started.elapsed().as_millis();
+    Ok(report)
+}
+
+fn tier_from_findings(tier: SkillCiTier, findings: Vec<SkillCiFinding>) -> SkillCiTierReport {
+    let status = if findings.iter().any(|finding| finding.severity == SkillCiSeverity::Error) {
+        SkillCiTierStatus::Failed
+    } else {
+        SkillCiTierStatus::Passed
+    };
+    SkillCiTierReport {
+        tier,
+        status,
+        duration_ms: 0,
+        findings,
+        details: None,
+    }
+}
+
+fn skipped_tier(tier: SkillCiTier, message: &str) -> SkillCiTierReport {
+    SkillCiTierReport {
+        tier,
+        status: SkillCiTierStatus::Skipped,
+        duration_ms: 0,
+        findings: vec![SkillCiFinding {
+            rule_id: "agentenv.skill.ci.skipped".to_owned(),
+            severity: SkillCiSeverity::Note,
+            message: message.to_owned(),
+            path: None,
+            line: None,
+        }],
+        details: None,
+    }
+}
+```
+
+Add this temporary static-lint helper in the same file. Task 2 replaces it with full lint behavior while keeping the public report shape.
+
+```rust
+fn run_static_lint(candidate_path: &std::path::Path) -> Result<Vec<SkillCiFinding>, SkillError> {
+    let mut findings = Vec::new();
+    let skill_md = candidate_path.join("SKILL.md");
+    let content = std::fs::read_to_string(&skill_md).map_err(|source| SkillError::Io {
+        path: skill_md.clone(),
+        source,
+    })?;
+    if has_unclosed_fence(&content) {
+        findings.push(SkillCiFinding {
+            rule_id: "agentenv.skill.markdown.unclosed-fence".to_owned(),
+            severity: SkillCiSeverity::Error,
+            message: "Markdown fenced code block is not closed".to_owned(),
+            path: Some(skill_md),
+            line: None,
+        });
+    }
+    Ok(findings)
+}
+
+fn has_unclosed_fence(content: &str) -> bool {
+    let mut open = false;
+    for line in content.lines() {
+        if line.trim_start().starts_with("```") {
+            open = !open;
+        }
+    }
+    open
+}
+```
+
+Modify `crates/agentenv-core/src/skills/mod.rs`:
+
+```rust
+mod ci;
+
+pub use ci::{
+    run_skill_ci, SkillCiCandidate, SkillCiFinding, SkillCiRegistrySkill,
+    SkillCiRegistrySnapshot, SkillCiRequest, SkillCiReport, SkillCiSeverity, SkillCiStatus,
+    SkillCiTier, SkillCiTierReport, SkillCiTierStatus,
+};
+```
+
+Modify `crates/agentenv-core/src/skills/error.rs`:
+
+```rust
+    #[error("invalid skill CI candidate `{path}`: {message}")]
+    InvalidSkillCiCandidate { path: PathBuf, message: String },
+    #[error("skill CI validation failed at tier `{tier}`")]
+    SkillCiFailed { tier: String },
+    #[error("failed to serialize skill CI SARIF: {message}")]
+    SkillCiSarif { message: String },
+```
+
+- [ ] **Step 4: Run tests to verify GREEN**
+
+Run:
+
+```bash
+cargo test -p agentenv-core --test skills_ci skill_ci_ -- --nocapture
+```
+
+Expected: PASS for the two `skill_ci_` tests in `skills_ci.rs`.
+
+- [ ] **Step 5: Commit Task 1**
+
+```bash
+git add crates/agentenv-core/src/skills/ci.rs crates/agentenv-core/src/skills/mod.rs crates/agentenv-core/src/skills/error.rs crates/agentenv-core/tests/skills_ci.rs
+git commit -m "feat(core): add skill ci report model"
+```
+
+## Task 2: Static Lint Tier and SARIF Serializer
+
+**Files:**
+- Modify: `crates/agentenv-core/src/skills/ci.rs`
+- Test: `crates/agentenv-core/tests/skills_ci.rs`
+
+- [ ] **Step 1: Add failing static lint and SARIF tests**
+
+Append these tests to `crates/agentenv-core/tests/skills_ci.rs`:
+
+```rust
+#[test]
+fn static_lint_rejects_secret_like_text_and_redacts_sarif() {
+    let bundle = skill_bundle(
+        "ci-secret",
+        "0.1.0",
+        "# Secret\n\nUse token sk-test-1234567890abcdefghijklmnop carefully.\n",
+    );
+
+    let report = run_skill_ci(SkillCiRequest {
+        candidate_path: bundle,
+        registry_snapshot: None,
+        fail_fast: true,
+        agent_runner: Arc::new(PanicAgentRunner),
+    })
+    .expect("ci should run");
+
+    let static_tier = report
+        .tiers
+        .iter()
+        .find(|tier| tier.tier == SkillCiTier::StaticLint)
+        .unwrap();
+    assert_eq!(static_tier.status, SkillCiTierStatus::Failed);
+    assert!(static_tier
+        .findings
+        .iter()
+        .any(|finding| finding.rule_id == "agentenv.skill.secret.detected"));
+
+    let sarif = agentenv_core::skills::skill_ci_sarif(&report).unwrap();
+    assert!(sarif.contains("agentenv.skill.secret.detected"));
+    assert!(!sarif.contains("sk-test-1234567890abcdefghijklmnop"));
+}
+
+#[test]
+fn static_lint_rejects_prerelease_versions() {
+    let bundle = skill_bundle("ci-prerelease", "1.0.0-alpha.1", "# Prerelease\n");
+
+    let report = run_skill_ci(SkillCiRequest {
+        candidate_path: bundle,
+        registry_snapshot: None,
+        fail_fast: true,
+        agent_runner: Arc::new(PanicAgentRunner),
+    })
+    .expect("ci should run");
+
+    let static_tier = report
+        .tiers
+        .iter()
+        .find(|tier| tier.tier == SkillCiTier::StaticLint)
+        .unwrap();
+    assert_eq!(static_tier.status, SkillCiTierStatus::Failed);
+    assert!(static_tier
+        .findings
+        .iter()
+        .any(|finding| finding.rule_id == "agentenv.skill.version.prerelease"));
+}
+
+#[test]
+fn static_lint_rejects_unclosed_frontmatter() {
+    let bundle = skill_bundle(
+        "ci-frontmatter",
+        "0.1.0",
+        "---\nname: ci-frontmatter\n# Missing close marker\n",
+    );
+
+    let report = run_skill_ci(SkillCiRequest {
+        candidate_path: bundle,
+        registry_snapshot: None,
+        fail_fast: true,
+        agent_runner: Arc::new(PanicAgentRunner),
+    })
+    .expect("ci should run");
+
+    let static_tier = report
+        .tiers
+        .iter()
+        .find(|tier| tier.tier == SkillCiTier::StaticLint)
+        .unwrap();
+    assert_eq!(static_tier.status, SkillCiTierStatus::Failed);
+    assert!(static_tier
+        .findings
+        .iter()
+        .any(|finding| finding.rule_id == "agentenv.skill.frontmatter.unclosed"));
+}
+```
+
+- [ ] **Step 2: Run tests to verify RED**
+
+Run:
+
+```bash
+cargo test -p agentenv-core --test skills_ci static_lint_ -- --nocapture
+```
+
+Expected: FAIL because `skill_ci_sarif` is not exported and the static lint tier does not yet detect secret-like text, prerelease versions, or unclosed frontmatter.
+
+- [ ] **Step 3: Implement static lint checks**
+
+In `crates/agentenv-core/src/skills/ci.rs`, replace `run_static_lint` with a version that loads the manifest, digest, self-test spec, declared entry content, and bundled text files. Use this helper shape:
+
+```rust
+fn run_static_lint(candidate_path: &std::path::Path) -> Result<Vec<SkillCiFinding>, SkillError> {
+    let mut findings = Vec::new();
+    let manifest = match load_skill_manifest(candidate_path) {
+        Ok(manifest) => manifest,
+        Err(error) => {
+            findings.push(error_finding(
+                "agentenv.skill.manifest.invalid",
+                error.to_string(),
+                Some(candidate_path.join("skill.yaml")),
+                None,
+            ));
+            return Ok(findings);
+        }
+    };
+
+    if !manifest.version.pre.is_empty() {
+        findings.push(error_finding(
+            "agentenv.skill.version.prerelease",
+            format!("manifest version `{}` is a prerelease", manifest.version),
+            Some(candidate_path.join("skill.yaml")),
+            None,
+        ));
+    }
+
+    let digest = compute_bundle_digest(candidate_path, &manifest)?;
+    if let Err(error) = super::signature::verify_skill_package_signature(&manifest, &digest, false)
+    {
+        findings.push(error_finding(
+            "agentenv.skill.signature.invalid",
+            error.to_string(),
+            Some(candidate_path.join("skill.yaml")),
+            None,
+        ));
+    }
+
+    if let Err(error) = load_skill_self_test_spec(candidate_path) {
+        findings.push(error_finding(
+            "agentenv.skill.self-test.invalid",
+            error.to_string(),
+            Some(candidate_path.join("skill.yaml")),
+            None,
+        ));
+    }
+
+    let entry_path = candidate_path.join(&manifest.entry);
+    let entry_content = std::fs::read_to_string(&entry_path).map_err(|source| SkillError::Io {
+        path: entry_path.clone(),
+        source,
+    })?;
+    lint_markdown(&entry_content, &entry_path, &mut findings);
+
+    for declared in &manifest.declared_files {
+        let path = candidate_path.join(declared);
+        if is_text_path(&path) {
+            let content = std::fs::read_to_string(&path).map_err(|source| SkillError::Io {
+                path: path.clone(),
+                source,
+            })?;
+            lint_secrets(&content, &path, &mut findings);
+        }
+    }
+
+    Ok(findings)
+}
+```
+
+Add these helpers in the same module:
+
+```rust
+fn error_finding(
+    rule_id: impl Into<String>,
+    message: impl Into<String>,
+    path: Option<PathBuf>,
+    line: Option<usize>,
+) -> SkillCiFinding {
+    SkillCiFinding {
+        rule_id: rule_id.into(),
+        severity: SkillCiSeverity::Error,
+        message: message.into(),
+        path,
+        line,
+    }
+}
+
+fn lint_markdown(content: &str, path: &std::path::Path, findings: &mut Vec<SkillCiFinding>) {
+    if content.starts_with("---\n") && !content[4..].contains("\n---") {
+        findings.push(error_finding(
+            "agentenv.skill.frontmatter.unclosed",
+            "SKILL.md frontmatter is missing a closing delimiter",
+            Some(path.to_path_buf()),
+            Some(1),
+        ));
+    }
+
+    let mut fence_line = None;
+    let mut previous_heading = 0usize;
+    for (index, line) in content.lines().enumerate() {
+        let line_number = index + 1;
+        if line.trim_start().starts_with("```") {
+            fence_line = if fence_line.is_some() { None } else { Some(line_number) };
+        }
+        let heading_level = line.chars().take_while(|character| *character == '#').count();
+        if heading_level > 0 && line.chars().nth(heading_level) == Some(' ') {
+            if previous_heading > 0 && heading_level > previous_heading + 1 {
+                findings.push(error_finding(
+                    "agentenv.skill.markdown.heading-jump",
+                    format!("heading jumps from level {previous_heading} to {heading_level}"),
+                    Some(path.to_path_buf()),
+                    Some(line_number),
+                ));
+            }
+            previous_heading = heading_level;
+        }
+    }
+
+    if let Some(line) = fence_line {
+        findings.push(error_finding(
+            "agentenv.skill.markdown.unclosed-fence",
+            "Markdown fenced code block is not closed",
+            Some(path.to_path_buf()),
+            Some(line),
+        ));
+    }
+}
+
+fn lint_secrets(content: &str, path: &std::path::Path, findings: &mut Vec<SkillCiFinding>) {
+    for (index, line) in content.lines().enumerate() {
+        let lower = line.to_ascii_lowercase();
+        let looks_like_secret = lower.contains("api_key")
+            || lower.contains("api-key")
+            || lower.contains("secret_key")
+            || lower.contains("access_token")
+            || lower.contains("private_key")
+            || line.contains("sk-");
+        if looks_like_secret {
+            findings.push(error_finding(
+                "agentenv.skill.secret.detected",
+                "secret-like content detected in bundled text",
+                Some(path.to_path_buf()),
+                Some(index + 1),
+            ));
+        }
+    }
+}
+
+fn is_text_path(path: &std::path::Path) -> bool {
+    matches!(
+        path.extension().and_then(|extension| extension.to_str()),
+        Some("md" | "yaml" | "yml" | "txt" | "json" | "toml" | "rs" | "sh")
+    )
+}
+```
+
+- [ ] **Step 4: Add SARIF serialization**
+
+Add `skill_ci_sarif` to `ci.rs`:
+
+```rust
+pub fn skill_ci_sarif(report: &SkillCiReport) -> Result<String, SkillError> {
+    let mut results = Vec::new();
+    for tier in &report.tiers {
+        if !matches!(tier.tier, SkillCiTier::StaticLint | SkillCiTier::AgentReview) {
+            continue;
+        }
+        for finding in &tier.findings {
+            if finding.severity == SkillCiSeverity::Note {
+                continue;
+            }
+            results.push(sarif_result(finding));
+        }
+    }
+    let sarif = serde_json::json!({
+        "version": "2.1.0",
+        "$schema": "https://json.schemastore.org/sarif-2.1.0.json",
+        "runs": [{
+            "tool": {
+                "driver": {
+                    "name": "agentenv skill ci",
+                    "informationUri": "https://github.com/windoliver/agentenv",
+                    "rules": sarif_rules(report)
+                }
+            },
+            "results": results
+        }]
+    });
+    serde_json::to_string_pretty(&sarif)
+        .map_err(|source| SkillError::SkillCiSarif { message: source.to_string() })
+}
+
+fn sarif_result(finding: &SkillCiFinding) -> serde_json::Value {
+    let mut region = serde_json::Map::new();
+    if let Some(line) = finding.line {
+        region.insert("startLine".to_owned(), serde_json::json!(line));
+    }
+    let location = match &finding.path {
+        Some(path) => serde_json::json!({
+            "physicalLocation": {
+                "artifactLocation": { "uri": path.to_string_lossy() },
+                "region": region
+            }
+        }),
+        None => serde_json::json!({}),
+    };
+    serde_json::json!({
+        "ruleId": finding.rule_id,
+        "level": sarif_level(finding.severity),
+        "message": { "text": finding.message },
+        "locations": [location]
+    })
+}
+
+fn sarif_level(severity: SkillCiSeverity) -> &'static str {
+    match severity {
+        SkillCiSeverity::Error => "error",
+        SkillCiSeverity::Warning => "warning",
+        SkillCiSeverity::Note => "note",
+    }
+}
+
+fn sarif_rules(report: &SkillCiReport) -> Vec<serde_json::Value> {
+    let mut rules = std::collections::BTreeSet::new();
+    for tier in &report.tiers {
+        for finding in &tier.findings {
+            rules.insert(finding.rule_id.clone());
+        }
+    }
+    rules
+        .into_iter()
+        .map(|id| serde_json::json!({ "id": id, "shortDescription": { "text": id } }))
+        .collect()
+}
+```
+
+Export `skill_ci_sarif` from `crates/agentenv-core/src/skills/mod.rs`:
+
+```rust
+pub use ci::{
+    run_skill_ci, skill_ci_sarif, SkillCiCandidate, SkillCiFinding, SkillCiRegistrySkill,
+    SkillCiRegistrySnapshot, SkillCiRequest, SkillCiReport, SkillCiSeverity, SkillCiStatus,
+    SkillCiTier, SkillCiTierReport, SkillCiTierStatus,
+};
+```
+
+- [ ] **Step 5: Run tests to verify GREEN**
+
+Run:
+
+```bash
+cargo test -p agentenv-core --test skills_ci static_lint_ -- --nocapture
+```
+
+Expected: PASS for all `static_lint_` tests.
+
+- [ ] **Step 6: Commit Task 2**
+
+```bash
+git add crates/agentenv-core/src/skills/ci.rs crates/agentenv-core/src/skills/mod.rs crates/agentenv-core/tests/skills_ci.rs
+git commit -m "feat(core): add skill ci static lint"
+```
+
+## Task 3: Deterministic Agent Review Tier
+
+**Files:**
+- Modify: `crates/agentenv-core/src/skills/ci.rs`
+- Test: `crates/agentenv-core/tests/skills_ci.rs`
+
+- [ ] **Step 1: Add failing review-tier tests**
+
+Append:
+
+```rust
+#[test]
+fn agent_review_fails_destructive_instruction_without_consent() {
+    let bundle = skill_bundle(
+        "ci-destructive",
+        "0.1.0",
+        "# Destructive\n\nRun `rm -rf target` immediately before asking the user.\n",
+    );
+
+    let report = run_skill_ci(SkillCiRequest {
+        candidate_path: bundle,
+        registry_snapshot: None,
+        fail_fast: false,
+        agent_runner: Arc::new(PanicAgentRunner),
+    })
+    .expect("ci should run");
+
+    let review = report
+        .tiers
+        .iter()
+        .find(|tier| tier.tier == SkillCiTier::AgentReview)
+        .unwrap();
+    assert_eq!(review.status, SkillCiTierStatus::Failed);
+    assert!(review
+        .findings
+        .iter()
+        .any(|finding| finding.rule_id == "agentenv.skill.review.destructive-without-consent"));
+}
+
+#[test]
+fn agent_review_passes_clear_bounded_non_destructive_skill() {
+    let bundle = skill_bundle(
+        "ci-clear",
+        "0.1.0",
+        "# Clear Skill\n\nUse this skill to inspect Rust files, summarize findings, and ask before changing files.\n",
+    );
+
+    let report = run_skill_ci(SkillCiRequest {
+        candidate_path: bundle,
+        registry_snapshot: None,
+        fail_fast: false,
+        agent_runner: Arc::new(PanicAgentRunner),
+    })
+    .expect("ci should run");
+
+    let review = report
+        .tiers
+        .iter()
+        .find(|tier| tier.tier == SkillCiTier::AgentReview)
+        .unwrap();
+    assert_eq!(review.status, SkillCiTierStatus::Passed);
+}
+```
+
+- [ ] **Step 2: Run tests to verify RED**
+
+Run:
+
+```bash
+cargo test -p agentenv-core --test skills_ci agent_review_ -- --nocapture
+```
+
+Expected: FAIL because `AgentReview` is still skipped or empty.
+
+- [ ] **Step 3: Add review trait and default judge**
+
+In `ci.rs`, add:
+
+```rust
+pub trait SkillReviewJudge: Send + Sync {
+    fn review(&self, input: SkillReviewInput<'_>) -> Result<SkillReviewReport, SkillError>;
+}
+
+pub struct SkillReviewInput<'a> {
+    pub manifest: &'a super::SkillManifest,
+    pub skill_md: &'a str,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+pub struct SkillReviewReport {
+    pub findings: Vec<SkillCiFinding>,
+}
+
+#[derive(Debug, Default, Clone, Copy)]
+pub struct RuleBasedSkillReviewJudge;
+
+impl SkillReviewJudge for RuleBasedSkillReviewJudge {
+    fn review(&self, input: SkillReviewInput<'_>) -> Result<SkillReviewReport, SkillError> {
+        let mut findings = Vec::new();
+        let text = input.skill_md.to_ascii_lowercase();
+
+        if input.manifest.description.as_deref().unwrap_or("").trim().len() < 8 {
+            findings.push(warning_finding(
+                "agentenv.skill.review.description-vague",
+                "description is too short to describe behavior",
+                Some(PathBuf::from("skill.yaml")),
+                None,
+            ));
+        }
+
+        let destructive = ["rm -rf", "delete all", "drop database", "format disk"];
+        let asks_consent = text.contains("ask before")
+            || text.contains("with user consent")
+            || text.contains("after confirmation")
+            || text.contains("explicit consent");
+        if destructive.iter().any(|needle| text.contains(needle)) && !asks_consent {
+            findings.push(error_finding(
+                "agentenv.skill.review.destructive-without-consent",
+                "destructive operation is described without explicit user consent",
+                Some(PathBuf::from("SKILL.md")),
+                None,
+            ));
+        }
+
+        if text.contains("api key") && !text.contains("credential") {
+            findings.push(error_finding(
+                "agentenv.skill.review.credential-handling",
+                "credential handling must use agentenv credential language",
+                Some(PathBuf::from("SKILL.md")),
+                None,
+            ));
+        }
+
+        Ok(SkillReviewReport { findings })
+    }
+}
+
+fn warning_finding(
+    rule_id: impl Into<String>,
+    message: impl Into<String>,
+    path: Option<PathBuf>,
+    line: Option<usize>,
+) -> SkillCiFinding {
+    SkillCiFinding {
+        rule_id: rule_id.into(),
+        severity: SkillCiSeverity::Warning,
+        message: message.into(),
+        path,
+        line,
+    }
+}
+```
+
+Wire the orchestrator after static lint. Load `SKILL.md` once and run `RuleBasedSkillReviewJudge.review(...)`. Convert findings with `tier_from_findings(SkillCiTier::AgentReview, findings)`.
+
+- [ ] **Step 4: Run tests to verify GREEN**
+
+Run:
+
+```bash
+cargo test -p agentenv-core --test skills_ci agent_review_ -- --nocapture
+```
+
+Expected: PASS for both `agent_review_` tests.
+
+- [ ] **Step 5: Commit Task 3**
+
+```bash
+git add crates/agentenv-core/src/skills/ci.rs crates/agentenv-core/tests/skills_ci.rs
+git commit -m "feat(core): add skill ci review tier"
+```
+
+## Task 4: Semantic Dedup Tier with Registry Snapshot
+
+**Files:**
+- Modify: `crates/agentenv-core/src/skills/ci.rs`
+- Test: `crates/agentenv-core/tests/skills_ci.rs`
+
+- [ ] **Step 1: Add failing dedup tests**
+
+Append:
+
+```rust
+#[test]
+fn semantic_dedup_fails_exact_fingerprint_match() {
+    let bundle = skill_bundle("ci-copy", "0.1.0", "# Copy\n\nSummarize Rust modules.\n");
+    let digest = {
+        let manifest = agentenv_core::skills::load_skill_manifest(&bundle).unwrap();
+        agentenv_core::skills::compute_bundle_digest(&bundle, &manifest).unwrap()
+    };
+
+    let report = run_skill_ci(SkillCiRequest {
+        candidate_path: bundle,
+        registry_snapshot: Some(agentenv_core::skills::SkillCiRegistrySnapshot {
+            skills: vec![agentenv_core::skills::SkillCiRegistrySkill {
+                name: "existing-copy".to_owned(),
+                version: "0.1.0".to_owned(),
+                description: "Existing copy".to_owned(),
+                procedure_text: "Summarize Rust modules.".to_owned(),
+                fingerprint: Some(digest),
+            }],
+        }),
+        fail_fast: false,
+        agent_runner: Arc::new(PanicAgentRunner),
+    })
+    .expect("ci should run");
+
+    let dedup = report
+        .tiers
+        .iter()
+        .find(|tier| tier.tier == SkillCiTier::SemanticDedup)
+        .unwrap();
+    assert_eq!(dedup.status, SkillCiTierStatus::Failed);
+    assert!(dedup
+        .findings
+        .iter()
+        .any(|finding| finding.rule_id == "agentenv.skill.dedup.probable-duplicate"));
+    assert_eq!(dedup.details.as_ref().unwrap()["novelty_score"], 0.0);
+}
+
+#[test]
+fn semantic_dedup_reports_high_novelty_without_snapshot() {
+    let bundle = skill_bundle("ci-new", "0.1.0", "# New\n\nInspect shell scripts for portability.\n");
+
+    let report = run_skill_ci(SkillCiRequest {
+        candidate_path: bundle,
+        registry_snapshot: None,
+        fail_fast: false,
+        agent_runner: Arc::new(PanicAgentRunner),
+    })
+    .expect("ci should run");
+
+    let dedup = report
+        .tiers
+        .iter()
+        .find(|tier| tier.tier == SkillCiTier::SemanticDedup)
+        .unwrap();
+    assert_eq!(dedup.status, SkillCiTierStatus::Passed);
+    assert_eq!(dedup.details.as_ref().unwrap()["novelty_score"], 0.9);
+}
+```
+
+- [ ] **Step 2: Run tests to verify RED**
+
+Run:
+
+```bash
+cargo test -p agentenv-core --test skills_ci semantic_dedup_ -- --nocapture
+```
+
+Expected: FAIL because semantic dedup details and duplicate findings are absent.
+
+- [ ] **Step 3: Implement dedup scoring**
+
+Add to `ci.rs`:
+
+```rust
+fn run_semantic_dedup(
+    manifest: &super::SkillManifest,
+    digest: &str,
+    skill_md: &str,
+    snapshot: Option<&SkillCiRegistrySnapshot>,
+) -> SkillCiTierReport {
+    let mut best: Option<(SkillCiRegistrySkill, f32, String)> = None;
+    let mut novelty = 0.9_f32;
+
+    if let Some(snapshot) = snapshot {
+        for existing in &snapshot.skills {
+            let similarity = if existing.fingerprint.as_deref() == Some(digest) {
+                1.0
+            } else {
+                jaccard(skill_md, &existing.procedure_text)
+                    .max(jaccard(manifest.description.as_deref().unwrap_or(""), &existing.description))
+            };
+            if best.as_ref().is_none_or(|(_, current, _)| similarity > *current) {
+                let reason = if existing.fingerprint.as_deref() == Some(digest) {
+                    "exact fingerprint match".to_owned()
+                } else {
+                    "local semantic similarity".to_owned()
+                };
+                best = Some((existing.clone(), similarity, reason));
+            }
+        }
+    }
+
+    let mut findings = Vec::new();
+    let probable_duplicate = best
+        .as_ref()
+        .is_some_and(|(_, similarity, _)| *similarity > 0.92);
+    if let Some((_, similarity, _)) = &best {
+        novelty = if *similarity > 0.92 {
+            0.0
+        } else if *similarity >= 0.85 {
+            0.3
+        } else if *similarity >= 0.45 {
+            0.6
+        } else {
+            0.9
+        };
+    }
+    if probable_duplicate {
+        findings.push(error_finding(
+            "agentenv.skill.dedup.probable-duplicate",
+            "candidate is probably a duplicate of an existing skill",
+            Some(PathBuf::from("SKILL.md")),
+            None,
+        ));
+    }
+
+    let nearest_neighbors: Vec<serde_json::Value> = best
+        .into_iter()
+        .map(|(skill, similarity, reason)| {
+            serde_json::json!({
+                "name": skill.name,
+                "version": skill.version,
+                "similarity": similarity,
+                "reason": reason
+            })
+        })
+        .collect();
+    let mut report = tier_from_findings(SkillCiTier::SemanticDedup, findings);
+    report.details = Some(serde_json::json!({
+        "nearest_neighbors": nearest_neighbors,
+        "novelty_score": novelty,
+        "probable_duplicate": probable_duplicate
+    }));
+    report
+}
+
+fn jaccard(left: &str, right: &str) -> f32 {
+    let left = tokens(left);
+    let right = tokens(right);
+    if left.is_empty() && right.is_empty() {
+        return 1.0;
+    }
+    let intersection = left.intersection(&right).count() as f32;
+    let union = left.union(&right).count() as f32;
+    if union == 0.0 { 0.0 } else { intersection / union }
+}
+
+fn tokens(value: &str) -> std::collections::BTreeSet<String> {
+    value
+        .split(|character: char| !character.is_ascii_alphanumeric())
+        .filter(|token| !token.is_empty())
+        .map(|token| token.to_ascii_lowercase())
+        .collect()
+}
+```
+
+Wire `run_semantic_dedup` after the review tier, passing `request.registry_snapshot.as_ref()`.
+
+- [ ] **Step 4: Run tests to verify GREEN**
+
+Run:
+
+```bash
+cargo test -p agentenv-core --test skills_ci semantic_dedup_ -- --nocapture
+```
+
+Expected: PASS for both `semantic_dedup_` tests.
+
+- [ ] **Step 5: Commit Task 4**
+
+```bash
+git add crates/agentenv-core/src/skills/ci.rs crates/agentenv-core/tests/skills_ci.rs
+git commit -m "feat(core): add skill ci dedup tier"
+```
+
+## Task 5: Functional Regression Tier
+
+**Files:**
+- Modify: `crates/agentenv-core/src/skills/ci.rs`
+- Test: `crates/agentenv-core/tests/skills_ci.rs`
+
+- [ ] **Step 1: Add failing functional-regression tests**
+
+Append:
+
+```rust
+#[test]
+fn functional_regression_fails_below_threshold() {
+    let bundle = skill_bundle("ci-low-score", "0.1.0", "# Low Score\n");
+    write_file(
+        &bundle.join("skill-test.yaml"),
+        "self_test:\n  runner: agentenv\n  assertions:\n    - type: file_exists\n      path: SKILL.md\n    - type: file_exists\n      path: missing-one\n    - type: file_exists\n      path: missing-two\n    - type: file_exists\n      path: missing-three\n    - type: file_exists\n      path: missing-four\n",
+    );
+
+    let report = run_skill_ci(SkillCiRequest {
+        candidate_path: bundle,
+        registry_snapshot: None,
+        fail_fast: false,
+        agent_runner: Arc::new(PanicAgentRunner),
+    })
+    .expect("ci should run");
+
+    let regression = report
+        .tiers
+        .iter()
+        .find(|tier| tier.tier == SkillCiTier::FunctionalRegression)
+        .unwrap();
+    assert_eq!(regression.status, SkillCiTierStatus::Failed);
+    assert!(regression
+        .findings
+        .iter()
+        .any(|finding| finding.rule_id == "agentenv.skill.self-test.score-below-threshold"));
+    assert_eq!(regression.details.as_ref().unwrap()["score"], 0.2);
+}
+
+#[test]
+fn functional_regression_passes_at_threshold() {
+    let bundle = skill_bundle("ci-threshold", "0.1.0", "# Threshold\n");
+    write_file(
+        &bundle.join("skill-test.yaml"),
+        "self_test:\n  runner: agentenv\n  assertions:\n    - type: file_exists\n      path: SKILL.md\n    - type: file_exists\n      path: skill.yaml\n    - type: file_exists\n      path: SKILL.md\n    - type: file_exists\n      path: skill.yaml\n    - type: file_exists\n      path: missing-one\n",
+    );
+
+    let report = run_skill_ci(SkillCiRequest {
+        candidate_path: bundle,
+        registry_snapshot: None,
+        fail_fast: false,
+        agent_runner: Arc::new(PanicAgentRunner),
+    })
+    .expect("ci should run");
+
+    let regression = report
+        .tiers
+        .iter()
+        .find(|tier| tier.tier == SkillCiTier::FunctionalRegression)
+        .unwrap();
+    assert_eq!(regression.status, SkillCiTierStatus::Passed);
+    assert_eq!(regression.details.as_ref().unwrap()["score"], 0.8);
+}
+```
+
+- [ ] **Step 2: Run tests to verify RED**
+
+Run:
+
+```bash
+cargo test -p agentenv-core --test skills_ci functional_regression_ -- --nocapture
+```
+
+Expected: FAIL because the functional regression tier is not yet calling `run_skill_self_test`.
+
+- [ ] **Step 3: Implement self-test tier**
+
+In `ci.rs`, add:
+
+```rust
+fn run_functional_regression(
+    candidate_path: &std::path::Path,
+    manifest: &super::SkillManifest,
+    digest: &str,
+    agent_runner: Arc<dyn AgentProduceRunner>,
+) -> Result<SkillCiTierReport, SkillError> {
+    let spec = load_skill_self_test_spec(candidate_path)?;
+    let report = super::run_skill_self_test(
+        candidate_path,
+        manifest.name.clone(),
+        manifest.version.to_string(),
+        digest.to_owned(),
+        &spec,
+        super::SkillSelfTestOptions::default(),
+        agent_runner,
+    )?;
+
+    let mut findings = Vec::new();
+    if !report.publishable {
+        findings.push(error_finding(
+            "agentenv.skill.self-test.score-below-threshold",
+            format!(
+                "self-test score {:.3} is below required threshold {:.3}",
+                report.score,
+                super::SELF_TEST_PUBLISH_THRESHOLD
+            ),
+            Some(PathBuf::from("skill-test.yaml")),
+            None,
+        ));
+    }
+
+    let mut tier = tier_from_findings(SkillCiTier::FunctionalRegression, findings);
+    tier.details = Some(serde_json::json!({
+        "score": report.score,
+        "passed": report.passed,
+        "total": report.total,
+        "publishable": report.publishable,
+        "self_test_digest": report.self_test_digest
+    }));
+    Ok(tier)
+}
+```
+
+Wire this as the fourth tier. When fail-fast skips this tier after an earlier failure, keep the skipped report instead of running the self-test.
+
+- [ ] **Step 4: Run tests to verify GREEN**
+
+Run:
+
+```bash
+cargo test -p agentenv-core --test skills_ci functional_regression_ -- --nocapture
+```
+
+Expected: PASS for both `functional_regression_` tests.
+
+- [ ] **Step 5: Run all core CI tests**
+
+Run:
+
+```bash
+cargo test -p agentenv-core --test skills_ci -- --nocapture
+```
+
+Expected: PASS for every test in `skills_ci.rs`.
+
+- [ ] **Step 6: Commit Task 5**
+
+```bash
+git add crates/agentenv-core/src/skills/ci.rs crates/agentenv-core/tests/skills_ci.rs
+git commit -m "feat(core): add skill ci self-test tier"
+```
+
+## Task 6: CLI Command
+
+**Files:**
+- Modify: `crates/agentenv/src/skills_cli.rs`
+- Modify: `crates/agentenv/tests/cli_behavior.rs`
+- Test: `crates/agentenv/tests/cli_behavior.rs`
+
+- [ ] **Step 1: Add failing CLI tests**
+
+Append these tests near the other skills CLI tests in `crates/agentenv/tests/cli_behavior.rs`:
+
+```rust
+#[test]
+fn skills_ci_json_passes_valid_bundle() {
+    let temp_dir = make_temp_dir("skills-ci-json-pass");
+    let bundle = temp_dir.join("bundle");
+    write_local_skill_bundle_with_skill_test_file(&bundle, "ci-cli-pass", "0.1.0", "CI CLI pass");
+
+    let output = Command::new(agentenv_bin())
+        .arg("skills")
+        .arg("ci")
+        .arg(&bundle)
+        .arg("--json")
+        .env("HOME", &temp_dir)
+        .current_dir(&temp_dir)
+        .output()
+        .unwrap();
+
+    assert!(output.status.success(), "{}", output_summary(&output));
+    let json: serde_json::Value = serde_json::from_slice(&output.stdout).unwrap();
+    assert_eq!(json["schema_version"], "0.1");
+    assert_eq!(json["candidate"]["name"], "ci-cli-pass");
+    assert_eq!(json["status"], "passed");
+}
+
+#[test]
+fn skills_ci_json_exits_one_for_invalid_bundle() {
+    let temp_dir = make_temp_dir("skills-ci-json-fail");
+    let bundle = temp_dir.join("bundle");
+    write_local_skill_bundle_with_skill_test_file(&bundle, "ci-cli-fail", "0.1.0", "CI CLI fail");
+    fs::write(bundle.join("SKILL.md"), "# Bad\n\n```rust\nfn main() {}\n").unwrap();
+
+    let output = Command::new(agentenv_bin())
+        .arg("skills")
+        .arg("ci")
+        .arg(&bundle)
+        .arg("--json")
+        .env("HOME", &temp_dir)
+        .current_dir(&temp_dir)
+        .output()
+        .unwrap();
+
+    assert_eq!(output.status.code(), Some(1), "{}", output_summary(&output));
+    let json: serde_json::Value = serde_json::from_slice(&output.stdout).unwrap();
+    assert_eq!(json["status"], "failed");
+    assert_eq!(json["tiers"][0]["tier"], "static_lint");
+}
+
+#[test]
+fn skills_ci_writes_sarif_file() {
+    let temp_dir = make_temp_dir("skills-ci-sarif");
+    let bundle = temp_dir.join("bundle");
+    let sarif = temp_dir.join("skill-ci.sarif");
+    write_local_skill_bundle_with_skill_test_file(&bundle, "ci-cli-sarif", "0.1.0", "CI CLI SARIF");
+    fs::write(bundle.join("SKILL.md"), "# Bad\n\n```rust\nfn main() {}\n").unwrap();
+
+    let output = Command::new(agentenv_bin())
+        .arg("skills")
+        .arg("ci")
+        .arg(&bundle)
+        .arg("--json")
+        .arg("--sarif")
+        .arg(&sarif)
+        .env("HOME", &temp_dir)
+        .current_dir(&temp_dir)
+        .output()
+        .unwrap();
+
+    assert_eq!(output.status.code(), Some(1), "{}", output_summary(&output));
+    let sarif_json: serde_json::Value =
+        serde_json::from_slice(&fs::read(&sarif).unwrap()).unwrap();
+    assert_eq!(sarif_json["runs"][0]["tool"]["driver"]["name"], "agentenv skill ci");
+}
+
+#[test]
+fn skills_ci_registry_snapshot_drives_dedup_failure() {
+    let temp_dir = make_temp_dir("skills-ci-dedup");
+    let bundle = temp_dir.join("bundle");
+    let snapshot = temp_dir.join("snapshot.json");
+    write_local_skill_bundle_with_skill_test_file(&bundle, "ci-cli-dedup", "0.1.0", "CI CLI dedup");
+    fs::write(
+        &snapshot,
+        r#"{"skills":[{"name":"existing","version":"0.1.0","description":"CI CLI dedup","procedure_text":"CI CLI dedup","fingerprint":null}]}"#,
+    )
+    .unwrap();
+
+    let output = Command::new(agentenv_bin())
+        .arg("skills")
+        .arg("ci")
+        .arg(&bundle)
+        .arg("--registry-snapshot")
+        .arg(&snapshot)
+        .arg("--no-fail-fast")
+        .arg("--json")
+        .env("HOME", &temp_dir)
+        .current_dir(&temp_dir)
+        .output()
+        .unwrap();
+
+    assert_eq!(output.status.code(), Some(1), "{}", output_summary(&output));
+    let json: serde_json::Value = serde_json::from_slice(&output.stdout).unwrap();
+    assert!(json["tiers"]
+        .as_array()
+        .unwrap()
+        .iter()
+        .any(|tier| tier["tier"] == "semantic_dedup" && tier["status"] == "failed"));
+}
+```
+
+- [ ] **Step 2: Run CLI tests to verify RED**
+
+Run:
+
+```bash
+cargo test -p agentenv --test cli_behavior skills_ci_ -- --nocapture
+```
+
+Expected: FAIL because clap does not know the `skills ci` subcommand.
+
+- [ ] **Step 3: Add CLI args and dispatch**
+
+Modify imports in `crates/agentenv/src/skills_cli.rs`:
+
+```rust
+use agentenv_core::skills::{
+    execute_skill_prune, load_project_skills_config, load_skill_trust_keys,
+    load_user_skills_config, merge_skills_config, plan_skill_prune, rebuild_skill_index,
+    run_skill_ci, skill_ci_sarif, verify_all_installed_skills, AgentProduceRequest,
+    AgentProduceRunner, InstalledSkill, InstalledSkillSelector, SkillAddRequest, SkillCacheLayout,
+    SkillCiRegistrySnapshot, SkillCiRequest, SkillCiStatus, SkillError, SkillPublishRequest,
+    SkillSearchHit, SkillService, SkillVerifyOptions, SkillVerifyStatus, SkillsConfig,
+    SkillsConfigOverride,
+};
+```
+
+Add the subcommand:
+
+```rust
+#[derive(Debug, Subcommand)]
+pub enum SkillsCommand {
+    Propose(SkillsProposeArgs),
+    Search(SkillsSearchArgs),
+    Add(SkillsAddArgs),
+    Install(SkillsInstallArgs),
+    List(SkillsListArgs),
+    Info(SkillsInfoArgs),
+    Remove(SkillsRemoveArgs),
+    Publish(SkillsPublishArgs),
+    Verify(SkillsVerifyArgs),
+    Ci(SkillsCiArgs),
+    Prune(SkillsPruneArgs),
+}
+
+#[derive(Debug, Args)]
+pub struct SkillsCiArgs {
+    pub path: PathBuf,
+    #[arg(long, value_name = "PATH")]
+    pub registry_snapshot: Option<PathBuf>,
+    #[arg(long, value_name = "PATH")]
+    pub sarif: Option<PathBuf>,
+    #[arg(long)]
+    pub json: bool,
+    #[arg(long)]
+    pub no_fail_fast: bool,
+}
+```
+
+Add dispatch arm:
+
+```rust
+        SkillsCommand::Ci(args) => run_ci(args, service).await,
+```
+
+Add `Ci(_)` to `registry_override_for_command` arm that returns `None`.
+
+Add `run_ci`:
+
+```rust
+async fn run_ci(args: SkillsCiArgs, service: SkillService) -> Result<()> {
+    let snapshot = match args.registry_snapshot.as_deref() {
+        Some(path) => {
+            let bytes = fs::read(path).with_context(|| format!("read `{}`", path.display()))?;
+            Some(
+                serde_json::from_slice::<SkillCiRegistrySnapshot>(&bytes)
+                    .with_context(|| format!("parse registry snapshot `{}`", path.display()))?,
+            )
+        }
+        None => None,
+    };
+    let report = run_skill_ci(SkillCiRequest {
+        candidate_path: args.path,
+        registry_snapshot: snapshot,
+        fail_fast: !args.no_fail_fast,
+        agent_runner: service.agent_produce_runner(),
+    })?;
+
+    if let Some(path) = args.sarif.as_deref() {
+        let sarif = skill_ci_sarif(&report)?;
+        if let Some(parent) = path.parent() {
+            fs::create_dir_all(parent)
+                .with_context(|| format!("create SARIF directory `{}`", parent.display()))?;
+        }
+        fs::write(path, sarif).with_context(|| format!("write SARIF `{}`", path.display()))?;
+    }
+
+    if args.json {
+        print_json(&report)?;
+    } else {
+        print_skill_ci_table(&report);
+    }
+
+    if report.status == SkillCiStatus::Passed {
+        Ok(())
+    } else {
+        std::process::exit(1);
+    }
+}
+```
+
+Because `SkillService` currently stores `agent_produce_runner` privately, add this method in `crates/agentenv-core/src/skills/service.rs`:
+
+```rust
+    pub fn agent_produce_runner(&self) -> Arc<dyn AgentProduceRunner> {
+        Arc::clone(&self.agent_produce_runner)
+    }
+```
+
+Add a human table helper in `skills_cli.rs`:
+
+```rust
+fn print_skill_ci_table(report: &agentenv_core::skills::SkillCiReport) {
+    println!("skill: {} {}", report.candidate.name, report.candidate.version);
+    println!("status: {:?}", report.status);
+    for tier in &report.tiers {
+        println!("{:?}: {:?}", tier.tier, tier.status);
+        for finding in &tier.findings {
+            eprintln!("  {:?}: {}", finding.severity, finding.message);
+        }
+    }
+}
+```
+
+- [ ] **Step 4: Run CLI tests to verify GREEN**
+
+Run:
+
+```bash
+cargo test -p agentenv --test cli_behavior skills_ci_ -- --nocapture
+```
+
+Expected: PASS for all `skills_ci_` tests.
+
+- [ ] **Step 5: Commit Task 6**
+
+```bash
+git add crates/agentenv-core/src/skills/service.rs crates/agentenv/src/skills_cli.rs crates/agentenv/tests/cli_behavior.rs
+git commit -m "feat(cli): add skills ci command"
+```
+
+## Task 7: GitHub Actions Workflow and README
+
+**Files:**
+- Add: `.github/workflows/skill-ci.yaml`
+- Modify: `README.md`
+- Test: `crates/agentenv/tests/cli_behavior.rs`
+
+- [ ] **Step 1: Add failing workflow smoke test**
+
+Append to `crates/agentenv/tests/cli_behavior.rs`:
+
+```rust
+#[test]
+fn skill_ci_workflow_references_cli_command() {
+    let workflow = fs::read_to_string(
+        PathBuf::from(env!("CARGO_MANIFEST_DIR"))
+            .join("../../.github/workflows/skill-ci.yaml"),
+    )
+    .unwrap();
+    assert!(workflow.contains("workflow_call"), "workflow was: {workflow}");
+    assert!(workflow.contains("agentenv skills ci"), "workflow was: {workflow}");
+    assert!(workflow.contains("upload-sarif"), "workflow was: {workflow}");
+}
+```
+
+- [ ] **Step 2: Run test to verify RED**
+
+Run:
+
+```bash
+cargo test -p agentenv --test cli_behavior skill_ci_workflow_references_cli_command -- --nocapture
+```
+
+Expected: FAIL because `.github/workflows/skill-ci.yaml` does not exist.
+
+- [ ] **Step 3: Add workflow**
+
+Create `.github/workflows/skill-ci.yaml`:
+
+```yaml
+name: Skill CI
+
+on:
+  workflow_call:
+    inputs:
+      registry-snapshot:
+        required: false
+        type: string
+  pull_request:
+    paths:
+      - ".agents/skills/**"
+      - "skills/**"
+      - "examples/**/skill.yaml"
+      - ".github/workflows/skill-ci.yaml"
+
+permissions:
+  contents: read
+  pull-requests: write
+  security-events: write
+
+jobs:
+  skill-ci:
+    name: validate skills
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v5
+      - uses: dtolnay/rust-toolchain@master
+        with:
+          toolchain: stable
+      - uses: Swatinem/rust-cache@v2
+      - name: Build agentenv
+        run: cargo build -p agentenv
+      - name: Discover skill candidates
+        id: discover
+        shell: bash
+        run: |
+          set -euo pipefail
+          mapfile -t skills < <(find . -name skill.yaml -not -path './target/*' -print | sed 's#/skill.yaml$##' | sort)
+          printf 'count=%s\n' "${#skills[@]}" >> "$GITHUB_OUTPUT"
+          printf '%s\n' "${skills[@]}" > skill-candidates.txt
+      - name: Run skill CI
+        if: steps.discover.outputs.count != '0'
+        shell: bash
+        run: |
+          set -euo pipefail
+          mkdir -p skill-ci-reports
+          status=0
+          while IFS= read -r skill_dir; do
+            safe_name="$(printf '%s' "$skill_dir" | tr -c 'A-Za-z0-9._-' '_')"
+            args=(target/debug/agentenv skills ci "$skill_dir" --json --sarif "skill-ci-reports/${safe_name}.sarif")
+            if [[ -n "${{ inputs.registry-snapshot || '' }}" ]]; then
+              args+=(--registry-snapshot "${{ inputs.registry-snapshot }}")
+            fi
+            if ! "${args[@]}" > "skill-ci-reports/${safe_name}.json"; then
+              status=1
+            fi
+          done < skill-candidates.txt
+          exit "$status"
+      - name: Upload SARIF
+        if: always() && steps.discover.outputs.count != '0'
+        uses: github/codeql-action/upload-sarif@v4
+        with:
+          sarif_file: skill-ci-reports
+      - name: Comment summary
+        if: always() && github.event_name == 'pull_request' && steps.discover.outputs.count != '0'
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const fs = require('fs');
+            const reports = fs.readdirSync('skill-ci-reports')
+              .filter((name) => name.endsWith('.json'))
+              .map((name) => JSON.parse(fs.readFileSync(`skill-ci-reports/${name}`, 'utf8')));
+            const lines = ['## Skill CI', '', '| Skill | Status | Tiers |', '|---|---|---|'];
+            for (const report of reports) {
+              const tiers = report.tiers.map((tier) => `${tier.tier}: ${tier.status}`).join('<br>');
+              lines.push(`| ${report.candidate.name}@${report.candidate.version} | ${report.status} | ${tiers} |`);
+            }
+            await github.rest.issues.createComment({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              issue_number: context.issue.number,
+              body: lines.join('\n')
+            });
+```
+
+- [ ] **Step 4: Update README**
+
+Add this section near the existing skills CLI documentation in `README.md`:
+
+```markdown
+### Skill CI
+
+`agentenv skills ci <path>` validates a skill publish candidate through four
+sequential tiers: static lint, deterministic review, semantic dedup, and the
+functional self-test gate. JSON output is intended for hubs and CI:
+
+```bash
+agentenv skills ci ./skills/my-skill --json --sarif skill-ci.sarif
+```
+
+`--registry-snapshot snapshot.json` supplies existing skill summaries for the
+semantic dedup tier. `gitleaks` may be installed to enrich local secret scans,
+but `agentenv` includes a portable built-in scanner and does not require
+`gitleaks`.
+```
+
+- [ ] **Step 5: Run workflow smoke test to verify GREEN**
+
+Run:
+
+```bash
+cargo test -p agentenv --test cli_behavior skill_ci_workflow_references_cli_command -- --nocapture
+```
+
+Expected: PASS for `skill_ci_workflow_references_cli_command`.
+
+- [ ] **Step 6: Commit Task 7**
+
+```bash
+git add .github/workflows/skill-ci.yaml README.md crates/agentenv/tests/cli_behavior.rs
+git commit -m "ci: add reusable skill validation workflow"
+```
+
+## Task 8: Full Verification and Cleanup
+
+**Files:**
+- Verify all changed files.
+
+- [ ] **Step 1: Run focused core tests**
+
+Run:
+
+```bash
+cargo test -p agentenv-core --test skills_ci -- --nocapture
+```
+
+Expected: PASS for every test in `skills_ci.rs`.
+
+- [ ] **Step 2: Run focused CLI tests**
+
+Run:
+
+```bash
+cargo test -p agentenv --test cli_behavior skills_ci_ -- --nocapture
+```
+
+Expected: PASS for all `skills_ci_` tests.
+
+- [ ] **Step 3: Run workflow smoke test**
+
+Run:
+
+```bash
+cargo test -p agentenv --test cli_behavior skill_ci_workflow_references_cli_command -- --nocapture
+```
+
+Expected: PASS for `skill_ci_workflow_references_cli_command`.
+
+- [ ] **Step 4: Run formatting**
+
+Run:
+
+```bash
+cargo fmt
+```
+
+Expected: command exits `0` and formats Rust files.
+
+- [ ] **Step 5: Run clippy**
+
+Run:
+
+```bash
+cargo clippy --workspace --all-targets -- -D warnings
+```
+
+Expected: command exits `0` with no warnings.
+
+- [ ] **Step 6: Run workspace tests**
+
+Run:
+
+```bash
+cargo test --workspace
+```
+
+Expected: command exits `0` with all workspace tests passing.
+
+- [ ] **Step 7: Inspect final diff**
+
+Run:
+
+```bash
+git diff --stat
+git diff --check
+```
+
+Expected: `git diff --check` exits `0`; diff stat contains only the files named in this plan and commits from prior tasks.
+
+- [ ] **Step 8: Commit final cleanup if needed**
+
+If formatting or cleanup changed files after Task 7, commit them:
+
+```bash
+git add crates/agentenv-core/src/skills/ci.rs crates/agentenv-core/src/skills/mod.rs crates/agentenv-core/src/skills/error.rs crates/agentenv-core/src/skills/service.rs crates/agentenv/src/skills_cli.rs crates/agentenv-core/tests/skills_ci.rs crates/agentenv/tests/cli_behavior.rs .github/workflows/skill-ci.yaml README.md
+git commit -m "chore: polish skill ci validation"
+```
+
+If `git diff --stat` shows no remaining changes, do not create an empty cleanup commit.
+
+## Self-Review
+
+- Spec coverage: Tasks 1-5 cover the four core tiers, fail-fast behavior, JSON shape, and SARIF. Task 6 covers the CLI. Task 7 covers GitHub Actions and README documentation. Task 8 covers the required verification commands.
+- Placeholder scan: This plan contains no deferred implementation markers and no unnamed files.
+- Type consistency: Public names are consistent across tasks: `SkillCiRequest`, `SkillCiReport`, `SkillCiRegistrySnapshot`, `SkillCiTier`, `SkillCiTierStatus`, `SkillCiStatus`, `run_skill_ci`, and `skill_ci_sarif`.

--- a/docs/superpowers/specs/2026-05-15-m7-10-skill-ci-validation-design.md
+++ b/docs/superpowers/specs/2026-05-15-m7-10-skill-ci-validation-design.md
@@ -1,0 +1,371 @@
+# M7-10 Skill CI Validation Design
+
+- Date: 2026-05-15
+- Issue: https://github.com/windoliver/agentenv/issues/36
+- Milestone: M7 Skills axis and registry
+- Depends on:
+  - https://github.com/windoliver/agentenv/issues/33
+  - https://github.com/windoliver/agentenv/issues/34
+- Affected crates: `agentenv-core`, `agentenv`
+- Other affected files: `.github/workflows/skill-ci.yaml`
+- Protocol impact: no driver protocol or schema-version change
+
+## Context
+
+Skills are core-managed artifacts. The current code already owns skill
+manifests, bundle digests, signatures, registry adapters, local install
+metadata, self-test execution, and self-test attestations. The reference hub
+from issue #34 is intentionally outside this repository, but its publish API
+should not need to reimplement the trust policy that core already enforces.
+
+Issue #36 adds a quality gate for skill hub publishes: four sequential tiers
+that fail fast from cheapest to most expensive. The right boundary is a
+reusable core validation engine and CLI command in this repository, plus a
+GitHub Actions workflow that calls the command. The hub can later invoke the
+same binary or library API server-side before accepting a publish.
+
+## Goals
+
+- Add a four-tier CI validation engine for a candidate skill bundle or skill
+  directory.
+- Run tiers sequentially and stop at the first failing tier by default.
+- Keep skill validation policy inside `agentenv-core::skills`, not inside a
+  driver, workflow script, or separate serialization format.
+- Expose the engine through `agentenv skills ci <path>`.
+- Emit stable JSON suitable for hub APIs, workflow comments, and tests.
+- Emit SARIF for tier 1 and tier 2 findings so GitHub code scanning can show
+  actionable diagnostics.
+- Add `.github/workflows/skill-ci.yaml` as a reusable workflow that validates
+  changed skill bundles on pull requests and workflow calls.
+- Reuse the existing self-test gate from issue #33 for tier 4.
+- Provide a clean seam for future hub-backed semantic dedup using pgvector,
+  Milvus, or another vector index without adding those services to core.
+
+## Non-Goals
+
+- Do not implement the skill hub service in this repository.
+- Do not add a fifth pluggable axis or a `SkillsDriver`.
+- Do not change the JSON-RPC driver protocol.
+- Do not add Python, Node, Docker, OpenSSL, Milvus, pgvector, or a model SDK as
+  a build-time dependency of core.
+- Do not require network access for local tests.
+- Do not make true LLM judging mandatory for CI. Tier 2 gets a deterministic
+  local reviewer first, with an interface that a hub or later command can back
+  with an LLM provider.
+- Do not persist registry publish decisions from the CI command. The command
+  validates and reports; publish code still owns storage and attestation
+  persistence.
+
+## User-Facing CLI
+
+Add:
+
+```text
+agentenv skills ci <path> [--registry-snapshot <path>] [--sarif <path>] [--json] [--no-fail-fast]
+```
+
+Behavior:
+
+- `<path>` points to an expanded skill directory or bundle path accepted by
+  existing skill loading code.
+- `--json` prints the complete validation report to stdout.
+- `--sarif <path>` writes SARIF containing tier 1 and tier 2 findings.
+- `--registry-snapshot <path>` points to a local JSON file containing existing
+  skill summaries for tier 3 dedup checks. This keeps local CI deterministic
+  and lets the hub export its own registry state later.
+- `--no-fail-fast` runs all tiers even after a failure. The default fail-fast
+  behavior matches the issue's cost model.
+
+Exit codes:
+
+- `0`: all requested tiers passed.
+- `1`: at least one tier failed.
+- `2`: CLI usage or unreadable input error.
+
+## Core API
+
+Add a focused module:
+
+```text
+crates/agentenv-core/src/skills/ci.rs
+```
+
+Primary model:
+
+```rust
+pub struct SkillCiRequest {
+    pub candidate_path: PathBuf,
+    pub registry_snapshot: Option<SkillCiRegistrySnapshot>,
+    pub fail_fast: bool,
+}
+
+pub struct SkillCiReport {
+    pub candidate: SkillCiCandidate,
+    pub status: SkillCiStatus,
+    pub tiers: Vec<SkillCiTierReport>,
+    pub started_at: OffsetDateTime,
+    pub completed_at: OffsetDateTime,
+}
+
+pub enum SkillCiTier {
+    StaticLint,
+    AgentReview,
+    SemanticDedup,
+    FunctionalRegression,
+}
+
+pub enum SkillCiStatus {
+    Passed,
+    Failed,
+    Skipped,
+}
+```
+
+The module stays below `SkillService` rather than replacing service publish
+gates. `SkillService::publish` can later call the same validator when hub
+policy needs to require the entire four-tier result, but this issue should
+start with the CLI/workflow validation path.
+
+## Tier 1 - Static Lint
+
+Tier 1 validates the bundle without model calls or sandbox work.
+
+Checks:
+
+- `skill.yaml` exists and passes existing manifest loading.
+- `SKILL.md` exists at the declared entry path.
+- `SKILL.md` frontmatter, when present, is YAML and agrees with manifest
+  identity fields already enforced by cache verification.
+- Markdown is structurally well formed for the first implementation:
+  headings are nested without jumping more than one level, fenced code blocks
+  are closed, and frontmatter has a closing delimiter.
+- No secret-like content appears in bundled text files. Core uses a small
+  deterministic scanner for common credential shapes. If `gitleaks` is present
+  on PATH, the CLI also runs it and merges findings, but missing `gitleaks`
+  does not fail the tier.
+- Manifest version parses as semver and is not a prerelease unless the command
+  is later given an explicit prerelease policy flag.
+- Package signature verifies through existing Ed25519 verification unless the
+  command is later extended with an explicit unsigned-development flag.
+- Self-test declaration loads and normalizes without conflicts.
+
+Findings include severity, message, path, and optional line. The tier fails on
+errors and passes with warnings.
+
+## Tier 2 - Agent Review
+
+Tier 2 reviews skill prose for clarity, safety, and structural accuracy with a
+bounded deterministic reviewer in the first implementation.
+
+The reviewer analyzes the manifest, `SKILL.md`, and self-test declaration. It
+emits:
+
+- `clarity`: description names the skill behavior, the body has enough
+  procedure detail, and required inputs are identifiable.
+- `safety`: destructive commands, credential handling, privilege escalation,
+  and irreversible file operations require explicit user consent.
+- `accuracy`: code blocks and examples are structurally plausible for their
+  declared language, referenced files exist in the bundle, and self-test
+  examples match supported assertion names.
+
+This tier intentionally does not add a required model provider. The core API
+uses a trait boundary:
+
+```rust
+pub trait SkillReviewJudge {
+    fn review(&self, input: SkillReviewInput) -> Result<SkillReviewReport, SkillError>;
+}
+```
+
+The default `RuleBasedSkillReviewJudge` is deterministic and used in CI. A
+future hub process can supply an LLM-backed judge through this same shape while
+keeping token budget and provider policy outside core.
+
+Tier 2 fails when any review item has `decision: fail`. It also contributes
+SARIF diagnostics for actionable line-level findings.
+
+## Tier 3 - Semantic Dedup
+
+Tier 3 computes a local semantic duplication result from candidate manifest and
+skill prose.
+
+For this issue, core should reuse the existing local scoring idea from
+`skills::propose`: normalized token similarity, exact fingerprint matching, and
+novelty buckets. This keeps CI deterministic and avoids a database dependency.
+
+Inputs:
+
+- Candidate manifest name, version, description, entry content, and digest.
+- Optional registry snapshot supplied by `--registry-snapshot`.
+
+Snapshot format:
+
+```json
+{
+  "skills": [
+    {
+      "name": "existing-skill",
+      "version": "0.1.0",
+      "description": "Short summary",
+      "procedure_text": "Skill body or indexed summary",
+      "fingerprint": "sha256:..."
+    }
+  ]
+}
+```
+
+Output:
+
+- `nearest_neighbors`: ordered list with name, version, similarity, and reason.
+- `novelty_score`: one of `0.0`, `0.3`, `0.6`, or `0.9`.
+- `probable_duplicate`: true when similarity is greater than `0.92` or an
+  exact fingerprint match exists.
+
+Tier 3 fails when `probable_duplicate` is true. A later hub can replace the
+local snapshot implementation with pgvector or Milvus while preserving this
+report shape.
+
+## Tier 4 - Functional Regression
+
+Tier 4 runs the existing self-test engine from issue #33.
+
+Behavior:
+
+- Load and normalize the candidate self-test declaration.
+- Run the self-test with the existing `AgentProduceRunner` integration used by
+  `agentenv skills verify` and `agentenv skills publish`.
+- Require score `>= 0.8`.
+- Include the self-test report and signed attestation summary in the CI report.
+
+Tier 4 fails if the self-test is missing, stale, below threshold, times out, or
+cannot produce a valid report. It does not publish or store the candidate.
+
+## JSON Report
+
+The top-level JSON report is stable enough for workflow comments and hub API
+consumers:
+
+```json
+{
+  "schema_version": "0.1",
+  "candidate": {
+    "name": "demo",
+    "version": "0.1.0",
+    "digest": "sha256:..."
+  },
+  "status": "failed",
+  "tiers": [
+    {
+      "tier": "static_lint",
+      "status": "passed",
+      "duration_ms": 42,
+      "findings": []
+    }
+  ]
+}
+```
+
+The CLI may render a concise table for humans when `--json` is not set, but
+tests should assert the JSON shape.
+
+## SARIF
+
+Add a small SARIF serializer for tier 1 and tier 2 findings. The serializer
+should be implemented in core with no extra crate unless an already-present
+workspace dependency provides enough structure.
+
+Rules:
+
+- One SARIF run named `agentenv skill ci`.
+- Rule IDs use stable strings such as `agentenv.skill.manifest.invalid`,
+  `agentenv.skill.markdown.unclosed-fence`, and
+  `agentenv.skill.review.destructive-without-consent`.
+- Only include line information when the checker can locate it reliably.
+- Do not include secret values in SARIF messages.
+
+## GitHub Actions Workflow
+
+Add `.github/workflows/skill-ci.yaml`.
+
+Shape:
+
+- Trigger on `workflow_call` so hub repositories can reuse it.
+- Trigger on `pull_request` for this repository when paths likely containing
+  skills change, including `.agents/skills/**`, `skills/**`, and examples added
+  later.
+- Build or install the local `agentenv` binary.
+- Discover candidate skill directories by looking for `skill.yaml`.
+- Run `agentenv skills ci <dir> --json --sarif <file>` for each candidate.
+- Upload SARIF when any SARIF file was produced.
+- Post a PR comment summarizing tier-by-tier results when running in a pull
+  request context.
+
+The workflow should not invent policy in shell. Shell only discovers inputs,
+calls the CLI, and formats the CLI's JSON report.
+
+## Error Handling
+
+Library code returns `SkillError` variants for:
+
+- invalid CI candidate path
+- markdown lint failure
+- secret-like bundled content
+- failed skill review
+- invalid registry snapshot
+- probable duplicate skill
+- SARIF serialization failure
+- CI tier failure summary
+
+CLI code uses `anyhow` for command context and maps validation failures to exit
+code `1`. It must not pattern-match opaque strings.
+
+No `.unwrap()` should be introduced outside tests.
+
+## Testing
+
+Core tests should cover:
+
+- Tier 1 accepts a valid signed skill with a self-test.
+- Tier 1 rejects invalid semver, missing entry file, unclosed Markdown fence,
+  frontmatter conflict, secret-like text, and invalid signature.
+- Tier 2 fails a skill that instructs destructive operations without consent.
+- Tier 2 passes a clear, bounded, non-destructive skill.
+- Tier 3 flags exact fingerprint matches and similarity above `0.92`.
+- Tier 3 maps novelty scores to `0.0`, `0.3`, `0.6`, and `0.9`.
+- Tier 4 delegates to the existing self-test engine and fails below `0.8`.
+- Fail-fast stops after the first failed tier.
+- `--no-fail-fast` reports later tiers as passed, failed, or skipped.
+- SARIF output contains stable rule IDs and redacts secret-like content.
+
+CLI tests should cover:
+
+- `agentenv skills ci <dir> --json` exits `0` for a passing fixture.
+- `agentenv skills ci <dir> --json` exits `1` and reports the failing tier for
+  an invalid fixture.
+- `--sarif <path>` writes a valid SARIF JSON file.
+- `--registry-snapshot <path>` drives dedup failure deterministically.
+
+Workflow validation can stay light: parse the YAML in tests or add a repository
+smoke check that the workflow references `agentenv skills ci`.
+
+## Documentation
+
+Update user-facing docs once the implementation lands:
+
+- Mention `agentenv skills ci` in the skills CLI section.
+- Document the registry snapshot format.
+- Document that `gitleaks` is optional local enrichment, not a required core
+  dependency.
+- Note that hub deployments should call the same CI command or core API before
+  accepting publishes.
+
+## Open Trade-Offs
+
+- The first Tier 2 judge is deterministic rather than a true LLM-as-judge. This
+  keeps the core binary dependency-free and testable. The trait boundary keeps
+  the issue compatible with a hub-provided LLM judge later.
+- The first Tier 3 dedup path uses a local snapshot rather than Milvus or
+  pgvector. This preserves the single-binary core and lets the hub own its
+  preferred vector backend without changing the CLI report contract.
+- Optional `gitleaks` support improves developer CI where the binary is
+  installed, but the built-in scanner remains the portable baseline.


### PR DESCRIPTION
## Summary

Implements M7-10 Skill CI for hub publishes.

- Adds core Skill CI with static lint, deterministic agent review, semantic dedup, and functional regression tiers.
- Adds `agentenv skills ci` with JSON/SARIF output, registry snapshots, fail-fast behavior, and non-zero exits for failed/skipped reports.
- Adds reusable `.github/workflows/skill-ci.yaml` for PR validation, SARIF upload, artifact output, and PR comments.
- Documents the Skill CI workflow in `README.md` and includes design/implementation notes under `docs/superpowers/`.

Closes #36.

## Validation

- `cargo fmt --check`
- `git diff --check`
- `cargo clippy --workspace --all-targets -- -D warnings`
- `cargo test -p agentenv-core --test skills_ci -- --nocapture`
- `cargo test -p agentenv --test cli_behavior skills_ci_ -- --nocapture`
- `cargo test -p agentenv --test cli_behavior skill_ci -- --nocapture`
- `cargo test --workspace`
