### PR TITLE
[codex] Adopt OTEL GenAI semconv in activity stream

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2449,7 +2449,11 @@ version = "0.31.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b84bcd6ae87133e903af7ef497404dda70c60d0ea14895fc8a5e6722754fc2a0"
 dependencies = [
+ "futures-core",
+ "futures-sink",
  "js-sys",
+ "pin-project-lite",
+ "thiserror 2.0.18",
 ]
 
 [[package]]
@@ -2491,6 +2495,8 @@ dependencies = [
  "futures-executor",
  "futures-util",
  "opentelemetry",
+ "percent-encoding",
+ "rand 0.9.4",
  "thiserror 2.0.18",
 ]
 
@@ -2801,8 +2807,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5ca0ecfa931c29007047d1bc58e623ab12e5590e8c7cc53200d5202b69266d8a"
 dependencies = [
  "libc",
- "rand_chacha",
+ "rand_chacha 0.3.1",
  "rand_core 0.6.4",
+]
+
+[[package]]
+name = "rand"
+version = "0.9.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "44c5af06bb1b7d3216d91932aed5265164bf384dc89cd6ba05cf59a35f5f76ea"
+dependencies = [
+ "rand_chacha 0.9.0",
+ "rand_core 0.9.5",
 ]
 
 [[package]]
@@ -2827,12 +2843,31 @@ dependencies = [
 ]
 
 [[package]]
+name = "rand_chacha"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d3022b5f1df60f26e1ffddd6c66e8aa15de382ae63b3a0c1bfc0e4d3e3f325cb"
+dependencies = [
+ "ppv-lite86",
+ "rand_core 0.9.5",
+]
+
+[[package]]
 name = "rand_core"
 version = "0.6.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ec0be4795e2f6a28069bec0b5ff3e2ac9bafc99e6a9a7dc3547996c5c816922c"
 dependencies = [
  "getrandom 0.2.17",
+]
+
+[[package]]
+name = "rand_core"
+version = "0.9.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "76afc826de14238e6e8c374ddcc1fa19e374fd8dd986b0d2af0d02377261d83c"
+dependencies = [
+ "getrandom 0.3.4",
 ]
 
 [[package]]

--- a/contrib/grafana/dashboards/agentenv-otel.json
+++ b/contrib/grafana/dashboards/agentenv-otel.json
@@ -1,0 +1,375 @@
+{
+  "annotations": {
+    "list": []
+  },
+  "editable": true,
+  "fiscalYearStartMonth": 0,
+  "graphTooltip": 0,
+  "id": null,
+  "links": [],
+  "liveNow": false,
+  "panels": [
+    {
+      "datasource": "${datasource}",
+      "fieldConfig": {
+        "defaults": {
+          "unit": "short"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 8,
+        "x": 0,
+        "y": 0
+      },
+      "id": 1,
+      "options": {
+        "legend": {
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "single",
+          "sort": "none"
+        }
+      },
+      "targets": [
+        {
+          "datasource": "${datasource}",
+          "editorMode": "code",
+          "expr": "sum by (status) (agentenv_envs_total)",
+          "legendFormat": "{{status}}",
+          "range": true,
+          "refId": "A"
+        }
+      ],
+      "title": "Known Envs by Status",
+      "type": "timeseries"
+    },
+    {
+      "datasource": "${datasource}",
+      "fieldConfig": {
+        "defaults": {
+          "unit": "ops"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 8,
+        "x": 8,
+        "y": 0
+      },
+      "id": 2,
+      "options": {
+        "legend": {
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "single",
+          "sort": "none"
+        }
+      },
+      "targets": [
+        {
+          "datasource": "${datasource}",
+          "editorMode": "code",
+          "expr": "sum by (kind, result) (rate(agentenv_events_total[5m]))",
+          "legendFormat": "{{kind}} {{result}}",
+          "range": true,
+          "refId": "A"
+        }
+      ],
+      "title": "Activity Events by Kind and Result",
+      "type": "timeseries"
+    },
+    {
+      "datasource": "${datasource}",
+      "fieldConfig": {
+        "defaults": {
+          "unit": "s"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 8,
+        "x": 16,
+        "y": 0
+      },
+      "id": 3,
+      "options": {
+        "legend": {
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "single",
+          "sort": "none"
+        }
+      },
+      "targets": [
+        {
+          "datasource": "${datasource}",
+          "editorMode": "code",
+          "expr": "histogram_quantile(0.95, sum by (le, gen_ai_operation_name, gen_ai_request_model) (rate(gen_ai_client_operation_duration_bucket[5m])))",
+          "legendFormat": "p95 {{gen_ai_operation_name}} {{gen_ai_request_model}}",
+          "range": true,
+          "refId": "A"
+        }
+      ],
+      "title": "GenAI Operation Duration p95",
+      "type": "timeseries"
+    },
+    {
+      "datasource": "${datasource}",
+      "fieldConfig": {
+        "defaults": {
+          "unit": "tps"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 8,
+        "x": 0,
+        "y": 8
+      },
+      "id": 4,
+      "options": {
+        "legend": {
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "single",
+          "sort": "none"
+        }
+      },
+      "targets": [
+        {
+          "datasource": "${datasource}",
+          "editorMode": "code",
+          "expr": "sum by (gen_ai_token_type, gen_ai_request_model) (rate(gen_ai_client_token_usage_sum[5m]))",
+          "legendFormat": "{{gen_ai_request_model}} {{gen_ai_token_type}}",
+          "range": true,
+          "refId": "A"
+        }
+      ],
+      "title": "GenAI Token Usage",
+      "type": "timeseries"
+    },
+    {
+      "datasource": "${datasource}",
+      "fieldConfig": {
+        "defaults": {
+          "unit": "ops"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 8,
+        "x": 8,
+        "y": 8
+      },
+      "id": 5,
+      "options": {
+        "legend": {
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "single",
+          "sort": "none"
+        }
+      },
+      "targets": [
+        {
+          "datasource": "${datasource}",
+          "editorMode": "code",
+          "expr": "sum by (gen_ai_tool_name, result) (rate(agentenv_gen_ai_tool_calls_total[5m]))",
+          "legendFormat": "{{gen_ai_tool_name}} {{result}}",
+          "range": true,
+          "refId": "A"
+        }
+      ],
+      "title": "Tool Call Rate and Failures",
+      "type": "timeseries"
+    },
+    {
+      "datasource": "${datasource}",
+      "fieldConfig": {
+        "defaults": {
+          "unit": "ops"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 8,
+        "x": 16,
+        "y": 8
+      },
+      "id": 6,
+      "options": {
+        "legend": {
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "single",
+          "sort": "none"
+        }
+      },
+      "targets": [
+        {
+          "datasource": "${datasource}",
+          "editorMode": "code",
+          "expr": "sum by (driver) (rate(agentenv_policy_blocks_total{kind=\"egress_denied\"}[5m]))",
+          "legendFormat": "{{driver}}",
+          "range": true,
+          "refId": "A"
+        }
+      ],
+      "title": "Egress Denials",
+      "type": "timeseries"
+    },
+    {
+      "datasource": "${datasource}",
+      "fieldConfig": {
+        "defaults": {
+          "unit": "short"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 8,
+        "x": 0,
+        "y": 16
+      },
+      "id": 7,
+      "options": {
+        "legend": {
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "single",
+          "sort": "none"
+        }
+      },
+      "targets": [
+        {
+          "datasource": "${datasource}",
+          "editorMode": "code",
+          "expr": "agentenv_approvals_pending_total",
+          "legendFormat": "pending",
+          "range": true,
+          "refId": "A"
+        },
+        {
+          "datasource": "${datasource}",
+          "editorMode": "code",
+          "expr": "sum by (result) (rate(agentenv_events_total{kind=\"approval_decided\"}[5m]))",
+          "legendFormat": "decided {{result}}",
+          "range": true,
+          "refId": "B"
+        }
+      ],
+      "title": "Approvals Pending and Decisions",
+      "type": "timeseries"
+    },
+    {
+      "datasource": "${datasource}",
+      "fieldConfig": {
+        "defaults": {
+          "unit": "ops"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 8,
+        "x": 8,
+        "y": 16
+      },
+      "id": 8,
+      "options": {
+        "legend": {
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "single",
+          "sort": "none"
+        }
+      },
+      "targets": [
+        {
+          "datasource": "${datasource}",
+          "editorMode": "code",
+          "expr": "sum by (sink) (rate(agentenv_event_drops_total[5m]))",
+          "legendFormat": "drops {{sink}}",
+          "range": true,
+          "refId": "A"
+        },
+        {
+          "datasource": "${datasource}",
+          "editorMode": "code",
+          "expr": "sum by (sink) (rate(agentenv_event_sink_errors_total[5m]))",
+          "legendFormat": "errors {{sink}}",
+          "range": true,
+          "refId": "B"
+        }
+      ],
+      "title": "Event Drops and Sink Errors",
+      "type": "timeseries"
+    }
+  ],
+  "refresh": "30s",
+  "schemaVersion": 39,
+  "tags": [
+    "agentenv",
+    "otel",
+    "genai"
+  ],
+  "templating": {
+    "list": [
+      {
+        "current": {},
+        "hide": 0,
+        "includeAll": false,
+        "label": "Prometheus",
+        "multi": false,
+        "name": "datasource",
+        "options": [],
+        "query": "prometheus",
+        "refresh": 1,
+        "regex": "",
+        "type": "datasource"
+      }
+    ]
+  },
+  "time": {
+    "from": "now-1h",
+    "to": "now"
+  },
+  "timepicker": {},
+  "timezone": "",
+  "title": "agentenv OTEL GenAI",
+  "uid": "agentenv-otel-genai",
+  "version": 1,
+  "weekStart": ""
+}

--- a/crates/agentenv-core/src/blueprint.rs
+++ b/crates/agentenv-core/src/blueprint.rs
@@ -22,6 +22,8 @@ pub struct Blueprint {
     pub state: Option<StateSection>,
     #[serde(default, skip_serializing_if = "SkillsSection::is_empty")]
     pub skills: SkillsSection,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub observability: Option<ObservabilitySection>,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize, JsonSchema)]
@@ -169,6 +171,24 @@ fn normalize_runtime_discovery_mcp_endpoint(
     Ok(parsed.to_string())
 }
 
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, JsonSchema)]
+pub struct ObservabilitySection {
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub otel: Option<OtelObservabilitySection>,
+    #[schemars(with = "BTreeMap<String, serde_json::Value>")]
+    #[serde(flatten, default)]
+    pub extra: BTreeMap<String, Value>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, JsonSchema)]
+pub struct OtelObservabilitySection {
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub endpoint: Option<String>,
+    #[schemars(with = "BTreeMap<String, serde_json::Value>")]
+    #[serde(flatten, default)]
+    pub extra: BTreeMap<String, Value>,
+}
+
 pub trait InterpolationResolver {
     fn resolve_env(&self, name: &str) -> Result<String, BlueprintError>;
     fn resolve_credstore(&self, name: &str) -> Result<String, BlueprintError>;
@@ -302,5 +322,47 @@ fn yaml_path_segment(value: &Value) -> String {
             Ok(rendered) => rendered.trim().to_string(),
             Err(_) => "<non-string-key>".to_string(),
         },
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn observability_otel_endpoint_parses_and_roundtrips() {
+        let yaml = r#"
+version: "0.1"
+min_agentenv_version: "0.0.1"
+sandbox:
+  driver: openshell
+agent:
+  driver: codex
+context:
+  driver: filesystem
+policy:
+  tier: restricted
+observability:
+  otel:
+    endpoint: grpc://collector:4317
+"#;
+
+        let blueprint = Blueprint::from_yaml(yaml).expect("parse blueprint");
+        let endpoint = blueprint
+            .observability
+            .as_ref()
+            .and_then(|section| section.otel.as_ref())
+            .and_then(|otel| otel.endpoint.as_deref());
+        assert_eq!(endpoint, Some("grpc://collector:4317"));
+
+        let rendered = serde_yaml::to_string(&blueprint).expect("serialize blueprint");
+        assert!(
+            rendered.contains("observability:"),
+            "rendered blueprint did not preserve observability: {rendered}"
+        );
+        assert!(
+            rendered.contains("endpoint: grpc://collector:4317"),
+            "rendered blueprint did not preserve OTEL endpoint: {rendered}"
+        );
     }
 }

--- a/crates/agentenv-core/src/lifecycle.rs
+++ b/crates/agentenv-core/src/lifecycle.rs
@@ -83,6 +83,8 @@ struct CanonicalBlueprint {
     state: Option<StateSection>,
     #[serde(default, skip_serializing_if = "SkillsSection::is_empty")]
     skills: SkillsSection,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    observability: Option<crate::blueprint::ObservabilitySection>,
 }
 
 #[derive(Debug, Clone, Serialize)]
@@ -574,6 +576,7 @@ fn canonical_blueprint(resolved: &ResolvedBlueprint) -> Result<CanonicalBlueprin
         policy: blueprint.policy.clone(),
         state: blueprint.state.clone(),
         skills: blueprint.skills.clone(),
+        observability: blueprint.observability.clone(),
     })
 }
 
@@ -612,6 +615,7 @@ pub(crate) fn portable_canonical_blueprint(
         policy: canonical.policy,
         state: canonical.state,
         skills: canonical.skills,
+        observability: canonical.observability,
     })
 }
 

--- a/crates/agentenv-core/src/lockfile.rs
+++ b/crates/agentenv-core/src/lockfile.rs
@@ -9,7 +9,8 @@ use crate::digest::{parse_sha256_digest, parse_sha256_hex, DigestError};
 
 const SUPPORTED_LOCKFILE_VERSION: &str = "0.1.0";
 const SUPPORTED_PROTOCOL_VERSION: &str = "0.1";
-pub const PORTABLE_LOCKFILE_VERSION: &str = "0.2.0";
+const PORTABLE_LOCKFILE_V2_VERSION: &str = "0.2.0";
+pub const PORTABLE_LOCKFILE_VERSION: &str = "0.3.0";
 
 #[derive(Debug, Clone, PartialEq, Eq)]
 #[allow(clippy::large_enum_variant)]
@@ -85,6 +86,8 @@ pub struct PortableComposition {
         skip_serializing_if = "crate::blueprint::SkillsSection::is_empty"
     )]
     pub skills: crate::blueprint::SkillsSection,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub observability: Option<crate::blueprint::ObservabilitySection>,
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
@@ -269,7 +272,7 @@ impl LockfileDocument {
 
         match version {
             SUPPORTED_LOCKFILE_VERSION => Ok(Self::Legacy(Lockfile::from_yaml(yaml)?)),
-            PORTABLE_LOCKFILE_VERSION => {
+            version if is_supported_portable_lockfile_version(version) => {
                 let lockfile: PortableLockfile =
                     serde_yaml::from_value(value).map_err(LockfileError::Deserialize)?;
                 lockfile.validate()?;
@@ -285,6 +288,7 @@ impl LockfileDocument {
 impl PortableLockfile {
     pub fn to_yaml_deterministic(&self) -> Result<String, LockfileError> {
         let mut lockfile = self.clone();
+        lockfile.version = PORTABLE_LOCKFILE_VERSION.to_owned();
         lockfile.skills.sort_by(|left, right| {
             left.name
                 .cmp(&right.name)
@@ -296,7 +300,7 @@ impl PortableLockfile {
     }
 
     pub fn validate(&self) -> Result<(), LockfileError> {
-        if self.version != PORTABLE_LOCKFILE_VERSION {
+        if !is_supported_portable_lockfile_version(&self.version) {
             return Err(LockfileError::UnsupportedVersion {
                 version: self.version.clone(),
             });
@@ -346,6 +350,13 @@ impl PortableLockfile {
 
         validate_credentials(&self.credentials)
     }
+}
+
+fn is_supported_portable_lockfile_version(version: &str) -> bool {
+    matches!(
+        version,
+        PORTABLE_LOCKFILE_V2_VERSION | PORTABLE_LOCKFILE_VERSION
+    )
 }
 
 fn validate_skill_pins(skills: &[SkillPin]) -> Result<(), LockfileError> {

--- a/crates/agentenv-core/src/portable_lockfile.rs
+++ b/crates/agentenv-core/src/portable_lockfile.rs
@@ -626,6 +626,7 @@ fn blueprint_yaml_from_portable_composition(
         policy: composition.policy.clone(),
         state: composition.state.clone(),
         skills: composition.skills.clone(),
+        observability: composition.observability.clone(),
     };
 
     serde_yaml::to_string(&blueprint)

--- a/crates/agentenv-core/src/runtime.rs
+++ b/crates/agentenv-core/src/runtime.rs
@@ -2109,7 +2109,7 @@ fn verify_snapshot_lockfile(lock_yaml: &str) -> RuntimeResult<crate::lockfile::P
     let document = crate::lockfile::LockfileDocument::from_yaml(lock_yaml)?;
     let crate::lockfile::LockfileDocument::Portable(lockfile) = document else {
         return Err(RuntimeError::PortableLockfileVerification {
-            details: "snapshot lock.yaml must be a portable 0.2.0 lockfile".to_owned(),
+            details: "snapshot lock.yaml must be a supported portable lockfile".to_owned(),
         });
     };
 
@@ -3150,6 +3150,7 @@ fn blueprint_yaml_from_portable_lockfile(
         policy: composition.policy.clone(),
         state: composition.state.clone(),
         skills: composition.skills.clone(),
+        observability: composition.observability.clone(),
     };
 
     serde_yaml::to_string(&blueprint).map_err(RuntimeError::lockfile_serialize)
@@ -12724,7 +12725,10 @@ policy:
         let persisted_lock =
             fs::read_to_string(root.join("envs").join("renamed-demo").join("lock.yaml"))
                 .expect("read persisted lockfile");
-        assert!(persisted_lock.contains("version: 0.2.0"));
+        assert!(persisted_lock.contains(&format!(
+            "version: {}",
+            crate::lockfile::PORTABLE_LOCKFILE_VERSION
+        )));
         assert!(persisted_lock.contains("name: renamed-demo"));
         assert!(!persisted_lock.contains("name: source-demo"));
         assert!(persisted_lock.contains("frozen-pinned.example"));

--- a/crates/agentenv-core/tests/portable_lockfile.rs
+++ b/crates/agentenv-core/tests/portable_lockfile.rs
@@ -1,7 +1,7 @@
 use agentenv_core::{
     driver_artifact::DriverArtifact,
     driver_catalog::DriverSource,
-    lockfile::{DriverSourcePin, LockfileDocument, SkillPin},
+    lockfile::{DriverSourcePin, LockfileDocument, SkillPin, PORTABLE_LOCKFILE_VERSION},
     portable_lockfile::{
         build_portable_lockfile, verify_portable_lockfile_yaml, PortableLockfileError,
         PortableLockfileInput, PortableVerifyIssueKind,
@@ -32,7 +32,7 @@ fn portable_lockfile_builder_is_byte_identical_for_repeated_calls() {
         .expect("render second lockfile");
 
     assert_eq!(first, second);
-    assert!(first.contains("version: 0.2.0"));
+    assert!(first.contains(&format!("version: {PORTABLE_LOCKFILE_VERSION}")));
     let expected_single_quoted = format!("driver_protocol_version: '{SCHEMA_VERSION}'");
     let expected_double_quoted = format!("driver_protocol_version: \"{SCHEMA_VERSION}\"");
     assert!(
@@ -103,6 +103,38 @@ fn portable_lockfile_builder_preserves_skill_runtime_discovery() {
     let report = verify_portable_lockfile_yaml(&rendered, &built_in_artifacts())
         .expect("verify portable lockfile");
     assert!(report.is_clean());
+}
+
+#[test]
+fn portable_lockfile_builder_preserves_observability_otel_endpoint() {
+    let lockfile = build_portable_lockfile(PortableLockfileInput {
+        name: "demo".to_owned(),
+        blueprint_yaml: observability_yaml(),
+        driver_artifacts: built_in_artifacts(),
+    })
+    .expect("build lockfile");
+
+    assert_eq!(
+        lockfile
+            .composition
+            .observability
+            .as_ref()
+            .and_then(|observability| observability.otel.as_ref())
+            .and_then(|otel| otel.endpoint.as_deref()),
+        Some("grpc://collector:4317")
+    );
+
+    let rendered = lockfile
+        .to_yaml_deterministic()
+        .expect("render portable lockfile");
+    assert!(
+        rendered.contains("observability:"),
+        "lockfile should preserve observability: {rendered}"
+    );
+    assert!(
+        rendered.contains("endpoint: grpc://collector:4317"),
+        "lockfile should preserve OTEL endpoint: {rendered}"
+    );
 }
 
 #[test]
@@ -262,6 +294,34 @@ fn portable_lockfile_document_round_trips_builder_output() {
 
     let parsed = LockfileDocument::from_yaml(&rendered).expect("parse rendered lockfile");
     assert!(matches!(parsed, LockfileDocument::Portable(_)));
+}
+
+#[test]
+fn portable_lockfile_serialization_normalizes_v2_to_current_version() {
+    let rendered_v3 = reference_portable_lockfile_yaml();
+    let rendered_v2 = rendered_v3.replacen(
+        &format!("version: {PORTABLE_LOCKFILE_VERSION}"),
+        "version: 0.2.0",
+        1,
+    );
+
+    let LockfileDocument::Portable(lockfile) =
+        LockfileDocument::from_yaml(&rendered_v2).expect("parse v2 portable lockfile")
+    else {
+        panic!("expected portable lockfile");
+    };
+    let normalized = lockfile
+        .to_yaml_deterministic()
+        .expect("serialize normalized portable lockfile");
+
+    assert!(
+        normalized.contains(&format!("version: {PORTABLE_LOCKFILE_VERSION}")),
+        "normalized lockfile should use current portable version: {normalized}"
+    );
+    assert!(
+        !normalized.contains("version: 0.2.0"),
+        "normalized lockfile should not keep old portable version: {normalized}"
+    );
 }
 
 #[test]
@@ -944,6 +1004,18 @@ skills:
     scopes: ["search", "get_manifest"]
 "#
     .to_owned()
+}
+
+fn observability_yaml() -> String {
+    let mut yaml = reference_yaml();
+    yaml.push_str(
+        r#"
+observability:
+  otel:
+    endpoint: grpc://collector:4317
+"#,
+    );
+    yaml
 }
 
 fn image_yaml() -> String {

--- a/crates/agentenv-core/tests/runtime_freeze.rs
+++ b/crates/agentenv-core/tests/runtime_freeze.rs
@@ -29,7 +29,10 @@ fn runtime_freeze_reads_persisted_env_and_returns_portable_lockfile() {
     )
     .unwrap();
 
-    assert!(rendered.contains("version: 0.2.0"));
+    assert!(rendered.contains(&format!(
+        "version: {}",
+        agentenv_core::lockfile::PORTABLE_LOCKFILE_VERSION
+    )));
     assert!(rendered.contains("name: demo"));
     assert!(rendered.contains("sandbox:"));
     assert!(rendered.contains("name: openshell"));

--- a/crates/agentenv-events/Cargo.toml
+++ b/crates/agentenv-events/Cargo.toml
@@ -19,9 +19,9 @@ agentenv-proto = { path = "../agentenv-proto" }
 async-trait.workspace = true
 ed25519-dalek.workspace = true
 hex.workspace = true
-opentelemetry = { workspace = true, optional = true }
-opentelemetry_sdk = { workspace = true, optional = true }
-opentelemetry-otlp = { workspace = true, optional = true, features = ["grpc-tonic", "logs"] }
+opentelemetry = { workspace = true, optional = true, features = ["logs", "trace"] }
+opentelemetry_sdk = { workspace = true, optional = true, features = ["logs", "trace"] }
+opentelemetry-otlp = { workspace = true, optional = true, features = ["grpc-tonic", "logs", "trace"] }
 rand_core = { workspace = true, features = ["getrandom"] }
 reqwest.workspace = true
 rusqlite.workspace = true

--- a/crates/agentenv-events/README.md
+++ b/crates/agentenv-events/README.md
@@ -28,3 +28,65 @@ Sink URI forms:
 Webhook sinks are validated by the CLI through the shared SSRF guard before
 construction, and redirects are disabled. OTEL dependencies are optional so
 default builds do not pull in the exporter stack.
+
+## OTEL and GenAI mapping
+
+`ActivityEvent` is the durable source of truth. The OTEL sink exports every
+activity event as an `agentenv.activity` log record with `agentenv.kind`,
+`agentenv.result`, `agentenv.trace_id`, and optional `agentenv.env`,
+`agentenv.reason_code`, and `agentenv.latency_ms` attributes.
+
+GenAI-aware activity uses OTEL GenAI semantic-convention attributes:
+
+- `gen_ai_model_call` maps to a client span. Supported attributes are
+  `gen_ai.provider.name`, `gen_ai.operation.name`, `gen_ai.request.model`,
+  `gen_ai.response.model`, `gen_ai.usage.input_tokens`,
+  `gen_ai.usage.output_tokens`, and `gen_ai.response.finish_reasons`.
+- `mcp_tool_call` maps to an internal tool span with `gen_ai.tool.name` and
+  optional `gen_ai.tool.call.id`.
+- `agent_turn` maps to an internal agent span with `gen_ai.agent.name`.
+
+Canonical OTEL output uses `gen_ai.provider.name`. The mapper accepts
+`gen_ai.system` only as an input alias for older event producers. Token aliases
+`gen_ai.usage.prompt_tokens` and `gen_ai.usage.completion_tokens` are accepted
+as inputs and exported as input/output token usage.
+
+## Prometheus metrics
+
+`agentenv metrics serve` renders these series from the activity store and local
+approval state:
+
+- `agentenv_envs_total{status}`
+- `agentenv_events_total{kind,env,result}`
+- `agentenv_sandbox_latency_seconds_bucket|sum|count{op,driver}`
+- `agentenv_mcp_tool_calls_total{tool,env,result}`
+- `gen_ai_client_token_usage_bucket|sum|count{gen_ai_provider_name,gen_ai_operation_name,gen_ai_token_type,gen_ai_request_model,env,result}`
+- `gen_ai_client_operation_duration_bucket|sum|count{gen_ai_provider_name,gen_ai_operation_name,gen_ai_request_model,env,result}`
+- `agentenv_gen_ai_tool_calls_total{gen_ai_tool_name,env,result}`
+- `agentenv_policy_blocks_total{kind,driver}`
+- `agentenv_approvals_pending_total`
+- `agentenv_build_oneflight_hits_total`
+- `agentenv_build_oneflight_misses_total`
+- `agentenv_build_queue_depth`
+- `agentenv_event_drops_total{sink}`
+- `agentenv_event_sink_errors_total{sink}`
+
+The GenAI histogram names and labels intentionally match OTEL GenAI Prometheus
+conventions where possible; agentenv-specific counters keep operational signals
+such as policy blocks and sink health visible. Sink health counters include
+zero-valued `sink="sqlite"` samples by default when no drops or write errors
+have been observed.
+
+## Redaction and cardinality
+
+Events are redacted before GenAI OTEL export. Prompt-like fields,
+response/body-like fields, API keys, tokens, secrets, and credential-looking
+values are removed or replaced with redacted values. Raw prompts, responses,
+headers, URLs with credentials, and request bodies must not be used as metric
+labels.
+
+Metric labels are intentionally bounded to stable identifiers such as env,
+event kind, result, provider, operation, request model, token type, tool name,
+driver, and sink. Drivers should put high-cardinality or sensitive details in
+event payload fields only when they can be safely redacted or omitted from
+export.

--- a/crates/agentenv-events/src/activity.rs
+++ b/crates/agentenv-events/src/activity.rs
@@ -14,6 +14,8 @@ pub enum ActivityKind {
     EgressAllowed,
     EgressDenied,
     McpToolCall,
+    AgentTurn,
+    GenAiModelCall,
     PolicyApplied,
     CredentialInjected,
     CredentialSet,
@@ -196,6 +198,18 @@ mod tests {
         assert_eq!(
             serde_json::to_value(ActivityKind::BuildQueueDepth).unwrap(),
             serde_json::json!("build_queue_depth")
+        );
+    }
+
+    #[test]
+    fn genai_activity_kinds_serialize_to_stable_snake_case() {
+        assert_eq!(
+            serde_json::to_value(ActivityKind::AgentTurn).unwrap(),
+            serde_json::json!("agent_turn")
+        );
+        assert_eq!(
+            serde_json::to_value(ActivityKind::GenAiModelCall).unwrap(),
+            serde_json::json!("gen_ai_model_call")
         );
     }
 

--- a/crates/agentenv-events/src/audit.rs
+++ b/crates/agentenv-events/src/audit.rs
@@ -74,6 +74,8 @@ impl AuditPolicy {
             ActivityKind::SandboxDestroy
             | ActivityKind::EgressAllowed
             | ActivityKind::McpToolCall
+            | ActivityKind::AgentTurn
+            | ActivityKind::GenAiModelCall
             | ActivityKind::SpawnRequested
             | ActivityKind::SpawnQueued
             | ActivityKind::SpawnAdmitted

--- a/crates/agentenv-events/src/genai.rs
+++ b/crates/agentenv-events/src/genai.rs
@@ -1,0 +1,792 @@
+use std::collections::BTreeMap;
+
+use serde_json::Value;
+
+use crate::redaction::redact_string;
+use crate::{ActivityEvent, ActivityKind, ActivityResult};
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum OtelGenAiSignalKind {
+    Span,
+    SpanEvent,
+    LogRecord,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum OtelSpanKindHint {
+    Client,
+    Internal,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum OtelSignalStatus {
+    Ok,
+    Error,
+    Denied,
+    PendingApproval,
+}
+
+#[derive(Debug, Clone, PartialEq)]
+pub enum OtelAttributeValue {
+    String(String),
+    I64(i64),
+    F64(f64),
+    Bool(bool),
+    StringArray(Vec<String>),
+}
+
+#[derive(Debug, Clone, PartialEq)]
+pub struct OtelGenAiSignal {
+    pub kind: OtelGenAiSignalKind,
+    pub name: String,
+    pub span_kind: Option<OtelSpanKindHint>,
+    pub operation_name: String,
+    pub attributes: BTreeMap<String, OtelAttributeValue>,
+    pub status: OtelSignalStatus,
+}
+
+pub fn map_event_to_genai_signal(event: &ActivityEvent) -> OtelGenAiSignal {
+    let redacted_event = event.clone().redacted();
+    let (kind, span_kind, operation_name) = signal_shape(&redacted_event);
+    let mut attributes = BTreeMap::new();
+
+    insert_base_attributes(&mut attributes, &redacted_event);
+    insert_error_type(&mut attributes, &redacted_event);
+    attributes.insert(
+        "gen_ai.operation.name".to_owned(),
+        OtelAttributeValue::String(operation_name.clone()),
+    );
+    insert_provider_name(&mut attributes, &redacted_event);
+
+    match redacted_event.kind {
+        ActivityKind::McpToolCall => insert_tool_attributes(&mut attributes, &redacted_event),
+        ActivityKind::AgentTurn => insert_agent_attributes(&mut attributes, &redacted_event),
+        ActivityKind::GenAiModelCall => {
+            insert_model_call_attributes(&mut attributes, &redacted_event, event);
+        }
+        _ => insert_extension_attributes(&mut attributes, &redacted_event),
+    }
+
+    OtelGenAiSignal {
+        kind,
+        name: signal_name(redacted_event.kind, &operation_name, &attributes),
+        span_kind,
+        operation_name,
+        attributes,
+        status: status_from_result(redacted_event.result),
+    }
+}
+
+fn signal_shape(event: &ActivityEvent) -> (OtelGenAiSignalKind, Option<OtelSpanKindHint>, String) {
+    match event.kind {
+        ActivityKind::McpToolCall => (
+            OtelGenAiSignalKind::Span,
+            Some(OtelSpanKindHint::Internal),
+            "execute_tool".to_owned(),
+        ),
+        ActivityKind::AgentTurn => (
+            OtelGenAiSignalKind::Span,
+            Some(OtelSpanKindHint::Internal),
+            "invoke_agent".to_owned(),
+        ),
+        ActivityKind::GenAiModelCall => (
+            OtelGenAiSignalKind::Span,
+            Some(OtelSpanKindHint::Client),
+            normalized_operation_name(string_from_keys(&event.extras, &["gen_ai.operation.name"])),
+        ),
+        _ => (
+            OtelGenAiSignalKind::LogRecord,
+            None,
+            activity_kind_name(event.kind).to_owned(),
+        ),
+    }
+}
+
+fn signal_name(
+    event_kind: ActivityKind,
+    operation_name: &str,
+    attributes: &BTreeMap<String, OtelAttributeValue>,
+) -> String {
+    let name_suffix = match event_kind {
+        ActivityKind::McpToolCall => string_attr(attributes, "gen_ai.tool.name"),
+        ActivityKind::AgentTurn => string_attr(attributes, "gen_ai.agent.name"),
+        ActivityKind::GenAiModelCall => string_attr(attributes, "gen_ai.request.model"),
+        _ => None,
+    };
+
+    name_suffix
+        .map(|suffix| format!("{operation_name} {suffix}"))
+        .unwrap_or_else(|| operation_name.to_owned())
+}
+
+fn insert_base_attributes(
+    attributes: &mut BTreeMap<String, OtelAttributeValue>,
+    event: &ActivityEvent,
+) {
+    attributes.insert(
+        "agentenv.event.kind".to_owned(),
+        OtelAttributeValue::String(activity_kind_name(event.kind).to_owned()),
+    );
+    attributes.insert(
+        "agentenv.event.result".to_owned(),
+        OtelAttributeValue::String(activity_result_name(event.result).to_owned()),
+    );
+    if !event.trace_id.is_empty() {
+        attributes.insert(
+            "agentenv.trace_id".to_owned(),
+            OtelAttributeValue::String(event.trace_id.clone()),
+        );
+    }
+    if let Some(env) = clean_string(event.env.as_deref()) {
+        attributes.insert("agentenv.env".to_owned(), OtelAttributeValue::String(env));
+    }
+    if let Some(reason_code) = sanitized_reason_code(event) {
+        attributes.insert(
+            "agentenv.reason_code".to_owned(),
+            OtelAttributeValue::String(reason_code),
+        );
+    }
+    if let Some(latency_ms) = event.latency_ms.and_then(|value| i64::try_from(value).ok()) {
+        attributes.insert(
+            "agentenv.latency_ms".to_owned(),
+            OtelAttributeValue::I64(latency_ms),
+        );
+    }
+}
+
+fn insert_error_type(attributes: &mut BTreeMap<String, OtelAttributeValue>, event: &ActivityEvent) {
+    match event.result {
+        ActivityResult::Error | ActivityResult::Denied => {
+            let error_type = sanitized_reason_code(event)
+                .filter(|reason_code| is_code_like_error_type(reason_code))
+                .unwrap_or_else(|| "_OTHER".to_owned());
+            attributes.insert(
+                "error.type".to_owned(),
+                OtelAttributeValue::String(error_type),
+            );
+        }
+        ActivityResult::Ok | ActivityResult::PendingApproval => {}
+    }
+}
+
+fn sanitized_reason_code(event: &ActivityEvent) -> Option<String> {
+    event.reason_code.as_deref().and_then(|reason_code| {
+        let redacted = redact_string(reason_code);
+        clean_string(Some(&redacted))
+    })
+}
+
+fn is_code_like_error_type(value: &str) -> bool {
+    (1..=64).contains(&value.len())
+        && value
+            .bytes()
+            .all(|byte| byte.is_ascii_alphanumeric() || matches!(byte, b'_' | b'.' | b'-' | b':'))
+}
+
+fn insert_provider_name(
+    attributes: &mut BTreeMap<String, OtelAttributeValue>,
+    event: &ActivityEvent,
+) {
+    if let Some(provider) =
+        string_from_keys(&event.extras, &["gen_ai.provider.name", "gen_ai.system"])
+            .or_else(|| string_from_keys(&event.subject, &["gen_ai.provider.name"]))
+    {
+        attributes.insert(
+            "gen_ai.provider.name".to_owned(),
+            OtelAttributeValue::String(provider),
+        );
+    }
+}
+
+fn insert_tool_attributes(
+    attributes: &mut BTreeMap<String, OtelAttributeValue>,
+    event: &ActivityEvent,
+) {
+    if let Some(tool_name) =
+        string_from_event_maps(event, &["gen_ai.tool.name", "tool.name", "name"])
+    {
+        attributes.insert(
+            "gen_ai.tool.name".to_owned(),
+            OtelAttributeValue::String(tool_name),
+        );
+    }
+    if let Some(call_id) = string_from_event_maps(event, &["gen_ai.tool.call.id", "call_id"]) {
+        attributes.insert(
+            "gen_ai.tool.call.id".to_owned(),
+            OtelAttributeValue::String(call_id),
+        );
+    }
+}
+
+fn insert_agent_attributes(
+    attributes: &mut BTreeMap<String, OtelAttributeValue>,
+    event: &ActivityEvent,
+) {
+    if let Some(agent_name) = string_from_keys(&event.extras, &["gen_ai.agent.name"])
+        .or_else(|| clean_string(event.env.as_deref()))
+    {
+        attributes.insert(
+            "gen_ai.agent.name".to_owned(),
+            OtelAttributeValue::String(agent_name),
+        );
+    }
+}
+
+fn insert_model_call_attributes(
+    attributes: &mut BTreeMap<String, OtelAttributeValue>,
+    event: &ActivityEvent,
+    original_event: &ActivityEvent,
+) {
+    copy_string_attr(
+        attributes,
+        "gen_ai.request.model",
+        event,
+        &["gen_ai.request.model", "request.model", "model"],
+    );
+    copy_string_attr(
+        attributes,
+        "gen_ai.response.model",
+        event,
+        &["gen_ai.response.model", "response.model"],
+    );
+    copy_i64_attr(
+        attributes,
+        "gen_ai.usage.input_tokens",
+        original_event,
+        &[
+            "gen_ai.usage.input_tokens",
+            "gen_ai.usage.prompt_tokens",
+            "input_tokens",
+            "prompt_tokens",
+        ],
+    );
+    copy_i64_attr(
+        attributes,
+        "gen_ai.usage.output_tokens",
+        original_event,
+        &[
+            "gen_ai.usage.output_tokens",
+            "gen_ai.usage.completion_tokens",
+            "output_tokens",
+            "completion_tokens",
+        ],
+    );
+    if let Some(finish_reasons) = string_array_from_event_maps(
+        event,
+        &[
+            "gen_ai.response.finish_reasons",
+            "gen_ai.response.finish_reason",
+            "finish_reasons",
+            "finish_reason",
+        ],
+    ) {
+        attributes.insert(
+            "gen_ai.response.finish_reasons".to_owned(),
+            OtelAttributeValue::StringArray(finish_reasons),
+        );
+    }
+}
+
+fn insert_extension_attributes(
+    attributes: &mut BTreeMap<String, OtelAttributeValue>,
+    event: &ActivityEvent,
+) {
+    if event.kind == ActivityKind::EgressDenied {
+        attributes.insert(
+            "agentenv.egress.denied".to_owned(),
+            OtelAttributeValue::Bool(true),
+        );
+    }
+
+    if let Some(request_id) = string_from_keys(&event.subject, &["request_id"]) {
+        attributes.insert(
+            "agentenv.approval.request_id".to_owned(),
+            OtelAttributeValue::String(request_id),
+        );
+    }
+    if let Some(kind) = string_from_keys(&event.subject, &["kind"])
+        .or_else(|| string_from_keys(&event.extras, &["approval.kind"]))
+    {
+        attributes.insert(
+            "agentenv.approval.kind".to_owned(),
+            OtelAttributeValue::String(kind),
+        );
+    }
+    if let Some(policy_name) = string_from_keys(&event.extras, &["policy.name"]) {
+        attributes.insert(
+            "agentenv.policy.name".to_owned(),
+            OtelAttributeValue::String(policy_name),
+        );
+    }
+
+    if let Some(default_scope) = string_from_keys(&event.extras, &["default_scope"]) {
+        attributes.insert(
+            "agentenv.approval.default_scope".to_owned(),
+            OtelAttributeValue::String(default_scope),
+        );
+    }
+    if let Some(decision) = string_from_keys(&event.extras, &["decision"]) {
+        attributes.insert(
+            "agentenv.approval.decision".to_owned(),
+            OtelAttributeValue::String(decision),
+        );
+    }
+    if let Some(scope) = string_from_keys(&event.extras, &["scope"]) {
+        attributes.insert(
+            "agentenv.approval.scope".to_owned(),
+            OtelAttributeValue::String(scope),
+        );
+    }
+}
+
+fn copy_string_attr(
+    attributes: &mut BTreeMap<String, OtelAttributeValue>,
+    canonical_key: &str,
+    event: &ActivityEvent,
+    keys: &[&str],
+) {
+    if let Some(value) = string_from_event_maps(event, keys) {
+        attributes.insert(canonical_key.to_owned(), OtelAttributeValue::String(value));
+    }
+}
+
+fn copy_i64_attr(
+    attributes: &mut BTreeMap<String, OtelAttributeValue>,
+    canonical_key: &str,
+    event: &ActivityEvent,
+    keys: &[&str],
+) {
+    if let Some(value) = i64_from_event_maps(event, keys) {
+        attributes.insert(canonical_key.to_owned(), OtelAttributeValue::I64(value));
+    }
+}
+
+fn string_from_event_maps(event: &ActivityEvent, keys: &[&str]) -> Option<String> {
+    string_from_keys(&event.subject, keys).or_else(|| string_from_keys(&event.extras, keys))
+}
+
+fn i64_from_event_maps(event: &ActivityEvent, keys: &[&str]) -> Option<i64> {
+    i64_from_keys(&event.subject, keys).or_else(|| i64_from_keys(&event.extras, keys))
+}
+
+fn string_array_from_event_maps(event: &ActivityEvent, keys: &[&str]) -> Option<Vec<String>> {
+    string_array_from_keys(&event.subject, keys)
+        .or_else(|| string_array_from_keys(&event.extras, keys))
+}
+
+fn string_from_keys(map: &BTreeMap<String, Value>, keys: &[&str]) -> Option<String> {
+    keys.iter()
+        .find_map(|key| map.get(*key).and_then(value_as_string))
+}
+
+fn i64_from_keys(map: &BTreeMap<String, Value>, keys: &[&str]) -> Option<i64> {
+    keys.iter()
+        .find_map(|key| map.get(*key).and_then(value_as_i64))
+}
+
+fn string_array_from_keys(map: &BTreeMap<String, Value>, keys: &[&str]) -> Option<Vec<String>> {
+    keys.iter()
+        .find_map(|key| map.get(*key).and_then(value_as_string_array))
+}
+
+fn value_as_string(value: &Value) -> Option<String> {
+    match value {
+        Value::String(raw) => clean_string(Some(raw)),
+        _ => None,
+    }
+}
+
+fn value_as_i64(value: &Value) -> Option<i64> {
+    match value {
+        Value::Number(number) => number
+            .as_i64()
+            .or_else(|| number.as_u64().and_then(|value| i64::try_from(value).ok())),
+        Value::String(raw) => clean_string(Some(raw)).and_then(|value| value.parse().ok()),
+        _ => None,
+    }
+}
+
+fn value_as_string_array(value: &Value) -> Option<Vec<String>> {
+    match value {
+        Value::Array(values) => {
+            let strings = values
+                .iter()
+                .filter_map(value_as_string)
+                .collect::<Vec<_>>();
+            (!strings.is_empty()).then_some(strings)
+        }
+        Value::String(_) => value_as_string(value).map(|value| vec![value]),
+        _ => None,
+    }
+}
+
+fn clean_string(value: Option<&str>) -> Option<String> {
+    value
+        .map(str::trim)
+        .filter(|value| !value.is_empty() && *value != "[redacted]")
+        .map(str::to_owned)
+}
+
+fn string_attr<'a>(
+    attributes: &'a BTreeMap<String, OtelAttributeValue>,
+    key: &str,
+) -> Option<&'a str> {
+    match attributes.get(key) {
+        Some(OtelAttributeValue::String(value)) => Some(value.as_str()),
+        _ => None,
+    }
+}
+
+fn normalized_operation_name(value: Option<String>) -> String {
+    match value.as_deref() {
+        Some(
+            "chat" | "create_agent" | "embeddings" | "execute_tool" | "generate_content"
+            | "invoke_agent" | "invoke_workflow" | "retrieval" | "text_completion",
+        ) => value.unwrap_or_default(),
+        _ => "chat".to_owned(),
+    }
+}
+
+fn status_from_result(result: ActivityResult) -> OtelSignalStatus {
+    match result {
+        ActivityResult::Ok => OtelSignalStatus::Ok,
+        ActivityResult::Error => OtelSignalStatus::Error,
+        ActivityResult::Denied => OtelSignalStatus::Denied,
+        ActivityResult::PendingApproval => OtelSignalStatus::PendingApproval,
+    }
+}
+
+fn activity_result_name(result: ActivityResult) -> &'static str {
+    match result {
+        ActivityResult::Ok => "ok",
+        ActivityResult::Error => "error",
+        ActivityResult::Denied => "denied",
+        ActivityResult::PendingApproval => "pending_approval",
+    }
+}
+
+fn activity_kind_name(kind: ActivityKind) -> &'static str {
+    match kind {
+        ActivityKind::SandboxCreate => "sandbox_create",
+        ActivityKind::SandboxDestroy => "sandbox_destroy",
+        ActivityKind::Exec => "exec",
+        ActivityKind::EgressAllowed => "egress_allowed",
+        ActivityKind::EgressDenied => "egress_denied",
+        ActivityKind::McpToolCall => "mcp_tool_call",
+        ActivityKind::AgentTurn => "agent_turn",
+        ActivityKind::GenAiModelCall => "gen_ai_model_call",
+        ActivityKind::PolicyApplied => "policy_applied",
+        ActivityKind::CredentialInjected => "credential_injected",
+        ActivityKind::CredentialSet => "credential_set",
+        ActivityKind::CredentialReset => "credential_reset",
+        ActivityKind::Auth => "auth",
+        ActivityKind::ApprovalRequested => "approval_requested",
+        ActivityKind::ApprovalDecided => "approval_decided",
+        ActivityKind::SpawnRequested => "spawn_requested",
+        ActivityKind::SpawnQueued => "spawn_queued",
+        ActivityKind::SpawnAdmitted => "spawn_admitted",
+        ActivityKind::SpawnRejected => "spawn_rejected",
+        ActivityKind::SpawnStarted => "spawn_started",
+        ActivityKind::SpawnReady => "spawn_ready",
+        ActivityKind::BuildOneflightHit => "build_oneflight_hit",
+        ActivityKind::BuildOneflightMiss => "build_oneflight_miss",
+        ActivityKind::BuildQueueDepth => "build_queue_depth",
+        ActivityKind::Log => "log",
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use serde_json::json;
+
+    use super::*;
+    use crate::{ActivityEvent, ActivityKind, ActivityResult};
+
+    #[test]
+    fn gen_ai_system_alias_maps_to_provider_name() {
+        let event = ActivityEvent::new(
+            "2026-05-18T12:00:00Z",
+            ActivityKind::GenAiModelCall,
+            ActivityResult::Ok,
+            "trace-genai",
+        )
+        .with_extra("gen_ai.system", json!("openai"));
+
+        let signal = map_event_to_genai_signal(&event);
+
+        assert_eq!(
+            signal.attributes.get("gen_ai.provider.name"),
+            Some(&OtelAttributeValue::String("openai".to_owned()))
+        );
+        assert!(!signal.attributes.contains_key("gen_ai.system"));
+    }
+
+    #[test]
+    fn mcp_tool_call_maps_to_execute_tool() {
+        let event = ActivityEvent::new(
+            "2026-05-18T12:00:00Z",
+            ActivityKind::McpToolCall,
+            ActivityResult::Ok,
+            "trace-tool",
+        )
+        .with_subject_value("name", json!("repo.search"));
+
+        let signal = map_event_to_genai_signal(&event);
+
+        assert_eq!(signal.kind, OtelGenAiSignalKind::Span);
+        assert_eq!(signal.span_kind, Some(OtelSpanKindHint::Internal));
+        assert_eq!(signal.name, "execute_tool repo.search");
+        assert_eq!(signal.operation_name, "execute_tool");
+        assert_eq!(
+            signal.attributes.get("gen_ai.operation.name"),
+            Some(&OtelAttributeValue::String("execute_tool".to_owned()))
+        );
+        assert_eq!(
+            signal.attributes.get("gen_ai.tool.name"),
+            Some(&OtelAttributeValue::String("repo.search".to_owned()))
+        );
+    }
+
+    #[test]
+    fn agent_turn_maps_to_invoke_agent() {
+        let event = ActivityEvent::new(
+            "2026-05-18T12:00:00Z",
+            ActivityKind::AgentTurn,
+            ActivityResult::Ok,
+            "trace-agent",
+        )
+        .with_env("codex");
+
+        let signal = map_event_to_genai_signal(&event);
+
+        assert_eq!(signal.kind, OtelGenAiSignalKind::Span);
+        assert_eq!(signal.span_kind, Some(OtelSpanKindHint::Internal));
+        assert_eq!(signal.name, "invoke_agent codex");
+        assert_eq!(signal.operation_name, "invoke_agent");
+        assert_eq!(
+            signal.attributes.get("gen_ai.agent.name"),
+            Some(&OtelAttributeValue::String("codex".to_owned()))
+        );
+    }
+
+    #[test]
+    fn model_call_maps_token_usage_attributes() {
+        let event = ActivityEvent::new(
+            "2026-05-18T12:00:00Z",
+            ActivityKind::GenAiModelCall,
+            ActivityResult::Ok,
+            "trace-model",
+        )
+        .with_extra("gen_ai.request.model", json!("gpt-4.1"))
+        .with_extra("gen_ai.response.model", json!("gpt-4.1-2026-04-14"))
+        .with_extra("gen_ai.usage.input_tokens", json!(123))
+        .with_extra("gen_ai.usage.output_tokens", json!(45));
+
+        let signal = map_event_to_genai_signal(&event);
+
+        assert_eq!(signal.name, "chat gpt-4.1");
+        assert_eq!(
+            signal.attributes.get("gen_ai.request.model"),
+            Some(&OtelAttributeValue::String("gpt-4.1".to_owned()))
+        );
+        assert_eq!(
+            signal.attributes.get("gen_ai.response.model"),
+            Some(&OtelAttributeValue::String("gpt-4.1-2026-04-14".to_owned()))
+        );
+        assert_eq!(
+            signal.attributes.get("gen_ai.usage.input_tokens"),
+            Some(&OtelAttributeValue::I64(123))
+        );
+        assert_eq!(
+            signal.attributes.get("gen_ai.usage.output_tokens"),
+            Some(&OtelAttributeValue::I64(45))
+        );
+    }
+
+    #[test]
+    fn secret_looking_extra_is_omitted_by_mapper() {
+        let event = ActivityEvent::new(
+            "2026-05-18T12:00:00Z",
+            ActivityKind::GenAiModelCall,
+            ActivityResult::Ok,
+            "trace-secret",
+        )
+        .with_extra("api_key", json!("sk-secret"))
+        .with_extra("gen_ai.request.model", json!("gpt-4.1"));
+
+        let signal = map_event_to_genai_signal(&event);
+        let rendered = format!("{:?}", signal.attributes);
+
+        assert!(!signal.attributes.contains_key("api_key"));
+        assert!(!rendered.contains("sk-secret"));
+        assert!(!rendered.contains("[redacted]"));
+    }
+
+    #[test]
+    fn model_call_defaults_custom_operation_name_to_chat() {
+        let custom_operation = "summarize this private customer prompt";
+        let event = ActivityEvent::new(
+            "2026-05-18T12:00:00Z",
+            ActivityKind::GenAiModelCall,
+            ActivityResult::Ok,
+            "trace-custom-op",
+        )
+        .with_extra("gen_ai.operation.name", json!(custom_operation))
+        .with_extra("gen_ai.request.model", json!("gpt-4.1"));
+
+        let signal = map_event_to_genai_signal(&event);
+        let rendered = format!("{:?}", signal);
+
+        assert_eq!(signal.operation_name, "chat");
+        assert_eq!(signal.name, "chat gpt-4.1");
+        assert_eq!(
+            signal.attributes.get("gen_ai.operation.name"),
+            Some(&OtelAttributeValue::String("chat".to_owned()))
+        );
+        assert!(!rendered.contains(custom_operation));
+    }
+
+    #[test]
+    fn approval_requested_maps_allowlisted_subject_attributes() {
+        let event = ActivityEvent::new(
+            "2026-05-18T12:00:00Z",
+            ActivityKind::ApprovalRequested,
+            ActivityResult::PendingApproval,
+            "trace-approval",
+        )
+        .with_subject_value("request_id", json!("apr-123"))
+        .with_subject_value("kind", json!("egress_host"))
+        .with_subject_value("subject", json!("https://example.test/path?token=secret"))
+        .with_extra("default_scope", json!("session"))
+        .with_extra(
+            "context",
+            json!({"url": "https://example.test/path?token=secret"}),
+        );
+
+        let signal = map_event_to_genai_signal(&event);
+        let rendered = format!("{:?}", signal.attributes);
+
+        assert_eq!(signal.kind, OtelGenAiSignalKind::LogRecord);
+        assert_eq!(
+            signal.attributes.get("agentenv.approval.request_id"),
+            Some(&OtelAttributeValue::String("apr-123".to_owned()))
+        );
+        assert_eq!(
+            signal.attributes.get("agentenv.approval.kind"),
+            Some(&OtelAttributeValue::String("egress_host".to_owned()))
+        );
+        assert_eq!(
+            signal.attributes.get("agentenv.approval.default_scope"),
+            Some(&OtelAttributeValue::String("session".to_owned()))
+        );
+        assert!(!signal.attributes.contains_key("agentenv.approval.context"));
+        assert!(!rendered.contains("token=secret"));
+    }
+
+    #[test]
+    fn scalar_reason_code_is_redacted_before_mapping() {
+        let event = ActivityEvent::new(
+            "2026-05-18T12:00:00Z",
+            ActivityKind::GenAiModelCall,
+            ActivityResult::Ok,
+            "trace-reason",
+        )
+        .with_reason_code("https://user:pass@example.test/path?token=secret#frag");
+
+        let signal = map_event_to_genai_signal(&event);
+        let rendered = format!("{:?}", signal.attributes);
+
+        assert_eq!(
+            signal.attributes.get("agentenv.reason_code"),
+            Some(&OtelAttributeValue::String(
+                "https://example.test/path".to_owned()
+            ))
+        );
+        assert!(!rendered.contains("user:pass"));
+        assert!(!rendered.contains("token=secret"));
+        assert!(!rendered.contains("#frag"));
+        assert!(!signal.attributes.contains_key("error.type"));
+    }
+
+    #[test]
+    fn denied_signal_emits_error_type_from_code_like_reason_code() {
+        let event = ActivityEvent::new(
+            "2026-05-18T12:00:00Z",
+            ActivityKind::EgressDenied,
+            ActivityResult::Denied,
+            "trace-denied-code",
+        )
+        .with_reason_code("not_in_policy");
+
+        let signal = map_event_to_genai_signal(&event);
+
+        assert_eq!(
+            signal.attributes.get("agentenv.reason_code"),
+            Some(&OtelAttributeValue::String("not_in_policy".to_owned()))
+        );
+        assert_eq!(
+            signal.attributes.get("error.type"),
+            Some(&OtelAttributeValue::String("not_in_policy".to_owned()))
+        );
+    }
+
+    #[test]
+    fn denied_signal_defaults_error_type_for_url_reason_code() {
+        let event = ActivityEvent::new(
+            "2026-05-18T12:00:00Z",
+            ActivityKind::EgressDenied,
+            ActivityResult::Denied,
+            "trace-denied",
+        )
+        .with_reason_code("https://user:pass@example.test/blocked?token=secret#frag");
+
+        let signal = map_event_to_genai_signal(&event);
+        let rendered = format!("{:?}", signal.attributes);
+
+        assert_eq!(
+            signal.attributes.get("agentenv.reason_code"),
+            Some(&OtelAttributeValue::String(
+                "https://example.test/blocked".to_owned()
+            ))
+        );
+        assert_eq!(
+            signal.attributes.get("error.type"),
+            Some(&OtelAttributeValue::String("_OTHER".to_owned()))
+        );
+        assert!(!rendered.contains("user:pass"));
+        assert!(!rendered.contains("token=secret"));
+        assert!(!rendered.contains("#frag"));
+    }
+
+    #[test]
+    fn error_signal_defaults_error_type_when_reason_code_missing() {
+        let event = ActivityEvent::new(
+            "2026-05-18T12:00:00Z",
+            ActivityKind::GenAiModelCall,
+            ActivityResult::Error,
+            "trace-error",
+        );
+
+        let signal = map_event_to_genai_signal(&event);
+
+        assert_eq!(
+            signal.attributes.get("error.type"),
+            Some(&OtelAttributeValue::String("_OTHER".to_owned()))
+        );
+    }
+
+    #[test]
+    fn pending_approval_signal_does_not_emit_error_type() {
+        let event = ActivityEvent::new(
+            "2026-05-18T12:00:00Z",
+            ActivityKind::ApprovalRequested,
+            ActivityResult::PendingApproval,
+            "trace-pending",
+        )
+        .with_reason_code("needs_approval");
+
+        let signal = map_event_to_genai_signal(&event);
+
+        assert!(!signal.attributes.contains_key("error.type"));
+    }
+}

--- a/crates/agentenv-events/src/lib.rs
+++ b/crates/agentenv-events/src/lib.rs
@@ -3,6 +3,7 @@
 pub mod activity;
 pub mod audit;
 pub mod dispatcher;
+pub mod genai;
 pub mod local_ops;
 pub mod metrics;
 #[cfg(feature = "otel")]
@@ -15,6 +16,10 @@ pub mod webhook;
 
 pub use activity::{ActivityEvent, ActivityKind, ActivityResult, ActorKind};
 pub use dispatcher::{EventDispatcher, EventEmitter, NoopEventEmitter, RecordingEventEmitter};
+pub use genai::{
+    map_event_to_genai_signal, OtelAttributeValue, OtelGenAiSignal, OtelGenAiSignalKind,
+    OtelSignalStatus, OtelSpanKindHint,
+};
 pub use local_ops::{
     default_store_path, EventImportReport, EventStoreError, EventStoreResult, LocalEventStore,
     StoredEvent, StoredEventKind,

--- a/crates/agentenv-events/src/metrics.rs
+++ b/crates/agentenv-events/src/metrics.rs
@@ -263,10 +263,17 @@ impl MetricsSnapshot {
             build_oneflight_hits_total,
             build_oneflight_misses_total,
             build_queue_depth,
-            event_drops_total: Vec::new(),
-            event_sink_errors_total: Vec::new(),
+            event_drops_total: default_sink_counter_metrics(),
+            event_sink_errors_total: default_sink_counter_metrics(),
         })
     }
+}
+
+fn default_sink_counter_metrics() -> Vec<SinkCounterMetric> {
+    vec![SinkCounterMetric {
+        sink: "sqlite".to_owned(),
+        count: 0,
+    }]
 }
 
 pub fn render_prometheus(snapshot: &MetricsSnapshot) -> String {
@@ -1064,6 +1071,17 @@ mod tests {
         let rendered = render_prometheus(&snapshot);
 
         assert!(rendered.contains("agentenv_build_queue_depth 0"));
+    }
+
+    #[test]
+    fn event_drops_total_includes_default_zero_sink_health_samples() {
+        let temp = tempfile::tempdir().unwrap();
+        let store = SqliteEventStore::open(temp.path().join("events.db")).unwrap();
+        let snapshot = MetricsSnapshot::from_store(&store, &[]).unwrap();
+        let rendered = render_prometheus(&snapshot);
+
+        assert!(rendered.contains("agentenv_event_drops_total{sink=\"sqlite\"} 0"));
+        assert!(rendered.contains("agentenv_event_sink_errors_total{sink=\"sqlite\"} 0"));
     }
 
     #[test]

--- a/crates/agentenv-events/src/metrics.rs
+++ b/crates/agentenv-events/src/metrics.rs
@@ -10,6 +10,29 @@ pub const LATENCY_BUCKET_LABELS: [&str; 12] = [
     "0.005", "0.01", "0.025", "0.05", "0.1", "0.25", "0.5", "1", "2.5", "5", "10", "+Inf",
 ];
 
+pub const GENAI_TOKEN_BUCKET_LABELS: [&str; 15] = [
+    "1", "4", "16", "64", "256", "1024", "4096", "16384", "65536", "262144", "1048576", "4194304",
+    "16777216", "67108864", "+Inf",
+];
+
+const GENAI_TOKEN_BUCKET_LIMITS: [Option<u64>; 15] = [
+    Some(1),
+    Some(4),
+    Some(16),
+    Some(64),
+    Some(256),
+    Some(1024),
+    Some(4096),
+    Some(16_384),
+    Some(65_536),
+    Some(262_144),
+    Some(1_048_576),
+    Some(4_194_304),
+    Some(16_777_216),
+    Some(67_108_864),
+    None,
+];
+
 const LATENCY_BUCKET_MILLIS: [Option<u64>; 12] = [
     Some(5),
     Some(10),
@@ -71,6 +94,76 @@ pub struct LatencySummaryMetric {
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]
+pub struct GenAiTokenUsageBucketMetric {
+    pub provider_name: Option<String>,
+    pub operation_name: String,
+    pub token_type: String,
+    pub request_model: Option<String>,
+    pub env: Option<String>,
+    pub result: String,
+    pub le: String,
+    pub count: u64,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct GenAiTokenUsageSummaryMetric {
+    pub provider_name: Option<String>,
+    pub operation_name: String,
+    pub token_type: String,
+    pub request_model: Option<String>,
+    pub env: Option<String>,
+    pub result: String,
+    pub sum: u64,
+    pub count: u64,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct GenAiOperationDurationBucketMetric {
+    pub provider_name: Option<String>,
+    pub operation_name: String,
+    pub request_model: Option<String>,
+    pub env: Option<String>,
+    pub result: String,
+    pub le: String,
+    pub count: u64,
+}
+
+#[derive(Debug, Clone, PartialEq)]
+pub struct GenAiOperationDurationSummaryMetric {
+    pub provider_name: Option<String>,
+    pub operation_name: String,
+    pub request_model: Option<String>,
+    pub env: Option<String>,
+    pub result: String,
+    pub sum_seconds: f64,
+    pub count: u64,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct GenAiToolCallMetric {
+    pub tool: String,
+    pub env: Option<String>,
+    pub result: String,
+    pub count: u64,
+}
+
+type GenAiTokenUsageKey = (
+    Option<String>,
+    String,
+    String,
+    Option<String>,
+    Option<String>,
+    String,
+);
+type GenAiOperationDurationKey = (
+    Option<String>,
+    String,
+    Option<String>,
+    Option<String>,
+    String,
+);
+
+#[derive(Debug, Clone, PartialEq, Eq)]
 pub struct SinkCounterMetric {
     pub sink: String,
     pub count: u64,
@@ -84,6 +177,11 @@ pub struct MetricsSnapshot {
     pub mcp_tool_calls_total: Vec<McpToolMetric>,
     pub sandbox_latency: Vec<LatencyBucketMetric>,
     pub sandbox_latency_summary: Vec<LatencySummaryMetric>,
+    pub genai_token_usage: Vec<GenAiTokenUsageBucketMetric>,
+    pub genai_token_usage_summary: Vec<GenAiTokenUsageSummaryMetric>,
+    pub genai_operation_duration: Vec<GenAiOperationDurationBucketMetric>,
+    pub genai_operation_duration_summary: Vec<GenAiOperationDurationSummaryMetric>,
+    pub genai_tool_calls_total: Vec<GenAiToolCallMetric>,
     pub approvals_pending_total: u64,
     pub build_oneflight_hits_total: u64,
     pub build_oneflight_misses_total: u64,
@@ -128,6 +226,20 @@ impl MetricsSnapshot {
             .collect();
         let (sandbox_latency, sandbox_latency_summary) =
             latency_metrics(store.sandbox_latency_rows()?);
+        let (genai_token_usage, genai_token_usage_summary) =
+            genai_token_usage_metrics(store.genai_token_usage_rows()?);
+        let (genai_operation_duration, genai_operation_duration_summary) =
+            genai_operation_duration_metrics(store.genai_operation_duration_rows()?);
+        let genai_tool_calls_total = store
+            .genai_tool_calls_by_tool_env_result()?
+            .into_iter()
+            .map(|row| GenAiToolCallMetric {
+                tool: row.tool,
+                env: row.env,
+                result: activity_result_label(row.result),
+                count: row.count,
+            })
+            .collect();
         let approvals_pending_total = store.approvals_pending_count()?;
         let build_oneflight_hits_total =
             store.count_events_by_kind(ActivityKind::BuildOneflightHit)?;
@@ -142,6 +254,11 @@ impl MetricsSnapshot {
             mcp_tool_calls_total,
             sandbox_latency,
             sandbox_latency_summary,
+            genai_token_usage,
+            genai_token_usage_summary,
+            genai_operation_duration,
+            genai_operation_duration_summary,
+            genai_tool_calls_total,
             approvals_pending_total,
             build_oneflight_hits_total,
             build_oneflight_misses_total,
@@ -240,6 +357,124 @@ pub fn render_prometheus(snapshot: &MetricsSnapshot) -> String {
             "agentenv_mcp_tool_calls_total",
             &[
                 ("tool", Some(row.tool.as_str())),
+                ("env", row.env.as_deref()),
+                ("result", Some(row.result.as_str())),
+            ],
+            row.count,
+        );
+    }
+
+    render_help_type(
+        &mut output,
+        "gen_ai_client_token_usage",
+        "GenAI client token usage.",
+        "histogram",
+    );
+    for row in &snapshot.genai_token_usage {
+        render_sample(
+            &mut output,
+            "gen_ai_client_token_usage_bucket",
+            &[
+                ("gen_ai_provider_name", row.provider_name.as_deref()),
+                ("gen_ai_operation_name", Some(row.operation_name.as_str())),
+                ("gen_ai_token_type", Some(row.token_type.as_str())),
+                ("gen_ai_request_model", row.request_model.as_deref()),
+                ("env", row.env.as_deref()),
+                ("result", Some(row.result.as_str())),
+                ("le", Some(row.le.as_str())),
+            ],
+            row.count,
+        );
+    }
+    for row in &snapshot.genai_token_usage_summary {
+        render_sample(
+            &mut output,
+            "gen_ai_client_token_usage_sum",
+            &[
+                ("gen_ai_provider_name", row.provider_name.as_deref()),
+                ("gen_ai_operation_name", Some(row.operation_name.as_str())),
+                ("gen_ai_token_type", Some(row.token_type.as_str())),
+                ("gen_ai_request_model", row.request_model.as_deref()),
+                ("env", row.env.as_deref()),
+                ("result", Some(row.result.as_str())),
+            ],
+            row.sum,
+        );
+        render_sample(
+            &mut output,
+            "gen_ai_client_token_usage_count",
+            &[
+                ("gen_ai_provider_name", row.provider_name.as_deref()),
+                ("gen_ai_operation_name", Some(row.operation_name.as_str())),
+                ("gen_ai_token_type", Some(row.token_type.as_str())),
+                ("gen_ai_request_model", row.request_model.as_deref()),
+                ("env", row.env.as_deref()),
+                ("result", Some(row.result.as_str())),
+            ],
+            row.count,
+        );
+    }
+
+    render_help_type(
+        &mut output,
+        "gen_ai_client_operation_duration",
+        "GenAI client operation duration in seconds.",
+        "histogram",
+    );
+    for row in &snapshot.genai_operation_duration {
+        render_sample(
+            &mut output,
+            "gen_ai_client_operation_duration_bucket",
+            &[
+                ("gen_ai_provider_name", row.provider_name.as_deref()),
+                ("gen_ai_operation_name", Some(row.operation_name.as_str())),
+                ("gen_ai_request_model", row.request_model.as_deref()),
+                ("env", row.env.as_deref()),
+                ("result", Some(row.result.as_str())),
+                ("le", Some(row.le.as_str())),
+            ],
+            row.count,
+        );
+    }
+    for row in &snapshot.genai_operation_duration_summary {
+        render_sample_float(
+            &mut output,
+            "gen_ai_client_operation_duration_sum",
+            &[
+                ("gen_ai_provider_name", row.provider_name.as_deref()),
+                ("gen_ai_operation_name", Some(row.operation_name.as_str())),
+                ("gen_ai_request_model", row.request_model.as_deref()),
+                ("env", row.env.as_deref()),
+                ("result", Some(row.result.as_str())),
+            ],
+            row.sum_seconds,
+        );
+        render_sample(
+            &mut output,
+            "gen_ai_client_operation_duration_count",
+            &[
+                ("gen_ai_provider_name", row.provider_name.as_deref()),
+                ("gen_ai_operation_name", Some(row.operation_name.as_str())),
+                ("gen_ai_request_model", row.request_model.as_deref()),
+                ("env", row.env.as_deref()),
+                ("result", Some(row.result.as_str())),
+            ],
+            row.count,
+        );
+    }
+
+    render_help_type(
+        &mut output,
+        "agentenv_gen_ai_tool_calls_total",
+        "Total GenAI tool calls by tool, environment, and result.",
+        "counter",
+    );
+    for row in &snapshot.genai_tool_calls_total {
+        render_sample(
+            &mut output,
+            "agentenv_gen_ai_tool_calls_total",
+            &[
+                ("gen_ai_tool_name", Some(row.tool.as_str())),
                 ("env", row.env.as_deref()),
                 ("result", Some(row.result.as_str())),
             ],
@@ -380,6 +615,127 @@ fn latency_metrics(
             buckets.push(LatencyBucketMetric {
                 op: op.clone(),
                 driver: driver.clone(),
+                le: (*label).to_owned(),
+                count,
+            });
+        }
+    }
+    (buckets, summaries)
+}
+
+fn genai_token_usage_metrics(
+    rows: Vec<crate::store::GenAiTokenUsageRow>,
+) -> (
+    Vec<GenAiTokenUsageBucketMetric>,
+    Vec<GenAiTokenUsageSummaryMetric>,
+) {
+    let mut grouped: BTreeMap<GenAiTokenUsageKey, Vec<u64>> = BTreeMap::new();
+    for row in rows {
+        grouped
+            .entry((
+                row.provider_name,
+                row.operation_name,
+                row.token_type,
+                row.request_model,
+                row.env,
+                activity_result_label(row.result),
+            ))
+            .or_default()
+            .push(row.tokens);
+    }
+
+    let mut buckets = Vec::new();
+    let mut summaries = Vec::new();
+    for ((provider_name, operation_name, token_type, request_model, env, result), tokens) in grouped
+    {
+        let count = tokens.len() as u64;
+        let sum = tokens.iter().sum::<u64>();
+        summaries.push(GenAiTokenUsageSummaryMetric {
+            provider_name: provider_name.clone(),
+            operation_name: operation_name.clone(),
+            token_type: token_type.clone(),
+            request_model: request_model.clone(),
+            env: env.clone(),
+            result: result.clone(),
+            sum,
+            count,
+        });
+
+        for (label, limit) in GENAI_TOKEN_BUCKET_LABELS
+            .iter()
+            .zip(GENAI_TOKEN_BUCKET_LIMITS)
+        {
+            let count = tokens
+                .iter()
+                .filter(|tokens| match limit {
+                    Some(limit) => **tokens <= limit,
+                    None => true,
+                })
+                .count() as u64;
+            buckets.push(GenAiTokenUsageBucketMetric {
+                provider_name: provider_name.clone(),
+                operation_name: operation_name.clone(),
+                token_type: token_type.clone(),
+                request_model: request_model.clone(),
+                env: env.clone(),
+                result: result.clone(),
+                le: (*label).to_owned(),
+                count,
+            });
+        }
+    }
+    (buckets, summaries)
+}
+
+fn genai_operation_duration_metrics(
+    rows: Vec<crate::store::GenAiOperationDurationRow>,
+) -> (
+    Vec<GenAiOperationDurationBucketMetric>,
+    Vec<GenAiOperationDurationSummaryMetric>,
+) {
+    let mut grouped: BTreeMap<GenAiOperationDurationKey, Vec<u64>> = BTreeMap::new();
+    for row in rows {
+        grouped
+            .entry((
+                row.provider_name,
+                row.operation_name,
+                row.request_model,
+                row.env,
+                activity_result_label(row.result),
+            ))
+            .or_default()
+            .push(row.latency_ms);
+    }
+
+    let mut buckets = Vec::new();
+    let mut summaries = Vec::new();
+    for ((provider_name, operation_name, request_model, env, result), latencies) in grouped {
+        let count = latencies.len() as u64;
+        let sum_seconds = latencies.iter().sum::<u64>() as f64 / 1000.0;
+        summaries.push(GenAiOperationDurationSummaryMetric {
+            provider_name: provider_name.clone(),
+            operation_name: operation_name.clone(),
+            request_model: request_model.clone(),
+            env: env.clone(),
+            result: result.clone(),
+            sum_seconds,
+            count,
+        });
+
+        for (label, limit_ms) in LATENCY_BUCKET_LABELS.iter().zip(LATENCY_BUCKET_MILLIS) {
+            let count = latencies
+                .iter()
+                .filter(|latency_ms| match limit_ms {
+                    Some(limit_ms) => **latency_ms <= limit_ms,
+                    None => true,
+                })
+                .count() as u64;
+            buckets.push(GenAiOperationDurationBucketMetric {
+                provider_name: provider_name.clone(),
+                operation_name: operation_name.clone(),
+                request_model: request_model.clone(),
+                env: env.clone(),
+                result: result.clone(),
                 le: (*label).to_owned(),
                 count,
             });
@@ -575,6 +931,82 @@ mod tests {
     }
 
     #[test]
+    fn prometheus_render_includes_genai_metrics() {
+        let temp = tempfile::tempdir().unwrap();
+        let store = SqliteEventStore::open(temp.path().join("events.db")).unwrap();
+        store
+            .append_many(&[event(
+                "2026-05-18T12:00:00Z",
+                ActivityKind::GenAiModelCall,
+                ActivityResult::Ok,
+            )
+            .with_env("demo")
+            .with_extra("gen_ai.system", serde_json::json!("openai"))
+            .with_extra("gen_ai.request.model", serde_json::json!("gpt-4.1"))
+            .with_extra("gen_ai.usage.input_tokens", serde_json::json!(300))
+            .with_extra("gen_ai.usage.output_tokens", serde_json::json!(20))
+            .with_extra("prompt", serde_json::json!("private prompt text"))
+            .with_extra("api_key", serde_json::json!("sk-secret"))
+            .with_latency_ms(250)])
+            .unwrap();
+
+        let snapshot = MetricsSnapshot::from_store(&store, &[]).unwrap();
+        let rendered = render_prometheus(&snapshot);
+
+        assert!(rendered.contains("# HELP gen_ai_client_token_usage "));
+        assert!(rendered.contains("# TYPE gen_ai_client_token_usage histogram"));
+        assert!(rendered.contains("# HELP gen_ai_client_operation_duration "));
+        assert!(rendered.contains("# TYPE gen_ai_client_operation_duration histogram"));
+        assert!(rendered.contains(
+            "gen_ai_client_token_usage_bucket{gen_ai_provider_name=\"openai\",gen_ai_operation_name=\"chat\",gen_ai_token_type=\"input\",gen_ai_request_model=\"gpt-4.1\",env=\"demo\",result=\"ok\",le=\"256\"} 0"
+        ));
+        assert!(rendered.contains(
+            "gen_ai_client_token_usage_bucket{gen_ai_provider_name=\"openai\",gen_ai_operation_name=\"chat\",gen_ai_token_type=\"input\",gen_ai_request_model=\"gpt-4.1\",env=\"demo\",result=\"ok\",le=\"1024\"} 1"
+        ));
+        assert!(rendered.contains(
+            "gen_ai_client_token_usage_sum{gen_ai_provider_name=\"openai\",gen_ai_operation_name=\"chat\",gen_ai_token_type=\"input\",gen_ai_request_model=\"gpt-4.1\",env=\"demo\",result=\"ok\"} 300"
+        ));
+        assert!(rendered.contains(
+            "gen_ai_client_token_usage_count{gen_ai_provider_name=\"openai\",gen_ai_operation_name=\"chat\",gen_ai_token_type=\"input\",gen_ai_request_model=\"gpt-4.1\",env=\"demo\",result=\"ok\"} 1"
+        ));
+        assert!(rendered.contains(
+            "gen_ai_client_operation_duration_bucket{gen_ai_provider_name=\"openai\",gen_ai_operation_name=\"chat\",gen_ai_request_model=\"gpt-4.1\",env=\"demo\",result=\"ok\",le=\"0.25\"} 1"
+        ));
+        assert!(rendered.contains(
+            "gen_ai_client_operation_duration_sum{gen_ai_provider_name=\"openai\",gen_ai_operation_name=\"chat\",gen_ai_request_model=\"gpt-4.1\",env=\"demo\",result=\"ok\"} 0.25"
+        ));
+        assert!(rendered.contains(
+            "gen_ai_client_operation_duration_count{gen_ai_provider_name=\"openai\",gen_ai_operation_name=\"chat\",gen_ai_request_model=\"gpt-4.1\",env=\"demo\",result=\"ok\"} 1"
+        ));
+        assert!(!rendered.contains("private prompt text"));
+        assert!(!rendered.contains("sk-secret"));
+    }
+
+    #[test]
+    fn prometheus_render_includes_genai_tool_calls_total_with_escaped_labels() {
+        let temp = tempfile::tempdir().unwrap();
+        let store = SqliteEventStore::open(temp.path().join("events.db")).unwrap();
+        store
+            .append_many(&[event(
+                "2026-05-18T12:00:00Z",
+                ActivityKind::McpToolCall,
+                ActivityResult::Ok,
+            )
+            .with_env("demo")
+            .with_subject_value("name", serde_json::json!("repo\\search\n\"tool"))])
+            .unwrap();
+
+        let snapshot = MetricsSnapshot::from_store(&store, &[]).unwrap();
+        let rendered = render_prometheus(&snapshot);
+
+        assert!(rendered.contains("# HELP agentenv_gen_ai_tool_calls_total "));
+        assert!(rendered.contains("# TYPE agentenv_gen_ai_tool_calls_total counter"));
+        assert!(rendered.contains(
+            "agentenv_gen_ai_tool_calls_total{gen_ai_tool_name=\"repo\\\\search\\n\\\"tool\",env=\"demo\",result=\"ok\"} 1"
+        ));
+    }
+
+    #[test]
     fn prometheus_render_includes_build_oneflight_metrics() {
         let temp = tempfile::tempdir().unwrap();
         let store = SqliteEventStore::open(temp.path().join("events.db")).unwrap();
@@ -646,6 +1078,11 @@ mod tests {
             mcp_tool_calls_total: Vec::new(),
             sandbox_latency: Vec::new(),
             sandbox_latency_summary: Vec::new(),
+            genai_token_usage: Vec::new(),
+            genai_token_usage_summary: Vec::new(),
+            genai_operation_duration: Vec::new(),
+            genai_operation_duration_summary: Vec::new(),
+            genai_tool_calls_total: Vec::new(),
             approvals_pending_total: 0,
             build_oneflight_hits_total: 0,
             build_oneflight_misses_total: 0,

--- a/crates/agentenv-events/src/otel.rs
+++ b/crates/agentenv-events/src/otel.rs
@@ -2,13 +2,19 @@ use std::collections::BTreeMap;
 
 use opentelemetry::{
     logs::{AnyValue, LogRecord as _, Logger as _, LoggerProvider as _, Severity},
-    Key,
+    trace::{Span as _, SpanKind, Status, Tracer as _, TracerProvider as _},
+    Array, Key, KeyValue, Value,
 };
 use opentelemetry_otlp::{ExportConfig, Protocol, WithExportConfig};
 use opentelemetry_sdk::logs::{SdkLogger, SdkLoggerProvider, SimpleLogProcessor};
+use opentelemetry_sdk::trace::{SdkTracer, SdkTracerProvider};
 
 use crate::{
     activity::{ActivityEvent, ActivityKind, ActivityResult},
+    genai::{
+        map_event_to_genai_signal, OtelAttributeValue, OtelGenAiSignalKind, OtelSignalStatus,
+        OtelSpanKindHint,
+    },
     sink::{EventSink, SinkError},
 };
 
@@ -42,30 +48,46 @@ pub fn map_event_to_otel_fields(event: &ActivityEvent) -> BTreeMap<String, Strin
 pub struct OtelSink {
     endpoint: String,
     logger: SdkLogger,
-    provider: SdkLoggerProvider,
+    log_provider: SdkLoggerProvider,
+    tracer: SdkTracer,
+    trace_provider: SdkTracerProvider,
+}
+
+#[derive(Debug, Clone, PartialEq)]
+struct OtelSpanExportPlan {
+    name: String,
+    kind: SpanKind,
+    status: Status,
+    attributes: Vec<KeyValue>,
 }
 
 impl OtelSink {
     pub fn new(endpoint: impl Into<String>) -> Result<Self, SinkError> {
         let endpoint = endpoint.into();
-        let exporter_config = ExportConfig {
-            endpoint: Some(normalize_grpc_endpoint(&endpoint)),
-            protocol: Protocol::Grpc,
-            timeout: None,
-        };
         let exporter = opentelemetry_otlp::LogExporter::builder()
             .with_tonic()
-            .with_export_config(exporter_config)
+            .with_export_config(export_config(&endpoint))
             .build()?;
-        let provider = SdkLoggerProvider::builder()
+        let log_provider = SdkLoggerProvider::builder()
             .with_log_processor(SimpleLogProcessor::new(exporter))
             .build();
-        let logger = provider.logger("agentenv-events");
+        let logger = log_provider.logger("agentenv-events");
+
+        let span_exporter = opentelemetry_otlp::SpanExporter::builder()
+            .with_tonic()
+            .with_export_config(export_config(&endpoint))
+            .build()?;
+        let trace_provider = SdkTracerProvider::builder()
+            .with_simple_exporter(span_exporter)
+            .build();
+        let tracer = trace_provider.tracer("agentenv-events");
 
         Ok(Self {
             endpoint,
             logger,
-            provider,
+            log_provider,
+            tracer,
+            trace_provider,
         })
     }
 
@@ -93,10 +115,111 @@ impl EventSink for OtelSink {
                     .into_iter()
                     .map(|(key, value)| (Key::new(key), AnyValue::from(value))),
             );
+            record.add_attributes(
+                genai_log_attributes(&event)
+                    .into_iter()
+                    .map(|(key, value)| (Key::new(key), otel_attribute_value_to_any_value(value))),
+            );
             self.logger.emit(record);
+
+            if let Some(plan) = genai_span_export_plan(&event) {
+                let mut span = self
+                    .tracer
+                    .span_builder(plan.name)
+                    .with_kind(plan.kind)
+                    .with_status(plan.status)
+                    .with_attributes(plan.attributes)
+                    .start(&self.tracer);
+                span.end();
+            }
         }
-        let _ = &self.provider;
+        let _ = (&self.log_provider, &self.trace_provider);
         Ok(())
+    }
+}
+
+fn export_config(endpoint: &str) -> ExportConfig {
+    ExportConfig {
+        endpoint: Some(normalize_grpc_endpoint(endpoint)),
+        protocol: Protocol::Grpc,
+        timeout: None,
+    }
+}
+
+fn genai_span_export_plan(event: &ActivityEvent) -> Option<OtelSpanExportPlan> {
+    let signal = map_event_to_genai_signal(event);
+    if signal.kind != OtelGenAiSignalKind::Span {
+        return None;
+    }
+
+    Some(OtelSpanExportPlan {
+        name: signal.name,
+        kind: span_kind(signal.span_kind),
+        status: span_status(signal.status),
+        attributes: signal
+            .attributes
+            .into_iter()
+            .map(|(key, value)| otel_attribute_value_to_key_value(key, value))
+            .collect(),
+    })
+}
+
+fn genai_log_attributes(event: &ActivityEvent) -> BTreeMap<String, OtelAttributeValue> {
+    let signal = map_event_to_genai_signal(event);
+    match signal.kind {
+        OtelGenAiSignalKind::Span => BTreeMap::new(),
+        OtelGenAiSignalKind::SpanEvent | OtelGenAiSignalKind::LogRecord => {
+            let legacy_fields = map_event_to_otel_fields(event);
+            signal
+                .attributes
+                .into_iter()
+                .filter(|(key, _)| !legacy_fields.contains_key(key))
+                .collect()
+        }
+    }
+}
+
+fn span_kind(kind: Option<OtelSpanKindHint>) -> SpanKind {
+    match kind {
+        Some(OtelSpanKindHint::Client) => SpanKind::Client,
+        Some(OtelSpanKindHint::Internal) | None => SpanKind::Internal,
+    }
+}
+
+fn span_status(status: OtelSignalStatus) -> Status {
+    match status {
+        OtelSignalStatus::Ok => Status::Ok,
+        OtelSignalStatus::Error => Status::error("error"),
+        OtelSignalStatus::Denied => Status::error("denied"),
+        OtelSignalStatus::PendingApproval => Status::Unset,
+    }
+}
+
+fn otel_attribute_value_to_key_value(key: String, value: OtelAttributeValue) -> KeyValue {
+    KeyValue::new(key, otel_attribute_value_to_value(value))
+}
+
+fn otel_attribute_value_to_value(value: OtelAttributeValue) -> Value {
+    match value {
+        OtelAttributeValue::String(value) => Value::String(value.into()),
+        OtelAttributeValue::I64(value) => Value::I64(value),
+        OtelAttributeValue::F64(value) => Value::F64(value),
+        OtelAttributeValue::Bool(value) => Value::Bool(value),
+        OtelAttributeValue::StringArray(values) => {
+            Value::Array(Array::String(values.into_iter().map(Into::into).collect()))
+        }
+    }
+}
+
+fn otel_attribute_value_to_any_value(value: OtelAttributeValue) -> AnyValue {
+    match value {
+        OtelAttributeValue::String(value) => AnyValue::from(value),
+        OtelAttributeValue::I64(value) => AnyValue::from(value),
+        OtelAttributeValue::F64(value) => AnyValue::from(value),
+        OtelAttributeValue::Bool(value) => AnyValue::from(value),
+        OtelAttributeValue::StringArray(values) => {
+            values.into_iter().map(AnyValue::from).collect::<AnyValue>()
+        }
     }
 }
 
@@ -166,6 +289,9 @@ fn activity_kind_name(kind: ActivityKind) -> &'static str {
 mod tests {
     use super::*;
     use crate::activity::{ActivityEvent, ActivityKind, ActivityResult};
+    use crate::genai::OtelAttributeValue;
+    use opentelemetry::{trace::SpanKind, Value};
+    use serde_json::json;
 
     #[test]
     fn maps_activity_event_to_otel_log_fields() {
@@ -202,6 +328,100 @@ mod tests {
         assert_eq!(
             activity_kind_name(ActivityKind::BuildQueueDepth),
             "build_queue_depth"
+        );
+    }
+
+    #[test]
+    fn plans_model_call_genai_span_export() {
+        let event = ActivityEvent::new(
+            "2026-05-18T12:00:00Z",
+            ActivityKind::GenAiModelCall,
+            ActivityResult::Ok,
+            "trace-model",
+        )
+        .with_extra("gen_ai.request.model", json!("gpt-4.1"))
+        .with_extra("gen_ai.usage.input_tokens", json!(123))
+        .with_extra("gen_ai.usage.output_tokens", json!(45));
+
+        let plan = genai_span_export_plan(&event).expect("model call should be a span");
+
+        assert_eq!(plan.name, "chat gpt-4.1");
+        assert_eq!(plan.kind, SpanKind::Client);
+        assert_span_attr(
+            &plan.attributes,
+            "gen_ai.operation.name",
+            Value::String("chat".to_owned().into()),
+        );
+        assert_span_attr(
+            &plan.attributes,
+            "gen_ai.request.model",
+            Value::String("gpt-4.1".to_owned().into()),
+        );
+        assert_span_attr(
+            &plan.attributes,
+            "gen_ai.usage.input_tokens",
+            Value::I64(123),
+        );
+        assert_span_attr(
+            &plan.attributes,
+            "gen_ai.usage.output_tokens",
+            Value::I64(45),
+        );
+    }
+
+    #[test]
+    fn plans_mcp_tool_call_genai_span_export() {
+        let event = ActivityEvent::new(
+            "2026-05-18T12:00:00Z",
+            ActivityKind::McpToolCall,
+            ActivityResult::Ok,
+            "trace-tool",
+        )
+        .with_subject_value("name", json!("repo.search"));
+
+        let plan = genai_span_export_plan(&event).expect("tool call should be a span");
+
+        assert_eq!(plan.name, "execute_tool repo.search");
+        assert_eq!(plan.kind, SpanKind::Internal);
+        assert_span_attr(
+            &plan.attributes,
+            "gen_ai.operation.name",
+            Value::String("execute_tool".to_owned().into()),
+        );
+        assert_span_attr(
+            &plan.attributes,
+            "gen_ai.tool.name",
+            Value::String("repo.search".to_owned().into()),
+        );
+    }
+
+    #[test]
+    fn maps_non_span_genai_semantic_attributes_for_logs() {
+        let event = ActivityEvent::new(
+            "2026-05-18T12:00:00Z",
+            ActivityKind::EgressDenied,
+            ActivityResult::Denied,
+            "trace-denied",
+        )
+        .with_latency_ms(42);
+
+        let attributes = genai_log_attributes(&event);
+
+        assert_eq!(
+            attributes.get("agentenv.egress.denied"),
+            Some(&OtelAttributeValue::Bool(true))
+        );
+        assert!(!attributes.contains_key("agentenv.trace_id"));
+        assert!(!attributes.contains_key("agentenv.latency_ms"));
+    }
+
+    fn assert_span_attr(attributes: &[opentelemetry::KeyValue], key: &str, value: Value) {
+        assert_eq!(
+            attributes
+                .iter()
+                .find(|attribute| attribute.key.as_str() == key)
+                .map(|attribute| &attribute.value),
+            Some(&value)
         );
     }
 }

--- a/crates/agentenv-events/src/otel.rs
+++ b/crates/agentenv-events/src/otel.rs
@@ -140,6 +140,8 @@ fn activity_kind_name(kind: ActivityKind) -> &'static str {
         ActivityKind::EgressAllowed => "egress_allowed",
         ActivityKind::EgressDenied => "egress_denied",
         ActivityKind::McpToolCall => "mcp_tool_call",
+        ActivityKind::AgentTurn => "agent_turn",
+        ActivityKind::GenAiModelCall => "gen_ai_model_call",
         ActivityKind::PolicyApplied => "policy_applied",
         ActivityKind::CredentialInjected => "credential_injected",
         ActivityKind::CredentialSet => "credential_set",

--- a/crates/agentenv-events/src/store.rs
+++ b/crates/agentenv-events/src/store.rs
@@ -12,6 +12,7 @@ use serde_json::Value;
 use thiserror::Error;
 
 use crate::activity::{ActivityEvent, ActivityKind, ActivityResult};
+use crate::genai::{map_event_to_genai_signal, OtelAttributeValue, OtelGenAiSignalKind};
 use crate::trace::{
     event_arguments, event_blueprint_id, event_request_id, event_tool_name, TraceQuery, TraceRun,
     TraceToolCall,
@@ -73,6 +74,35 @@ pub struct PolicyBlockCount {
 
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct McpToolCount {
+    pub tool: String,
+    pub env: Option<String>,
+    pub result: ActivityResult,
+    pub count: u64,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct GenAiTokenUsageRow {
+    pub provider_name: Option<String>,
+    pub operation_name: String,
+    pub token_type: String,
+    pub request_model: Option<String>,
+    pub env: Option<String>,
+    pub result: ActivityResult,
+    pub tokens: u64,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct GenAiOperationDurationRow {
+    pub provider_name: Option<String>,
+    pub operation_name: String,
+    pub request_model: Option<String>,
+    pub env: Option<String>,
+    pub result: ActivityResult,
+    pub latency_ms: u64,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct GenAiToolCallCount {
     pub tool: String,
     pub env: Option<String>,
     pub result: ActivityResult,
@@ -522,6 +552,130 @@ impl SqliteEventStore {
         Ok(rows)
     }
 
+    pub fn genai_token_usage_rows(&self) -> StoreResult<Vec<GenAiTokenUsageRow>> {
+        let events = self.genai_metric_events(&[ActivityKind::GenAiModelCall])?;
+        let mut rows = Vec::new();
+
+        for event in events {
+            let signal = map_event_to_genai_signal(&event);
+            let provider_name = string_attribute(&signal.attributes, "gen_ai.provider.name");
+            let request_model = string_attribute(&signal.attributes, "gen_ai.request.model");
+
+            for (attribute, token_type) in [
+                ("gen_ai.usage.input_tokens", "input"),
+                ("gen_ai.usage.output_tokens", "output"),
+            ] {
+                let Some(tokens) = positive_u64_attribute(&signal.attributes, attribute) else {
+                    continue;
+                };
+                rows.push(GenAiTokenUsageRow {
+                    provider_name: provider_name.clone(),
+                    operation_name: signal.operation_name.clone(),
+                    token_type: token_type.to_owned(),
+                    request_model: request_model.clone(),
+                    env: event.env.clone(),
+                    result: event.result,
+                    tokens,
+                });
+            }
+        }
+
+        rows.sort_by(|left, right| {
+            (
+                &left.provider_name,
+                &left.operation_name,
+                &left.token_type,
+                &left.request_model,
+                &left.env,
+                enum_to_sort_label(left.result),
+                left.tokens,
+            )
+                .cmp(&(
+                    &right.provider_name,
+                    &right.operation_name,
+                    &right.token_type,
+                    &right.request_model,
+                    &right.env,
+                    enum_to_sort_label(right.result),
+                    right.tokens,
+                ))
+        });
+        Ok(rows)
+    }
+
+    pub fn genai_operation_duration_rows(&self) -> StoreResult<Vec<GenAiOperationDurationRow>> {
+        let events = self.genai_metric_events(&[
+            ActivityKind::AgentTurn,
+            ActivityKind::McpToolCall,
+            ActivityKind::GenAiModelCall,
+        ])?;
+        let mut rows = Vec::new();
+
+        for event in events {
+            let Some(latency_ms) = event.latency_ms else {
+                continue;
+            };
+            let signal = map_event_to_genai_signal(&event);
+            if signal.kind != OtelGenAiSignalKind::Span {
+                continue;
+            }
+            rows.push(GenAiOperationDurationRow {
+                provider_name: string_attribute(&signal.attributes, "gen_ai.provider.name"),
+                operation_name: signal.operation_name,
+                request_model: string_attribute(&signal.attributes, "gen_ai.request.model"),
+                env: event.env,
+                result: event.result,
+                latency_ms,
+            });
+        }
+
+        rows.sort_by(|left, right| {
+            (
+                &left.provider_name,
+                &left.operation_name,
+                &left.request_model,
+                &left.env,
+                enum_to_sort_label(left.result),
+                left.latency_ms,
+            )
+                .cmp(&(
+                    &right.provider_name,
+                    &right.operation_name,
+                    &right.request_model,
+                    &right.env,
+                    enum_to_sort_label(right.result),
+                    right.latency_ms,
+                ))
+        });
+        Ok(rows)
+    }
+
+    pub fn genai_tool_calls_by_tool_env_result(&self) -> StoreResult<Vec<GenAiToolCallCount>> {
+        let events = self.genai_metric_events(&[ActivityKind::McpToolCall])?;
+        let mut grouped: BTreeMap<(String, Option<String>, String), (ActivityResult, u64)> =
+            BTreeMap::new();
+
+        for event in events {
+            let signal = map_event_to_genai_signal(&event);
+            let tool = string_attribute(&signal.attributes, "gen_ai.tool.name")
+                .unwrap_or_else(|| "unknown".to_owned());
+            let result = event.result;
+            let key = (tool, event.env, enum_to_sort_label(result));
+            let (_, count) = grouped.entry(key).or_insert((result, 0));
+            *count = count.saturating_add(1);
+        }
+
+        Ok(grouped
+            .into_iter()
+            .map(|((tool, env, _), (result, count))| GenAiToolCallCount {
+                tool,
+                env,
+                result,
+                count,
+            })
+            .collect())
+    }
+
     pub fn sandbox_latency_rows(&self) -> StoreResult<Vec<SandboxLatencyRow>> {
         self.sandbox_latency_rows_for_env(None)
     }
@@ -608,6 +762,57 @@ impl SqliteEventStore {
         let conn = Connection::open_with_flags(path, database_open_flags())?;
         conn.busy_timeout(Duration::from_secs(5))?;
         Ok(conn)
+    }
+
+    fn genai_metric_events(&self, kinds: &[ActivityKind]) -> StoreResult<Vec<ActivityEvent>> {
+        let conn = self.connection()?;
+        let mut sql = String::from(
+            r#"
+            SELECT
+                id,
+                ts,
+                kind,
+                env,
+                actor_json,
+                subject_json,
+                result,
+                latency_ms,
+                trace_id,
+                reason_code,
+                extras_json
+            FROM activity_events
+            WHERE kind IN (
+            "#,
+        );
+        sql.push_str(
+            &std::iter::repeat_n("?", kinds.len())
+                .collect::<Vec<_>>()
+                .join(", "),
+        );
+        sql.push_str(
+            r#"
+            )
+            ORDER BY id ASC
+            "#,
+        );
+        let query_params = kinds
+            .iter()
+            .map(|kind| enum_to_db_string(*kind, "kind").map(SqlValue::Text))
+            .collect::<StoreResult<Vec<_>>>()?;
+        let mut stmt = conn.prepare(&sql)?;
+        let raw_rows = stmt.query_map(params_from_iter(query_params), raw_event_from_row)?;
+
+        let mut events = Vec::new();
+        for raw in raw_rows {
+            let raw = match raw {
+                Ok(raw) => raw,
+                Err(_) => continue,
+            };
+            if let Ok(stored) = raw.try_into_stored_event() {
+                events.push(stored.event);
+            }
+        }
+        Ok(events)
     }
 }
 
@@ -1093,6 +1298,33 @@ fn count_to_u64(count: i64) -> StoreResult<u64> {
     u64::try_from(count).map_err(|_| StoreError::CountOutOfRange(count))
 }
 
+fn string_attribute(
+    attributes: &BTreeMap<String, OtelAttributeValue>,
+    key: &str,
+) -> Option<String> {
+    match attributes.get(key) {
+        Some(OtelAttributeValue::String(value)) => Some(value.clone()),
+        _ => None,
+    }
+}
+
+fn positive_u64_attribute(
+    attributes: &BTreeMap<String, OtelAttributeValue>,
+    key: &str,
+) -> Option<u64> {
+    match attributes.get(key) {
+        Some(OtelAttributeValue::I64(value)) if *value > 0 => u64::try_from(*value).ok(),
+        _ => None,
+    }
+}
+
+fn enum_to_sort_label<T>(value: T) -> String
+where
+    T: Serialize,
+{
+    enum_to_db_string(value, "sort").unwrap_or_else(|_| String::new())
+}
+
 fn sandbox_op_from_kind(kind: ActivityKind) -> Option<&'static str> {
     match kind {
         ActivityKind::SandboxCreate => Some("create"),
@@ -1435,6 +1667,167 @@ mod tests {
                 && count.env.as_deref() == Some("other")
                 && count.result == ActivityResult::Ok
                 && count.count == 1));
+    }
+
+    #[test]
+    fn genai_token_usage_rows_derives_model_call_tokens_with_provider_alias() {
+        let temp = tempfile::tempdir().unwrap();
+        let store = SqliteEventStore::open(temp.path().join("events.db")).unwrap();
+
+        store
+            .append_many(&[
+                event(
+                    "2026-05-18T12:00:00Z",
+                    ActivityKind::GenAiModelCall,
+                    "demo",
+                    ActivityResult::Ok,
+                )
+                .with_extra("gen_ai.system", serde_json::json!("openai"))
+                .with_extra("gen_ai.request.model", serde_json::json!("gpt-4.1"))
+                .with_extra("gen_ai.usage.input_tokens", serde_json::json!(123))
+                .with_extra("gen_ai.usage.output_tokens", serde_json::json!(45))
+                .with_extra("prompt", serde_json::json!("private prompt text"))
+                .with_extra("api_key", serde_json::json!("sk-secret")),
+                event(
+                    "2026-05-18T12:00:01Z",
+                    ActivityKind::GenAiModelCall,
+                    "demo",
+                    ActivityResult::Ok,
+                )
+                .with_extra("gen_ai.system", serde_json::json!("openai"))
+                .with_extra("gen_ai.request.model", serde_json::json!("gpt-4.1"))
+                .with_extra("gen_ai.usage.input_tokens", serde_json::json!(0))
+                .with_extra("gen_ai.usage.output_tokens", serde_json::json!(-1)),
+            ])
+            .unwrap();
+
+        let rows = store.genai_token_usage_rows().unwrap();
+
+        assert_eq!(rows.len(), 2);
+        assert!(rows.iter().any(|row| {
+            row.provider_name.as_deref() == Some("openai")
+                && row.operation_name == "chat"
+                && row.token_type == "input"
+                && row.request_model.as_deref() == Some("gpt-4.1")
+                && row.env.as_deref() == Some("demo")
+                && row.result == ActivityResult::Ok
+                && row.tokens == 123
+        }));
+        assert!(rows.iter().any(|row| {
+            row.provider_name.as_deref() == Some("openai")
+                && row.operation_name == "chat"
+                && row.token_type == "output"
+                && row.request_model.as_deref() == Some("gpt-4.1")
+                && row.env.as_deref() == Some("demo")
+                && row.result == ActivityResult::Ok
+                && row.tokens == 45
+        }));
+    }
+
+    #[test]
+    fn genai_metric_rows_skip_malformed_persisted_events() {
+        let temp = tempfile::tempdir().unwrap();
+        let store = SqliteEventStore::open(temp.path().join("events.db")).unwrap();
+        let conn = Connection::open(store.path()).unwrap();
+        conn.execute(
+            r#"
+            INSERT INTO activity_events (
+                ts,
+                kind,
+                env,
+                actor_json,
+                subject_json,
+                result,
+                latency_ms,
+                trace_id,
+                reason_code,
+                extras_json
+            )
+            VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, ?9, ?10)
+            "#,
+            params![
+                "2026-05-18T12:00:00Z",
+                enum_to_db_string(ActivityKind::GenAiModelCall, "kind").unwrap(),
+                "demo",
+                "{}",
+                "{}",
+                enum_to_db_string(ActivityResult::Ok, "result").unwrap(),
+                Option::<i64>::None,
+                "trace-malformed",
+                Option::<String>::None,
+                "{not-valid-json",
+            ],
+        )
+        .unwrap();
+        drop(conn);
+        store
+            .append_many(&[event(
+                "2026-05-18T12:00:01Z",
+                ActivityKind::GenAiModelCall,
+                "demo",
+                ActivityResult::Ok,
+            )
+            .with_extra("gen_ai.system", serde_json::json!("openai"))
+            .with_extra("gen_ai.request.model", serde_json::json!("gpt-4.1"))
+            .with_extra("gen_ai.usage.input_tokens", serde_json::json!(123))])
+            .unwrap();
+
+        let rows = store.genai_token_usage_rows().unwrap();
+
+        assert_eq!(rows.len(), 1);
+        assert_eq!(rows[0].provider_name.as_deref(), Some("openai"));
+        assert_eq!(rows[0].operation_name, "chat");
+        assert_eq!(rows[0].token_type, "input");
+        assert_eq!(rows[0].request_model.as_deref(), Some("gpt-4.1"));
+        assert_eq!(rows[0].env.as_deref(), Some("demo"));
+        assert_eq!(rows[0].result, ActivityResult::Ok);
+        assert_eq!(rows[0].tokens, 123);
+    }
+
+    #[test]
+    fn genai_tool_calls_by_tool_env_result_counts_mapped_subject_keys() {
+        let temp = tempfile::tempdir().unwrap();
+        let store = SqliteEventStore::open(temp.path().join("events.db")).unwrap();
+
+        store
+            .append_many(&[
+                event(
+                    "2026-05-18T12:00:00Z",
+                    ActivityKind::McpToolCall,
+                    "demo",
+                    ActivityResult::Ok,
+                )
+                .with_subject_value("name", serde_json::json!("repo.search")),
+                event(
+                    "2026-05-18T12:00:01Z",
+                    ActivityKind::McpToolCall,
+                    "demo",
+                    ActivityResult::Ok,
+                )
+                .with_subject_value("gen_ai.tool.name", serde_json::json!("repo.search")),
+                event(
+                    "2026-05-18T12:00:02Z",
+                    ActivityKind::McpToolCall,
+                    "demo",
+                    ActivityResult::Error,
+                ),
+            ])
+            .unwrap();
+
+        let rows = store.genai_tool_calls_by_tool_env_result().unwrap();
+
+        assert!(rows.iter().any(|row| {
+            row.tool == "repo.search"
+                && row.env.as_deref() == Some("demo")
+                && row.result == ActivityResult::Ok
+                && row.count == 2
+        }));
+        assert!(rows.iter().any(|row| {
+            row.tool == "unknown"
+                && row.env.as_deref() == Some("demo")
+                && row.result == ActivityResult::Error
+                && row.count == 1
+        }));
     }
 
     #[test]

--- a/crates/agentenv-plugin/src/jsonrpc.rs
+++ b/crates/agentenv-plugin/src/jsonrpc.rs
@@ -514,6 +514,8 @@ fn rich_activity_kind_to_event_kind(kind: agentenv_proto::RichActivityKind) -> E
         agentenv_proto::RichActivityKind::EgressAllowed => EventActivityKind::EgressAllowed,
         agentenv_proto::RichActivityKind::EgressDenied => EventActivityKind::EgressDenied,
         agentenv_proto::RichActivityKind::McpToolCall => EventActivityKind::McpToolCall,
+        agentenv_proto::RichActivityKind::AgentTurn => EventActivityKind::AgentTurn,
+        agentenv_proto::RichActivityKind::GenAiModelCall => EventActivityKind::GenAiModelCall,
         agentenv_proto::RichActivityKind::PolicyApplied => EventActivityKind::PolicyApplied,
         agentenv_proto::RichActivityKind::CredentialInjected => {
             EventActivityKind::CredentialInjected
@@ -1246,6 +1248,30 @@ mod tests {
 
         assert_eq!(event.kind, agentenv_events::ActivityKind::McpToolCall);
         assert_eq!(event.subject["tool"], json!("search"));
+    }
+
+    #[test]
+    fn rich_genai_activity_notification_converts_new_kinds() {
+        let raw = json!({
+            "jsonrpc": "2.0",
+            "method": "event/activity",
+            "params": {
+                "ts": "2026-04-26T12:00:00Z",
+                "kind": "gen_ai_model_call",
+                "env": "demo",
+                "actor": {"driver": "codex"},
+                "subject": {"model": "gpt-5"},
+                "result": "ok",
+                "trace_id": "trace-plugin",
+                "extras": {}
+            }
+        });
+
+        let notification: RpcNotificationEnvelope = serde_json::from_value(raw).unwrap();
+        let event = notification_to_activity_event(notification, "fallback-trace").unwrap();
+
+        assert_eq!(event.kind, agentenv_events::ActivityKind::GenAiModelCall);
+        assert_eq!(event.subject["model"], json!("gpt-5"));
     }
 
     #[test]

--- a/crates/agentenv-proto/schema/driver-activity-event-params.json
+++ b/crates/agentenv-proto/schema/driver-activity-event-params.json
@@ -113,6 +113,8 @@
         "egress_allowed",
         "egress_denied",
         "mcp_tool_call",
+        "agent_turn",
+        "gen_ai_model_call",
         "policy_applied",
         "credential_injected",
         "credential_set",

--- a/crates/agentenv-proto/src/types.rs
+++ b/crates/agentenv-proto/src/types.rs
@@ -70,6 +70,8 @@ pub enum RichActivityKind {
     EgressAllowed,
     EgressDenied,
     McpToolCall,
+    AgentTurn,
+    GenAiModelCall,
     PolicyApplied,
     CredentialInjected,
     CredentialSet,
@@ -964,5 +966,18 @@ surprise: true
             .expect_err("unknown fields must fail closed");
 
         assert!(error.to_string().contains("surprise"));
+    }
+
+    #[test]
+    fn rich_activity_genai_kinds_round_trip() {
+        for (kind, wire_value) in [
+            (RichActivityKind::AgentTurn, "agent_turn"),
+            (RichActivityKind::GenAiModelCall, "gen_ai_model_call"),
+        ] {
+            let encoded = serde_json::to_value(&kind).unwrap();
+            assert_eq!(encoded, serde_json::json!(wire_value));
+            let decoded: RichActivityKind = serde_json::from_value(encoded).unwrap();
+            assert_eq!(decoded, kind);
+        }
     }
 }

--- a/crates/agentenv/README.md
+++ b/crates/agentenv/README.md
@@ -61,6 +61,18 @@ default. Additional sinks can be attached with repeated `--events-sink` flags:
 - `webhook:https://example.test/events?kinds=egress_denied`
 - `otel:grpc://collector:4317` when `agentenv-events/otel` is enabled
 
+Blueprints can configure a create/reproduce-time OTEL sink:
+
+```yaml
+observability:
+  otel:
+    endpoint: grpc://collector:4317
+```
+
+This is resolved into the environment's event dispatcher when the blueprint is
+applied. `--events-sink otel:grpc://collector:4317` remains additive and scoped
+to the CLI command where it is passed; it does not rewrite the blueprint.
+
 Audit-sensitive events are signed synchronously before command success or
 failure is reported, so audit write failures are surfaced instead of being hidden
 behind the original operation result.

--- a/crates/agentenv/src/builtin_factory.rs
+++ b/crates/agentenv/src/builtin_factory.rs
@@ -1191,6 +1191,7 @@ mod tests {
                 },
                 state: None,
                 skills: agentenv_core::blueprint::SkillsSection::default(),
+                observability: None,
             },
             policy: PortablePolicy {
                 declared: agentenv_core::blueprint::PolicySection {

--- a/crates/agentenv/src/main.rs
+++ b/crates/agentenv/src/main.rs
@@ -23,7 +23,7 @@ use agentenv_credstore::{CredentialStore, CredentialStoreError, SecretString};
 use agentenv_events::{
     audit::{AuditPolicy, AuditSigningKey, AuditStore},
     metrics::{render_prometheus, EnvMetricRow, MetricsSnapshot},
-    sink::{JsonlSink, SqliteSink},
+    sink::{JsonlSink, SinkError, SqliteSink},
     store::{parse_legacy_jsonl_activity_event, EventQuery, SqliteEventStore, StoredEvent},
     ActivityEvent, ActivityKind, ActivityResult, EventDispatcher, EventEmitter, EventSink,
     SinkConfig, WebhookConfig, WebhookSink,
@@ -964,8 +964,16 @@ async fn run_create(args: CreateArgs, event_sink_args: &[String]) -> Result<()> 
             Err(error) => Err(error.into()),
         }
     } else {
-        let sink_args = combined_create_sink_args(&blueprint_yaml, event_sink_args)?;
-        let dispatcher = build_event_dispatcher(&options, Some(&args.name), &sink_args)?;
+        let sink_args = match combined_create_sink_args(&blueprint_yaml, event_sink_args) {
+            Ok(sink_args) => sink_args,
+            Err(error) if args.json => exit_json_error(reason_for_sink_setup_error(&error), error),
+            Err(error) => return Err(error),
+        };
+        let dispatcher = match build_event_dispatcher(&options, Some(&args.name), &sink_args) {
+            Ok(dispatcher) => dispatcher,
+            Err(error) if args.json => exit_json_error(reason_for_sink_setup_error(&error), error),
+            Err(error) => return Err(error),
+        };
         let emitter = Arc::new(AuditingEventEmitter::new(
             dispatcher.emitter(),
             audit_signing_key_path(&options),
@@ -3031,6 +3039,9 @@ fn build_event_dispatcher_with_otel_validator(
     let mut sinks: Vec<Box<dyn EventSink>> = Vec::new();
     add_default_event_sinks(&mut sinks, options, env)?;
     for raw in sink_args {
+        if let Some(endpoint) = raw.strip_prefix("otel:") {
+            validate_otel_endpoint(endpoint)?;
+        }
         match SinkConfig::parse(raw)? {
             SinkConfig::DefaultSqlite => {}
             SinkConfig::Sqlite { path } => sinks.push(Box::new(SqliteSink::new(path))),
@@ -3079,6 +3090,17 @@ fn blueprint_otel_sink_args(blueprint_yaml: &str) -> Result<Vec<String>> {
 
     otel_sink_validation_url(endpoint)?;
     Ok(vec![format!("otel:{endpoint}")])
+}
+
+fn reason_for_sink_setup_error(error: &anyhow::Error) -> ReasonCode {
+    if matches!(
+        error.downcast_ref::<SinkError>(),
+        Some(SinkError::UnsupportedFeature { .. })
+    ) {
+        ReasonCode::CapabilityMissing
+    } else {
+        ReasonCode::InvalidBlueprint
+    }
 }
 
 fn combined_create_sink_args(

--- a/crates/agentenv/src/main.rs
+++ b/crates/agentenv/src/main.rs
@@ -35,6 +35,7 @@ use serde::{Deserialize, Serialize};
 use sha2::{Digest, Sha256};
 use tokio::io::{AsyncReadExt, AsyncWriteExt};
 use tracing_subscriber::EnvFilter;
+use url::{Host, Url};
 
 mod builtin_factory;
 mod bundle_cli;
@@ -963,7 +964,8 @@ async fn run_create(args: CreateArgs, event_sink_args: &[String]) -> Result<()> 
             Err(error) => Err(error.into()),
         }
     } else {
-        let dispatcher = build_event_dispatcher(&options, Some(&args.name), event_sink_args)?;
+        let sink_args = combined_create_sink_args(&blueprint_yaml, event_sink_args)?;
+        let dispatcher = build_event_dispatcher(&options, Some(&args.name), &sink_args)?;
         let emitter = Arc::new(AuditingEventEmitter::new(
             dispatcher.emitter(),
             audit_signing_key_path(&options),
@@ -3019,6 +3021,15 @@ fn build_event_dispatcher(
     env: Option<&str>,
     sink_args: &[String],
 ) -> Result<EventDispatcher> {
+    build_event_dispatcher_with_otel_validator(options, env, sink_args, validate_otel_sink_endpoint)
+}
+
+fn build_event_dispatcher_with_otel_validator(
+    options: &agentenv_core::runtime::RuntimeOptions,
+    env: Option<&str>,
+    sink_args: &[String],
+    validate_otel_endpoint: impl Fn(&str) -> Result<()>,
+) -> Result<EventDispatcher> {
     let mut sinks: Vec<Box<dyn EventSink>> = Vec::new();
     add_default_event_sinks(&mut sinks, options, env)?;
     for raw in sink_args {
@@ -3027,6 +3038,7 @@ fn build_event_dispatcher(
             SinkConfig::Sqlite { path } => sinks.push(Box::new(SqliteSink::new(path))),
             SinkConfig::Jsonl { path } => sinks.push(Box::new(JsonlSink::new(path))),
             SinkConfig::OtelGrpc { endpoint } => {
+                validate_otel_endpoint(&endpoint)?;
                 sinks.push(agentenv_events::sink::otel_grpc_sink(endpoint)?);
             }
             SinkConfig::Webhook { config } => {
@@ -3053,6 +3065,33 @@ fn build_event_dispatcher(
     Ok(EventDispatcher::with_sinks(1024, sinks))
 }
 
+fn blueprint_otel_sink_args(blueprint_yaml: &str) -> Result<Vec<String>> {
+    let blueprint = agentenv_core::blueprint::Blueprint::from_yaml(blueprint_yaml)
+        .context("failed to parse blueprint observability configuration")?;
+    let Some(endpoint) = blueprint
+        .observability
+        .as_ref()
+        .and_then(|observability| observability.otel.as_ref())
+        .and_then(|otel| otel.endpoint.as_deref())
+        .map(str::trim)
+        .filter(|endpoint| !endpoint.is_empty())
+    else {
+        return Ok(Vec::new());
+    };
+
+    otel_sink_validation_url(endpoint)?;
+    Ok(vec![format!("otel:{endpoint}")])
+}
+
+fn combined_create_sink_args(
+    blueprint_yaml: &str,
+    cli_sink_args: &[String],
+) -> Result<Vec<String>> {
+    let mut sink_args = blueprint_otel_sink_args(blueprint_yaml)?;
+    sink_args.extend(cli_sink_args.iter().cloned());
+    Ok(sink_args)
+}
+
 fn build_destroy_event_dispatcher(
     options: &agentenv_core::runtime::RuntimeOptions,
     sink_args: &[String],
@@ -3072,6 +3111,49 @@ fn validate_webhook_sink_url(config: &WebhookConfig) -> Result<()> {
         )
     })?;
     Ok(())
+}
+
+fn validate_otel_sink_endpoint(endpoint: &str) -> Result<()> {
+    let validation_url = otel_sink_validation_url(endpoint)?;
+    let sanitized = agentenv_core::security::ssrf::sanitize_untrusted_url_text(endpoint);
+    agentenv_core::security::ssrf::validate_outbound(
+        &validation_url,
+        agentenv_core::security::ssrf::SsrfOptions::default(),
+    )
+    .with_context(|| format!("OTEL events sink failed SSRF validation for `{sanitized}`"))?;
+    Ok(())
+}
+
+fn otel_sink_validation_url(endpoint: &str) -> Result<Url> {
+    let sanitized = agentenv_core::security::ssrf::sanitize_untrusted_url_text(endpoint);
+    let grpc_url = Url::parse(endpoint)
+        .with_context(|| format!("invalid OTEL events sink endpoint `{sanitized}`"))?;
+    if grpc_url.scheme() != "grpc" || grpc_url.host().is_none() {
+        bail!("invalid OTEL events sink endpoint `{sanitized}`");
+    }
+    if !grpc_url.username().is_empty() || grpc_url.password().is_some() {
+        bail!("invalid OTEL events sink endpoint `{sanitized}`");
+    }
+    if !["", "/"].contains(&grpc_url.path())
+        || grpc_url.query().is_some()
+        || grpc_url.fragment().is_some()
+    {
+        bail!("invalid OTEL events sink endpoint `{sanitized}`");
+    }
+
+    let host = match grpc_url.host().expect("host was checked above") {
+        Host::Domain(host) => host.to_owned(),
+        Host::Ipv4(ip) => ip.to_string(),
+        Host::Ipv6(ip) => format!("[{ip}]"),
+    };
+    let port = grpc_url
+        .port()
+        .map(|port| format!(":{port}"))
+        .unwrap_or_default();
+
+    Url::parse(&format!("https://{host}{port}")).with_context(|| {
+        format!("failed to prepare OTEL events sink endpoint `{sanitized}` for SSRF validation")
+    })
 }
 
 fn add_default_event_sinks(
@@ -4128,6 +4210,111 @@ policy:
         );
     }
 
+    #[test]
+    fn blueprint_otel_sink_args_returns_configured_endpoint() {
+        let yaml = r#"
+version: "0.1"
+min_agentenv_version: "0.0.1"
+sandbox:
+  driver: openshell
+agent:
+  driver: codex
+context:
+  driver: filesystem
+policy:
+  tier: restricted
+observability:
+  otel:
+    endpoint: grpc://collector:4317
+"#;
+
+        let sink_args = blueprint_otel_sink_args(yaml).expect("blueprint sink args");
+
+        assert_eq!(sink_args, vec!["otel:grpc://collector:4317"]);
+    }
+
+    #[test]
+    fn blueprint_otel_sink_args_rejects_invalid_endpoint_without_leaking_credentials() {
+        let yaml = r#"
+version: "0.1"
+min_agentenv_version: "0.0.1"
+sandbox:
+  driver: openshell
+agent:
+  driver: codex
+context:
+  driver: filesystem
+policy:
+  tier: restricted
+observability:
+  otel:
+    endpoint: https://token@example.com:4317
+"#;
+
+        let error = blueprint_otel_sink_args(yaml)
+            .expect_err("invalid credential-bearing endpoint must fail");
+
+        let rendered = format!("{error:#}");
+        assert!(
+            !rendered.contains("token@") && !rendered.contains("token"),
+            "blueprint OTEL endpoint error leaked credentials: {rendered}"
+        );
+    }
+
+    #[test]
+    fn combined_create_sink_args_includes_blueprint_and_cli_sinks() {
+        let yaml = r#"
+version: "0.1"
+min_agentenv_version: "0.0.1"
+sandbox:
+  driver: openshell
+agent:
+  driver: codex
+context:
+  driver: filesystem
+policy:
+  tier: restricted
+observability:
+  otel:
+    endpoint: grpc://collector:4317
+"#;
+        let cli_sinks = vec!["file:/tmp/agentenv-events.jsonl".to_owned()];
+
+        let sink_args = combined_create_sink_args(yaml, &cli_sinks).expect("combined sink args");
+
+        assert_eq!(
+            sink_args,
+            vec![
+                "otel:grpc://collector:4317".to_owned(),
+                "file:/tmp/agentenv-events.jsonl".to_owned()
+            ]
+        );
+    }
+
+    #[test]
+    fn unsafe_blueprint_otel_endpoint_is_rejected() {
+        let error = validate_otel_sink_endpoint("grpc://127.0.0.1:4317")
+            .expect_err("loopback OTEL endpoint must be rejected");
+
+        let rendered = format!("{error:#}");
+        assert!(
+            rendered.contains("OTEL events sink failed SSRF validation"),
+            "unexpected error: {rendered}"
+        );
+    }
+
+    #[test]
+    fn unsafe_blueprint_otel_endpoint_error_redacts_credentials() {
+        let error = validate_otel_sink_endpoint("grpc://token@127.0.0.1:4317")
+            .expect_err("credential-bearing OTEL endpoint must be rejected");
+
+        let rendered = format!("{error:#}");
+        assert!(
+            !rendered.contains("token@"),
+            "OTEL endpoint error leaked credentials: {rendered}"
+        );
+    }
+
     #[tokio::test]
     async fn create_time_events_do_not_materialize_final_env_dir() {
         let root = make_temp_dir("create-time-events-global-only");
@@ -4223,17 +4410,18 @@ policy:
         };
         let sinks = vec!["otel:grpc://collector:4317".to_owned()];
 
-        let dispatcher = match build_event_dispatcher(&options, None, &sinks) {
-            Ok(dispatcher) => dispatcher,
-            Err(error) => {
-                let rendered = format!("{error:#}");
-                assert!(
-                    rendered.contains("events sink requires feature `otel`"),
-                    "unexpected error: {rendered}"
-                );
-                return;
-            }
-        };
+        let dispatcher =
+            match build_event_dispatcher_with_otel_validator(&options, None, &sinks, |_| Ok(())) {
+                Ok(dispatcher) => dispatcher,
+                Err(error) => {
+                    let rendered = format!("{error:#}");
+                    assert!(
+                        rendered.contains("events sink requires feature `otel`"),
+                        "unexpected error: {rendered}"
+                    );
+                    return;
+                }
+            };
 
         let sink_names = dispatcher
             .counters()

--- a/crates/agentenv/src/main.rs
+++ b/crates/agentenv/src/main.rs
@@ -22,7 +22,7 @@ use agentenv_core::hardening::HardeningLintSeverity;
 use agentenv_credstore::{CredentialStore, CredentialStoreError, SecretString};
 use agentenv_events::{
     audit::{AuditPolicy, AuditSigningKey, AuditStore},
-    metrics::{render_prometheus, EnvMetricRow, MetricsSnapshot, SinkCounterMetric},
+    metrics::{render_prometheus, EnvMetricRow, MetricsSnapshot},
     sink::{JsonlSink, SqliteSink},
     store::{parse_legacy_jsonl_activity_event, EventQuery, SqliteEventStore, StoredEvent},
     ActivityEvent, ActivityKind, ActivityResult, EventDispatcher, EventEmitter, EventSink,
@@ -2393,10 +2393,8 @@ fn render_metrics_body(options: &agentenv_core::runtime::RuntimeOptions) -> Resu
     let store = SqliteEventStore::open(global_events_db_path(options))
         .context("open global activity database")?;
     let env_rows = env_status_metrics(options)?;
-    let mut snapshot =
+    let snapshot =
         MetricsSnapshot::from_store(&store, &env_rows).context("build metrics snapshot")?;
-    snapshot.event_drops_total = Vec::<SinkCounterMetric>::new();
-    snapshot.event_sink_errors_total = Vec::<SinkCounterMetric>::new();
     Ok(render_prometheus(&snapshot))
 }
 

--- a/crates/agentenv/tests/cli_behavior.rs
+++ b/crates/agentenv/tests/cli_behavior.rs
@@ -66,7 +66,10 @@ fn freeze_persisted_env_writes_default_lockfile() {
     );
 
     let rendered = fs::read_to_string(temp_dir.join("agentenv.lock")).unwrap();
-    assert!(rendered.contains("version: 0.2.0"));
+    assert!(rendered.contains(&format!(
+        "version: {}",
+        agentenv_core::lockfile::PORTABLE_LOCKFILE_VERSION
+    )));
     assert!(rendered.contains("name: demo"));
 }
 
@@ -6230,7 +6233,13 @@ fn freeze_persisted_env_output_dash_prints_lockfile_without_dash_file() {
         String::from_utf8_lossy(&output.stderr)
     );
     let stdout = String::from_utf8_lossy(&output.stdout);
-    assert!(stdout.contains("version: 0.2.0"), "stdout was: {stdout}");
+    assert!(
+        stdout.contains(&format!(
+            "version: {}",
+            agentenv_core::lockfile::PORTABLE_LOCKFILE_VERSION
+        )),
+        "stdout was: {stdout}"
+    );
     assert!(stdout.contains("name: demo"), "stdout was: {stdout}");
     assert!(
         !temp_dir.join("-").exists(),

--- a/crates/agentenv/tests/cli_behavior.rs
+++ b/crates/agentenv/tests/cli_behavior.rs
@@ -2,6 +2,7 @@ use std::{
     collections::{BTreeMap, BTreeSet},
     fs,
     io::{BufRead, BufReader, Read, Write},
+    net::TcpListener,
     path::{Path, PathBuf},
     process::{self, Command, Stdio},
     sync::{
@@ -152,6 +153,79 @@ fn dashboard_has_prometheus_datasource_variable(dashboard: &serde_json::Value) -
                         .is_some_and(|name| !name.is_empty())
             })
         })
+}
+
+#[test]
+fn metrics_serve_exposes_genai_metrics_over_http() {
+    let temp_dir = make_temp_dir("metrics-serve-genai");
+    write_minimal_env_state(&temp_dir, "demo");
+    seed_global_activity_db(
+        &temp_dir,
+        &[
+            activity_event(
+                "2026-05-18T00:00:00Z",
+                ActivityKind::GenAiModelCall,
+                ActivityResult::Ok,
+                "trace-model-call",
+            )
+            .with_latency_ms(250)
+            .with_extra("gen_ai.provider.name", json!("openai"))
+            .with_extra("gen_ai.operation.name", json!("chat"))
+            .with_extra("gen_ai.request.model", json!("gpt-4.1"))
+            .with_extra("gen_ai.usage.input_tokens", json!(12))
+            .with_extra("gen_ai.usage.output_tokens", json!(5)),
+            activity_event(
+                "2026-05-18T00:00:01Z",
+                ActivityKind::McpToolCall,
+                ActivityResult::Ok,
+                "trace-tool-call",
+            )
+            .with_latency_ms(10)
+            .with_subject_value("gen_ai.tool.name", json!("fs_read")),
+        ],
+    );
+    let port = free_tcp_port();
+    let mut child = Command::new(agentenv_bin())
+        .arg("metrics")
+        .arg("serve")
+        .arg("--port")
+        .arg(port.to_string())
+        .env("HOME", &temp_dir)
+        .stdout(Stdio::null())
+        .stderr(Stdio::null())
+        .spawn()
+        .unwrap();
+
+    let body = wait_for_metrics_body(&mut child, port);
+    let _ = child.kill();
+    let _ = child.wait();
+
+    assert!(
+        body.contains("agentenv_envs_total{status=\"running\"} 1"),
+        "metrics body was:\n{body}"
+    );
+    assert!(
+        body.contains("agentenv_event_drops_total{sink=\"sqlite\"} 0"),
+        "metrics body was:\n{body}"
+    );
+    assert!(
+        body.contains("agentenv_event_sink_errors_total{sink=\"sqlite\"} 0"),
+        "metrics body was:\n{body}"
+    );
+    assert!(
+        body.contains("gen_ai_client_token_usage_sum{gen_ai_provider_name=\"openai\",gen_ai_operation_name=\"chat\",gen_ai_token_type=\"input\",gen_ai_request_model=\"gpt-4.1\",env=\"demo\",result=\"ok\"} 12"),
+        "metrics body was:\n{body}"
+    );
+    assert!(
+        body.contains("gen_ai_client_operation_duration_count{gen_ai_provider_name=\"openai\",gen_ai_operation_name=\"chat\",gen_ai_request_model=\"gpt-4.1\",env=\"demo\",result=\"ok\"} 1"),
+        "metrics body was:\n{body}"
+    );
+    assert!(
+        body.contains(
+            "agentenv_gen_ai_tool_calls_total{gen_ai_tool_name=\"fs_read\",env=\"demo\",result=\"ok\"} 1"
+        ),
+        "metrics body was:\n{body}"
+    );
 }
 
 #[test]
@@ -4010,6 +4084,64 @@ fn create_preflight_json_invalid_blueprint_uses_stable_error() {
 }
 
 #[test]
+fn create_json_rejects_unsafe_blueprint_otel_endpoint_before_env_creation() {
+    let temp_dir = make_temp_dir("create-json-unsafe-blueprint-otel");
+    let blueprint = temp_dir.join("agentenv.yaml");
+    fs::write(
+        &blueprint,
+        r#"
+version: 0.1.0
+min_agentenv_version: 0.0.1-alpha0
+sandbox:
+  driver: openshell
+agent:
+  driver: codex
+context:
+  driver: none
+policy:
+  tier: balanced
+  presets: []
+observability:
+  otel:
+    endpoint: grpc://127.0.0.1:4317
+"#,
+    )
+    .unwrap();
+
+    let output = Command::new(agentenv_bin())
+        .arg("create")
+        .arg("demo")
+        .arg("--blueprint")
+        .arg(&blueprint)
+        .arg("--json")
+        .arg("--non-interactive")
+        .env("HOME", &temp_dir)
+        .current_dir(&temp_dir)
+        .output()
+        .unwrap();
+
+    assert!(!output.status.success(), "{}", output_summary(&output));
+    let json: serde_json::Value = serde_json::from_slice(&output.stderr).unwrap_or_else(|error| {
+        panic!("stderr was not JSON ({error}): {}", output_summary(&output))
+    });
+    assert_eq!(json["reason_code"], "invalid_blueprint");
+    let message = json["message"].as_str().unwrap_or_default();
+    assert!(
+        message.contains("OTEL events sink failed SSRF validation"),
+        "stderr was: {}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+    assert!(
+        !temp_dir
+            .join(".agentenv")
+            .join("envs")
+            .join("demo")
+            .exists(),
+        "create wrote env state before rejecting the unsafe OTEL endpoint"
+    );
+}
+
+#[test]
 fn list_json_returns_empty_rows_when_registry_missing() {
     let temp_dir = make_temp_dir("list-json-empty");
 
@@ -5887,6 +6019,12 @@ fn logs_env_kind_follow_polls_empty_sqlite_activity_store() {
         .stderr(process::Stdio::piped())
         .spawn()
         .unwrap();
+    let stdout = child.stdout.take().unwrap();
+    let stderr = child.stderr.take().unwrap();
+    let stdout_buffer = Arc::new(Mutex::new(String::new()));
+    let stderr_buffer = Arc::new(Mutex::new(String::new()));
+    let stdout_reader = spawn_line_reader(stdout, Arc::clone(&stdout_buffer));
+    let stderr_reader = spawn_line_reader(stderr, Arc::clone(&stderr_buffer));
 
     thread::sleep(Duration::from_millis(500));
     assert!(
@@ -5904,15 +6042,22 @@ fn logs_env_kind_follow_polls_empty_sqlite_activity_store() {
         .with_subject_value("target", serde_json::json!("api.example.test:443"))])
         .unwrap();
 
-    thread::sleep(Duration::from_millis(600));
+    wait_for_buffer_contains(
+        &mut child,
+        &stdout_buffer,
+        "trace-follow-sqlite",
+        Duration::from_secs(5),
+    );
     let _ = child.kill();
-    let output = child.wait_with_output().unwrap();
+    let _ = child.wait();
+    stdout_reader.join().unwrap();
+    stderr_reader.join().unwrap();
 
-    let stdout = String::from_utf8_lossy(&output.stdout);
+    let stdout = stdout_buffer.lock().unwrap();
     assert!(
         stdout.contains("trace-follow-sqlite"),
         "stdout was: {stdout}\nstderr was: {}",
-        String::from_utf8_lossy(&output.stderr)
+        stderr_buffer.lock().unwrap()
     );
 }
 
@@ -6820,6 +6965,90 @@ fn make_temp_dir(prefix: &str) -> PathBuf {
     let path = std::env::temp_dir().join(unique);
     fs::create_dir_all(&path).unwrap();
     path
+}
+
+fn free_tcp_port() -> u16 {
+    TcpListener::bind(("127.0.0.1", 0))
+        .unwrap()
+        .local_addr()
+        .unwrap()
+        .port()
+}
+
+fn wait_for_metrics_body(child: &mut process::Child, port: u16) -> String {
+    let url = format!("http://127.0.0.1:{port}/metrics");
+    let deadline = Instant::now() + LOCAL_HTTP_TEST_TIMEOUT;
+    loop {
+        let last_error = match reqwest::blocking::get(&url) {
+            Ok(response) if response.status().is_success() => {
+                return response.text().unwrap();
+            }
+            Ok(response) => {
+                format!("HTTP {}", response.status())
+            }
+            Err(error) => error.to_string(),
+        };
+
+        if let Some(status) = child.try_wait().unwrap() {
+            panic!(
+                "metrics server exited before serving /metrics: {status}; last error: {last_error}"
+            );
+        }
+        if Instant::now() >= deadline {
+            panic!(
+                "metrics server did not serve /metrics before timeout; last error: {last_error}"
+            );
+        }
+        thread::sleep(Duration::from_millis(50));
+    }
+}
+
+fn spawn_line_reader<R>(reader: R, buffer: Arc<Mutex<String>>) -> thread::JoinHandle<()>
+where
+    R: Read + Send + 'static,
+{
+    thread::spawn(move || {
+        let reader = BufReader::new(reader);
+        for line in reader.lines() {
+            let Ok(line) = line else {
+                break;
+            };
+            let mut buffer = buffer.lock().unwrap();
+            buffer.push_str(&line);
+            buffer.push('\n');
+        }
+    })
+}
+
+fn wait_for_buffer_contains(
+    child: &mut process::Child,
+    buffer: &Arc<Mutex<String>>,
+    needle: &str,
+    timeout: Duration,
+) {
+    let deadline = Instant::now() + timeout;
+    loop {
+        {
+            let buffer = buffer.lock().unwrap();
+            if buffer.contains(needle) {
+                return;
+            }
+        }
+
+        if let Some(status) = child.try_wait().unwrap() {
+            panic!(
+                "process exited before output contained `{needle}`: {status}; stdout was: {}",
+                buffer.lock().unwrap()
+            );
+        }
+        if Instant::now() >= deadline {
+            panic!(
+                "timed out waiting for output to contain `{needle}`; stdout was: {}",
+                buffer.lock().unwrap()
+            );
+        }
+        thread::sleep(Duration::from_millis(50));
+    }
 }
 
 fn make_executable(path: &Path) {

--- a/crates/agentenv/tests/cli_behavior.rs
+++ b/crates/agentenv/tests/cli_behavior.rs
@@ -36,9 +36,122 @@ use time::OffsetDateTime;
 const LOCAL_HTTP_TEST_TIMEOUT: Duration = Duration::from_secs(30);
 const APPROVALS_SERVER_START_TIMEOUT: Duration = Duration::from_secs(60);
 const PTY_QUIT_TIMEOUT: Duration = Duration::from_secs(15);
+const DASHBOARD_PATH: &str = "../../contrib/grafana/dashboards/agentenv-otel.json";
 
 fn agentenv_bin() -> &'static str {
     env!("CARGO_BIN_EXE_agentenv")
+}
+
+fn dashboard_prometheus_expressions(value: &serde_json::Value) -> Vec<String> {
+    let mut expressions = Vec::new();
+    collect_dashboard_expressions(value, &mut expressions);
+    expressions
+}
+
+fn collect_dashboard_expressions(value: &serde_json::Value, expressions: &mut Vec<String>) {
+    match value {
+        serde_json::Value::Object(map) => {
+            if let Some(expr) = map.get("expr").and_then(serde_json::Value::as_str) {
+                expressions.push(expr.to_owned());
+            }
+            for child in map.values() {
+                collect_dashboard_expressions(child, expressions);
+            }
+        }
+        serde_json::Value::Array(values) => {
+            for child in values {
+                collect_dashboard_expressions(child, expressions);
+            }
+        }
+        _ => {}
+    }
+}
+
+fn dashboard_metric_identifiers(expressions: &[String]) -> BTreeSet<String> {
+    let mut metrics = BTreeSet::new();
+    for expr in expressions {
+        for token in expr.split(|c: char| !(c.is_ascii_alphanumeric() || c == '_' || c == ':')) {
+            if token.starts_with("agentenv_") || token.starts_with("gen_ai_client_") {
+                metrics.insert(token.to_owned());
+            }
+        }
+    }
+    metrics
+}
+
+#[test]
+fn dashboard_json_references_only_emitted_metrics() {
+    let dashboard_path = Path::new(env!("CARGO_MANIFEST_DIR")).join(DASHBOARD_PATH);
+    let dashboard = fs::read_to_string(&dashboard_path).unwrap_or_else(|err| {
+        panic!(
+            "failed to read dashboard {}: {err}",
+            dashboard_path.display()
+        )
+    });
+    let dashboard: serde_json::Value =
+        serde_json::from_str(&dashboard).expect("dashboard JSON parses");
+    assert!(
+        dashboard_has_prometheus_datasource_variable(&dashboard),
+        "dashboard should include a Prometheus datasource variable"
+    );
+
+    let expressions = dashboard_prometheus_expressions(&dashboard);
+    assert!(
+        !expressions.is_empty(),
+        "dashboard should contain Prometheus target expressions"
+    );
+
+    let required_metrics = [
+        "agentenv_envs_total",
+        "agentenv_events_total",
+        "gen_ai_client_operation_duration_bucket",
+        "gen_ai_client_token_usage_sum",
+        "agentenv_gen_ai_tool_calls_total",
+        "agentenv_policy_blocks_total",
+        "agentenv_approvals_pending_total",
+        "agentenv_event_drops_total",
+        "agentenv_event_sink_errors_total",
+    ];
+    for metric in required_metrics {
+        assert!(
+            expressions.iter().any(|expr| expr.contains(metric)),
+            "dashboard does not reference required metric `{metric}`; expressions: {expressions:?}"
+        );
+    }
+
+    let allowed_metrics = [
+        "agentenv_approvals_pending_total",
+        "agentenv_envs_total",
+        "agentenv_event_drops_total",
+        "agentenv_event_sink_errors_total",
+        "agentenv_events_total",
+        "agentenv_gen_ai_tool_calls_total",
+        "agentenv_policy_blocks_total",
+        "gen_ai_client_operation_duration_bucket",
+        "gen_ai_client_token_usage_sum",
+    ];
+    let allowed_metrics = allowed_metrics.into_iter().collect::<BTreeSet<_>>();
+    let referenced_metrics = dashboard_metric_identifiers(&expressions);
+    for metric in &referenced_metrics {
+        assert!(
+            allowed_metrics.contains(metric.as_str()),
+            "dashboard references non-emitted or unapproved metric `{metric}`; expressions: {expressions:?}"
+        );
+    }
+}
+
+fn dashboard_has_prometheus_datasource_variable(dashboard: &serde_json::Value) -> bool {
+    dashboard["templating"]["list"]
+        .as_array()
+        .is_some_and(|variables| {
+            variables.iter().any(|variable| {
+                variable["type"] == "datasource"
+                    && variable["query"] == "prometheus"
+                    && variable["name"]
+                        .as_str()
+                        .is_some_and(|name| !name.is_empty())
+            })
+        })
 }
 
 #[test]

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -360,7 +360,34 @@ This matters for agents running long tasks: closing your laptop doesn't kill the
 
 ### Activity event stream
 
-Every core operation emits a structured event (append-only JSONL). Sinks: SQLite (default), OTEL export, file, webhook. Used by:
+`ActivityEvent` is the native source of truth for operational history. Core and
+drivers emit typed activity events for sandbox lifecycle, policy decisions,
+approvals, MCP tool calls, agent turns, and GenAI model calls. The default sink
+persists those events to SQLite; file, webhook, and OTEL sinks are additive.
+
+OTEL export maps the same native activity events into OpenTelemetry log records
+and, for GenAI activity, semantic-convention spans. `gen_ai_model_call` events
+become client spans with GenAI attributes such as `gen_ai.provider.name`,
+`gen_ai.operation.name`, request/response model names, token counts, finish
+reasons, and status. `agent_turn` and MCP tool activity are exported as internal
+GenAI spans or span events where applicable. The mapper accepts
+`gen_ai.system` as an input alias, but canonical output uses
+`gen_ai.provider.name`.
+
+`agentenv metrics serve` renders a Prometheus-compatible view derived from the
+activity store and approval state. The GenAI series follow OTEL GenAI metric
+names for model-call duration and token usage, and agentenv-specific counters
+track tool calls, policy blocks, approval backlog, event drops, and sink write
+errors. Sink health counters expose zero-valued default samples for the default
+SQLite sink when no drops or write errors have been observed.
+
+Redaction happens before OTEL GenAI export for prompt-like, response-like, and
+credential-looking fields. Metrics intentionally keep label cardinality bounded:
+environment, result, event kind, provider, operation, request model, token type,
+tool name, driver, and sink are labels; prompt content, raw URLs, credentials,
+request bodies, and response bodies are not labels.
+
+Used by:
 
 - `agentenv logs --follow` — streaming view
 - `agentenv term` — ratatui-based operator TUI (k9s/openshell-term style)

--- a/docs/DRIVER_PROTOCOL.md
+++ b/docs/DRIVER_PROTOCOL.md
@@ -296,7 +296,9 @@ shape. The legacy `ActivityEventParams` shape remains valid for compatibility:
 ```
 
 Rich `DriverActivityEventParams` include typed kind/result fields plus structured
-actor, subject, and extras maps:
+actor, subject, and extras maps. Rich `kind` values include lifecycle,
+policy, approval, MCP, and GenAI activity such as `agent_turn` and
+`gen_ai_model_call`:
 
 ```json
 {
@@ -316,6 +318,26 @@ actor, subject, and extras maps:
   }
 }
 ```
+
+GenAI events may carry OTEL GenAI semantic-convention attributes in `subject`
+or `extras`. The accepted fields are:
+
+- `gen_ai.provider.name` for the provider. Current canonical output uses this
+  field; `gen_ai.system` is accepted only as an input alias and is not emitted
+  as the canonical OTEL attribute.
+- `gen_ai.operation.name` for the model operation. If omitted on
+  `gen_ai_model_call`, core defaults to `chat`.
+- `gen_ai.request.model` and `gen_ai.response.model` for model identity.
+- `gen_ai.usage.input_tokens` and `gen_ai.usage.output_tokens`, with
+  `gen_ai.usage.prompt_tokens` and `gen_ai.usage.completion_tokens` accepted as
+  input aliases.
+- `gen_ai.response.finish_reasons` or `gen_ai.response.finish_reason`.
+- `gen_ai.tool.name` and `gen_ai.tool.call.id` for MCP/tool activity.
+- `gen_ai.agent.name` for agent-turn spans.
+
+Prompt text, response bodies, credentials, raw headers, and other
+high-cardinality payloads should not be sent as GenAI attributes. Core redacts
+credential-looking and prompt/response-like fields before OTEL GenAI export.
 
 ### `event/approval_requested`
 

--- a/docs/superpowers/plans/2026-05-18-otel-genai-semconv.md
+++ b/docs/superpowers/plans/2026-05-18-otel-genai-semconv.md
@@ -1,0 +1,2146 @@
+# OTEL GenAI Semantic Conventions Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Implement issue #44 by exporting agentenv activity events as current OpenTelemetry GenAI telemetry, adding blueprint OTLP config, GenAI Prometheus metrics, and a Grafana dashboard in one PR.
+
+**Architecture:** Keep `agentenv-events::ActivityEvent` as the source of truth. Add a focused GenAI semantic mapper in `agentenv-events`, then have OTLP export and Prometheus metrics consume that mapper. Add blueprint `observability.otel.endpoint` as an additive event sink input without changing driver method names or credential transport.
+
+**Tech Stack:** Rust 2021, serde, serde_json, rusqlite JSON queries, tokio, opentelemetry 0.31, opentelemetry_sdk 0.31, opentelemetry-otlp 0.31.1, Prometheus text exposition, Grafana dashboard JSON.
+
+---
+
+## File Structure
+
+- Modify `crates/agentenv-events/Cargo.toml`: enable OTEL `trace` and `logs` features and keep the feature gated behind `otel`.
+- Modify `crates/agentenv-events/src/lib.rs`: export the new `genai` module.
+- Modify `crates/agentenv-events/src/activity.rs`: add `AgentTurn` and `GenAiModelCall` event kinds and serialization tests.
+- Create `crates/agentenv-events/src/genai.rs`: own all GenAI semantic convention normalization and low-cardinality signal mapping.
+- Modify `crates/agentenv-events/src/otel.rs`: export spans for GenAI operations and log records for agentenv lifecycle/security events.
+- Modify `crates/agentenv-events/src/store.rs`: add GenAI aggregate queries for token usage, operation duration, and tool calls.
+- Modify `crates/agentenv-events/src/metrics.rs`: add Prometheus GenAI metric rows and rendering.
+- Modify `crates/agentenv-events/README.md`: document OTEL GenAI attributes and Prometheus labels.
+- Modify `crates/agentenv-proto/src/types.rs`: add rich activity variants for `agent_turn` and `gen_ai_model_call`.
+- Modify generated schema `crates/agentenv-proto/schema/driver-activity-event-params.json` by running the proto build.
+- Modify `crates/agentenv-plugin/src/jsonrpc.rs`: convert the new rich activity kinds into `agentenv-events` kinds.
+- Modify `crates/agentenv-core/src/blueprint.rs`: add optional `observability.otel.endpoint`.
+- Modify `crates/agentenv-core/src/lifecycle.rs`: preserve observability config through blueprint resolve/freeze.
+- Modify `crates/agentenv-core/tests/roundtrip.rs`: cover blueprint parsing and round-trip.
+- Modify `crates/agentenv/src/main.rs`: add blueprint OTEL endpoint to event dispatcher construction and validate it through SSRF checks.
+- Modify `crates/agentenv/tests/cli_behavior.rs`: cover create-time blueprint OTEL sink configuration and unsafe endpoint rejection.
+- Modify `docs/ARCHITECTURE.md`: document GenAI observability mapping.
+- Modify `docs/DRIVER_PROTOCOL.md`: document the additive rich activity kinds and GenAI metadata fields.
+- Modify `crates/agentenv/README.md`: document blueprint and CLI OTEL configuration.
+- Create `contrib/grafana/dashboards/agentenv-otel.json`: Prometheus dashboard using emitted metrics only.
+- Add or modify tests in the files above.
+
+## Task 1: Add Activity And Protocol GenAI Kinds
+
+**Files:**
+- Modify: `crates/agentenv-events/src/activity.rs`
+- Modify: `crates/agentenv-proto/src/types.rs`
+- Modify: `crates/agentenv-plugin/src/jsonrpc.rs`
+- Modify: `crates/agentenv-proto/schema/driver-activity-event-params.json`
+
+- [ ] **Step 1: Add failing activity serialization tests**
+
+Add this test to the existing `#[cfg(test)] mod tests` in `crates/agentenv-events/src/activity.rs`:
+
+```rust
+#[test]
+fn genai_activity_kinds_serialize_to_stable_snake_case() {
+    assert_eq!(
+        serde_json::to_value(ActivityKind::AgentTurn).unwrap(),
+        serde_json::json!("agent_turn")
+    );
+    assert_eq!(
+        serde_json::to_value(ActivityKind::GenAiModelCall).unwrap(),
+        serde_json::json!("gen_ai_model_call")
+    );
+}
+```
+
+- [ ] **Step 2: Add failing rich driver conversion test**
+
+Add this test to `mod notification_tests` in `crates/agentenv-plugin/src/jsonrpc.rs`:
+
+```rust
+#[test]
+fn rich_genai_activity_notification_converts_new_kinds() {
+    let raw = json!({
+        "jsonrpc": "2.0",
+        "method": "event/activity",
+        "params": {
+            "ts": "2026-05-18T12:00:00Z",
+            "kind": "gen_ai_model_call",
+            "env": "demo",
+            "actor": {"driver": "inference-openai"},
+            "subject": {"request_id": "req-otel"},
+            "result": "ok",
+            "latency_ms": 125,
+            "trace_id": "trace-genai",
+            "extras": {
+                "gen_ai.provider.name": "openai",
+                "gen_ai.request.model": "gpt-4.1-mini",
+                "gen_ai.usage.input_tokens": 12,
+                "gen_ai.usage.output_tokens": 34
+            }
+        }
+    });
+
+    let notification: RpcNotificationEnvelope = serde_json::from_value(raw).unwrap();
+    let event = notification_to_activity_event(notification, "fallback-trace").unwrap();
+
+    assert_eq!(event.kind, agentenv_events::ActivityKind::GenAiModelCall);
+    assert_eq!(event.result, agentenv_events::ActivityResult::Ok);
+    assert_eq!(event.env.as_deref(), Some("demo"));
+    assert_eq!(event.trace_id, "trace-genai");
+    assert_eq!(event.extras["gen_ai.provider.name"], json!("openai"));
+    assert_eq!(event.extras["gen_ai.request.model"], json!("gpt-4.1-mini"));
+}
+```
+
+- [ ] **Step 3: Run tests to verify they fail**
+
+Run:
+
+```bash
+cargo test -p agentenv-events genai_activity_kinds_serialize_to_stable_snake_case
+cargo test -p agentenv-plugin rich_genai_activity_notification_converts_new_kinds
+```
+
+Expected:
+
+```text
+error[E0599]: no variant or associated item named `AgentTurn`
+error[E0599]: no variant or associated item named `GenAiModelCall`
+```
+
+- [ ] **Step 4: Add event and proto variants**
+
+In `crates/agentenv-events/src/activity.rs`, add the new variants after `McpToolCall`:
+
+```rust
+    McpToolCall,
+    AgentTurn,
+    GenAiModelCall,
+    PolicyApplied,
+```
+
+In `crates/agentenv-proto/src/types.rs`, add matching rich activity variants after `McpToolCall`:
+
+```rust
+    McpToolCall,
+    AgentTurn,
+    GenAiModelCall,
+    PolicyApplied,
+```
+
+In `crates/agentenv-plugin/src/jsonrpc.rs`, update `rich_activity_kind_to_event_kind`:
+
+```rust
+        agentenv_proto::RichActivityKind::McpToolCall => EventActivityKind::McpToolCall,
+        agentenv_proto::RichActivityKind::AgentTurn => EventActivityKind::AgentTurn,
+        agentenv_proto::RichActivityKind::GenAiModelCall => EventActivityKind::GenAiModelCall,
+        agentenv_proto::RichActivityKind::PolicyApplied => EventActivityKind::PolicyApplied,
+```
+
+- [ ] **Step 5: Add proto round-trip test and regenerate schema**
+
+Add this test to `#[cfg(test)] mod tests` in `crates/agentenv-proto/src/types.rs`:
+
+```rust
+#[test]
+fn rich_activity_genai_kinds_round_trip() {
+    let agent_turn: RichActivityKind = serde_json::from_value(serde_json::json!("agent_turn")).unwrap();
+    let model_call: RichActivityKind =
+        serde_json::from_value(serde_json::json!("gen_ai_model_call")).unwrap();
+
+    assert_eq!(agent_turn, RichActivityKind::AgentTurn);
+    assert_eq!(model_call, RichActivityKind::GenAiModelCall);
+    assert_eq!(
+        serde_json::to_value(RichActivityKind::AgentTurn).unwrap(),
+        serde_json::json!("agent_turn")
+    );
+    assert_eq!(
+        serde_json::to_value(RichActivityKind::GenAiModelCall).unwrap(),
+        serde_json::json!("gen_ai_model_call")
+    );
+}
+```
+
+Run:
+
+```bash
+cargo test -p agentenv-proto rich_activity_genai_kinds_round_trip
+```
+
+Expected: PASS and `crates/agentenv-proto/schema/driver-activity-event-params.json` includes `agent_turn` and `gen_ai_model_call`.
+
+- [ ] **Step 6: Run focused tests**
+
+Run:
+
+```bash
+cargo test -p agentenv-events genai_activity_kinds_serialize_to_stable_snake_case
+cargo test -p agentenv-plugin rich_genai_activity_notification_converts_new_kinds
+```
+
+Expected: both commands PASS.
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add crates/agentenv-events/src/activity.rs crates/agentenv-proto/src/types.rs crates/agentenv-plugin/src/jsonrpc.rs crates/agentenv-proto/schema/driver-activity-event-params.json
+git commit -m "feat: add genai activity event kinds"
+```
+
+## Task 2: Add GenAI Semantic Mapping
+
+**Files:**
+- Create: `crates/agentenv-events/src/genai.rs`
+- Modify: `crates/agentenv-events/src/lib.rs`
+
+- [ ] **Step 1: Write failing mapper tests**
+
+Create `crates/agentenv-events/src/genai.rs` with this test module first:
+
+```rust
+use std::collections::BTreeMap;
+
+use serde_json::Value;
+
+use crate::activity::{ActivityEvent, ActivityKind, ActivityResult};
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn event(kind: ActivityKind) -> ActivityEvent {
+        ActivityEvent::new("2026-05-18T12:00:00Z", kind, ActivityResult::Ok, "trace-genai")
+            .with_env("demo")
+    }
+
+    #[test]
+    fn normalizes_legacy_gen_ai_system_to_provider_name() {
+        let signal = map_event_to_genai_signal(
+            &event(ActivityKind::GenAiModelCall)
+                .with_extra("gen_ai.system", serde_json::json!("openai"))
+                .with_extra("gen_ai.request.model", serde_json::json!("gpt-4.1-mini")),
+        )
+        .unwrap();
+
+        assert_eq!(signal.kind, OtelGenAiSignalKind::Span);
+        assert_eq!(signal.operation_name.as_deref(), Some("chat"));
+        assert_eq!(signal.attributes["gen_ai.provider.name"], OtelAttributeValue::String("openai".to_owned()));
+        assert_eq!(signal.attributes["gen_ai.request.model"], OtelAttributeValue::String("gpt-4.1-mini".to_owned()));
+        assert!(!signal.attributes.contains_key("gen_ai.system"));
+    }
+
+    #[test]
+    fn maps_mcp_tool_call_to_execute_tool_span() {
+        let signal = map_event_to_genai_signal(
+            &event(ActivityKind::McpToolCall)
+                .with_subject_value("tool", serde_json::json!("filesystem.read"))
+                .with_subject_value("tool_call_id", serde_json::json!("toolu_123")),
+        )
+        .unwrap();
+
+        assert_eq!(signal.kind, OtelGenAiSignalKind::Span);
+        assert_eq!(signal.name, "gen_ai.execute_tool filesystem.read");
+        assert_eq!(signal.operation_name.as_deref(), Some("execute_tool"));
+        assert_eq!(signal.attributes["gen_ai.tool.name"], OtelAttributeValue::String("filesystem.read".to_owned()));
+        assert_eq!(signal.attributes["gen_ai.tool.call.id"], OtelAttributeValue::String("toolu_123".to_owned()));
+    }
+
+    #[test]
+    fn maps_agent_turn_to_invoke_agent_span() {
+        let signal = map_event_to_genai_signal(
+            &event(ActivityKind::AgentTurn)
+                .with_extra("gen_ai.agent.name", serde_json::json!("codex"))
+                .with_latency_ms(250),
+        )
+        .unwrap();
+
+        assert_eq!(signal.kind, OtelGenAiSignalKind::Span);
+        assert_eq!(signal.name, "gen_ai.invoke_agent codex");
+        assert_eq!(signal.operation_name.as_deref(), Some("invoke_agent"));
+        assert_eq!(signal.duration_ms, Some(250));
+        assert_eq!(signal.attributes["gen_ai.agent.name"], OtelAttributeValue::String("codex".to_owned()));
+    }
+
+    #[test]
+    fn maps_token_usage_as_integer_attributes() {
+        let signal = map_event_to_genai_signal(
+            &event(ActivityKind::GenAiModelCall)
+                .with_extra("gen_ai.provider.name", serde_json::json!("anthropic"))
+                .with_extra("gen_ai.request.model", serde_json::json!("claude-sonnet-4-5"))
+                .with_extra("gen_ai.usage.input_tokens", serde_json::json!(123))
+                .with_extra("gen_ai.usage.output_tokens", serde_json::json!(45))
+                .with_extra("gen_ai.response.finish_reasons", serde_json::json!(["stop"])),
+        )
+        .unwrap();
+
+        assert_eq!(signal.attributes["gen_ai.usage.input_tokens"], OtelAttributeValue::I64(123));
+        assert_eq!(signal.attributes["gen_ai.usage.output_tokens"], OtelAttributeValue::I64(45));
+        assert_eq!(
+            signal.attributes["gen_ai.response.finish_reasons"],
+            OtelAttributeValue::StringArray(vec!["stop".to_owned()])
+        );
+    }
+}
+```
+
+- [ ] **Step 2: Export the module and verify failure**
+
+Add to `crates/agentenv-events/src/lib.rs`:
+
+```rust
+pub mod genai;
+```
+
+Run:
+
+```bash
+cargo test -p agentenv-events genai::
+```
+
+Expected: FAIL with missing `OtelGenAiSignalKind`, `OtelAttributeValue`, and `map_event_to_genai_signal`.
+
+- [ ] **Step 3: Implement mapper types and constants**
+
+Add this code above the test module in `crates/agentenv-events/src/genai.rs`:
+
+```rust
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum OtelGenAiSignalKind {
+    Span,
+    SpanEvent,
+    LogRecord,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum OtelSpanKindHint {
+    Client,
+    Internal,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum OtelSignalStatus {
+    Ok,
+    Error,
+    Denied,
+    PendingApproval,
+}
+
+#[derive(Debug, Clone, PartialEq)]
+pub enum OtelAttributeValue {
+    String(String),
+    I64(i64),
+    F64(f64),
+    Bool(bool),
+    StringArray(Vec<String>),
+}
+
+#[derive(Debug, Clone, PartialEq)]
+pub struct OtelGenAiSignal {
+    pub kind: OtelGenAiSignalKind,
+    pub name: String,
+    pub span_kind: OtelSpanKindHint,
+    pub operation_name: Option<String>,
+    pub duration_ms: Option<u64>,
+    pub status: OtelSignalStatus,
+    pub attributes: BTreeMap<String, OtelAttributeValue>,
+}
+
+const ATTR_OPERATION_NAME: &str = "gen_ai.operation.name";
+const ATTR_PROVIDER_NAME: &str = "gen_ai.provider.name";
+const ATTR_REQUEST_MODEL: &str = "gen_ai.request.model";
+const ATTR_RESPONSE_MODEL: &str = "gen_ai.response.model";
+const ATTR_INPUT_TOKENS: &str = "gen_ai.usage.input_tokens";
+const ATTR_OUTPUT_TOKENS: &str = "gen_ai.usage.output_tokens";
+const ATTR_FINISH_REASONS: &str = "gen_ai.response.finish_reasons";
+const ATTR_TOOL_NAME: &str = "gen_ai.tool.name";
+const ATTR_TOOL_CALL_ID: &str = "gen_ai.tool.call.id";
+const ATTR_AGENT_NAME: &str = "gen_ai.agent.name";
+const ATTR_AGENT_VERSION: &str = "gen_ai.agent.version";
+```
+
+- [ ] **Step 4: Implement event mapping**
+
+Add this implementation below the constants:
+
+```rust
+pub fn map_event_to_genai_signal(event: &ActivityEvent) -> Option<OtelGenAiSignal> {
+    let event = event.clone().redacted();
+    let mut attributes = base_attributes(&event);
+    let status = signal_status(event.result);
+
+    match event.kind {
+        ActivityKind::McpToolCall => {
+            let tool = string_from_maps(&event, &[ATTR_TOOL_NAME, "tool", "name"])
+                .unwrap_or_else(|| "unknown".to_owned());
+            let call_id = string_from_maps(&event, &[ATTR_TOOL_CALL_ID, "tool_call_id", "call_id"]);
+            attributes.insert(
+                ATTR_OPERATION_NAME.to_owned(),
+                OtelAttributeValue::String("execute_tool".to_owned()),
+            );
+            attributes.insert(ATTR_TOOL_NAME.to_owned(), OtelAttributeValue::String(tool.clone()));
+            if let Some(call_id) = call_id {
+                attributes.insert(ATTR_TOOL_CALL_ID.to_owned(), OtelAttributeValue::String(call_id));
+            }
+            Some(OtelGenAiSignal {
+                kind: OtelGenAiSignalKind::Span,
+                name: format!("gen_ai.execute_tool {tool}"),
+                span_kind: OtelSpanKindHint::Internal,
+                operation_name: Some("execute_tool".to_owned()),
+                duration_ms: event.latency_ms,
+                status,
+                attributes,
+            })
+        }
+        ActivityKind::AgentTurn => {
+            let agent = string_from_maps(&event, &[ATTR_AGENT_NAME, "agent"])
+                .or_else(|| event.env.clone())
+                .unwrap_or_else(|| "agent".to_owned());
+            attributes.insert(
+                ATTR_OPERATION_NAME.to_owned(),
+                OtelAttributeValue::String("invoke_agent".to_owned()),
+            );
+            attributes.insert(ATTR_AGENT_NAME.to_owned(), OtelAttributeValue::String(agent.clone()));
+            if let Some(version) = string_from_maps(&event, &[ATTR_AGENT_VERSION, "agent_version"]) {
+                attributes.insert(ATTR_AGENT_VERSION.to_owned(), OtelAttributeValue::String(version));
+            }
+            Some(OtelGenAiSignal {
+                kind: OtelGenAiSignalKind::Span,
+                name: format!("gen_ai.invoke_agent {agent}"),
+                span_kind: OtelSpanKindHint::Internal,
+                operation_name: Some("invoke_agent".to_owned()),
+                duration_ms: event.latency_ms,
+                status,
+                attributes,
+            })
+        }
+        ActivityKind::GenAiModelCall => {
+            copy_genai_attributes(&event, &mut attributes);
+            attributes
+                .entry(ATTR_OPERATION_NAME.to_owned())
+                .or_insert_with(|| OtelAttributeValue::String("chat".to_owned()));
+            let operation = attribute_string(&attributes, ATTR_OPERATION_NAME)
+                .unwrap_or_else(|| "chat".to_owned());
+            Some(OtelGenAiSignal {
+                kind: OtelGenAiSignalKind::Span,
+                name: format!("gen_ai.{operation}"),
+                span_kind: OtelSpanKindHint::Client,
+                operation_name: Some(operation),
+                duration_ms: event.latency_ms,
+                status,
+                attributes,
+            })
+        }
+        ActivityKind::ApprovalRequested
+        | ActivityKind::ApprovalDecided
+        | ActivityKind::EgressDenied
+        | ActivityKind::PolicyApplied => {
+            add_agentenv_security_attributes(&event, &mut attributes);
+            Some(OtelGenAiSignal {
+                kind: OtelGenAiSignalKind::LogRecord,
+                name: format!("agentenv.{}", activity_kind_name(event.kind)),
+                span_kind: OtelSpanKindHint::Internal,
+                operation_name: None,
+                duration_ms: event.latency_ms,
+                status,
+                attributes,
+            })
+        }
+        _ => {
+            add_agentenv_security_attributes(&event, &mut attributes);
+            Some(OtelGenAiSignal {
+                kind: OtelGenAiSignalKind::LogRecord,
+                name: format!("agentenv.{}", activity_kind_name(event.kind)),
+                span_kind: OtelSpanKindHint::Internal,
+                operation_name: None,
+                duration_ms: event.latency_ms,
+                status,
+                attributes,
+            })
+        }
+    }
+}
+```
+
+- [ ] **Step 5: Implement helper functions**
+
+Add these helpers in `crates/agentenv-events/src/genai.rs`:
+
+```rust
+fn base_attributes(event: &ActivityEvent) -> BTreeMap<String, OtelAttributeValue> {
+    let mut attributes = BTreeMap::new();
+    attributes.insert(
+        "agentenv.event.kind".to_owned(),
+        OtelAttributeValue::String(activity_kind_name(event.kind).to_owned()),
+    );
+    attributes.insert(
+        "agentenv.event.result".to_owned(),
+        OtelAttributeValue::String(activity_result_name(event.result).to_owned()),
+    );
+    attributes.insert(
+        "agentenv.trace_id".to_owned(),
+        OtelAttributeValue::String(event.trace_id.clone()),
+    );
+    if let Some(env) = &event.env {
+        attributes.insert("agentenv.env".to_owned(), OtelAttributeValue::String(env.clone()));
+    }
+    if let Some(reason) = &event.reason_code {
+        attributes.insert(
+            "agentenv.reason_code".to_owned(),
+            OtelAttributeValue::String(reason.clone()),
+        );
+    }
+    attributes
+}
+
+fn copy_genai_attributes(event: &ActivityEvent, attributes: &mut BTreeMap<String, OtelAttributeValue>) {
+    copy_string_attr(event, attributes, ATTR_PROVIDER_NAME, &[ATTR_PROVIDER_NAME, "gen_ai.system", "provider"]);
+    copy_string_attr(event, attributes, ATTR_OPERATION_NAME, &[ATTR_OPERATION_NAME, "operation"]);
+    copy_string_attr(event, attributes, ATTR_REQUEST_MODEL, &[ATTR_REQUEST_MODEL, "model", "request_model"]);
+    copy_string_attr(event, attributes, ATTR_RESPONSE_MODEL, &[ATTR_RESPONSE_MODEL, "response_model"]);
+    copy_i64_attr(event, attributes, ATTR_INPUT_TOKENS, &[ATTR_INPUT_TOKENS, "input_tokens"]);
+    copy_i64_attr(event, attributes, ATTR_OUTPUT_TOKENS, &[ATTR_OUTPUT_TOKENS, "output_tokens"]);
+    copy_string_array_attr(event, attributes, ATTR_FINISH_REASONS, &[ATTR_FINISH_REASONS, "finish_reasons"]);
+}
+
+fn add_agentenv_security_attributes(event: &ActivityEvent, attributes: &mut BTreeMap<String, OtelAttributeValue>) {
+    if event.kind == ActivityKind::EgressDenied {
+        attributes.insert("agentenv.egress.denied".to_owned(), OtelAttributeValue::Bool(true));
+    }
+    if matches!(event.kind, ActivityKind::ApprovalRequested | ActivityKind::ApprovalDecided) {
+        if let Some(kind) = string_from_maps(event, &["kind", "approval_kind"]) {
+            attributes.insert("agentenv.approval.kind".to_owned(), OtelAttributeValue::String(kind));
+        }
+        if let Some(request_id) = string_from_maps(event, &["request_id"]) {
+            attributes.insert(
+                "agentenv.approval.request_id".to_owned(),
+                OtelAttributeValue::String(request_id),
+            );
+        }
+    }
+    if event.kind == ActivityKind::PolicyApplied {
+        let hot_reloaded = bool_from_maps(event, &["hot_reloaded"]).unwrap_or(false);
+        attributes.insert("agentenv.policy.reload".to_owned(), OtelAttributeValue::Bool(hot_reloaded));
+    }
+}
+
+fn copy_string_attr(
+    event: &ActivityEvent,
+    attributes: &mut BTreeMap<String, OtelAttributeValue>,
+    canonical: &str,
+    keys: &[&str],
+) {
+    if let Some(value) = string_from_maps(event, keys) {
+        attributes.insert(canonical.to_owned(), OtelAttributeValue::String(value));
+    }
+}
+
+fn copy_i64_attr(
+    event: &ActivityEvent,
+    attributes: &mut BTreeMap<String, OtelAttributeValue>,
+    canonical: &str,
+    keys: &[&str],
+) {
+    if let Some(value) = i64_from_maps(event, keys) {
+        attributes.insert(canonical.to_owned(), OtelAttributeValue::I64(value));
+    }
+}
+
+fn copy_string_array_attr(
+    event: &ActivityEvent,
+    attributes: &mut BTreeMap<String, OtelAttributeValue>,
+    canonical: &str,
+    keys: &[&str],
+) {
+    if let Some(value) = string_array_from_maps(event, keys) {
+        attributes.insert(canonical.to_owned(), OtelAttributeValue::StringArray(value));
+    }
+}
+
+fn string_from_maps(event: &ActivityEvent, keys: &[&str]) -> Option<String> {
+    keys.iter()
+        .find_map(|key| value_from_event(event, key))
+        .and_then(|value| value.as_str().map(ToOwned::to_owned))
+}
+
+fn i64_from_maps(event: &ActivityEvent, keys: &[&str]) -> Option<i64> {
+    keys.iter()
+        .find_map(|key| value_from_event(event, key))
+        .and_then(Value::as_i64)
+}
+
+fn bool_from_maps(event: &ActivityEvent, keys: &[&str]) -> Option<bool> {
+    keys.iter()
+        .find_map(|key| value_from_event(event, key))
+        .and_then(Value::as_bool)
+}
+
+fn string_array_from_maps(event: &ActivityEvent, keys: &[&str]) -> Option<Vec<String>> {
+    keys.iter().find_map(|key| {
+        value_from_event(event, key).and_then(|value| {
+            value.as_array().map(|items| {
+                items
+                    .iter()
+                    .filter_map(Value::as_str)
+                    .map(ToOwned::to_owned)
+                    .collect::<Vec<_>>()
+            })
+        })
+    })
+}
+
+fn value_from_event<'a>(event: &'a ActivityEvent, key: &str) -> Option<&'a Value> {
+    event
+        .extras
+        .get(key)
+        .or_else(|| event.subject.get(key))
+        .or_else(|| event.actor.get(key))
+}
+
+fn attribute_string(attributes: &BTreeMap<String, OtelAttributeValue>, key: &str) -> Option<String> {
+    match attributes.get(key) {
+        Some(OtelAttributeValue::String(value)) => Some(value.clone()),
+        _ => None,
+    }
+}
+
+fn signal_status(result: ActivityResult) -> OtelSignalStatus {
+    match result {
+        ActivityResult::Ok => OtelSignalStatus::Ok,
+        ActivityResult::Error => OtelSignalStatus::Error,
+        ActivityResult::Denied => OtelSignalStatus::Denied,
+        ActivityResult::PendingApproval => OtelSignalStatus::PendingApproval,
+    }
+}
+
+pub fn activity_kind_name(kind: ActivityKind) -> &'static str {
+    match kind {
+        ActivityKind::SandboxCreate => "sandbox_create",
+        ActivityKind::SandboxDestroy => "sandbox_destroy",
+        ActivityKind::Exec => "exec",
+        ActivityKind::EgressAllowed => "egress_allowed",
+        ActivityKind::EgressDenied => "egress_denied",
+        ActivityKind::McpToolCall => "mcp_tool_call",
+        ActivityKind::AgentTurn => "agent_turn",
+        ActivityKind::GenAiModelCall => "gen_ai_model_call",
+        ActivityKind::PolicyApplied => "policy_applied",
+        ActivityKind::CredentialInjected => "credential_injected",
+        ActivityKind::CredentialSet => "credential_set",
+        ActivityKind::CredentialReset => "credential_reset",
+        ActivityKind::Auth => "auth",
+        ActivityKind::ApprovalRequested => "approval_requested",
+        ActivityKind::ApprovalDecided => "approval_decided",
+        ActivityKind::SpawnRequested => "spawn_requested",
+        ActivityKind::SpawnQueued => "spawn_queued",
+        ActivityKind::SpawnAdmitted => "spawn_admitted",
+        ActivityKind::SpawnRejected => "spawn_rejected",
+        ActivityKind::SpawnStarted => "spawn_started",
+        ActivityKind::SpawnReady => "spawn_ready",
+        ActivityKind::BuildOneflightHit => "build_oneflight_hit",
+        ActivityKind::BuildOneflightMiss => "build_oneflight_miss",
+        ActivityKind::BuildQueueDepth => "build_queue_depth",
+        ActivityKind::Log => "log",
+    }
+}
+
+fn activity_result_name(result: ActivityResult) -> &'static str {
+    match result {
+        ActivityResult::Ok => "ok",
+        ActivityResult::Error => "error",
+        ActivityResult::Denied => "denied",
+        ActivityResult::PendingApproval => "pending_approval",
+    }
+}
+```
+
+- [ ] **Step 6: Run mapper tests**
+
+Run:
+
+```bash
+cargo test -p agentenv-events genai::
+```
+
+Expected: all GenAI mapper tests PASS.
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add crates/agentenv-events/src/lib.rs crates/agentenv-events/src/genai.rs
+git commit -m "feat: map activity events to otel genai signals"
+```
+
+## Task 3: Add GenAI Prometheus Metrics
+
+**Files:**
+- Modify: `crates/agentenv-events/src/store.rs`
+- Modify: `crates/agentenv-events/src/metrics.rs`
+
+- [ ] **Step 1: Add failing store aggregate tests**
+
+Add this test to `#[cfg(test)] mod tests` in `crates/agentenv-events/src/store.rs`:
+
+```rust
+#[test]
+fn sqlite_store_aggregates_genai_usage_duration_and_tool_calls() {
+    let temp = tempfile::tempdir().unwrap();
+    let store = SqliteEventStore::open(temp.path().join("events.db")).unwrap();
+    store
+        .append_many(&[
+            event(
+                "2026-05-18T12:00:00Z",
+                ActivityKind::GenAiModelCall,
+                "demo",
+                ActivityResult::Ok,
+            )
+            .with_latency_ms(250)
+            .with_extra("gen_ai.provider.name", serde_json::json!("openai"))
+            .with_extra("gen_ai.operation.name", serde_json::json!("chat"))
+            .with_extra("gen_ai.request.model", serde_json::json!("gpt-4.1-mini"))
+            .with_extra("gen_ai.usage.input_tokens", serde_json::json!(12))
+            .with_extra("gen_ai.usage.output_tokens", serde_json::json!(34)),
+            event(
+                "2026-05-18T12:00:01Z",
+                ActivityKind::McpToolCall,
+                "demo",
+                ActivityResult::Error,
+            )
+            .with_subject_value("tool", serde_json::json!("filesystem.read")),
+        ])
+        .unwrap();
+
+    let usage = store.genai_token_usage_rows().unwrap();
+    assert!(usage.iter().any(|row| {
+        row.provider == "openai"
+            && row.operation == "chat"
+            && row.model == "gpt-4.1-mini"
+            && row.token_type == "input"
+            && row.tokens == 12
+    }));
+    assert!(usage.iter().any(|row| row.token_type == "output" && row.tokens == 34));
+
+    let duration = store.genai_operation_duration_rows().unwrap();
+    assert_eq!(duration[0].duration_ms, 250);
+
+    let tools = store.genai_tool_calls_by_tool_env_result().unwrap();
+    assert_eq!(tools[0].tool, "filesystem.read");
+    assert_eq!(tools[0].result, ActivityResult::Error);
+}
+```
+
+- [ ] **Step 2: Run store test to verify failure**
+
+Run:
+
+```bash
+cargo test -p agentenv-events sqlite_store_aggregates_genai_usage_duration_and_tool_calls
+```
+
+Expected: FAIL with missing aggregate row types and methods.
+
+- [ ] **Step 3: Add store row types**
+
+In `crates/agentenv-events/src/store.rs`, add these structs near `McpToolCount`:
+
+```rust
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct GenAiTokenUsageRow {
+    pub provider: String,
+    pub operation: String,
+    pub model: String,
+    pub token_type: String,
+    pub tokens: u64,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct GenAiOperationDurationRow {
+    pub provider: String,
+    pub operation: String,
+    pub model: String,
+    pub duration_ms: u64,
+}
+```
+
+- [ ] **Step 4: Add store aggregate methods**
+
+Add these methods to `impl SqliteEventStore` after `mcp_tool_calls_by_tool_env_result`:
+
+```rust
+pub fn genai_token_usage_rows(&self) -> StoreResult<Vec<GenAiTokenUsageRow>> {
+    let conn = self.connection()?;
+    let model_call = enum_to_db_string(ActivityKind::GenAiModelCall, "kind")?;
+    let mut stmt = conn.prepare(
+        r#"
+        SELECT
+            COALESCE(json_extract(extras_json, '$."gen_ai.provider.name"'), json_extract(extras_json, '$."gen_ai.system"'), 'unknown') AS provider,
+            COALESCE(json_extract(extras_json, '$."gen_ai.operation.name"'), 'chat') AS operation,
+            COALESCE(json_extract(extras_json, '$."gen_ai.request.model"'), 'unknown') AS model,
+            CASE usage.token_type WHEN 'input' THEN 'input' ELSE 'output' END AS token_type,
+            usage.tokens
+        FROM activity_events
+        JOIN (
+            SELECT id, 'input' AS token_type,
+                   CASE WHEN json_type(extras_json, '$."gen_ai.usage.input_tokens"') = 'integer'
+                        THEN json_extract(extras_json, '$."gen_ai.usage.input_tokens"')
+                        ELSE 0 END AS tokens
+            FROM activity_events
+            UNION ALL
+            SELECT id, 'output' AS token_type,
+                   CASE WHEN json_type(extras_json, '$."gen_ai.usage.output_tokens"') = 'integer'
+                        THEN json_extract(extras_json, '$."gen_ai.usage.output_tokens"')
+                        ELSE 0 END AS tokens
+            FROM activity_events
+        ) AS usage ON usage.id = activity_events.id
+        WHERE kind = ?1 AND usage.tokens > 0
+        ORDER BY provider ASC, operation ASC, model ASC, token_type ASC
+        "#,
+    )?;
+    let rows = stmt.query_map(params![model_call], |row| {
+        let tokens = row.get::<_, i64>(4)?;
+        Ok((
+            row.get::<_, String>(0)?,
+            row.get::<_, String>(1)?,
+            row.get::<_, String>(2)?,
+            row.get::<_, String>(3)?,
+            tokens,
+        ))
+    })?;
+
+    let mut out = Vec::new();
+    for row in rows {
+        let (provider, operation, model, token_type, tokens) = row?;
+        out.push(GenAiTokenUsageRow {
+            provider,
+            operation,
+            model,
+            token_type,
+            tokens: count_to_u64(tokens)?,
+        });
+    }
+    Ok(out)
+}
+
+pub fn genai_operation_duration_rows(&self) -> StoreResult<Vec<GenAiOperationDurationRow>> {
+    let conn = self.connection()?;
+    let model_call = enum_to_db_string(ActivityKind::GenAiModelCall, "kind")?;
+    let agent_turn = enum_to_db_string(ActivityKind::AgentTurn, "kind")?;
+    let tool_call = enum_to_db_string(ActivityKind::McpToolCall, "kind")?;
+    let mut stmt = conn.prepare(
+        r#"
+        SELECT
+            COALESCE(json_extract(extras_json, '$."gen_ai.provider.name"'), json_extract(extras_json, '$."gen_ai.system"'), 'agentenv') AS provider,
+            COALESCE(json_extract(extras_json, '$."gen_ai.operation.name"'),
+                CASE kind
+                    WHEN ?2 THEN 'invoke_agent'
+                    WHEN ?3 THEN 'execute_tool'
+                    ELSE 'chat'
+                END
+            ) AS operation,
+            COALESCE(json_extract(extras_json, '$."gen_ai.request.model"'), 'unknown') AS model,
+            latency_ms
+        FROM activity_events
+        WHERE latency_ms IS NOT NULL
+          AND kind IN (?1, ?2, ?3)
+        ORDER BY provider ASC, operation ASC, model ASC, latency_ms ASC
+        "#,
+    )?;
+    let rows = stmt.query_map(params![model_call, agent_turn, tool_call], |row| {
+        Ok((
+            row.get::<_, String>(0)?,
+            row.get::<_, String>(1)?,
+            row.get::<_, String>(2)?,
+            row.get::<_, i64>(3)?,
+        ))
+    })?;
+
+    let mut out = Vec::new();
+    for row in rows {
+        let (provider, operation, model, duration_ms) = row?;
+        if duration_ms < 0 {
+            return Err(StoreError::NegativeLatency(duration_ms));
+        }
+        out.push(GenAiOperationDurationRow {
+            provider,
+            operation,
+            model,
+            duration_ms: u64::try_from(duration_ms).map_err(|_| StoreError::NegativeLatency(duration_ms))?,
+        });
+    }
+    Ok(out)
+}
+
+pub fn genai_tool_calls_by_tool_env_result(&self) -> StoreResult<Vec<McpToolCount>> {
+    self.mcp_tool_calls_by_tool_env_result()
+}
+```
+
+- [ ] **Step 5: Add failing metrics render test**
+
+Add assertions to `prometheus_render_includes_required_series` in `crates/agentenv-events/src/metrics.rs` by inserting the new metric names in the `series` array:
+
+```rust
+            "gen_ai_client_token_usage",
+            "gen_ai_client_operation_duration",
+            "agentenv_gen_ai_tool_calls_total",
+```
+
+Add this test to `crates/agentenv-events/src/metrics.rs`:
+
+```rust
+#[test]
+fn prometheus_render_includes_genai_metrics() {
+    let temp = tempfile::tempdir().unwrap();
+    let store = SqliteEventStore::open(temp.path().join("events.db")).unwrap();
+    store
+        .append_many(&[
+            event(
+                "2026-05-18T12:00:00Z",
+                ActivityKind::GenAiModelCall,
+                ActivityResult::Ok,
+            )
+            .with_env("demo")
+            .with_latency_ms(250)
+            .with_extra("gen_ai.provider.name", serde_json::json!("openai"))
+            .with_extra("gen_ai.operation.name", serde_json::json!("chat"))
+            .with_extra("gen_ai.request.model", serde_json::json!("gpt-4.1-mini"))
+            .with_extra("gen_ai.usage.input_tokens", serde_json::json!(12))
+            .with_extra("gen_ai.usage.output_tokens", serde_json::json!(34)),
+            event(
+                "2026-05-18T12:00:01Z",
+                ActivityKind::McpToolCall,
+                ActivityResult::Error,
+            )
+            .with_env("demo")
+            .with_subject_value("tool", serde_json::json!("filesystem.read")),
+        ])
+        .unwrap();
+
+    let snapshot = MetricsSnapshot::from_store(&store, &[]).unwrap();
+    let rendered = render_prometheus(&snapshot);
+
+    assert!(rendered.contains("gen_ai_client_token_usage_bucket"));
+    assert!(rendered.contains("gen_ai_client_operation_duration_bucket"));
+    assert!(rendered.contains("agentenv_gen_ai_tool_calls_total"));
+    assert!(rendered.contains("gen_ai_provider_name=\"openai\""));
+    assert!(rendered.contains("gen_ai_token_type=\"input\""));
+    assert!(rendered.contains("gen_ai_tool_name=\"filesystem.read\""));
+}
+```
+
+- [ ] **Step 6: Run metrics test to verify failure**
+
+Run:
+
+```bash
+cargo test -p agentenv-events prometheus_render_includes_genai_metrics
+```
+
+Expected: FAIL because `MetricsSnapshot` has no GenAI fields and the renderer lacks GenAI output.
+
+- [ ] **Step 7: Implement metrics snapshot fields and renderers**
+
+In `crates/agentenv-events/src/metrics.rs`, add row structs:
+
+```rust
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct GenAiTokenUsageBucketMetric {
+    pub provider: String,
+    pub operation: String,
+    pub model: String,
+    pub token_type: String,
+    pub le: String,
+    pub count: u64,
+}
+
+#[derive(Debug, Clone, PartialEq)]
+pub struct GenAiTokenUsageSummaryMetric {
+    pub provider: String,
+    pub operation: String,
+    pub model: String,
+    pub token_type: String,
+    pub sum: u64,
+    pub count: u64,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct GenAiOperationDurationBucketMetric {
+    pub provider: String,
+    pub operation: String,
+    pub model: String,
+    pub le: String,
+    pub count: u64,
+}
+
+#[derive(Debug, Clone, PartialEq)]
+pub struct GenAiOperationDurationSummaryMetric {
+    pub provider: String,
+    pub operation: String,
+    pub model: String,
+    pub sum_seconds: f64,
+    pub count: u64,
+}
+```
+
+Add fields to `MetricsSnapshot`:
+
+```rust
+    pub genai_token_usage: Vec<GenAiTokenUsageBucketMetric>,
+    pub genai_token_usage_summary: Vec<GenAiTokenUsageSummaryMetric>,
+    pub genai_operation_duration: Vec<GenAiOperationDurationBucketMetric>,
+    pub genai_operation_duration_summary: Vec<GenAiOperationDurationSummaryMetric>,
+    pub genai_tool_calls_total: Vec<McpToolMetric>,
+```
+
+Add constants:
+
+```rust
+const GENAI_TOKEN_BUCKETS: [u64; 14] = [
+    1, 4, 16, 64, 256, 1_024, 4_096, 16_384, 65_536, 262_144, 1_048_576,
+    4_194_304, 16_777_216, 67_108_864,
+];
+```
+
+In `MetricsSnapshot::from_store`, populate the fields:
+
+```rust
+let (genai_token_usage, genai_token_usage_summary) =
+    genai_token_usage_metrics(store.genai_token_usage_rows()?);
+let (genai_operation_duration, genai_operation_duration_summary) =
+    genai_operation_duration_metrics(store.genai_operation_duration_rows()?);
+let genai_tool_calls_total = store
+    .genai_tool_calls_by_tool_env_result()?
+    .into_iter()
+    .map(|row| McpToolMetric {
+        tool: row.tool,
+        env: row.env,
+        result: activity_result_label(row.result),
+        count: row.count,
+    })
+    .collect();
+```
+
+Add the fields to the `Ok(Self { ... })` initializer.
+
+- [ ] **Step 8: Add metric helper functions**
+
+Add these helpers near `latency_metrics`:
+
+```rust
+fn genai_token_usage_metrics(
+    rows: Vec<crate::store::GenAiTokenUsageRow>,
+) -> (Vec<GenAiTokenUsageBucketMetric>, Vec<GenAiTokenUsageSummaryMetric>) {
+    let mut grouped: BTreeMap<(String, String, String, String), Vec<u64>> = BTreeMap::new();
+    for row in rows {
+        grouped
+            .entry((row.provider, row.operation, row.model, row.token_type))
+            .or_default()
+            .push(row.tokens);
+    }
+
+    let mut buckets = Vec::new();
+    let mut summaries = Vec::new();
+    for ((provider, operation, model, token_type), values) in grouped {
+        let count = values.len() as u64;
+        let sum = values.iter().sum::<u64>();
+        summaries.push(GenAiTokenUsageSummaryMetric {
+            provider: provider.clone(),
+            operation: operation.clone(),
+            model: model.clone(),
+            token_type: token_type.clone(),
+            sum,
+            count,
+        });
+        for boundary in GENAI_TOKEN_BUCKETS {
+            buckets.push(GenAiTokenUsageBucketMetric {
+                provider: provider.clone(),
+                operation: operation.clone(),
+                model: model.clone(),
+                token_type: token_type.clone(),
+                le: boundary.to_string(),
+                count: values.iter().filter(|value| **value <= boundary).count() as u64,
+            });
+        }
+        buckets.push(GenAiTokenUsageBucketMetric {
+            provider,
+            operation,
+            model,
+            token_type,
+            le: "+Inf".to_owned(),
+            count,
+        });
+    }
+    (buckets, summaries)
+}
+
+fn genai_operation_duration_metrics(
+    rows: Vec<crate::store::GenAiOperationDurationRow>,
+) -> (
+    Vec<GenAiOperationDurationBucketMetric>,
+    Vec<GenAiOperationDurationSummaryMetric>,
+) {
+    let mut grouped: BTreeMap<(String, String, String), Vec<u64>> = BTreeMap::new();
+    for row in rows {
+        grouped
+            .entry((row.provider, row.operation, row.model))
+            .or_default()
+            .push(row.duration_ms);
+    }
+
+    let mut buckets = Vec::new();
+    let mut summaries = Vec::new();
+    for ((provider, operation, model), values) in grouped {
+        let count = values.len() as u64;
+        let sum_seconds = values.iter().sum::<u64>() as f64 / 1000.0;
+        summaries.push(GenAiOperationDurationSummaryMetric {
+            provider: provider.clone(),
+            operation: operation.clone(),
+            model: model.clone(),
+            sum_seconds,
+            count,
+        });
+        for (label, limit_ms) in LATENCY_BUCKET_LABELS.iter().zip(LATENCY_BUCKET_MILLIS) {
+            buckets.push(GenAiOperationDurationBucketMetric {
+                provider: provider.clone(),
+                operation: operation.clone(),
+                model: model.clone(),
+                le: (*label).to_owned(),
+                count: values
+                    .iter()
+                    .filter(|duration_ms| match limit_ms {
+                        Some(limit_ms) => **duration_ms <= limit_ms,
+                        None => true,
+                    })
+                    .count() as u64,
+            });
+        }
+    }
+    (buckets, summaries)
+}
+```
+
+- [ ] **Step 9: Render GenAI metrics**
+
+In `render_prometheus`, after `agentenv_mcp_tool_calls_total`, render:
+
+```rust
+render_help_type(
+    &mut output,
+    "gen_ai_client_token_usage",
+    "Token usage from GenAI model calls.",
+    "histogram",
+);
+for row in &snapshot.genai_token_usage {
+    render_sample(
+        &mut output,
+        "gen_ai_client_token_usage_bucket",
+        &[
+            ("gen_ai_provider_name", Some(row.provider.as_str())),
+            ("gen_ai_operation_name", Some(row.operation.as_str())),
+            ("gen_ai_request_model", Some(row.model.as_str())),
+            ("gen_ai_token_type", Some(row.token_type.as_str())),
+            ("le", Some(row.le.as_str())),
+        ],
+        row.count,
+    );
+}
+for row in &snapshot.genai_token_usage_summary {
+    render_sample(
+        &mut output,
+        "gen_ai_client_token_usage_sum",
+        &[
+            ("gen_ai_provider_name", Some(row.provider.as_str())),
+            ("gen_ai_operation_name", Some(row.operation.as_str())),
+            ("gen_ai_request_model", Some(row.model.as_str())),
+            ("gen_ai_token_type", Some(row.token_type.as_str())),
+        ],
+        row.sum,
+    );
+    render_sample(
+        &mut output,
+        "gen_ai_client_token_usage_count",
+        &[
+            ("gen_ai_provider_name", Some(row.provider.as_str())),
+            ("gen_ai_operation_name", Some(row.operation.as_str())),
+            ("gen_ai_request_model", Some(row.model.as_str())),
+            ("gen_ai_token_type", Some(row.token_type.as_str())),
+        ],
+        row.count,
+    );
+}
+
+render_help_type(
+    &mut output,
+    "gen_ai_client_operation_duration",
+    "GenAI operation duration in seconds.",
+    "histogram",
+);
+for row in &snapshot.genai_operation_duration {
+    render_sample(
+        &mut output,
+        "gen_ai_client_operation_duration_bucket",
+        &[
+            ("gen_ai_provider_name", Some(row.provider.as_str())),
+            ("gen_ai_operation_name", Some(row.operation.as_str())),
+            ("gen_ai_request_model", Some(row.model.as_str())),
+            ("le", Some(row.le.as_str())),
+        ],
+        row.count,
+    );
+}
+for row in &snapshot.genai_operation_duration_summary {
+    render_sample_float(
+        &mut output,
+        "gen_ai_client_operation_duration_sum",
+        &[
+            ("gen_ai_provider_name", Some(row.provider.as_str())),
+            ("gen_ai_operation_name", Some(row.operation.as_str())),
+            ("gen_ai_request_model", Some(row.model.as_str())),
+        ],
+        row.sum_seconds,
+    );
+    render_sample(
+        &mut output,
+        "gen_ai_client_operation_duration_count",
+        &[
+            ("gen_ai_provider_name", Some(row.provider.as_str())),
+            ("gen_ai_operation_name", Some(row.operation.as_str())),
+            ("gen_ai_request_model", Some(row.model.as_str())),
+        ],
+        row.count,
+    );
+}
+
+render_help_type(
+    &mut output,
+    "agentenv_gen_ai_tool_calls_total",
+    "Total GenAI tool calls by tool, environment, and result.",
+    "counter",
+);
+for row in &snapshot.genai_tool_calls_total {
+    render_sample(
+        &mut output,
+        "agentenv_gen_ai_tool_calls_total",
+        &[
+            ("gen_ai_tool_name", Some(row.tool.as_str())),
+            ("env", row.env.as_deref()),
+            ("result", Some(row.result.as_str())),
+        ],
+        row.count,
+    );
+}
+```
+
+- [ ] **Step 10: Run metrics tests**
+
+Run:
+
+```bash
+cargo test -p agentenv-events sqlite_store_aggregates_genai_usage_duration_and_tool_calls
+cargo test -p agentenv-events prometheus_render_includes_genai_metrics
+```
+
+Expected: both commands PASS.
+
+- [ ] **Step 11: Commit**
+
+```bash
+git add crates/agentenv-events/src/store.rs crates/agentenv-events/src/metrics.rs
+git commit -m "feat: expose genai prometheus metrics"
+```
+
+## Task 4: Export GenAI Spans Through OTLP
+
+**Files:**
+- Modify: `crates/agentenv-events/Cargo.toml`
+- Modify: `crates/agentenv-events/src/sink.rs`
+- Modify: `crates/agentenv-events/src/otel.rs`
+
+- [ ] **Step 1: Add failing OTEL mapping export tests**
+
+In `crates/agentenv-events/src/otel.rs`, replace `maps_activity_event_to_otel_log_fields` with:
+
+```rust
+#[test]
+fn maps_genai_model_call_to_span_signal_fields() {
+    let event = ActivityEvent::new(
+        "2026-05-18T12:00:00Z",
+        ActivityKind::GenAiModelCall,
+        ActivityResult::Ok,
+        "trace-otel",
+    )
+    .with_env("demo")
+    .with_latency_ms(42)
+    .with_extra("gen_ai.provider.name", serde_json::json!("openai"))
+    .with_extra("gen_ai.request.model", serde_json::json!("gpt-4.1-mini"))
+    .with_extra("gen_ai.usage.input_tokens", serde_json::json!(12));
+
+    let signal = crate::genai::map_event_to_genai_signal(&event).unwrap();
+
+    assert_eq!(signal.kind, crate::genai::OtelGenAiSignalKind::Span);
+    assert_eq!(signal.operation_name.as_deref(), Some("chat"));
+    assert_eq!(
+        signal.attributes["gen_ai.provider.name"],
+        crate::genai::OtelAttributeValue::String("openai".to_owned())
+    );
+    assert_eq!(
+        signal.attributes["gen_ai.usage.input_tokens"],
+        crate::genai::OtelAttributeValue::I64(12)
+    );
+}
+```
+
+Add this sink construction test:
+
+```rust
+#[test]
+fn otel_sink_normalizes_grpc_endpoint_for_trace_and_log_exporters() {
+    assert_eq!(
+        normalize_grpc_endpoint("grpc://collector:4317"),
+        "http://collector:4317"
+    );
+}
+```
+
+- [ ] **Step 2: Run OTEL tests to verify failure**
+
+Run:
+
+```bash
+cargo test -p agentenv-events --features otel maps_genai_model_call_to_span_signal_fields otel_sink_normalizes_grpc_endpoint_for_trace_and_log_exporters
+```
+
+Expected: FAIL because `OtelSink` has no trace exporter/provider fields after dependency features are adjusted.
+
+- [ ] **Step 3: Enable trace features**
+
+In `crates/agentenv-events/Cargo.toml`, change the OTEL feature and OTLP dependency:
+
+```toml
+[features]
+default = []
+otel = ["dep:opentelemetry", "dep:opentelemetry_sdk", "dep:opentelemetry-otlp"]
+
+[dependencies]
+opentelemetry = { workspace = true, optional = true, features = ["logs", "trace"] }
+opentelemetry_sdk = { workspace = true, optional = true, features = ["logs", "trace"] }
+opentelemetry-otlp = { workspace = true, optional = true, features = ["grpc-tonic", "logs", "trace"] }
+```
+
+- [ ] **Step 4: Extend `OtelSink` fields**
+
+Update imports in `crates/agentenv-events/src/otel.rs`:
+
+```rust
+use opentelemetry::{
+    logs::{AnyValue, LogRecord as _, Logger as _, LoggerProvider as _, Severity},
+    trace::{Span, SpanBuilder, SpanKind, Status, Tracer as _, TracerProvider as _},
+    Key, KeyValue,
+};
+use opentelemetry_otlp::{ExportConfig, Protocol, WithExportConfig};
+use opentelemetry_sdk::{
+    logs::{SdkLogger, SdkLoggerProvider, SimpleLogProcessor},
+    trace::{SdkTracer, SdkTracerProvider},
+};
+
+use crate::genai::{
+    map_event_to_genai_signal, OtelAttributeValue, OtelGenAiSignal, OtelGenAiSignalKind,
+    OtelSignalStatus, OtelSpanKindHint,
+};
+```
+
+Change `OtelSink`:
+
+```rust
+pub struct OtelSink {
+    endpoint: String,
+    logger: SdkLogger,
+    log_provider: SdkLoggerProvider,
+    tracer: SdkTracer,
+    trace_provider: SdkTracerProvider,
+}
+```
+
+- [ ] **Step 5: Build trace and log providers**
+
+Replace `OtelSink::new` with:
+
+```rust
+pub fn new(endpoint: impl Into<String>) -> Result<Self, SinkError> {
+    let endpoint = endpoint.into();
+    let normalized_endpoint = normalize_grpc_endpoint(&endpoint);
+    let log_exporter = opentelemetry_otlp::LogExporter::builder()
+        .with_tonic()
+        .with_export_config(ExportConfig {
+            endpoint: Some(normalized_endpoint.clone()),
+            protocol: Protocol::Grpc,
+            timeout: None,
+        })
+        .build()?;
+    let log_provider = SdkLoggerProvider::builder()
+        .with_log_processor(SimpleLogProcessor::new(log_exporter))
+        .build();
+    let logger = log_provider.logger("agentenv-events");
+
+    let span_exporter = opentelemetry_otlp::SpanExporter::builder()
+        .with_tonic()
+        .with_export_config(ExportConfig {
+            endpoint: Some(normalized_endpoint),
+            protocol: Protocol::Grpc,
+            timeout: None,
+        })
+        .build()?;
+    let trace_provider = SdkTracerProvider::builder()
+        .with_simple_exporter(span_exporter)
+        .build();
+    let tracer = trace_provider.tracer("agentenv-events");
+
+    Ok(Self {
+        endpoint,
+        logger,
+        log_provider,
+        tracer,
+        trace_provider,
+    })
+}
+```
+
+- [ ] **Step 6: Export spans and logs**
+
+Replace the body of `write_batch` with:
+
+```rust
+for event in events {
+    if let Some(signal) = map_event_to_genai_signal(&event) {
+        match signal.kind {
+            OtelGenAiSignalKind::Span => self.emit_span(signal),
+            OtelGenAiSignalKind::SpanEvent | OtelGenAiSignalKind::LogRecord => {
+                self.emit_log(signal);
+            }
+        }
+    }
+}
+let _ = (&self.log_provider, &self.trace_provider);
+Ok(())
+```
+
+Add methods:
+
+```rust
+fn emit_span(&self, signal: OtelGenAiSignal) {
+    let mut span = SpanBuilder::from_name(signal.name.clone())
+        .with_kind(span_kind(signal.span_kind))
+        .with_status(span_status(signal.status))
+        .start(&self.tracer);
+    for attribute in signal_attributes(&signal) {
+        span.set_attribute(attribute);
+    }
+    span.end();
+}
+
+fn emit_log(&self, signal: OtelGenAiSignal) {
+    let mut record = self.logger.create_log_record();
+    record.set_event_name(signal.name.clone());
+    record.set_target("agentenv-events");
+    record.set_severity_number(severity_number_for_status(signal.status));
+    record.set_severity_text(severity_text_for_status(signal.status));
+    record.set_body(AnyValue::from(signal.name.clone()));
+    record.add_attributes(
+        signal
+            .attributes
+            .into_iter()
+            .map(|(key, value)| (Key::new(key), any_value(value))),
+    );
+    self.logger.emit(record);
+}
+```
+
+Add helpers:
+
+```rust
+fn signal_attributes(signal: &OtelGenAiSignal) -> Vec<KeyValue> {
+    signal
+        .attributes
+        .iter()
+        .map(|(key, value)| KeyValue::new(key.clone(), attribute_value(value.clone())))
+        .collect()
+}
+
+fn attribute_value(value: OtelAttributeValue) -> opentelemetry::Value {
+    match value {
+        OtelAttributeValue::String(value) => opentelemetry::Value::String(value.into()),
+        OtelAttributeValue::I64(value) => opentelemetry::Value::I64(value),
+        OtelAttributeValue::F64(value) => opentelemetry::Value::F64(value),
+        OtelAttributeValue::Bool(value) => opentelemetry::Value::Bool(value),
+        OtelAttributeValue::StringArray(values) => opentelemetry::Value::Array(
+            opentelemetry::Array::String(values.into_iter().map(Into::into).collect()),
+        ),
+    }
+}
+
+fn any_value(value: OtelAttributeValue) -> AnyValue {
+    match value {
+        OtelAttributeValue::String(value) => AnyValue::from(value),
+        OtelAttributeValue::I64(value) => AnyValue::from(value),
+        OtelAttributeValue::F64(value) => AnyValue::from(value),
+        OtelAttributeValue::Bool(value) => AnyValue::from(value),
+        OtelAttributeValue::StringArray(values) => {
+            AnyValue::ListAny(values.into_iter().map(AnyValue::from).collect())
+        }
+    }
+}
+
+fn span_kind(kind: OtelSpanKindHint) -> SpanKind {
+    match kind {
+        OtelSpanKindHint::Client => SpanKind::Client,
+        OtelSpanKindHint::Internal => SpanKind::Internal,
+    }
+}
+
+fn span_status(status: OtelSignalStatus) -> Status {
+    match status {
+        OtelSignalStatus::Ok => Status::Ok,
+        OtelSignalStatus::Error => Status::error("error"),
+        OtelSignalStatus::Denied => Status::error("denied"),
+        OtelSignalStatus::PendingApproval => Status::Unset,
+    }
+}
+
+fn severity_number_for_status(status: OtelSignalStatus) -> Severity {
+    match status {
+        OtelSignalStatus::Ok => Severity::Info,
+        OtelSignalStatus::PendingApproval => Severity::Warn,
+        OtelSignalStatus::Denied | OtelSignalStatus::Error => Severity::Error,
+    }
+}
+
+fn severity_text_for_status(status: OtelSignalStatus) -> &'static str {
+    match status {
+        OtelSignalStatus::Ok => "INFO",
+        OtelSignalStatus::PendingApproval => "WARN",
+        OtelSignalStatus::Denied | OtelSignalStatus::Error => "ERROR",
+    }
+}
+```
+
+- [ ] **Step 7: Keep compatibility field mapper**
+
+Keep `map_event_to_otel_fields` for existing tests by implementing it through the new signal:
+
+```rust
+pub fn map_event_to_otel_fields(event: &ActivityEvent) -> BTreeMap<String, String> {
+    map_event_to_genai_signal(event)
+        .map(|signal| {
+            signal
+                .attributes
+                .into_iter()
+                .map(|(key, value)| (key, display_attribute_value(value)))
+                .collect()
+        })
+        .unwrap_or_default()
+}
+
+fn display_attribute_value(value: OtelAttributeValue) -> String {
+    match value {
+        OtelAttributeValue::String(value) => value,
+        OtelAttributeValue::I64(value) => value.to_string(),
+        OtelAttributeValue::F64(value) => value.to_string(),
+        OtelAttributeValue::Bool(value) => value.to_string(),
+        OtelAttributeValue::StringArray(values) => values.join(","),
+    }
+}
+```
+
+- [ ] **Step 8: Run OTEL tests**
+
+Run:
+
+```bash
+cargo test -p agentenv-events --features otel otel::
+```
+
+Expected: PASS.
+
+- [ ] **Step 9: Commit**
+
+```bash
+git add crates/agentenv-events/Cargo.toml crates/agentenv-events/src/sink.rs crates/agentenv-events/src/otel.rs
+git commit -m "feat: export genai telemetry to otlp"
+```
+
+## Task 5: Add Blueprint OTEL Configuration
+
+**Files:**
+- Modify: `crates/agentenv-core/src/blueprint.rs`
+- Modify: `crates/agentenv-core/src/lifecycle.rs`
+- Modify: `crates/agentenv-core/tests/roundtrip.rs`
+- Modify: `crates/agentenv/src/main.rs`
+- Modify: `crates/agentenv/tests/cli_behavior.rs`
+
+- [ ] **Step 1: Add failing blueprint parsing test**
+
+Add this test to `crates/agentenv-core/tests/roundtrip.rs`:
+
+```rust
+#[test]
+fn blueprint_parses_observability_otel_endpoint() {
+    let yaml = r#"
+version: "1"
+min_agentenv_version: "0.0.1-alpha0"
+sandbox: { driver: openshell }
+agent: { driver: codex }
+context: { driver: none }
+policy: { tier: balanced, presets: [] }
+observability:
+  otel:
+    endpoint: grpc://collector.example.com:4317
+"#;
+
+    let blueprint = agentenv_core::blueprint::Blueprint::from_yaml(yaml).unwrap();
+    assert_eq!(
+        blueprint
+            .observability
+            .as_ref()
+            .and_then(|section| section.otel.as_ref())
+            .and_then(|otel| otel.endpoint.as_deref()),
+        Some("grpc://collector.example.com:4317")
+    );
+}
+```
+
+- [ ] **Step 2: Run parsing test to verify failure**
+
+Run:
+
+```bash
+cargo test -p agentenv-core blueprint_parses_observability_otel_endpoint
+```
+
+Expected: FAIL because `Blueprint` has no `observability` field.
+
+- [ ] **Step 3: Add blueprint section types**
+
+In `crates/agentenv-core/src/blueprint.rs`, add this field to `Blueprint` after `state`:
+
+```rust
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub observability: Option<ObservabilitySection>,
+```
+
+Add these structs near `StateSection`:
+
+```rust
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, JsonSchema)]
+pub struct ObservabilitySection {
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub otel: Option<OtelObservabilitySection>,
+    #[schemars(with = "BTreeMap<String, serde_json::Value>")]
+    #[serde(flatten, default)]
+    pub extra: BTreeMap<String, Value>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, JsonSchema)]
+#[serde(deny_unknown_fields)]
+pub struct OtelObservabilitySection {
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub endpoint: Option<String>,
+}
+```
+
+- [ ] **Step 4: Update internal blueprint construction**
+
+Search for `Blueprint {` in tests and support code:
+
+```bash
+rg -n "Blueprint \\{" crates/agentenv-core
+```
+
+For every literal construction, add:
+
+```rust
+        observability: None,
+```
+
+Run:
+
+```bash
+cargo test -p agentenv-core blueprint_parses_observability_otel_endpoint
+```
+
+Expected: PASS.
+
+- [ ] **Step 5: Add failing CLI dispatcher test**
+
+Add this test to `#[cfg(test)] mod tests` in `crates/agentenv/src/main.rs`:
+
+```rust
+#[test]
+fn blueprint_otel_endpoint_is_loaded_from_yaml() {
+    let yaml = r#"
+version: "1"
+min_agentenv_version: "0.0.1-alpha0"
+sandbox: { driver: openshell }
+agent: { driver: codex }
+context: { driver: none }
+policy: { tier: balanced, presets: [] }
+observability:
+  otel:
+    endpoint: grpc://collector.example.com:4317
+"#;
+
+    let endpoints = blueprint_otel_sink_args(yaml).unwrap();
+
+    assert_eq!(endpoints, vec!["otel:grpc://collector.example.com:4317"]);
+}
+```
+
+- [ ] **Step 6: Implement blueprint sink extraction**
+
+In `crates/agentenv/src/main.rs`, add:
+
+```rust
+fn blueprint_otel_sink_args(blueprint_yaml: &str) -> Result<Vec<String>> {
+    let blueprint = agentenv_core::blueprint::Blueprint::from_yaml(blueprint_yaml)
+        .context("parse blueprint observability config")?;
+    let Some(endpoint) = blueprint
+        .observability
+        .and_then(|section| section.otel)
+        .and_then(|otel| otel.endpoint)
+    else {
+        return Ok(Vec::new());
+    };
+    Ok(vec![format!("otel:{endpoint}")])
+}
+
+fn combined_create_sink_args(blueprint_yaml: &str, cli_sink_args: &[String]) -> Result<Vec<String>> {
+    let mut sinks = blueprint_otel_sink_args(blueprint_yaml)?;
+    sinks.extend(cli_sink_args.iter().cloned());
+    Ok(sinks)
+}
+```
+
+Update `run_create` so it passes combined sinks into `build_event_dispatcher`:
+
+```rust
+let sink_args = combined_create_sink_args(&blueprint_yaml, event_sink_args)?;
+let dispatcher = build_event_dispatcher(&options, Some(&args.name), &sink_args)?;
+```
+
+Keep the exact local variable names from the current `run_create`; only replace the sink argument passed to dispatcher construction.
+
+- [ ] **Step 7: Validate OTEL endpoint through SSRF guard**
+
+Add this function next to `validate_webhook_sink_url`:
+
+```rust
+fn validate_otel_sink_endpoint(endpoint: &str) -> Result<()> {
+    let authority = endpoint
+        .strip_prefix("grpc://")
+        .context("OTEL endpoint must use grpc://host:port")?;
+    let url = url::Url::parse(&format!("https://{authority}"))
+        .with_context(|| format!("invalid OTEL endpoint `{endpoint}`"))?;
+    agentenv_core::security::ssrf::validate_outbound(
+        &url,
+        agentenv_core::security::ssrf::SsrfOptions::default(),
+    )
+    .with_context(|| format!("OTEL endpoint failed SSRF validation for `{endpoint}`"))?;
+    Ok(())
+}
+```
+
+Update `build_event_dispatcher` arm:
+
+```rust
+            SinkConfig::OtelGrpc { endpoint } => {
+                validate_otel_sink_endpoint(&endpoint)?;
+                sinks.push(agentenv_events::sink::otel_grpc_sink(endpoint)?);
+            }
+```
+
+- [ ] **Step 8: Add unsafe endpoint CLI test**
+
+Add this test to `crates/agentenv/tests/cli_behavior.rs`:
+
+```rust
+#[test]
+fn create_rejects_unsafe_blueprint_otel_endpoint() {
+    let temp_dir = make_temp_dir("unsafe-blueprint-otel");
+    let blueprint = temp_dir.join("agentenv.yaml");
+    std::fs::write(
+        &blueprint,
+        r#"
+version: "1"
+min_agentenv_version: "0.0.1-alpha0"
+sandbox: { driver: openshell }
+agent: { driver: codex }
+context: { driver: none }
+policy: { tier: balanced, presets: [] }
+observability:
+  otel:
+    endpoint: grpc://127.0.0.1:4317
+"#,
+    )
+    .unwrap();
+
+    let output = Command::new(agentenv_bin())
+        .arg("create")
+        .arg("demo")
+        .arg("--file")
+        .arg(&blueprint)
+        .env("HOME", &temp_dir)
+        .current_dir(&temp_dir)
+        .output()
+        .unwrap();
+
+    assert!(!output.status.success());
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    assert!(stderr.contains("OTEL endpoint failed SSRF validation"), "{stderr}");
+}
+```
+
+- [ ] **Step 9: Run blueprint and CLI tests**
+
+Run:
+
+```bash
+cargo test -p agentenv-core blueprint_parses_observability_otel_endpoint
+cargo test -p agentenv blueprint_otel_endpoint_is_loaded_from_yaml
+cargo test -p agentenv --test cli_behavior create_rejects_unsafe_blueprint_otel_endpoint
+```
+
+Expected: all commands PASS.
+
+- [ ] **Step 10: Commit**
+
+```bash
+git add crates/agentenv-core/src/blueprint.rs crates/agentenv-core/src/lifecycle.rs crates/agentenv-core/tests/roundtrip.rs crates/agentenv/src/main.rs crates/agentenv/tests/cli_behavior.rs
+git commit -m "feat: configure otel endpoint from blueprint"
+```
+
+## Task 6: Add Dashboard And Documentation
+
+**Files:**
+- Create: `contrib/grafana/dashboards/agentenv-otel.json`
+- Modify: `docs/ARCHITECTURE.md`
+- Modify: `docs/DRIVER_PROTOCOL.md`
+- Modify: `crates/agentenv-events/README.md`
+- Modify: `crates/agentenv/README.md`
+- Modify: `crates/agentenv/tests/cli_behavior.rs`
+
+- [ ] **Step 1: Add dashboard validity test**
+
+Add this test to `crates/agentenv/tests/cli_behavior.rs`:
+
+```rust
+#[test]
+fn grafana_dashboard_is_valid_json_and_references_emitted_metrics() {
+    let dashboard_path = std::path::Path::new(env!("CARGO_MANIFEST_DIR"))
+        .join("../../contrib/grafana/dashboards/agentenv-otel.json");
+    let content = std::fs::read_to_string(&dashboard_path).unwrap();
+    let dashboard: serde_json::Value = serde_json::from_str(&content).unwrap();
+    let rendered = serde_json::to_string(&dashboard).unwrap();
+
+    for metric in [
+        "agentenv_envs_total",
+        "agentenv_events_total",
+        "gen_ai_client_operation_duration_bucket",
+        "gen_ai_client_token_usage_bucket",
+        "agentenv_gen_ai_tool_calls_total",
+        "agentenv_policy_blocks_total",
+        "agentenv_approvals_pending_total",
+        "agentenv_event_drops_total",
+        "agentenv_event_sink_errors_total",
+    ] {
+        assert!(rendered.contains(metric), "dashboard missing {metric}");
+    }
+}
+```
+
+- [ ] **Step 2: Run dashboard test to verify failure**
+
+Run:
+
+```bash
+cargo test -p agentenv --test cli_behavior grafana_dashboard_is_valid_json_and_references_emitted_metrics
+```
+
+Expected: FAIL because the dashboard file does not exist.
+
+- [ ] **Step 3: Create Grafana dashboard JSON**
+
+Create `contrib/grafana/dashboards/agentenv-otel.json`:
+
+```json
+{
+  "annotations": {
+    "list": []
+  },
+  "editable": true,
+  "fiscalYearStartMonth": 0,
+  "graphTooltip": 0,
+  "links": [],
+  "panels": [
+    {
+      "datasource": "${DS_PROMETHEUS}",
+      "fieldConfig": {"defaults": {"unit": "short"}, "overrides": []},
+      "gridPos": {"h": 4, "w": 6, "x": 0, "y": 0},
+      "id": 1,
+      "targets": [{"expr": "sum by (status) (agentenv_envs_total)", "legendFormat": "{{status}}", "refId": "A"}],
+      "title": "Environments",
+      "type": "stat"
+    },
+    {
+      "datasource": "${DS_PROMETHEUS}",
+      "fieldConfig": {"defaults": {"unit": "ops"}, "overrides": []},
+      "gridPos": {"h": 8, "w": 12, "x": 6, "y": 0},
+      "id": 2,
+      "targets": [{"expr": "sum by (kind, result) (rate(agentenv_events_total[5m]))", "legendFormat": "{{kind}} {{result}}", "refId": "A"}],
+      "title": "Activity Events",
+      "type": "timeseries"
+    },
+    {
+      "datasource": "${DS_PROMETHEUS}",
+      "fieldConfig": {"defaults": {"unit": "s"}, "overrides": []},
+      "gridPos": {"h": 8, "w": 12, "x": 0, "y": 8},
+      "id": 3,
+      "targets": [{"expr": "histogram_quantile(0.95, sum by (le, gen_ai_operation_name) (rate(gen_ai_client_operation_duration_bucket[5m])))", "legendFormat": "p95 {{gen_ai_operation_name}}", "refId": "A"}],
+      "title": "GenAI Operation Duration p95",
+      "type": "timeseries"
+    },
+    {
+      "datasource": "${DS_PROMETHEUS}",
+      "fieldConfig": {"defaults": {"unit": "short"}, "overrides": []},
+      "gridPos": {"h": 8, "w": 12, "x": 12, "y": 8},
+      "id": 4,
+      "targets": [{"expr": "sum by (gen_ai_token_type, gen_ai_request_model) (rate(gen_ai_client_token_usage_sum[5m]))", "legendFormat": "{{gen_ai_request_model}} {{gen_ai_token_type}}", "refId": "A"}],
+      "title": "Token Usage",
+      "type": "timeseries"
+    },
+    {
+      "datasource": "${DS_PROMETHEUS}",
+      "fieldConfig": {"defaults": {"unit": "ops"}, "overrides": []},
+      "gridPos": {"h": 8, "w": 12, "x": 0, "y": 16},
+      "id": 5,
+      "targets": [{"expr": "sum by (gen_ai_tool_name, result) (rate(agentenv_gen_ai_tool_calls_total[5m]))", "legendFormat": "{{gen_ai_tool_name}} {{result}}", "refId": "A"}],
+      "title": "Tool Calls",
+      "type": "timeseries"
+    },
+    {
+      "datasource": "${DS_PROMETHEUS}",
+      "fieldConfig": {"defaults": {"unit": "ops"}, "overrides": []},
+      "gridPos": {"h": 8, "w": 12, "x": 12, "y": 16},
+      "id": 6,
+      "targets": [{"expr": "sum by (driver) (rate(agentenv_policy_blocks_total[5m]))", "legendFormat": "{{driver}}", "refId": "A"}],
+      "title": "Egress Denials",
+      "type": "timeseries"
+    },
+    {
+      "datasource": "${DS_PROMETHEUS}",
+      "fieldConfig": {"defaults": {"unit": "short"}, "overrides": []},
+      "gridPos": {"h": 4, "w": 6, "x": 18, "y": 0},
+      "id": 7,
+      "targets": [{"expr": "agentenv_approvals_pending_total", "legendFormat": "pending", "refId": "A"}],
+      "title": "Pending Approvals",
+      "type": "stat"
+    },
+    {
+      "datasource": "${DS_PROMETHEUS}",
+      "fieldConfig": {"defaults": {"unit": "short"}, "overrides": []},
+      "gridPos": {"h": 8, "w": 24, "x": 0, "y": 24},
+      "id": 8,
+      "targets": [
+        {"expr": "sum by (sink) (rate(agentenv_event_drops_total[5m]))", "legendFormat": "drops {{sink}}", "refId": "A"},
+        {"expr": "sum by (sink) (rate(agentenv_event_sink_errors_total[5m]))", "legendFormat": "errors {{sink}}", "refId": "B"}
+      ],
+      "title": "Event Pipeline Health",
+      "type": "timeseries"
+    }
+  ],
+  "refresh": "30s",
+  "schemaVersion": 39,
+  "style": "dark",
+  "tags": ["agentenv", "otel", "genai"],
+  "templating": {
+    "list": [
+      {
+        "current": {"selected": false, "text": "Prometheus", "value": "Prometheus"},
+        "hide": 0,
+        "includeAll": false,
+        "label": "Prometheus datasource",
+        "multi": false,
+        "name": "DS_PROMETHEUS",
+        "options": [],
+        "query": "prometheus",
+        "refresh": 1,
+        "regex": "",
+        "type": "datasource"
+      }
+    ]
+  },
+  "time": {"from": "now-6h", "to": "now"},
+  "timezone": "browser",
+  "title": "agentenv OTEL GenAI",
+  "uid": "agentenv-otel-genai",
+  "version": 1,
+  "weekStart": ""
+}
+```
+
+- [ ] **Step 4: Update docs**
+
+In `docs/ARCHITECTURE.md`, update the Observability section with:
+
+```markdown
+The activity stream also exports an OTEL GenAI view. Native `ActivityEvent`
+records remain the source of truth; `agentenv-events` maps agent turns to
+`gen_ai.operation.name=invoke_agent`, MCP tool calls to
+`gen_ai.operation.name=execute_tool`, and model calls to current GenAI
+attributes such as `gen_ai.provider.name`, `gen_ai.request.model`, and
+`gen_ai.usage.*`. The old `gen_ai.system` name is accepted as an input alias
+and normalized to `gen_ai.provider.name` on export.
+```
+
+In `docs/DRIVER_PROTOCOL.md`, add under rich `DriverActivityEventParams`:
+
+```markdown
+Schema `1.2` rich activity kind values also include `agent_turn` and
+`gen_ai_model_call`. Drivers can attach GenAI metadata through `extras` using
+current OpenTelemetry names such as `gen_ai.provider.name`,
+`gen_ai.request.model`, `gen_ai.usage.input_tokens`,
+`gen_ai.usage.output_tokens`, `gen_ai.response.finish_reasons`,
+`gen_ai.tool.name`, and `gen_ai.tool.call.id`. The legacy
+`gen_ai.system` key is accepted as an input alias for `gen_ai.provider.name`.
+Drivers must not include prompt text, completion text, credentials, or tool
+argument payloads in activity metadata.
+```
+
+In `crates/agentenv-events/README.md`, add:
+
+```markdown
+## OTEL GenAI Mapping
+
+When built with `agentenv-events/otel`, `otel:grpc://host:4317` exports GenAI
+operation spans for `agent_turn`, `gen_ai_model_call`, and `mcp_tool_call`
+events. The mapper emits current OpenTelemetry GenAI attributes including
+`gen_ai.provider.name`, `gen_ai.operation.name`, `gen_ai.request.model`,
+`gen_ai.usage.input_tokens`, `gen_ai.usage.output_tokens`,
+`gen_ai.tool.name`, and `gen_ai.tool.call.id`. `gen_ai.system` is accepted only
+as an input alias and is normalized to `gen_ai.provider.name`.
+
+Prometheus output uses underscore-safe names:
+`gen_ai_client_token_usage_*`, `gen_ai_client_operation_duration_*`, and
+`agentenv_gen_ai_tool_calls_total`.
+```
+
+In `crates/agentenv/README.md`, add:
+
+````markdown
+Blueprints can add an OTLP collector endpoint:
+
+```yaml
+observability:
+  otel:
+    endpoint: grpc://collector.example.com:4317
+```
+
+The endpoint is validated through the same outbound URL safety checks as
+webhook sinks. CLI sink flags remain available:
+
+```bash
+agentenv --events-sink otel:grpc://collector.example.com:4317 create demo
+```
+````
+
+- [ ] **Step 5: Run docs and dashboard tests**
+
+Run:
+
+```bash
+cargo test -p agentenv --test cli_behavior grafana_dashboard_is_valid_json_and_references_emitted_metrics
+```
+
+Expected: PASS.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add contrib/grafana/dashboards/agentenv-otel.json docs/ARCHITECTURE.md docs/DRIVER_PROTOCOL.md crates/agentenv-events/README.md crates/agentenv/README.md crates/agentenv/tests/cli_behavior.rs
+git commit -m "docs: add otel genai dashboard"
+```
+
+## Task 7: Final Verification
+
+**Files:**
+- Verify all modified files.
+
+- [ ] **Step 1: Format**
+
+Run:
+
+```bash
+cargo fmt
+```
+
+Expected: exits 0 with no stdout.
+
+- [ ] **Step 2: Run focused package tests**
+
+Run:
+
+```bash
+cargo test -p agentenv-events
+cargo test -p agentenv-events --features otel
+cargo test -p agentenv-proto
+cargo test -p agentenv-plugin
+cargo test -p agentenv-core blueprint observability
+cargo test -p agentenv --test cli_behavior metrics
+```
+
+Expected: all commands PASS.
+
+- [ ] **Step 3: Run full workspace tests**
+
+Run:
+
+```bash
+cargo test --workspace
+```
+
+Expected: PASS.
+
+- [ ] **Step 4: Run clippy**
+
+Run:
+
+```bash
+cargo clippy --workspace -- -D warnings
+```
+
+Expected: PASS with no warnings.
+
+- [ ] **Step 5: Inspect git status**
+
+Run:
+
+```bash
+git status --short
+```
+
+Expected: only intentional files are modified, or the worktree is clean after the final commit.
+
+- [ ] **Step 6: Commit verification fixes**
+
+If formatting or clippy changed files, commit them:
+
+```bash
+git add .
+git commit -m "chore: verify otel genai integration"
+```
+
+Expected: either a new commit is created for verification-only changes or Git reports that there is nothing to commit.

--- a/docs/superpowers/specs/2026-05-18-otel-genai-semconv-design.md
+++ b/docs/superpowers/specs/2026-05-18-otel-genai-semconv-design.md
@@ -1,0 +1,367 @@
+# H-8 Design: OTEL GenAI Semantic Conventions For Activity Events
+
+- Date: 2026-05-18
+- Issue: https://github.com/windoliver/agentenv/issues/44
+- Milestone: M6 Day-2 operations hardening
+- Depends on: https://github.com/windoliver/agentenv/issues/23
+- Affected crates: `agentenv-events`, `agentenv-core`, `agentenv`, `agentenv-proto`, `agentenv-plugin`
+
+## 1. Context And Goals
+
+Issue #44 aligns the M6-1 activity event stream with OpenTelemetry GenAI
+semantic conventions so agentenv telemetry can plug into common observability
+stacks without custom adapters.
+
+M6-1 is already present locally:
+
+1. `agentenv-events` owns `ActivityEvent`, async dispatch, SQLite storage,
+   audit hash chains, webhook and OTEL sinks, and Prometheus rendering.
+2. `agentenv-core` emits lifecycle events through `EventEmitter`.
+3. `agentenv-plugin` converts driver notifications into `ActivityEvent`.
+4. `agentenv metrics serve` renders existing `agentenv_*` Prometheus series.
+
+This design keeps that architecture. `ActivityEvent` remains the durable native
+event format and the OTEL GenAI mapper becomes an export and metrics view over
+that model.
+
+The current OpenTelemetry GenAI semantic convention pages are version 1.41.0
+and mark these conventions as development. The current attribute names use
+`gen_ai.provider.name` and `gen_ai.operation.name`; the older `gen_ai.system`
+name in the issue body is treated as an accepted input alias, not the canonical
+output name.
+
+## 2. Scope And Non-Goals
+
+### In scope
+
+1. Map agentenv activity events to OTEL GenAI-compatible spans, span events,
+   log records, and attributes.
+2. Emit OTLP telemetry to `observability.otel.endpoint` from blueprint config.
+3. Keep `--events-sink otel:grpc://collector:4317` supported for CLI use.
+4. Add GenAI-derived Prometheus metrics alongside existing `agentenv_*` series.
+5. Add a default Grafana dashboard at
+   `contrib/grafana/dashboards/agentenv-otel.json`.
+6. Document supported GenAI attributes, aliases, redaction rules, and limits.
+7. Add tests for mapping, configuration, metrics, dashboard validity, and
+   backwards compatibility.
+
+### Out of scope
+
+1. Exporting prompt bodies, completion bodies, system instructions, or MCP
+   payload contents by default.
+2. Replacing the native activity/audit store with OTEL as the source of truth.
+3. Adding a second agent-to-context protocol.
+4. Requiring every driver to emit OTEL directly.
+5. Adding high-cardinality labels such as arbitrary tool arguments, URLs with
+   query strings, prompt hashes, or blueprint digests to Prometheus metrics.
+
+## 3. Design Direction
+
+Use the existing `agentenv-events` crate as the central observability boundary.
+The full implementation should add a GenAI semantic mapping layer rather than a
+parallel telemetry model.
+
+`ActivityEvent` stays the format persisted to SQLite, audit logs, JSONL, and
+webhooks. The OTEL layer reads an `ActivityEvent` and produces an
+`OtelGenAiSignal` value that contains:
+
+1. a signal kind: span, span event, or log record
+2. a span/log name
+3. a span kind hint
+4. a stable operation name
+5. semantic attributes
+6. agentenv extension attributes
+7. a status derived from `ActivityResult`
+
+This gives tests a stable, SDK-independent target and keeps callers independent
+from the exact OpenTelemetry Rust SDK export APIs.
+
+## 4. Event Mapping
+
+### Canonical attributes
+
+The mapper emits current GenAI semantic convention names where available:
+
+| Attribute | Source |
+|---|---|
+| `gen_ai.operation.name` | derived from activity kind or `extras` |
+| `gen_ai.provider.name` | `extras["gen_ai.provider.name"]`, `extras["gen_ai.system"]`, inference driver name, or configured default |
+| `gen_ai.request.model` | `extras["gen_ai.request.model"]` or model aliases |
+| `gen_ai.response.model` | `extras["gen_ai.response.model"]` |
+| `gen_ai.usage.input_tokens` | numeric `extras["gen_ai.usage.input_tokens"]` |
+| `gen_ai.usage.output_tokens` | numeric `extras["gen_ai.usage.output_tokens"]` |
+| `gen_ai.response.finish_reasons` | string array from `extras` |
+| `gen_ai.tool.name` | tool name in subject or extras |
+| `gen_ai.tool.call.id` | tool call id in subject or extras |
+| `gen_ai.agent.name` | env name or explicit agent name |
+| `gen_ai.agent.version` | explicit agent version when present |
+| `server.address` / `server.port` | validated endpoint host/port when available |
+
+The mapper also preserves low-cardinality agentenv fields:
+
+| Attribute | Source |
+|---|---|
+| `agentenv.event.kind` | activity kind |
+| `agentenv.event.result` | activity result |
+| `agentenv.env` | event env |
+| `agentenv.trace_id` | activity trace id |
+| `agentenv.reason_code` | reason code |
+| `agentenv.egress.denied` | `true` for denied egress |
+| `agentenv.approval.kind` | approval kind |
+| `agentenv.approval.request_id` | approval request id |
+| `agentenv.policy.reload` | `true` for policy reload events |
+
+### Activity kind mapping
+
+| Activity kind | OTEL representation |
+|---|---|
+| `mcp_tool_call` | span with `gen_ai.operation.name=execute_tool` |
+| `agent_turn` | span with `gen_ai.operation.name=invoke_agent` |
+| `gen_ai_model_call` | span with request/response model and token attributes |
+| `approval_requested` | event/log with `agentenv.approval.*`, result `pending_approval` |
+| `approval_decided` | event/log with `agentenv.approval.*` |
+| `egress_denied` | event/log with `agentenv.egress.denied=true` |
+| `policy_applied` | event/log with `agentenv.policy.reload=true` when hot reloaded |
+| other lifecycle events | event/log with `agentenv.*` attributes |
+
+`ActivityKind` does not currently have an explicit `AgentTurn` or `ModelCall`
+variant. The PR should add the smallest compatible representation:
+
+1. Add `AgentTurn` and `GenAiModelCall` to `agentenv-events::ActivityKind`.
+2. Add matching `RichActivityKind` variants to `agentenv-proto`.
+3. Keep legacy driver activity parameters accepted.
+4. Allow existing `McpToolCall` events to represent `execute_tool` without
+   driver changes.
+
+This is an additive schema change. It does not alter existing method names or
+core-to-driver requests.
+
+### Alias handling
+
+The mapper accepts these input aliases in `extras` and normalizes output:
+
+| Input alias | Canonical output |
+|---|---|
+| `gen_ai.system` | `gen_ai.provider.name` |
+| `gen_ai.request.max_tokens` | `gen_ai.request.max_tokens` |
+| `gen_ai.usage.input_tokens` | `gen_ai.usage.input_tokens` |
+| `gen_ai.usage.output_tokens` | `gen_ai.usage.output_tokens` |
+| `gen_ai.tool.call.id` | `gen_ai.tool.call.id` |
+
+Aliases exist for compatibility with older issue text and external emitters.
+New agentenv code should use canonical names.
+
+## 5. OTLP Export
+
+The existing `OtelSink` currently exports log records with `agentenv.*`
+attributes. The full PR extends this in two layers:
+
+1. `otel::map_event_to_genai_signal(event) -> OtelGenAiSignal`
+2. `OtelSink` export of `OtelGenAiSignal` through the OpenTelemetry SDK
+
+The mapper is the stable contract. Tests must assert the span/log names,
+operation names, semantic attributes, status, and redaction behavior without a
+live collector.
+
+The sink must export true OTLP trace spans for `agent_turn`,
+`gen_ai_model_call`, and `mcp_tool_call`. Approval, egress, policy, and other
+agentenv security/lifecycle events can be exported as OTLP log records and as
+span events when a parent trace context is available. Span export requires
+adding the OpenTelemetry trace SDK/exporter features already compatible with the
+workspace's pinned OpenTelemetry version.
+
+Exported spans and logs must carry `gen_ai.operation.name`, all available
+`gen_ai.*` attributes, status and error fields derived from `ActivityResult`,
+and trace correlation through `agentenv.trace_id`.
+
+## 6. Blueprint And CLI Configuration
+
+Add an optional blueprint section:
+
+```yaml
+observability:
+  otel:
+    endpoint: grpc://collector:4317
+```
+
+Model changes:
+
+1. Add `ObservabilitySection` to `agentenv-core::blueprint::Blueprint`.
+2. Add `OtelObservabilitySection { endpoint: Option<String> }`.
+3. Validate OTEL endpoints through the same URL safety path used for webhook
+   sinks before network export.
+4. Treat blueprint OTEL config as additive to default SQLite storage.
+5. Keep `--events-sink otel:grpc://collector:4317` as an explicit CLI sink.
+
+Precedence:
+
+1. CLI `--events-sink` always applies to the current command.
+2. Blueprint `observability.otel.endpoint` applies to lifecycle commands that
+   load a blueprint, such as `create`.
+3. Reader commands such as `logs`, `audit`, `stats`, and `metrics serve` read
+   stores and do not export events.
+
+The implementation must not write an env store or emit create-time events until
+runtime commit points already used by M6-1 are respected.
+
+## 7. Prometheus Metrics
+
+Keep all existing `agentenv_*` series. Add bounded-cardinality GenAI metrics
+derived from persisted events:
+
+1. `gen_ai_client_token_usage_bucket`
+2. `gen_ai_client_token_usage_sum`
+3. `gen_ai_client_token_usage_count`
+4. `gen_ai_client_operation_duration_bucket`
+5. `gen_ai_client_operation_duration_sum`
+6. `gen_ai_client_operation_duration_count`
+7. `agentenv_gen_ai_tool_calls_total`
+
+Prometheus metric and label names use safe underscores while preserving
+semantic meaning:
+
+| Prometheus label | Semantic meaning |
+|---|---|
+| `gen_ai_provider_name` | `gen_ai.provider.name` |
+| `gen_ai_operation_name` | `gen_ai.operation.name` |
+| `gen_ai_token_type` | `gen_ai.token.type` |
+| `gen_ai_request_model` | `gen_ai.request.model` |
+| `gen_ai_tool_name` | `gen_ai.tool.name` |
+| `env` | agentenv environment |
+| `result` | activity result |
+
+Token histograms use the OTEL-recommended token-oriented bucket boundaries:
+`1`, `4`, `16`, `64`, `256`, `1024`, `4096`, `16384`, `65536`, `262144`,
+`1048576`, `4194304`, `16777216`, and `67108864`. Operation duration uses the
+existing duration bucket style so it stays consistent with current
+`agentenv_sandbox_latency_seconds` output.
+
+Do not include raw endpoint URLs, request ids, trace ids, prompt hashes, or tool
+arguments as Prometheus labels.
+
+## 8. Grafana Dashboard
+
+Add `contrib/grafana/dashboards/agentenv-otel.json` with a Prometheus data
+source variable and panels for:
+
+1. known envs by status
+2. activity event volume by kind/result
+3. GenAI operation duration p95
+4. input/output token usage
+5. tool call rate and failures
+6. egress denials
+7. pending approvals and approval decisions
+8. event drops and sink errors
+
+The dashboard should use only metrics emitted by `agentenv metrics serve` and
+avoid assumptions about a specific backend beyond Prometheus-compatible query
+support.
+
+## 9. Redaction And Cardinality
+
+All GenAI mapping happens after `ActivityEvent::redacted()` or applies the same
+redaction helpers before export. Credential-looking keys and values must not
+appear in:
+
+1. SQLite
+2. JSONL
+3. audit export
+4. OTLP attributes
+5. Prometheus metrics
+6. CLI output
+
+Prompt and completion content are opt-in only and not part of this issue. The
+default implementation exports metadata, counts, status, and timings.
+
+Metric labels must stay low-cardinality. The mapper should include values only
+from allowlisted semantic fields.
+
+## 10. Tests
+
+Add focused tests for:
+
+1. `ActivityKind::AgentTurn` and `ActivityKind::GenAiModelCall` serialization.
+2. Rich driver activity conversion for new kinds.
+3. `gen_ai.system` alias normalization to `gen_ai.provider.name`.
+4. `mcp_tool_call` mapping to `execute_tool` with `gen_ai.tool.name`.
+5. agent turn mapping to `invoke_agent` with `gen_ai.agent.name`.
+6. token usage and duration metric aggregation.
+7. OTEL sink URI plus blueprint endpoint configuration.
+8. SSRF rejection for unsafe OTEL endpoints.
+9. Prometheus render output for the new GenAI series.
+10. dashboard JSON parsing and expected metric references.
+11. docs examples that avoid old canonical names.
+
+Run at least:
+
+```bash
+cargo fmt
+cargo test -p agentenv-events
+cargo test -p agentenv-proto
+cargo test -p agentenv-plugin
+cargo test -p agentenv-core blueprint observability
+cargo test -p agentenv cli_behavior metrics
+cargo clippy --workspace -- -D warnings
+```
+
+Before PR handoff, run:
+
+```bash
+cargo test --workspace
+```
+
+## 11. Documentation
+
+Update:
+
+1. `docs/ARCHITECTURE.md` observability section with OTEL GenAI mapping.
+2. `docs/DRIVER_PROTOCOL.md` with additive rich activity kinds and accepted
+   GenAI metadata fields.
+3. `crates/agentenv-events/README.md` with supported OTEL attributes.
+4. `crates/agentenv/README.md` with blueprint and CLI configuration examples.
+
+Docs should explicitly say that agentenv follows the current
+`gen_ai.provider.name` convention and accepts `gen_ai.system` only as an input
+compatibility alias.
+
+## 12. Trade-Offs
+
+1. Keeping `ActivityEvent` as source of truth avoids duplicate observability
+   pipelines, but the mapper must be careful about incomplete metadata.
+2. Additive `ActivityKind` and proto variants are low risk, but still require
+   schema regeneration and plugin tests.
+3. Prometheus cannot represent dotted OTEL attribute names as label keys
+   directly, so label names use underscores while documentation maps them back
+   to semantic attributes.
+4. Adding true OTLP trace export increases dependency surface, but it directly
+   satisfies #44 and keeps agent/tool operations usable in trace-first
+   backends.
+
+## 13. Acceptance Criteria
+
+1. `agentenv-events` maps native events to current OTEL GenAI semantic spans,
+   span events, log records, and attributes.
+2. Agent turns produce `gen_ai.operation.name=invoke_agent`.
+3. Tool calls produce `gen_ai.operation.name=execute_tool`.
+4. Model calls include provider, model, token usage, finish reasons, and status
+   when present.
+5. Approval, egress, and policy events include `agentenv.*` extension
+   attributes.
+6. `observability.otel.endpoint` configures OTLP export.
+7. `/metrics` exposes existing `agentenv_*` series plus GenAI-derived metrics.
+8. `contrib/grafana/dashboards/agentenv-otel.json` is valid JSON and uses
+   emitted metrics.
+9. Secrets and prompt bodies are not exported by default.
+10. `cargo fmt`, `cargo clippy --workspace -- -D warnings`, and
+    `cargo test --workspace` pass.
+
+## 14. References
+
+- OpenTelemetry GenAI client spans:
+  https://opentelemetry.io/docs/specs/semconv/gen-ai/gen-ai-spans/
+- OpenTelemetry GenAI agent and framework spans:
+  https://opentelemetry.io/docs/specs/semconv/gen-ai/gen-ai-agent-spans/
+- OpenTelemetry GenAI metrics:
+  https://opentelemetry.io/docs/specs/semconv/gen-ai/gen-ai-metrics/
+- OpenTelemetry GenAI attribute registry:
+  https://opentelemetry.io/docs/specs/semconv/registry/attributes/gen-ai/


### PR DESCRIPTION
Closes #44.

## Summary
- add rich activity kinds for agent turns and GenAI model calls across events, protocol schema, and plugin JSON-RPC conversion
- map activity events to OpenTelemetry GenAI semantic convention attributes and export GenAI spans through OTLP while keeping existing activity logs
- add Prometheus GenAI metrics, default sink health samples, and a Grafana dashboard for activity/GenAI/approval/security signals
- preserve `observability.otel.endpoint` through blueprint parsing, create sink wiring, freeze/reproduce portable lockfiles, and SSRF validation

## Affected crates
- `agentenv`
- `agentenv-core`
- `agentenv-events`
- `agentenv-plugin`
- `agentenv-proto`

## Notes
- canonical GenAI provider attribution uses `gen_ai.provider.name`; `gen_ai.system` is accepted only as an input alias and is not emitted
- GenAI metric rows skip malformed persisted events without dropping valid rows
- OTEL endpoint configuration is rejected through the existing SSRF guard and credential-bearing endpoint diagnostics are sanitized

## Verification
- `cargo fmt --check`
- `cargo test --workspace`
- `cargo clippy --workspace -- -D warnings`
- `cargo clippy -p agentenv-events --features otel -- -D warnings`
- `cargo test -p agentenv-events --features otel`
