### PR TITLE
[codex] Bound OpenShell CLI commands

### DIFF
--- a/crates/drivers/sandbox-openshell/README.md
+++ b/crates/drivers/sandbox-openshell/README.md
@@ -55,3 +55,8 @@ Integration test command:
 ```bash
 AGENTENV_RUN_OPENSHELL_INTEGRATION=1 cargo test -p sandbox-openshell --features integration -- --ignored
 ```
+
+Long-running non-interactive OpenShell subprocesses are bounded by
+`AGENTENV_OPENSHELL_COMMAND_TIMEOUT_MS`, defaulting to 15 minutes. Lower this
+value when diagnosing a stuck local gateway so integration tests fail quickly
+instead of waiting indefinitely.

--- a/crates/drivers/sandbox-openshell/src/lib.rs
+++ b/crates/drivers/sandbox-openshell/src/lib.rs
@@ -4,14 +4,16 @@ use std::{
     collections::BTreeMap,
     fs::{self, OpenOptions},
     io,
+    io::Read,
     io::Write,
     net::{IpAddr, SocketAddr},
+    os::unix::process::CommandExt,
     path::Component,
     path::{Path, PathBuf},
-    process::{Child, Command},
-    sync::{Arc, Mutex},
+    process::{Child, Command, Stdio},
+    sync::{mpsc, Arc, Mutex},
     thread,
-    time::Duration,
+    time::{Duration, Instant},
 };
 
 #[cfg(test)]
@@ -85,6 +87,9 @@ const DNS_GUARD_FALLBACK_NAMESERVERS: [&str; 2] = ["1.1.1.1", "8.8.8.8"];
 const DNS_GUARD_PIDFILE: &str = "/etc/agentenv/dns-guard.pid";
 const DNS_GUARD_LOG_PATH: &str = "/var/log/agentenv-openshell-dns-guard.log";
 const DNS_GUARD_RESOLV_BACKUP_PATH: &str = "/etc/agentenv/resolv.conf.pre-agentenv-dns-guard";
+const OPEN_SHELL_COMMAND_TIMEOUT_ENV: &str = "AGENTENV_OPENSHELL_COMMAND_TIMEOUT_MS";
+const DEFAULT_OPEN_SHELL_COMMAND_TIMEOUT: Duration = Duration::from_secs(900);
+const PROCESS_COMMAND_POLL_INTERVAL: Duration = Duration::from_millis(25);
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum UpdateDisposition {
@@ -131,11 +136,25 @@ trait SpawnedCommand: Send {
     fn terminate(&mut self) -> io::Result<()>;
 }
 
-#[derive(Debug, Default)]
-struct ProcessCommandRunner;
+#[derive(Debug, Clone)]
+struct ProcessCommandRunner {
+    timeout: Duration,
+}
+
+impl Default for ProcessCommandRunner {
+    fn default() -> Self {
+        Self {
+            timeout: configured_openshell_command_timeout(),
+        }
+    }
+}
 
 struct ProcessSpawnedCommand {
     child: Child,
+}
+
+struct ProcessOutputReader {
+    receiver: mpsc::Receiver<io::Result<Vec<u8>>>,
 }
 
 impl CommandRunner for ProcessCommandRunner {
@@ -144,15 +163,59 @@ impl CommandRunner for ProcessCommandRunner {
     }
 
     fn run(&self, program: &str, request: &CommandRequest) -> io::Result<CommandOutput> {
-        let output = Command::new(program)
+        let command = command_string(program, &request.args);
+        let mut child_command = Command::new(program);
+        child_command
             .args(&request.args)
             .envs(&request.env)
-            .output()?;
+            .stdout(Stdio::piped())
+            .stderr(Stdio::piped())
+            .process_group(0);
+        let mut child = child_command.spawn()?;
+
+        let stdout = child
+            .stdout
+            .take()
+            .ok_or_else(|| io::Error::other(format!("failed to capture stdout for `{command}`")))?;
+        let stderr = child
+            .stderr
+            .take()
+            .ok_or_else(|| io::Error::other(format!("failed to capture stderr for `{command}`")))?;
+        let stdout_reader = read_process_output(stdout);
+        let stderr_reader = read_process_output(stderr);
+        let started = Instant::now();
+
+        let status = loop {
+            if let Some(status) = child.try_wait()? {
+                break status;
+            }
+
+            if started.elapsed() >= self.timeout {
+                terminate_timed_out_process(&mut child);
+                return Err(command_timeout_error(&command, self.timeout));
+            }
+
+            let remaining = self.timeout.saturating_sub(started.elapsed());
+            thread::sleep(PROCESS_COMMAND_POLL_INTERVAL.min(remaining));
+        };
+
+        let Some(stdout) =
+            collect_process_output_before_timeout(stdout_reader, started, self.timeout)?
+        else {
+            terminate_timed_out_process(&mut child);
+            return Err(command_timeout_error(&command, self.timeout));
+        };
+        let Some(stderr) =
+            collect_process_output_before_timeout(stderr_reader, started, self.timeout)?
+        else {
+            terminate_timed_out_process(&mut child);
+            return Err(command_timeout_error(&command, self.timeout));
+        };
 
         Ok(CommandOutput {
-            status: output.status.code(),
-            stdout: String::from_utf8_lossy(&output.stdout).into_owned(),
-            stderr: String::from_utf8_lossy(&output.stderr).into_owned(),
+            status: status.code(),
+            stdout: String::from_utf8_lossy(&stdout).into_owned(),
+            stderr: String::from_utf8_lossy(&stderr).into_owned(),
         })
     }
 
@@ -192,6 +255,69 @@ impl SpawnedCommand for ProcessSpawnedCommand {
         let _ = self.child.wait();
         Ok(())
     }
+}
+
+fn read_process_output<R>(mut reader: R) -> ProcessOutputReader
+where
+    R: Read + Send + 'static,
+{
+    let (sender, receiver) = mpsc::channel();
+    thread::spawn(move || {
+        let mut output = Vec::new();
+        let result = reader.read_to_end(&mut output).map(|_| output);
+        let _ = sender.send(result);
+    });
+    ProcessOutputReader { receiver }
+}
+
+fn collect_process_output_before_timeout(
+    reader: ProcessOutputReader,
+    started: Instant,
+    timeout: Duration,
+) -> io::Result<Option<Vec<u8>>> {
+    let Some(remaining) = timeout.checked_sub(started.elapsed()) else {
+        return Ok(None);
+    };
+    if remaining.is_zero() {
+        return Ok(None);
+    }
+
+    match reader.receiver.recv_timeout(remaining) {
+        Ok(result) => result.map(Some),
+        Err(mpsc::RecvTimeoutError::Timeout) => Ok(None),
+        Err(mpsc::RecvTimeoutError::Disconnected) => Err(io::Error::other(
+            "command output reader thread stopped early",
+        )),
+    }
+}
+
+fn terminate_timed_out_process(child: &mut Child) {
+    let process_group_id = child.id() as i32;
+    let _ = Command::new("kill")
+        .arg("-KILL")
+        .arg("--")
+        .arg(format!("-{process_group_id}"))
+        .stdout(Stdio::null())
+        .stderr(Stdio::null())
+        .status();
+    let _ = child.kill();
+    let _ = child.wait();
+}
+
+fn command_timeout_error(command: &str, timeout: Duration) -> io::Error {
+    io::Error::new(
+        io::ErrorKind::TimedOut,
+        format!("command `{command}` timed out after {timeout:?}"),
+    )
+}
+
+fn configured_openshell_command_timeout() -> Duration {
+    std::env::var(OPEN_SHELL_COMMAND_TIMEOUT_ENV)
+        .ok()
+        .and_then(|raw| raw.parse::<u64>().ok())
+        .filter(|millis| *millis > 0)
+        .map(Duration::from_millis)
+        .unwrap_or(DEFAULT_OPEN_SHELL_COMMAND_TIMEOUT)
 }
 
 #[cfg(test)]
@@ -432,7 +558,7 @@ impl Default for OpenShellDriver {
     fn default() -> Self {
         Self {
             binary: OPEN_SHELL_BINARY.to_owned(),
-            runner: Arc::new(ProcessCommandRunner),
+            runner: Arc::new(ProcessCommandRunner::default()),
             host_bootstrap: true,
             runtime_app_override: None,
             workdir: Mutex::new(default_agentenv_workdir()),
@@ -1704,6 +1830,10 @@ impl OpenShellDriver {
     }
 
     fn create_command_failure_may_have_created_sandbox(err: &DriverError) -> bool {
+        if let DriverError::CommandSpawn { source, .. } = err {
+            return source.kind() == io::ErrorKind::TimedOut;
+        }
+
         let DriverError::CommandFailed { stdout, stderr, .. } = err else {
             return false;
         };
@@ -3599,7 +3729,7 @@ mod driver_tests {
             atomic::{AtomicUsize, Ordering},
             mpsc, Arc, Mutex,
         },
-        time::Duration,
+        time::{Duration, Instant},
     };
 
     use agentenv_core::{driver::SandboxDriver, security::ssrf::StaticDnsResolver};
@@ -3618,8 +3748,8 @@ mod driver_tests {
     use super::{
         command_request, command_request_with_env, command_string, extract_semver_token,
         shell_quote, CommandCall, CommandOutput, CommandRunner, CommandScript, CommandScriptResult,
-        OpenShellDriver, RecordingCommandRunner, OPEN_SHELL_INSTALL_URL, SANDBOX_WORKING_DIR,
-        TMUX_AGENTENV_COMMAND_OPTION, TMUX_AGENTENV_HANDLE_OPTION,
+        OpenShellDriver, ProcessCommandRunner, RecordingCommandRunner, OPEN_SHELL_INSTALL_URL,
+        SANDBOX_WORKING_DIR, TMUX_AGENTENV_COMMAND_OPTION, TMUX_AGENTENV_HANDLE_OPTION,
         TMUX_AGENTENV_SESSION_NAME_OPTION, TMUX_SESSION_FORMAT,
     };
 
@@ -3630,6 +3760,7 @@ mod driver_tests {
     }
 
     static PATH_LOCK: Mutex<()> = Mutex::new(());
+    static COMMAND_TIMEOUT_ENV_LOCK: Mutex<()> = Mutex::new(());
 
     struct PathRestoreGuard {
         original: Option<OsString>,
@@ -3641,6 +3772,90 @@ mod driver_tests {
                 std::env::set_var("PATH", original);
             } else {
                 std::env::remove_var("PATH");
+            }
+        }
+    }
+
+    #[test]
+    fn process_command_runner_times_out_hung_commands() {
+        let _env_lock = COMMAND_TIMEOUT_ENV_LOCK.lock().expect("lock timeout env");
+        let original = std::env::var_os("AGENTENV_OPENSHELL_COMMAND_TIMEOUT_MS");
+        std::env::set_var("AGENTENV_OPENSHELL_COMMAND_TIMEOUT_MS", "50");
+        let _restore = TimeoutEnvRestoreGuard { original };
+
+        let started = Instant::now();
+        let err = ProcessCommandRunner::default()
+            .run("/bin/sh", &command_request(&["-c", "/bin/sleep 2"]))
+            .expect_err("hung command should time out");
+
+        assert_eq!(err.kind(), io::ErrorKind::TimedOut);
+        assert!(
+            started.elapsed() < Duration::from_secs(1),
+            "timeout did not stop the subprocess promptly: {:?}",
+            started.elapsed()
+        );
+        assert!(
+            err.to_string().contains("timed out"),
+            "unexpected timeout error: {err}"
+        );
+    }
+
+    #[test]
+    fn process_command_runner_timeout_does_not_wait_for_descendant_stdout() {
+        let _env_lock = COMMAND_TIMEOUT_ENV_LOCK.lock().expect("lock timeout env");
+        let original = std::env::var_os("AGENTENV_OPENSHELL_COMMAND_TIMEOUT_MS");
+        std::env::set_var("AGENTENV_OPENSHELL_COMMAND_TIMEOUT_MS", "50");
+        let _restore = TimeoutEnvRestoreGuard { original };
+
+        let started = Instant::now();
+        let err = ProcessCommandRunner::default()
+            .run(
+                "/bin/sh",
+                &command_request(&["-c", "(/bin/sleep 2) & /bin/sleep 2"]),
+            )
+            .expect_err("hung command should time out");
+
+        assert_eq!(err.kind(), io::ErrorKind::TimedOut);
+        assert!(
+            started.elapsed() < Duration::from_secs(1),
+            "timeout waited for descendant stdout to close: {:?}",
+            started.elapsed()
+        );
+    }
+
+    #[test]
+    fn process_command_runner_timeout_covers_output_drain_after_child_exit() {
+        let _env_lock = COMMAND_TIMEOUT_ENV_LOCK.lock().expect("lock timeout env");
+        let original = std::env::var_os("AGENTENV_OPENSHELL_COMMAND_TIMEOUT_MS");
+        std::env::set_var("AGENTENV_OPENSHELL_COMMAND_TIMEOUT_MS", "50");
+        let _restore = TimeoutEnvRestoreGuard { original };
+
+        let started = Instant::now();
+        let err = ProcessCommandRunner::default()
+            .run(
+                "/bin/sh",
+                &command_request(&["-c", "(/bin/sleep 2) & true"]),
+            )
+            .expect_err("inherited stdout should keep the command bounded");
+
+        assert_eq!(err.kind(), io::ErrorKind::TimedOut);
+        assert!(
+            started.elapsed() < Duration::from_secs(1),
+            "timeout did not cover output drain: {:?}",
+            started.elapsed()
+        );
+    }
+
+    struct TimeoutEnvRestoreGuard {
+        original: Option<OsString>,
+    }
+
+    impl Drop for TimeoutEnvRestoreGuard {
+        fn drop(&mut self) {
+            if let Some(original) = self.original.take() {
+                std::env::set_var("AGENTENV_OPENSHELL_COMMAND_TIMEOUT_MS", original);
+            } else {
+                std::env::remove_var("AGENTENV_OPENSHELL_COMMAND_TIMEOUT_MS");
             }
         }
     }
@@ -7836,6 +8051,88 @@ mod driver_tests {
                 CommandCall {
                     program: "openshell".to_owned(),
                     request: command_request(&["sandbox", "delete", "leaked-sandbox"]),
+                },
+            ]
+        );
+    }
+
+    #[test]
+    fn create_rolls_back_when_timed_out_create_left_sandbox() {
+        let runner = Arc::new(RecordingCommandRunner::new(vec![
+            CommandScript::failure(
+                "openshell",
+                &[
+                    "sandbox",
+                    "create",
+                    "--name",
+                    "timed-out-sandbox",
+                    "--no-auto-providers",
+                    "--from",
+                    "openclaw",
+                    "--",
+                    "true",
+                ],
+                io::ErrorKind::TimedOut,
+                "timed out after 2s",
+            ),
+            CommandScript::output(
+                "openshell",
+                &["sandbox", "get", "timed-out-sandbox"],
+                Some(0),
+                "NAME timed-out-sandbox\n",
+                "",
+            ),
+            CommandScript::success(
+                "openshell",
+                &["sandbox", "delete", "timed-out-sandbox"],
+                "",
+                "",
+            ),
+        ]));
+        let driver = OpenShellDriver::with_command_runner(runner.clone());
+
+        let runtime = tokio::runtime::Builder::new_current_thread()
+            .enable_all()
+            .build()
+            .expect("runtime");
+        let err = runtime
+            .block_on(async {
+                driver
+                    .create(SandboxSpec {
+                        image: None,
+                        env: BTreeMap::new(),
+                        policy: None,
+                        metadata: BTreeMap::from([("name".to_owned(), json!("timed-out-sandbox"))]),
+                    })
+                    .await
+            })
+            .expect_err("timeout should be returned after rollback");
+
+        assert!(err.to_string().contains("timed out"));
+        assert_eq!(
+            runner.calls(),
+            vec![
+                CommandCall {
+                    program: "openshell".to_owned(),
+                    request: command_request(&[
+                        "sandbox",
+                        "create",
+                        "--name",
+                        "timed-out-sandbox",
+                        "--no-auto-providers",
+                        "--from",
+                        "openclaw",
+                        "--",
+                        "true",
+                    ]),
+                },
+                CommandCall {
+                    program: "openshell".to_owned(),
+                    request: command_request(&["sandbox", "get", "timed-out-sandbox"]),
+                },
+                CommandCall {
+                    program: "openshell".to_owned(),
+                    request: command_request(&["sandbox", "delete", "timed-out-sandbox"]),
                 },
             ]
         );

--- a/crates/drivers/sandbox-openshell/tests/apply_policy.rs
+++ b/crates/drivers/sandbox-openshell/tests/apply_policy.rs
@@ -3,10 +3,24 @@ use sandbox_openshell::{
     classify_policy_update, translate_for_openshell, translate_for_openshell_with_binaries,
     UpdateDisposition,
 };
-use std::path::{Path, PathBuf};
-use std::sync::Mutex;
+use std::{
+    io::{self, Read},
+    os::unix::process::CommandExt,
+    path::{Path, PathBuf},
+    process::{Command, Output, Stdio},
+    sync::{mpsc, Mutex},
+    thread,
+    time::{Duration, Instant},
+};
 
 static PATH_LOCK: Mutex<()> = Mutex::new(());
+const OPEN_SHELL_COMMAND_TIMEOUT_ENV: &str = "AGENTENV_OPENSHELL_COMMAND_TIMEOUT_MS";
+const DEFAULT_LIVE_CLI_TIMEOUT: Duration = Duration::from_secs(300);
+const PROCESS_COMMAND_POLL_INTERVAL: Duration = Duration::from_millis(25);
+
+struct ProcessOutputReader {
+    receiver: mpsc::Receiver<io::Result<Vec<u8>>>,
+}
 
 #[test]
 fn filesystem_or_process_changes_require_recreate() {
@@ -277,7 +291,8 @@ fn translated_policy_is_accepted_by_real_openshell_cli() {
     std::fs::write(&policy_path, translated.policy_yaml).expect("write policy");
 
     let sandbox = format!("agentenv-policy-test-{suffix}");
-    let create_output = std::process::Command::new("openshell")
+    let mut create_command = Command::new("openshell");
+    create_command
         .args([
             "sandbox",
             "create",
@@ -289,14 +304,17 @@ fn translated_policy_is_accepted_by_real_openshell_cli() {
             "--policy",
         ])
         .arg(&policy_path)
-        .args(["--", "true"])
-        .output()
-        .expect("create openshell sandbox");
+        .args(["--", "true"]);
+    let create_output = match run_command_with_timeout(create_command) {
+        Ok(output) => output,
+        Err(error) => {
+            let _ = delete_sandbox(&sandbox);
+            panic!("create openshell sandbox: {error}");
+        }
+    };
 
     if !create_output.status.success() {
-        let _ = std::process::Command::new("openshell")
-            .args(["sandbox", "delete", &sandbox])
-            .output();
+        let _ = delete_sandbox(&sandbox);
     }
     assert!(
         create_output.status.success(),
@@ -305,17 +323,14 @@ fn translated_policy_is_accepted_by_real_openshell_cli() {
         String::from_utf8_lossy(&create_output.stderr)
     );
 
-    let output = std::process::Command::new("openshell")
+    let mut policy_command = Command::new("openshell");
+    policy_command
         .args(["policy", "set", &sandbox, "--policy"])
         .arg(&policy_path)
-        .arg("--wait")
-        .output()
-        .expect("run openshell");
+        .arg("--wait");
+    let output = run_command_with_timeout(policy_command);
 
-    let cleanup_output = std::process::Command::new("openshell")
-        .args(["sandbox", "delete", &sandbox])
-        .output()
-        .expect("delete openshell sandbox");
+    let cleanup_output = delete_sandbox(&sandbox).expect("delete openshell sandbox");
     assert!(
         cleanup_output.status.success(),
         "stdout: {}\nstderr: {}",
@@ -323,6 +338,7 @@ fn translated_policy_is_accepted_by_real_openshell_cli() {
         String::from_utf8_lossy(&cleanup_output.stderr)
     );
 
+    let output = output.expect("run openshell");
     assert!(
         output.status.success(),
         "stdout: {}\nstderr: {}",
@@ -334,10 +350,9 @@ fn translated_policy_is_accepted_by_real_openshell_cli() {
 }
 
 fn openshell_gateway_available() -> bool {
-    match std::process::Command::new("openshell")
-        .arg("status")
-        .output()
-    {
+    let mut command = Command::new("openshell");
+    command.arg("status");
+    match run_command_with_timeout(command) {
         Ok(output) if output.status.success() => true,
         Ok(output) => {
             eprintln!(
@@ -354,6 +369,128 @@ fn openshell_gateway_available() -> bool {
             false
         }
     }
+}
+
+fn delete_sandbox(sandbox: &str) -> io::Result<Output> {
+    let mut command = Command::new("openshell");
+    command.args(["sandbox", "delete", sandbox]);
+    run_command_with_timeout(command)
+}
+
+fn run_command_with_timeout(mut command: Command) -> io::Result<Output> {
+    let timeout = live_cli_timeout();
+    command
+        .stdout(Stdio::piped())
+        .stderr(Stdio::piped())
+        .process_group(0);
+    let mut child = command.spawn()?;
+    let stdout = child
+        .stdout
+        .take()
+        .ok_or_else(|| io::Error::other("failed to capture stdout for live OpenShell command"))?;
+    let stderr = child
+        .stderr
+        .take()
+        .ok_or_else(|| io::Error::other("failed to capture stderr for live OpenShell command"))?;
+    let stdout_reader = read_process_output(stdout);
+    let stderr_reader = read_process_output(stderr);
+    let started = Instant::now();
+
+    let status = loop {
+        if let Some(status) = child.try_wait()? {
+            break status;
+        }
+
+        if started.elapsed() >= timeout {
+            terminate_timed_out_process(&mut child);
+            return Err(io::Error::new(
+                io::ErrorKind::TimedOut,
+                format!("live OpenShell command timed out after {timeout:?}"),
+            ));
+        }
+
+        let remaining = timeout.saturating_sub(started.elapsed());
+        thread::sleep(PROCESS_COMMAND_POLL_INTERVAL.min(remaining));
+    };
+
+    let Some(stdout) = collect_process_output_before_timeout(stdout_reader, started, timeout)?
+    else {
+        terminate_timed_out_process(&mut child);
+        return Err(io::Error::new(
+            io::ErrorKind::TimedOut,
+            format!("live OpenShell command timed out after {timeout:?}"),
+        ));
+    };
+    let Some(stderr) = collect_process_output_before_timeout(stderr_reader, started, timeout)?
+    else {
+        terminate_timed_out_process(&mut child);
+        return Err(io::Error::new(
+            io::ErrorKind::TimedOut,
+            format!("live OpenShell command timed out after {timeout:?}"),
+        ));
+    };
+
+    Ok(Output {
+        status,
+        stdout,
+        stderr,
+    })
+}
+
+fn read_process_output<R>(mut reader: R) -> ProcessOutputReader
+where
+    R: Read + Send + 'static,
+{
+    let (sender, receiver) = mpsc::channel();
+    thread::spawn(move || {
+        let mut output = Vec::new();
+        let result = reader.read_to_end(&mut output).map(|_| output);
+        let _ = sender.send(result);
+    });
+    ProcessOutputReader { receiver }
+}
+
+fn collect_process_output_before_timeout(
+    reader: ProcessOutputReader,
+    started: Instant,
+    timeout: Duration,
+) -> io::Result<Option<Vec<u8>>> {
+    let Some(remaining) = timeout.checked_sub(started.elapsed()) else {
+        return Ok(None);
+    };
+    if remaining.is_zero() {
+        return Ok(None);
+    }
+
+    match reader.receiver.recv_timeout(remaining) {
+        Ok(result) => result.map(Some),
+        Err(mpsc::RecvTimeoutError::Timeout) => Ok(None),
+        Err(mpsc::RecvTimeoutError::Disconnected) => Err(io::Error::other(
+            "command output reader thread stopped early",
+        )),
+    }
+}
+
+fn terminate_timed_out_process(child: &mut std::process::Child) {
+    let process_group_id = child.id() as i32;
+    let _ = Command::new("kill")
+        .arg("-KILL")
+        .arg("--")
+        .arg(format!("-{process_group_id}"))
+        .stdout(Stdio::null())
+        .stderr(Stdio::null())
+        .status();
+    let _ = child.kill();
+    let _ = child.wait();
+}
+
+fn live_cli_timeout() -> Duration {
+    std::env::var(OPEN_SHELL_COMMAND_TIMEOUT_ENV)
+        .ok()
+        .and_then(|raw| raw.parse::<u64>().ok())
+        .filter(|millis| *millis > 0)
+        .map(Duration::from_millis)
+        .unwrap_or(DEFAULT_LIVE_CLI_TIMEOUT)
 }
 
 fn write_fake_binary(dir: &Path, binary: &str, executable: bool) {

--- a/docs/superpowers/specs/2026-05-20-m8-1-blueprint-registry-design.md
+++ b/docs/superpowers/specs/2026-05-20-m8-1-blueprint-registry-design.md
@@ -1,0 +1,398 @@
+# M8-1 Design: Blueprint Registry
+
+- Date: 2026-05-20
+- Issue: https://github.com/windoliver/agentenv/issues/46
+- Milestone: M8 Team-mode adoption
+- Depends on:
+  - https://github.com/windoliver/agentenv/issues/27
+  - https://github.com/windoliver/agentenv/issues/28
+  - https://github.com/windoliver/agentenv/issues/31
+- Affected future crates: `agentenv`, `agentenv-core`
+- Protocol impact: no driver protocol or schema-version change
+
+## Context
+
+M7 established that skills are core-managed artifacts, not a `ContextDriver`
+sub-kind and not a fifth pluggable axis. The skills registry already owns the
+hard parts that a blueprint registry would otherwise duplicate: registry
+configuration, filesystem/HTTP/OCI/git adapters, artifact digests, signature
+checks, self-test attestations, local cache layout, publish gates, and
+provenance.
+
+M7-5 also made a frozen `agentenv` environment exportable as an installable
+skill bundle. That bundle contains `blueprint.yaml`, `agentenv.lock`, and
+metadata marking it as an `agentenv` bundle. M8 should treat that bundle as the
+canonical published blueprint artifact instead of inventing a separate package
+format.
+
+The user-facing goal remains blueprint-native:
+
+```text
+agentenv install github.com/alice/myapp
+agentenv create myapp --from alice/myapp
+agentenv publish --blueprint ./myapp --registry ghcr.io/alice
+```
+
+The implementation behind that UX should reuse the M7 skill registry and trust
+chain.
+
+## Goals
+
+1. Let users install reusable blueprints published by other users or teams.
+2. Reuse the M7 skills registry adapters and trust model.
+3. Keep installed blueprints available through stable handles such as
+   `alice/myapp` for `agentenv create --from`.
+4. Verify the bundled `agentenv.lock` before recording an installed blueprint.
+5. Make `agentenv install <source>` fetch and verify only. It must not create
+   or apply an environment.
+6. Let `agentenv create --from <source>` either use an installed handle or
+   perform an explicit one-shot fetch, verify, and create flow.
+7. Preserve the four-axis architecture and avoid any driver protocol change.
+
+## Non-Goals
+
+1. Do not add a standalone blueprint registry service for the first M8 slice.
+2. Do not add a `BlueprintDriver`, `RegistryDriver`, or any new JSON-RPC driver
+   method.
+3. Do not introduce a second serialization format. Published blueprint bundles
+   remain YAML plus the existing skill package metadata.
+4. Do not make `agentenv install` create, start, or mutate an environment.
+5. Do not support unverified remote blueprint installation as the default.
+   Remote installs require a lockfile and the same artifact verification rules
+   used by skills.
+
+## Registry Decision
+
+### Recommended: merged registry, blueprint-specific view
+
+Blueprints should piggy-back on the M7 skills registry. A published blueprint is
+an `agentenv` skill bundle whose manifest includes the existing bundle markers
+and whose contents include `blueprint.yaml` and `agentenv.lock`.
+
+Installation writes the artifact into the existing immutable skills cache, then
+records a blueprint-specific alias under `~/.agentenv/blueprints/`. The alias is
+a view over the installed artifact, not a second copy of the bundle.
+
+This gives users a blueprint-native handle while keeping one artifact store and
+one trust chain:
+
+```text
+~/.agentenv/
+  skills/
+    myapp/
+      1.2.0/
+        content/
+          skill.yaml
+          SKILL.md
+          blueprint.yaml
+          agentenv.lock
+        installed.yaml
+  blueprints/
+    index.json
+    alice/
+      myapp/
+        1.2.0/
+          installed.json
+```
+
+`installed.json` records:
+
+1. scope and name, for example `alice/myapp`
+2. version
+3. source, registry, and source kind
+4. skill artifact name, version, digest, and installed path
+5. relative blueprint path, normally `blueprint.yaml`
+6. relative lockfile path, normally `agentenv.lock`
+7. verification status and verified timestamp
+8. deprecation or yanking metadata when supplied by the registry
+
+### Alternative: separate blueprint registry
+
+A separate registry would keep semantics clean because skills and blueprints
+are not identical user concepts. It would also duplicate registry config,
+credential resolution, SSRF validation, artifact signatures, cache behavior,
+publish gates, yanking, and provenance. That creates two hubs to run and two
+trust chains to audit before there is evidence that blueprints need a different
+transport.
+
+### Alternative: local-only blueprint clones
+
+`agentenv install` could clone or fetch directly into
+`~/.agentenv/blueprints/<scope>/<name>/` without touching the skills cache.
+That matches the simplest reading of the issue, but it bypasses M7's artifact
+dedupe, registry search, signatures, self-test attestations, and publish
+infrastructure. It also makes M7-5 bundle export less useful.
+
+## Artifact Contract
+
+A registry-published blueprint artifact should be an M7 skill bundle with these
+requirements:
+
+1. `skill.yaml` is present and valid.
+2. `agentenv_bundle: true` and `agentenv_schema: "0.1"` are present.
+3. `blueprint.yaml` is listed in `files`.
+4. `agentenv.lock` is listed in `files`.
+5. The bundle digest and signature policy pass the existing skills verifier.
+6. `agentenv verify agentenv.lock` passes before the blueprint alias is
+   recorded.
+7. The lockfile blueprint hash matches `blueprint.yaml`.
+
+GitHub shorthand sources may start as raw blueprint repositories for authoring
+convenience. A raw repository install is valid only when the root contains
+`agentenv.yaml` and `agentenv.lock`. Core normalizes that into an internal
+transient bundle during install, pins the resolved commit, verifies the
+lockfile, and records the same blueprint alias metadata. Publishing should
+still produce the canonical M7 skill bundle.
+
+## URL Scheme Spec
+
+### Installed handles
+
+```text
+<scope>/<name>
+<scope>/<name>@<version>
+```
+
+Handles resolve through `~/.agentenv/blueprints/index.json`. Without a version,
+the current installed version is used. Installing a newer version may move the
+current pointer only after verification succeeds.
+
+### GitHub shorthand
+
+```text
+github.com/<owner>/<repo>
+github.com/<owner>/<repo>@<semver-or-ref>
+github.com/<owner>/<repo>//<subdir>
+```
+
+The first implementation should support the root path form. Subdirectory and
+explicit ref support can be added without changing the overall model.
+
+Resolution rules:
+
+1. Normalize to `git+https://github.com/<owner>/<repo>`.
+2. Use non-interactive git fetch behavior from the M7 git registry backend.
+3. Resolve the default branch unless a version or ref is explicit.
+4. Require `agentenv.yaml` and `agentenv.lock` at the resolved blueprint root
+   for raw repositories.
+5. Pin the commit SHA in `installed.json`.
+6. Run lockfile verification before installing the alias.
+
+If the repository root contains a complete M7 bundle, install it through the
+skill service and then create the blueprint alias from the bundled files.
+
+### OCI
+
+```text
+ghcr.io/<owner>/<name>:<version>
+oci://ghcr.io/<owner>/<name>:<version>
+```
+
+OCI uses the existing M7 OCI registry adapter and skill artifact media type.
+Blueprint artifacts are distinguished by bundle metadata and optional OCI
+annotations, not by a new driver or new protocol. The install flow rejects OCI
+artifacts that do not contain `blueprint.yaml` and `agentenv.lock`.
+
+### HTTP registry
+
+```text
+https://registry.agentenv.dev/community/<name>
+https://registry.agentenv.dev/community/<name>@<version>
+```
+
+HTTP registries may expose blueprint discovery at:
+
+```text
+/.well-known/agent-blueprints
+```
+
+The well-known document maps blueprint handles to existing skill-registry
+artifact descriptors. The HTTP adapter still validates every outbound URL
+through the SSRF module and rejects redirects or artifact paths outside the
+configured registry authority.
+
+## Install UX
+
+```text
+agentenv install <source> [--name <scope/name>] [--version <semver>] [--json]
+agentenv install <source> --as blueprint
+```
+
+`--as blueprint` is optional when the artifact declares `agentenv_bundle: true`
+or when the source shape is clearly a raw blueprint repository. If detection is
+ambiguous, the CLI should ask in interactive mode and fail with a clear
+diagnostic in non-interactive mode.
+
+Install steps:
+
+1. Parse the source as an installed handle, GitHub shorthand, OCI reference,
+   HTTP registry URL, filesystem path, or git URL.
+2. Fetch into a staging directory through the existing skills registry service
+   when possible.
+3. Validate bundle metadata or normalize a raw GitHub blueprint repo into a
+   transient bundle.
+4. Verify signatures, digest, self-test attestation policy, and
+   `agentenv.lock`.
+5. Install the artifact into `~/.agentenv/skills/`.
+6. Write or update the blueprint alias under `~/.agentenv/blueprints/`.
+7. Print the handle that can be used with `agentenv create --from`.
+
+Install must not create an environment. It should be safe to run repeatedly; an
+existing identical digest is a no-op, while a same-version different digest is
+an error unless a later design adds explicit replacement semantics.
+
+## Publish UX
+
+```text
+agentenv publish --blueprint <env-or-path> --registry <name-or-url> \
+  [--name <scope/name>] [--version <semver>] [--json]
+```
+
+This is a user-friendly facade over two existing M7 concepts:
+
+1. freeze and bundle an environment as a skill with `agentenv bundle --as-skill`
+2. publish the resulting bundle with the skills registry service
+
+For a directory source, the command should require enough information to freeze
+an existing environment or use a supplied lockfile. It should not publish a
+bare `agentenv.yaml` without a lockfile.
+
+Publish steps:
+
+1. Resolve the source environment or project directory.
+2. Produce or validate `blueprint.yaml` and `agentenv.lock`.
+3. Emit an M7-compatible skill bundle with blueprint markers.
+4. Run the skill CI and self-test attestation gate required by M7 publish.
+5. Publish through filesystem, HTTP, or OCI registries.
+6. Return a blueprint handle and install URL.
+
+Git registry publish remains unsupported in the first implementation, matching
+M7's read-only git backend.
+
+## `agentenv create --from`
+
+The existing CLI already uses `--from <DOCKERFILE>` together with `--blueprint`
+for BYO Dockerfile overlays. M8 can add blueprint source semantics without
+breaking that flow by interpreting `--from` based on context:
+
+1. `agentenv create <env> --blueprint <file> --from <dockerfile>` keeps the
+   existing Dockerfile overlay behavior.
+2. `agentenv create <env> --from <source>` with no `--blueprint` treats
+   `<source>` as a blueprint handle, URL, registry reference, or local bundle.
+3. A future explicit `--from-dockerfile <path>` alias can make the old meaning
+   easier to discover, but the old paired form should continue to work.
+
+Create from an installed handle:
+
+```text
+agentenv create myapp --from alice/myapp
+```
+
+Core reads the alias, loads the cached `blueprint.yaml` and `agentenv.lock`,
+verifies that the installed artifact digest still matches the alias, verifies
+the lockfile, and then runs the normal create/reproduce planning path.
+
+Create from a URL:
+
+```text
+agentenv create myapp --from github.com/alice/myapp
+```
+
+Core performs the same resolution and verification as `agentenv install`, then
+continues into create. This is an explicit apply operation because the user
+chose `create`. The resolved artifact should be cached and aliased when the
+source declares a stable scope/name; one-shot anonymous URLs may remain in the
+content-addressed cache without a friendly alias.
+
+## Error Handling
+
+Core should expose typed errors for:
+
+1. unsupported blueprint source scheme
+2. ambiguous source kind
+3. missing `blueprint.yaml`, `agentenv.yaml`, or `agentenv.lock`
+4. lockfile verification failure
+5. artifact kind mismatch, such as installing a plain skill as a blueprint
+6. alias collision with different digest
+7. yanked version install attempt
+8. deprecated version warning
+9. GitHub source missing a pinned commit after fetch
+10. registry URL rejected by SSRF validation
+
+CLI errors should include the source and the failing phase, but must not leak
+credentials or bearer tokens from registry configuration.
+
+## Versioning, Yanking, And Deprecation
+
+Blueprint versions use semantic versions from the underlying bundle manifest.
+Registry resolution follows M7 patterns:
+
+1. exact versions are reproducible and preferred for automation
+2. omitted versions select the highest non-yanked semver at install time
+3. installed aliases are pinned after installation and do not float during
+   `create`
+4. yanked versions cannot be newly installed unless a later recovery flag is
+   explicitly added
+5. deprecated versions may be installed but print a warning and record the
+   deprecation message in alias metadata
+
+`agentenv freeze` and `agentenv reproduce` continue to rely on exact lockfile
+pins. Registry metadata helps users find and install artifacts; it does not
+replace lockfile reproducibility.
+
+## Security And Trust
+
+Blueprint registry support must reuse the existing security posture:
+
+1. registry URLs pass through the SSRF validator
+2. signatures and self-test attestations are enforced through M7 skill publish
+   rules
+3. credentials stay in the host credstore and do not flow through driver RPC
+4. raw GitHub installs pin the resolved commit
+5. remote installs require a lockfile
+6. install and create plans display the source, version, digest, and registry
+   before applying environment changes
+
+No additional runtime dependency is required. Git sources use the existing
+non-interactive `git` command strategy from the M7 backend; HTTP and OCI keep
+using `reqwest` with `rustls`.
+
+## Future Implementation Shape
+
+Implementation should add a small core layer above skills rather than changing
+the skills service itself:
+
+```rust
+pub struct BlueprintInstallService { /* root, skills, ssrf */ }
+
+impl BlueprintInstallService {
+    pub async fn install(&self, request: BlueprintInstallRequest)
+        -> Result<InstalledBlueprint, BlueprintInstallError>;
+
+    pub async fn resolve_for_create(&self, source: &str)
+        -> Result<ResolvedBlueprintSource, BlueprintInstallError>;
+}
+```
+
+The service owns alias metadata, source parsing, raw GitHub normalization, and
+lockfile verification. It delegates artifact fetch, signature checks, publish,
+and local cache writes to `SkillService`.
+
+Future tests should cover:
+
+1. installing an M7 bundle as a blueprint alias
+2. rejecting a plain skill without blueprint files
+3. rejecting a remote blueprint without `agentenv.lock`
+4. create from installed alias uses pinned cached content
+5. create from URL performs fetch, verify, cache, and create
+6. existing `--blueprint <file> --from <dockerfile>` behavior remains intact
+7. HTTP and OCI sources reject artifacts outside the configured authority
+8. yanked and deprecated registry metadata affects install decisions
+
+## Rollout Notes
+
+The first implementation PR should list `agentenv` and `agentenv-core` as
+affected crates and explicitly note that `agentenv-proto` is unchanged. The PR
+should also call out the CLI compatibility rule for the existing Dockerfile
+`--from` behavior, because that is the main user-facing ambiguity introduced by
+this design.


### PR DESCRIPTION
## Summary

- Add a bounded timeout for non-interactive OpenShell subprocesses via `AGENTENV_OPENSHELL_COMMAND_TIMEOUT_MS`.
- Treat timed-out `openshell sandbox create` as an ambiguous create failure and attempt rollback cleanup when the sandbox exists.
- Bound the live OpenShell CLI policy test's create/set/delete subprocesses so local gateway failures fail quickly instead of hanging.
- Document the timeout override in the OpenShell driver README.

## Root Cause

A local OpenShell gateway or Docker credential failure could leave the CLI blocked during `sandbox create`. Because the driver used unbounded `Command::output()`, the test and E2E flow could hang indefinitely instead of returning an actionable timeout and cleanup path.

## Validation

- `cargo fmt --all --check`
- `git diff --check`
- `cargo clippy --workspace --all-targets -- -D warnings`
- `cargo test --workspace`
- `cargo test -p sandbox-openshell -- --nocapture`
- `bash tests/install/test_install.sh`
- `AGENTENV_RUN_OPENSHELL_INTEGRATION=1 AGENTENV_OPENSHELL_COMMAND_TIMEOUT_MS=600000 cargo test -p sandbox-openshell --features integration --test integration openshell_create_exec_policy_logs_and_destroy_flow -- --ignored --nocapture`
- `AGENTENV_RUN_OPENSHELL_INTEGRATION=1 AGENTENV_OPENSHELL_COMMAND_TIMEOUT_MS=600000 cargo test -p sandbox-openshell --test apply_policy translated_policy_is_accepted_by_real_openshell_cli -- --ignored --nocapture`

Closes #46
